### PR TITLE
Make rules configurable, add server_clear_site_data rule

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,5 @@
 [alias]
 # Run coverage via cargo-tarpaulin (requires cargo-tarpaulin installed)
 coverage = "tarpaulin --out Xml --skip-clean"
+# Run clippy with all features and targets, treating warnings as errors
+lint = "clippy --all-features --all-targets -- -D warnings"

--- a/config_example.toml
+++ b/config_example.toml
@@ -26,3 +26,9 @@ connection_efficiency = true
 server_cache_control_present = true
 server_etag_or_last_modified = true
 server_x_content_type_options = true
+server_response_405_allow = true
+server_charset_specification = true
+
+# Configurable rule example - specify custom logout paths
+[rules.server_clear_site_data]
+paths = ["/logout", "/signout", "/auth/logout", "/api/v1/logout"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,11 @@ suppress_headers = []             # Headers to suppress from server responses
 
 ### Lint Rules Configuration (Optional)
 
-The `[rules]` section allows you to enable or disable specific lint rules. If a rule is omitted, it defaults to `true` (enabled).
+The `[rules]` section allows you to enable, disable, or configure specific lint rules. If a rule is omitted, it defaults to `true` (enabled).
+
+#### Simple Boolean Toggle
+
+Most rules can be enabled or disabled with a boolean value:
 
 ```toml
 [rules]
@@ -79,6 +83,27 @@ connection_efficiency = true
 server_cache_control_present = true
 server_etag_or_last_modified = true
 server_x_content_type_options = true
+
+# Disable a specific rule
+server_response_405_allow = false
 ```
 
-See [Rules Documentation](rules.md) for details on each rule.
+#### Configurable Rules
+
+Some rules support additional configuration options beyond simple enable/disable. Use TOML tables to configure these rules:
+
+```toml
+# Configure server_clear_site_data with custom logout paths
+[rules.server_clear_site_data]
+paths = ["/logout", "/signout", "/auth/logout", "/api/v1/logout"]
+```
+
+When a rule has configuration options, it's automatically enabled unless explicitly set to `false`:
+
+```toml
+[rules]
+# This completely disables the rule, ignoring any configuration
+server_clear_site_data = false
+```
+
+See [Rules Documentation](rules.md) for details on each rule and their configuration options.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,3 +21,5 @@ SPDX-License-Identifier: ISC
 - [server_etag_or_last_modified](rules/server_etag_or_last_modified.md) - Checks for `ETag` or `Last-Modified` headers.
 - [server_x_content_type_options](rules/server_x_content_type_options.md) - Checks for `X-Content-Type-Options: nosniff`.
 - [server_response_405_allow](rules/server_response_405_allow.md) - Checks `Allow` header is present on `405` responses.
+- [server_charset_specification](rules/server_charset_specification.md) - Checks text-based `Content-Type` headers include charset parameter.
+- [server_clear_site_data](rules/server_clear_site_data.md) - Checks logout endpoints include `Clear-Site-Data` header (configurable paths).

--- a/docs/rules/server_clear_site_data.md
+++ b/docs/rules/server_clear_site_data.md
@@ -1,0 +1,100 @@
+<!--
+SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+
+SPDX-License-Identifier: ISC
+-->
+
+# server_clear_site_data
+
+**Severity**: warn
+
+## Description
+
+This rule checks that logout/signout endpoints include the `Clear-Site-Data` header to properly clear client-side storage (cookies, cache, storage) when a user logs out.
+
+## Why It Matters
+
+When a user logs out, it's important to clear all client-side data to prevent:
+- Session token leakage if the device is shared
+- Sensitive cached data remaining accessible
+- Potential security vulnerabilities from stale authentication data
+
+The `Clear-Site-Data` header is a standard way to instruct the browser to clear various types of data.
+
+## Configuration
+
+This rule is **configurable** and allows you to specify which paths should be considered logout endpoints.
+
+### Default Configuration
+
+If not configured, the rule checks these default paths:
+- `/logout`
+- `/signout`
+
+### Custom Configuration
+
+You can configure custom paths in your `config.toml`:
+
+```toml
+[rules.server_clear_site_data]
+paths = ["/logout", "/signout", "/auth/logout", "/api/logout"]
+```
+
+### Disabling the Rule
+
+To disable this rule completely:
+
+```toml
+[rules]
+server_clear_site_data = false
+```
+
+## Violation Example
+
+```http
+POST /logout HTTP/1.1
+Host: example.com
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
+
+This will trigger a violation because the logout endpoint doesn't include the `Clear-Site-Data` header.
+
+## Compliant Example
+
+```http
+POST /logout HTTP/1.1
+Host: example.com
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+Clear-Site-Data: "*"
+```
+
+or more specifically:
+
+```http
+POST /logout HTTP/1.1
+Host: example.com
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+Clear-Site-Data: "cache", "cookies", "storage"
+```
+
+## Best Practices
+
+1. **Use `"*"` for complete cleanup**: `Clear-Site-Data: "*"` clears all types of data
+2. **Be specific if needed**: You can target specific data types: `"cache"`, `"cookies"`, `"storage"`, `"executionContexts"`
+3. **Consider all logout paths**: Configure all paths where users can log out (web UI, API endpoints, etc.)
+4. **Test thoroughly**: Some browsers have varying support for this header
+
+## References
+
+- [MDN: Clear-Site-Data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data)
+- [W3C Clear Site Data Specification](https://www.w3.org/TR/clear-site-data/)
+
+## Rule Category
+
+Server Response Header

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -29,7 +29,9 @@ pub fn lint_response(
 
     for rule in crate::rules::RULES {
         if cfg.is_enabled(rule.id()) {
-            if let Some(v) = rule.check_response(client, resource, status, headers, conn, state) {
+            if let Some(v) =
+                rule.check_response(client, resource, status, headers, conn, state, cfg)
+            {
                 out.push(v);
             }
         }
@@ -51,7 +53,8 @@ pub fn lint_request(
 
     for rule in crate::rules::RULES {
         if cfg.is_enabled(rule.id()) {
-            if let Some(v) = rule.check_request(client, resource, method, headers, conn, state) {
+            if let Some(v) = rule.check_request(client, resource, method, headers, conn, state, cfg)
+            {
                 out.push(v);
             }
         }
@@ -113,8 +116,14 @@ mod tests {
         let client = make_test_client();
         let state = crate::state::StateStore::new(300);
         let mut rules = std::collections::HashMap::new();
-        rules.insert("server_cache_control_present".to_string(), false);
-        rules.insert("server_etag_or_last_modified".to_string(), false);
+        rules.insert(
+            "server_cache_control_present".to_string(),
+            toml::Value::Boolean(false),
+        );
+        rules.insert(
+            "server_etag_or_last_modified".to_string(),
+            toml::Value::Boolean(false),
+        );
         let cfg = Config {
             rules,
             tls: crate::config::TlsConfig::default(),

--- a/src/rules/client_accept_encoding_present.rs
+++ b/src/rules/client_accept_encoding_present.rs
@@ -22,6 +22,7 @@ impl Rule for ClientAcceptEncodingPresent {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if !headers.contains_key("accept-encoding") {
             Some(Violation {
@@ -48,8 +49,15 @@ mod tests {
         let method = hyper::Method::GET;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -66,8 +74,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("accept-encoding", "gzip".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }

--- a/src/rules/client_cache_respect.rs
+++ b/src/rules/client_cache_respect.rs
@@ -22,6 +22,7 @@ impl Rule for ClientCacheRespect {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         // Check if we have a previous response for this client+resource
         let previous = state.get_previous(client, resource)?;
@@ -77,6 +78,7 @@ mod tests {
 
         let headers = HeaderMap::new();
         let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12345".parse()?);
+        let cfg = crate::config::Config::default();
         let violation = rule.check_request(
             &client,
             resource,
@@ -84,6 +86,7 @@ mod tests {
             &headers,
             &conn,
             &store,
+            &cfg,
         );
 
         assert!(violation.is_none());
@@ -106,6 +109,7 @@ mod tests {
         let mut req_headers = HeaderMap::new();
         req_headers.insert("if-none-match", "\"abc123\"".parse()?);
         let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12345".parse()?);
+        let cfg = crate::config::Config::default();
         let violation = rule.check_request(
             &client,
             resource,
@@ -113,6 +117,7 @@ mod tests {
             &req_headers,
             &conn,
             &store,
+            &cfg,
         );
 
         assert!(violation.is_none());
@@ -134,6 +139,7 @@ mod tests {
         // Second request WITHOUT conditional headers
         let req_headers = HeaderMap::new();
         let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12345".parse()?);
+        let cfg = crate::config::Config::default();
         let violation = rule.check_request(
             &client,
             resource,
@@ -141,6 +147,7 @@ mod tests {
             &req_headers,
             &conn,
             &store,
+            &cfg,
         );
 
         assert!(violation.is_some());
@@ -166,6 +173,7 @@ mod tests {
         // since server didn't provide validators
         let req_headers = HeaderMap::new();
         let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12345".parse()?);
+        let cfg = crate::config::Config::default();
         let violation = rule.check_request(
             &client,
             resource,
@@ -173,6 +181,7 @@ mod tests {
             &req_headers,
             &conn,
             &store,
+            &cfg,
         );
 
         assert!(violation.is_none());

--- a/src/rules/client_user_agent_present.rs
+++ b/src/rules/client_user_agent_present.rs
@@ -22,6 +22,7 @@ impl Rule for ClientUserAgentPresent {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if !headers.contains_key("user-agent") {
             Some(Violation {
@@ -48,8 +49,15 @@ mod tests {
         let method = hyper::Method::GET;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -66,8 +74,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("user-agent", "curl/7.68.0".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }

--- a/src/rules/config_cache.rs
+++ b/src/rules/config_cache.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Generic configuration caching for rules.
+//!
+//! This module provides a reusable pattern for rules that need to parse and cache
+//! their configuration once at startup, avoiding redundant TOML parsing on every request.
+//!
+//! # Usage Pattern
+//!
+//! 1. Define a static cache with your parsed config type:
+//!    ```ignore
+//!    static CACHED_CONFIG: RuleConfigCache<Vec<String>> = RuleConfigCache::new();
+//!    ```
+//!
+//! 2. In `validate_config`, parse and store the configuration:
+//!    ```ignore
+//!    fn validate_config(&self, config: &Config) -> anyhow::Result<()> {
+//!        let parsed = parse_my_config(config)?;  // Your parsing logic
+//!        CACHED_CONFIG.set(parsed);
+//!        Ok(())
+//!    }
+//!    ```
+//!
+//! 3. In `check_request`/`check_response`, retrieve the cached config:
+//!    ```ignore
+//!    fn check_response(...) -> Option<Violation> {
+//!        let config = CACHED_CONFIG.get_or_init(|| {
+//!            panic!("Config not initialized - validate_config should have been called")
+//!        });
+//!        // Use config...
+//!    }
+//!    ```
+//!
+//! # Thread Safety
+//!
+//! - In production: Uses `OnceLock` for thread-safe, one-time initialization
+//! - In tests: Uses `thread_local!` storage to prevent cross-test contamination
+//!
+//! # Example
+//!
+//! See `server_clear_site_data.rs` for a complete implementation example.
+
+#[cfg(test)]
+use std::marker::PhantomData;
+#[cfg(not(test))]
+use std::sync::OnceLock;
+
+/// A generic configuration cache that can be used by any rule.
+///
+/// In production, uses OnceLock for thread-safe one-time initialization.
+/// In tests, uses thread-local storage to avoid cross-test contamination.
+pub struct RuleConfigCache<T: Clone + Send + Sync + 'static> {
+    #[cfg(not(test))]
+    cell: OnceLock<T>,
+    #[cfg(test)]
+    _marker: PhantomData<T>,
+}
+
+impl<T: Clone + Send + Sync + 'static> Default for RuleConfigCache<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Clone + Send + Sync + 'static> RuleConfigCache<T> {
+    /// Create a new configuration cache.
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(not(test))]
+            cell: OnceLock::new(),
+            #[cfg(test)]
+            _marker: PhantomData,
+        }
+    }
+
+    /// Set the cached value. Should be called during validate_config.
+    #[cfg(not(test))]
+    pub fn set(&self, value: T) {
+        self.cell.set(value).ok();
+    }
+
+    /// Get the cached value, or initialize it with the provided function.
+    /// Should be called during check_request/check_response.
+    #[cfg(not(test))]
+    pub fn get_or_init<F>(&self, f: F) -> &T
+    where
+        F: FnOnce() -> T,
+    {
+        self.cell.get_or_init(f)
+    }
+}
+
+// Test implementation uses thread-local storage to avoid cross-test contamination
+#[cfg(test)]
+thread_local! {
+    static TEST_CACHE_REGISTRY: std::cell::RefCell<std::collections::HashMap<usize, Box<dyn std::any::Any>>> = std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+#[cfg(test)]
+impl<T: Clone + Send + Sync + 'static> RuleConfigCache<T> {
+    /// Get a unique key for this cache instance
+    fn key(&self) -> usize {
+        self as *const _ as usize
+    }
+
+    /// Set the cached value in tests
+    pub fn set(&self, value: T) {
+        TEST_CACHE_REGISTRY.with(|registry| {
+            registry
+                .borrow_mut()
+                .insert(self.key(), Box::new(Some(value)));
+        });
+    }
+
+    /// Get the cached value or initialize it in tests
+    pub fn get_or_init<F>(&self, f: F) -> T
+    where
+        F: FnOnce() -> T,
+    {
+        TEST_CACHE_REGISTRY.with(|registry| {
+            let mut map = registry.borrow_mut();
+            let key = self.key();
+
+            if let Some(boxed) = map.get(&key) {
+                if let Some(Some(value)) = boxed.downcast_ref::<Option<T>>() {
+                    return value.clone();
+                }
+            }
+
+            // Not cached yet, initialize it
+            let value = f();
+            map.insert(key, Box::new(Some(value.clone())));
+            value
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_stores_and_retrieves_value() {
+        let cache = RuleConfigCache::<Vec<String>>::new();
+        let data = vec!["test".to_string()];
+
+        cache.set(data.clone());
+        let retrieved = cache.get_or_init(|| panic!("Should not call init"));
+
+        assert_eq!(retrieved, data);
+    }
+
+    #[test]
+    fn cache_initializes_if_not_set() {
+        let cache = RuleConfigCache::<i32>::new();
+        let value = cache.get_or_init(|| 42);
+
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn different_caches_are_independent() {
+        let cache1 = RuleConfigCache::<String>::new();
+        let cache2 = RuleConfigCache::<String>::new();
+
+        cache1.set("cache1".to_string());
+        cache2.set("cache2".to_string());
+
+        assert_eq!(cache1.get_or_init(|| "wrong".to_string()), "cache1");
+        assert_eq!(cache2.get_or_init(|| "wrong".to_string()), "cache2");
+    }
+}

--- a/src/rules/connection_efficiency.rs
+++ b/src/rules/connection_efficiency.rs
@@ -29,6 +29,7 @@ impl Rule for ConnectionEfficiency {
         _headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         let count = state.get_connection_count(client);
 
@@ -67,8 +68,15 @@ mod tests {
         let conn = make_test_conn();
 
         // First request, no history
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 
@@ -88,8 +96,15 @@ mod tests {
             state.record_transaction(&client, "http://test.com", 200, &headers);
         }
         let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12351".parse()?);
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
 
         assert!(violation.is_some());
         let v = violation.ok_or_else(|| anyhow::anyhow!("expected violation"))?;
@@ -111,8 +126,15 @@ mod tests {
             state.record_transaction(&client, "http://test.com", 200, &headers);
         }
 
-        let violation =
-            rule.check_request(&client, "http://test.com", &method, &headers, &conn, &state);
+        let violation = rule.check_request(
+            &client,
+            "http://test.com",
+            &method,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,6 +9,13 @@ use hyper::{HeaderMap, Method};
 pub trait Rule: Send + Sync {
     fn id(&self) -> &'static str;
 
+    /// Validate the rule's configuration. Called once at startup.
+    /// Returns an error if the configuration is invalid.
+    fn validate_config(&self, _config: &crate::config::Config) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn check_request(
         &self,
         _client: &ClientIdentifier,
@@ -17,10 +24,12 @@ pub trait Rule: Send + Sync {
         _headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         None
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn check_response(
         &self,
         _client: &ClientIdentifier,
@@ -29,17 +38,32 @@ pub trait Rule: Send + Sync {
         _headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         None
     }
 }
 
+/// Validate all enabled rules' configurations
+pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
+    for rule in RULES {
+        if config.is_enabled(rule.id()) {
+            rule.validate_config(config).map_err(|e| {
+                anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
+            })?;
+        }
+    }
+    Ok(())
+}
+
 pub mod client_accept_encoding_present;
 pub mod client_cache_respect;
 pub mod client_user_agent_present;
+pub mod config_cache;
 pub mod connection_efficiency;
 pub mod server_cache_control_present;
 pub mod server_charset_specification;
+pub mod server_clear_site_data;
 pub mod server_etag_or_last_modified;
 pub mod server_response_405_allow;
 pub mod server_x_content_type_options;
@@ -49,6 +73,7 @@ pub const RULES: &[&dyn Rule] = &[
     &server_etag_or_last_modified::ServerEtagOrLastModified,
     &server_x_content_type_options::ServerXContentTypeOptions,
     &server_response_405_allow::ServerResponse405Allow,
+    &server_clear_site_data::ServerClearSiteData,
     &client_user_agent_present::ClientUserAgentPresent,
     &client_accept_encoding_present::ClientAcceptEncodingPresent,
     &client_cache_respect::ClientCacheRespect,

--- a/src/rules/server_cache_control_present.rs
+++ b/src/rules/server_cache_control_present.rs
@@ -22,6 +22,7 @@ impl Rule for ServerCacheControlPresent {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if status == 200 && !headers.contains_key("cache-control") {
             Some(Violation {
@@ -48,8 +49,15 @@ mod tests {
         let status = 200;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -66,8 +74,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("cache-control", "no-cache".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -79,8 +94,15 @@ mod tests {
         let status = 404;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 }

--- a/src/rules/server_charset_specification.rs
+++ b/src/rules/server_charset_specification.rs
@@ -22,6 +22,7 @@ impl Rule for ServerCharsetSpecification {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if let Some(content_type) = headers.get(hyper::header::CONTENT_TYPE) {
             if let Ok(ct_str) = content_type.to_str() {
@@ -59,8 +60,15 @@ mod tests {
             "text/html; charset=utf-8".parse()?,
         );
 
-        let violation =
-            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            200,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -76,8 +84,15 @@ mod tests {
             "text/html;charset=utf-8".parse()?,
         );
 
-        let violation =
-            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            200,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -93,8 +108,15 @@ mod tests {
             "TEXT/HTML;CHARSET=UTF-8".parse()?,
         );
 
-        let violation =
-            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            200,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -107,8 +129,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(hyper::header::CONTENT_TYPE, "text/html".parse()?);
 
-        let violation =
-            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            200,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -125,8 +154,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(hyper::header::CONTENT_TYPE, "application/json".parse()?);
 
-        let violation =
-            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            200,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -138,8 +174,15 @@ mod tests {
         let conn = make_test_conn();
         let headers = HeaderMap::new();
 
-        let violation =
-            rule.check_response(&client, "http://test.com", 200, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            200,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }

--- a/src/rules/server_clear_site_data.rs
+++ b/src/rules/server_clear_site_data.rs
@@ -1,0 +1,459 @@
+// SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+use crate::lint::Violation;
+use crate::rules::config_cache::RuleConfigCache;
+use crate::rules::Rule;
+use crate::state::{ClientIdentifier, StateStore};
+use hyper::HeaderMap;
+
+static CACHED_PATHS: RuleConfigCache<Vec<String>> = RuleConfigCache::new();
+
+pub struct ServerClearSiteData;
+
+/// Parse and validate paths configuration for this rule
+fn parse_paths_config(config: &crate::config::Config) -> anyhow::Result<Vec<String>> {
+    // If no config is provided, use defaults
+    let Some(rule_config) = config.get_rule_config("server_clear_site_data") else {
+        return Ok(vec!["/logout".to_string(), "/signout".to_string()]);
+    };
+
+    // If config is provided, it must be a table with a "paths" array
+    let table = rule_config.as_table().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Configuration must be a table with 'paths' field, e.g., [rules.server_clear_site_data]\npaths = [\"/logout\"]"
+        )
+    })?;
+
+    // "paths" field is required
+    let paths_value = table.get("paths").ok_or_else(|| {
+        anyhow::anyhow!("Configuration table must contain 'paths' field with array of strings")
+    })?;
+
+    // "paths" must be an array
+    let paths_array = paths_value.as_array().ok_or_else(|| {
+        anyhow::anyhow!(
+            "'paths' field must be an array of strings, e.g., paths = [\"/logout\", \"/signout\"]"
+        )
+    })?;
+
+    // Array must not be empty
+    if paths_array.is_empty() {
+        return Err(anyhow::anyhow!(
+            "'paths' array cannot be empty - provide at least one path or disable the rule"
+        ));
+    }
+
+    // Parse and validate all items
+    let mut paths = Vec::new();
+    for (idx, item) in paths_array.iter().enumerate() {
+        let path = item.as_str().ok_or_else(|| {
+            anyhow::anyhow!(
+                "'paths' array item at index {} is not a string: {:?}",
+                idx,
+                item
+            )
+        })?;
+        paths.push(path.to_string());
+    }
+
+    Ok(paths)
+}
+
+impl Rule for ServerClearSiteData {
+    fn id(&self) -> &'static str {
+        "server_clear_site_data"
+    }
+
+    fn validate_config(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        // Parse and cache the config - if it succeeds, config is valid
+        let paths = parse_paths_config(config)?;
+        CACHED_PATHS.set(paths);
+        Ok(())
+    }
+
+    fn check_response(
+        &self,
+        _client: &ClientIdentifier,
+        resource: &str,
+        status: u16,
+        headers: &HeaderMap,
+        _conn: &crate::connection::ConnectionMetadata,
+        _state: &StateStore,
+        config: &crate::config::Config,
+    ) -> Option<Violation> {
+        // Only check successful responses
+        if !(200..300).contains(&status) {
+            return None;
+        }
+
+        // Get configured paths from cache
+        let paths = CACHED_PATHS.get_or_init(|| {
+            parse_paths_config(config)
+                .unwrap_or_else(|_| vec!["/logout".to_string(), "/signout".to_string()])
+        });
+
+        // Check if the current resource path matches any configured path
+        let resource_path = extract_path_from_resource(resource);
+
+        // Check if resource path matches any configured path
+        let is_logout_path = paths.contains(&resource_path);
+
+        if is_logout_path && !headers.contains_key("clear-site-data") {
+            Some(Violation {
+                rule: self.id().into(),
+                severity: "warn".into(),
+                message: format!(
+                    "Logout endpoint '{}' should include Clear-Site-Data header to properly clear client-side storage",
+                    resource_path
+                ),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Extract the path from a resource URL string
+fn extract_path_from_resource(resource: &str) -> String {
+    // Try to find the path portion of the URL
+    // Format: scheme://host:port/path?query#fragment
+
+    // Find where the path starts (after the host)
+    if let Some(pos) = resource.find("://") {
+        // Skip past the scheme://
+        let after_scheme = &resource[pos + 3..];
+
+        // Find the first '/' which marks the start of the path
+        if let Some(path_start) = after_scheme.find('/') {
+            let path_with_query = &after_scheme[path_start..];
+
+            // Remove query string and fragment
+            return path_with_query
+                .split('?')
+                .next()
+                .unwrap_or(path_with_query)
+                .split('#')
+                .next()
+                .unwrap_or(path_with_query)
+                .to_string();
+        }
+    }
+
+    // Fallback: just remove query and fragment
+    resource
+        .split('?')
+        .next()
+        .unwrap_or(resource)
+        .split('#')
+        .next()
+        .unwrap_or(resource)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{make_test_conn, make_test_context};
+    use hyper::HeaderMap;
+
+    #[test]
+    fn check_response_logout_missing_header() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 200;
+        let headers = HeaderMap::new();
+        let conn = make_test_conn();
+        let cfg = crate::config::Config::default();
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/logout",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        let Some(v) = violation else {
+            panic!("Expected violation but got None");
+        };
+        assert_eq!(v.rule, "server_clear_site_data");
+        assert_eq!(v.severity, "warn");
+        assert!(v.message.contains("Clear-Site-Data"));
+        Ok(())
+    }
+
+    #[test]
+    fn check_response_logout_present_header() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 200;
+        let mut headers = HeaderMap::new();
+        headers.insert("clear-site-data", "\"*\"".parse()?);
+        let conn = make_test_conn();
+        let cfg = crate::config::Config::default();
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/logout",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        assert!(violation.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn check_response_non_logout_path() {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 200;
+        let headers = HeaderMap::new();
+        let conn = make_test_conn();
+        let cfg = crate::config::Config::default();
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/api/data",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn check_response_custom_configured_path() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 200;
+        let headers = HeaderMap::new();
+        let conn = make_test_conn();
+
+        // Configure custom paths
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "paths".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("/custom/logout".to_string()),
+                toml::Value::String("/auth/signout".to_string()),
+            ]),
+        );
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::Table(table),
+        );
+
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/custom/logout",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        assert!(violation.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn check_response_default_signout_path() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 200;
+        let headers = HeaderMap::new();
+        let conn = make_test_conn();
+        let cfg = crate::config::Config::default();
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/signout",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        assert!(violation.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn check_response_error_status_ignored() {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 404;
+        let headers = HeaderMap::new();
+        let conn = make_test_conn();
+        let cfg = crate::config::Config::default();
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/logout",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        assert!(violation.is_none());
+    }
+
+    #[test]
+    fn check_response_logout_with_query_params() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let (client, state) = make_test_context();
+        let status = 200;
+        let headers = HeaderMap::new();
+        let conn = make_test_conn();
+        let cfg = crate::config::Config::default();
+        let violation = rule.check_response(
+            &client,
+            "http://test.com/logout?redirect=/home",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &cfg,
+        );
+        assert!(violation.is_some());
+        Ok(())
+    }
+
+    // Configuration validation tests
+    #[test]
+    fn validate_config_with_valid_paths() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "paths".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("/logout".to_string()),
+                toml::Value::String("/signout".to_string()),
+            ]),
+        );
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::Table(table),
+        );
+
+        assert!(rule.validate_config(&cfg).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_config_with_no_config_uses_defaults() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let cfg = crate::config::Config::default();
+        assert!(rule.validate_config(&cfg).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_config_rejects_non_table() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::String("/logout".to_string()),
+        );
+
+        let result = rule.validate_config(&cfg);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Configuration must be a table"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_config_rejects_missing_paths_field() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let mut cfg = crate::config::Config::default();
+        let table = toml::map::Map::new(); // Empty table, no "paths" field
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::Table(table),
+        );
+
+        let result = rule.validate_config(&cfg);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must contain 'paths' field"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_config_rejects_non_array_paths() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "paths".to_string(),
+            toml::Value::String("/logout".to_string()),
+        );
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::Table(table),
+        );
+
+        let result = rule.validate_config(&cfg);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be an array of strings"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_config_rejects_empty_paths_array() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert("paths".to_string(), toml::Value::Array(vec![]));
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::Table(table),
+        );
+
+        let result = rule.validate_config(&cfg);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_config_rejects_non_string_path_items() -> anyhow::Result<()> {
+        let rule = ServerClearSiteData;
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "paths".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("/logout".to_string()),
+                toml::Value::Integer(42), // Invalid: not a string
+                toml::Value::String("/signout".to_string()),
+            ]),
+        );
+        cfg.rules.insert(
+            "server_clear_site_data".to_string(),
+            toml::Value::Table(table),
+        );
+
+        let result = rule.validate_config(&cfg);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("not a string"));
+        assert!(err_msg.contains("index 1"));
+        Ok(())
+    }
+}

--- a/src/rules/server_etag_or_last_modified.rs
+++ b/src/rules/server_etag_or_last_modified.rs
@@ -22,6 +22,7 @@ impl Rule for ServerEtagOrLastModified {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if status == 200 && !headers.contains_key("etag") && !headers.contains_key("last-modified")
         {
@@ -49,8 +50,15 @@ mod tests {
         let status = 200;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -67,8 +75,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("etag", "\"12345\"".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -81,8 +96,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -94,8 +116,15 @@ mod tests {
         let status = 404;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 }

--- a/src/rules/server_response_405_allow.rs
+++ b/src/rules/server_response_405_allow.rs
@@ -22,6 +22,7 @@ impl Rule for ServerResponse405Allow {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if status == 405 && !headers.contains_key("allow") {
             Some(Violation {
@@ -48,8 +49,15 @@ mod tests {
         let status = 405;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -66,8 +74,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("allow", "GET, HEAD".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -79,8 +94,15 @@ mod tests {
         let status = 200;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 }

--- a/src/rules/server_x_content_type_options.rs
+++ b/src/rules/server_x_content_type_options.rs
@@ -22,6 +22,7 @@ impl Rule for ServerXContentTypeOptions {
         headers: &HeaderMap,
         _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if (200..300).contains(&status) && !headers.contains_key("x-content-type-options") {
             Some(Violation {
@@ -48,8 +49,15 @@ mod tests {
         let status = 200;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -66,8 +74,15 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-content-type-options", "nosniff".parse()?);
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
         Ok(())
     }
@@ -79,8 +94,15 @@ mod tests {
         let status = 404;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 
@@ -91,8 +113,15 @@ mod tests {
         let status = 101;
         let headers = HeaderMap::new();
         let conn = make_test_conn();
-        let violation =
-            rule.check_response(&client, "http://test.com", status, &headers, &conn, &state);
+        let violation = rule.check_response(
+            &client,
+            "http://test.com",
+            status,
+            &headers,
+            &conn,
+            &state,
+            &crate::config::Config::default(),
+        );
         assert!(violation.is_none());
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -20,6 +20,11 @@ pub fn make_test_context() -> (ClientIdentifier, StateStore) {
     (make_test_client(), StateStore::new(300))
 }
 
+/// Create a test config with default values
+pub fn make_test_config() -> crate::config::Config {
+    crate::config::Config::default()
+}
+
 /// Create a test connection metadata with standard test address
 pub fn make_test_conn() -> crate::connection::ConnectionMetadata {
     crate::connection::ConnectionMetadata::new(SocketAddr::new(


### PR DESCRIPTION
 - Introduces changes to the configuration system to allow for configuration of individual rules.
 - Introduces the server_clear_site_data rule, with a configurable list of logout-like paths that enable the validation.

<!--
SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>

SPDX-License-Identifier: ISC
-->

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
