### PR TITLE
Add server_charset_specification rule

### DIFF
--- a/docs/rules/server_charset_specification.md
+++ b/docs/rules/server_charset_specification.md
@@ -1,0 +1,31 @@
+<!--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+
+SPDX-License-Identifier: ISC
+-->
+
+# Charset Specification
+
+## Description
+This rule checks if `Content-Type` headers for text-based resources (starting with `text/`) include a `charset` parameter.
+
+Specifying the character encoding is crucial for security and correct rendering. If the charset is not explicitly defined, browsers may attempt to guess the encoding (MIME sniffing), which can lead to Cross-Site Scripting (XSS) vulnerabilities or incorrect display of characters.
+
+## Specifications
+- [MDN Web Docs: Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)
+- [RFC 9110: Content-Type](https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type)
+
+## Examples
+
+### ✅ Good Response
+```http
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+```
+
+### ❌ Bad Response
+```http
+HTTP/1.1 200 OK
+Content-Type: text/html
+# Missing charset parameter
+```

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -614,10 +614,11 @@ mod tests {
             .and(wiremock::matchers::path("/ok"))
             .respond_with(
                 ResponseTemplate::new(200)
+                    .set_body_bytes("ok".as_bytes())
                     .insert_header("cache-control", "max-age=1")
                     .insert_header("etag", "W/\"1\"")
                     .insert_header("x-content-type-options", "nosniff")
-                    .set_body_string("ok"),
+                    .insert_header("content-type", "text/plain; charset=utf-8"),
             )
             .mount(&mock)
             .await;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -39,6 +39,7 @@ pub mod client_cache_respect;
 pub mod client_user_agent_present;
 pub mod connection_efficiency;
 pub mod server_cache_control_present;
+pub mod server_charset_specification;
 pub mod server_etag_or_last_modified;
 pub mod server_x_content_type_options;
 
@@ -50,4 +51,5 @@ pub const RULES: &[&dyn Rule] = &[
     &client_accept_encoding_present::ClientAcceptEncodingPresent,
     &client_cache_respect::ClientCacheRespect,
     &connection_efficiency::ConnectionEfficiency,
+    &server_charset_specification::ServerCharsetSpecification,
 ];

--- a/src/rules/server_charset_specification.rs
+++ b/src/rules/server_charset_specification.rs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+use crate::lint::Violation;
+use crate::rules::Rule;
+use crate::state::{ClientIdentifier, StateStore};
+use hyper::HeaderMap;
+
+pub struct ServerCharsetSpecification;
+
+impl Rule for ServerCharsetSpecification {
+    fn id(&self) -> &'static str {
+        "server_charset_specification"
+    }
+
+    fn check_response(
+        &self,
+        _client: &ClientIdentifier,
+        _resource: &str,
+        _status: u16,
+        headers: &HeaderMap,
+        _conn: &crate::connection::ConnectionMetadata,
+        _state: &StateStore,
+    ) -> Option<Violation> {
+        if let Some(content_type) = headers.get(hyper::header::CONTENT_TYPE) {
+            if let Ok(ct_str) = content_type.to_str() {
+                let ct_lower = ct_str.to_lowercase();
+                if ct_lower.starts_with("text/")
+                    && !ct_lower.contains(";charset=")
+                    && !ct_lower.contains("; charset=")
+                {
+                    return Some(Violation {
+                        rule: self.id().into(),
+                        severity: "warn".into(),
+                        message: "Text-based Content-Type header missing charset parameter.".into(),
+                    });
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{make_test_conn, make_test_context};
+    use hyper::HeaderMap;
+
+    #[test]
+    fn check_response_no_violation_with_charset() {
+        let rule = ServerCharsetSpecification;
+        let (client, state) = make_test_context();
+        let conn = make_test_conn();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            hyper::header::CONTENT_TYPE,
+            "text/html; charset=utf-8".parse().unwrap(),
+        );
+
+        let violation =
+            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn check_response_no_violation_with_charset_nospace() {
+        let rule = ServerCharsetSpecification;
+        let (client, state) = make_test_context();
+        let conn = make_test_conn();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            hyper::header::CONTENT_TYPE,
+            "text/html;charset=utf-8".parse().unwrap(),
+        );
+
+        let violation =
+            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn check_response_no_violation_with_charset_case_insensitive() {
+        let rule = ServerCharsetSpecification;
+        let (client, state) = make_test_context();
+        let conn = make_test_conn();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            hyper::header::CONTENT_TYPE,
+            "TEXT/HTML;CHARSET=UTF-8".parse().unwrap(),
+        );
+
+        let violation =
+            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn check_response_violation_missing_charset() {
+        let rule = ServerCharsetSpecification;
+        let (client, state) = make_test_context();
+        let conn = make_test_conn();
+        let mut headers = HeaderMap::new();
+        headers.insert(hyper::header::CONTENT_TYPE, "text/html".parse().unwrap());
+
+        let violation =
+            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        assert!(violation.is_some());
+        assert_eq!(
+            violation.unwrap().message,
+            "Text-based Content-Type header missing charset parameter."
+        );
+    }
+
+    #[test]
+    fn check_response_no_violation_non_text() {
+        let rule = ServerCharsetSpecification;
+        let (client, state) = make_test_context();
+        let conn = make_test_conn();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            hyper::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+
+        let violation =
+            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn check_response_no_violation_no_content_type() {
+        let rule = ServerCharsetSpecification;
+        let (client, state) = make_test_context();
+        let conn = make_test_conn();
+        let headers = HeaderMap::new();
+
+        let violation =
+            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        assert!(violation.is_none());
+    }
+}


### PR DESCRIPTION
Servers should be explicit about response charset

<!--
SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>

SPDX-License-Identifier: ISC
-->

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Simple manual verification

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
