### PR TITLE
Simplify rule interface by removing ConnectionMetadata

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,7 +75,7 @@ impl Rule for MyRuleName {
 
 4. **Add tests in same file**: Must cover both violation and non-violation cases. Use `test_helpers`:
 ```rust
-use crate::test_helpers::{make_test_client, make_test_conn, make_test_context};
+use crate::test_helpers::{make_test_client, make_test_context};
 ```
 
 5. **Document in `docs/rules/<rule_name>.md`** and link from `docs/rules.md`

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ impl Rule for MyRule {
         "category_my_rule_name"
     }
 
-    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, conn: &crate::connection::ConnectionMetadata, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
+    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
         // Implementation
     }
 }
@@ -92,8 +92,8 @@ impl Rule for ClientHostHeader {
     fn id(&self) -> &'static str { "client_host_header" }
     fn scope(&self) -> crate::rules::RuleScope { crate::rules::RuleScope::Client }
 
-    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, conn: &crate::connection::ConnectionMetadata, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
-        // Check tx.request.headers
+    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
+        // Check tx
     }
 }
 ```

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -482,12 +482,12 @@ where
     };
 
     // Evaluate lint rules using config
-    let violations = lint::lint_transaction(&tx, &conn_metadata, &shared.cfg, &shared.state);
+    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
     tx.violations = violations.clone();
 
     // Record transaction in state for future analysis
     shared.state.record_transaction(&tx);
-    shared.state.record_connection(&client_id, &conn_metadata);
+    shared.state.record_connection(&client_id);
 
     // Write capture (we don't capture bodies in MVP)
     let _ = captures.write_transaction(&tx).await;

--- a/src/rules/client_accept_encoding_present.rs
+++ b/src/rules/client_accept_encoding_present.rs
@@ -20,7 +20,6 @@ impl Rule for ClientAcceptEncodingPresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -39,16 +38,14 @@ impl Rule for ClientAcceptEncodingPresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
 
     #[test]
     fn check_request_missing_header() -> anyhow::Result<()> {
         let rule = ClientAcceptEncodingPresent;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
         let tx = crate::test_helpers::make_test_transaction();
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -65,9 +62,7 @@ mod tests {
         tx.request
             .headers
             .insert("accept-encoding", "gzip".parse()?);
-        let conn = make_test_conn();
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         assert!(violation.is_none());
         Ok(())
     }

--- a/src/rules/client_cache_respect.rs
+++ b/src/rules/client_cache_respect.rs
@@ -20,7 +20,6 @@ impl Rule for ClientCacheRespect {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -106,7 +105,6 @@ mod tests {
         }
 
         // build request headers from pairs when needed (assigned later into transaction)
-        let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12345".parse()?);
         let cfg = crate::config::Config::default();
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
@@ -114,7 +112,7 @@ mod tests {
         tx.request.uri = resource.to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(req_headers_pairs.as_slice());
-        let violation = rule.check_transaction(&tx, &conn, &store, &cfg);
+        let violation = rule.check_transaction(&tx, &store, &cfg);
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/client_user_agent_present.rs
+++ b/src/rules/client_user_agent_present.rs
@@ -20,7 +20,6 @@ impl Rule for ClientUserAgentPresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -39,7 +38,7 @@ impl Rule for ClientUserAgentPresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -53,11 +52,9 @@ mod tests {
         let rule = ClientUserAgentPresent;
         let (_client, state) = make_test_context();
         use crate::test_helpers::make_test_transaction;
-        let conn = make_test_conn();
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/message_connection_header_tokens_valid.rs
+++ b/src/rules/message_connection_header_tokens_valid.rs
@@ -20,7 +20,6 @@ impl Rule for MessageConnectionHeaderTokensValid {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -74,7 +73,7 @@ impl Rule for MessageConnectionHeaderTokensValid {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
@@ -90,7 +89,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageConnectionHeaderTokensValid;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
@@ -102,7 +100,7 @@ mod tests {
         }
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let v = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
         } else {
@@ -124,7 +122,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageConnectionHeaderTokensValid;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -138,7 +135,7 @@ mod tests {
             headers: hm,
         });
 
-        let v = rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let v = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
         } else {
@@ -152,7 +149,6 @@ mod tests {
     fn multiple_tokens_and_spacing() -> anyhow::Result<()> {
         let rule = MessageConnectionHeaderTokensValid;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
@@ -163,7 +159,7 @@ mod tests {
         tx.request.headers = hm;
 
         assert!(rule
-            .check_transaction(&tx, &conn, &state, &crate::config::Config::default())
+            .check_transaction(&tx, &state, &crate::config::Config::default())
             .is_none());
         Ok(())
     }
@@ -172,7 +168,6 @@ mod tests {
     fn multiple_header_fields_validation() -> anyhow::Result<()> {
         let rule = MessageConnectionHeaderTokensValid;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
@@ -185,7 +180,7 @@ mod tests {
 
         // Should report a violation due to invalid 'a/b' token
         assert!(rule
-            .check_transaction(&tx, &conn, &state, &crate::config::Config::default())
+            .check_transaction(&tx, &state, &crate::config::Config::default())
             .is_some());
         Ok(())
     }
@@ -194,13 +189,12 @@ mod tests {
     fn missing_header_returns_none() -> anyhow::Result<()> {
         let rule = MessageConnectionHeaderTokensValid;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = hyper::HeaderMap::new();
 
         assert!(rule
-            .check_transaction(&tx, &conn, &state, &crate::config::Config::default())
+            .check_transaction(&tx, &state, &crate::config::Config::default())
             .is_none());
         Ok(())
     }

--- a/src/rules/message_connection_upgrade.rs
+++ b/src/rules/message_connection_upgrade.rs
@@ -20,7 +20,6 @@ impl Rule for MessageConnectionUpgrade {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -71,7 +70,7 @@ fn check_connection_upgrade_map(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -89,11 +88,9 @@ mod tests {
         let rule = MessageConnectionUpgrade;
         let (_client, state) = make_test_context();
         use crate::test_helpers::make_test_transaction;
-        let conn = make_test_conn();
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());
@@ -114,10 +111,8 @@ mod tests {
         let (_client, state) = make_test_context();
         let status = 101; // Switching Protocols
         use crate::test_helpers::make_test_transaction_with_response;
-        let conn = make_test_conn();
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/message_content_length.rs
+++ b/src/rules/message_content_length.rs
@@ -20,7 +20,6 @@ impl Rule for MessageContentLength {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -111,7 +110,7 @@ impl Rule for MessageContentLength {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
@@ -130,14 +129,13 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageContentLength;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
         hm.insert(hyper::header::CONTENT_LENGTH, HeaderValue::from_str(value)?);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let v = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         if expect_violation {
             assert!(v.is_some(), "value '{}' expected violation", value);
         } else {
@@ -161,7 +159,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageContentLength;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -171,7 +168,7 @@ mod tests {
             headers: hm,
         });
 
-        let v = rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let v = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         if expect_violation {
             assert!(v.is_some(), "response value '{}' expected violation", value);
         } else {
@@ -194,7 +191,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageContentLength;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         // request
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -204,7 +200,7 @@ mod tests {
         }
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let v = rule.check_transaction(&tx, &state, &crate::config::Config::default());
         if expect_violation {
             assert!(
                 v.is_some(),
@@ -230,7 +226,7 @@ mod tests {
             headers: hm2,
         });
 
-        let v2 = rule.check_transaction(&tx2, &conn, &state, &crate::config::Config::default());
+        let v2 = rule.check_transaction(&tx2, &state, &crate::config::Config::default());
         if expect_violation {
             assert!(
                 v2.is_some(),

--- a/src/rules/message_content_length_vs_transfer_encoding.rs
+++ b/src/rules/message_content_length_vs_transfer_encoding.rs
@@ -20,7 +20,6 @@ impl Rule for MessageContentLengthVsTransferEncoding {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -55,7 +54,7 @@ impl Rule for MessageContentLengthVsTransferEncoding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -69,12 +68,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageContentLengthVsTransferEncoding;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());
@@ -96,11 +93,9 @@ mod tests {
         let rule = MessageContentLengthVsTransferEncoding;
         let (_client, state) = make_test_context();
         let status = 200;
-        let conn = make_test_conn();
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/message_header_field_names_token.rs
+++ b/src/rules/message_header_field_names_token.rs
@@ -20,7 +20,6 @@ impl Rule for MessageHeaderFieldNamesToken {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -64,7 +63,7 @@ impl Rule for MessageHeaderFieldNamesToken {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use hyper::header::HeaderName;
     use rstest::rstest;
 
@@ -80,7 +79,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageHeaderFieldNamesToken;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         // If header name cannot be parsed into HeaderName, treat as violation (invalid header)
         for (k, _) in &header_pairs {
@@ -97,8 +95,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
 
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());
@@ -117,7 +114,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageHeaderFieldNamesToken;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
 
         for (k, _) in &header_pairs {
             if HeaderName::from_bytes(k.as_bytes()).is_err() {
@@ -133,8 +129,7 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -35,7 +35,6 @@ pub trait Rule: Send + Sync {
     fn check_transaction(
         &self,
         _tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation>;

--- a/src/rules/server_cache_control_present.rs
+++ b/src/rules/server_cache_control_present.rs
@@ -20,15 +20,14 @@ impl Rule for ServerCacheControlPresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
-        config: &crate::config::Config,
+        _config: &crate::config::Config,
     ) -> Option<Violation> {
         if let Some(resp) = &tx.response {
             if resp.status == 200 && !resp.headers.contains_key("cache-control") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: crate::rules::get_rule_severity(config, self.id()),
+                    severity: crate::rules::get_rule_severity(_config, self.id()),
                     message: "Response 200 without Cache-Control header".into(),
                 });
             }
@@ -40,7 +39,7 @@ impl Rule for ServerCacheControlPresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -55,14 +54,12 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerCacheControlPresent;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = match header {
             Some((k, v)) => make_test_transaction_with_response(status, &[(k, v)]),
             None => make_test_transaction_with_response(status, &[]),
         };
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_charset_specification.rs
+++ b/src/rules/server_charset_specification.rs
@@ -20,7 +20,6 @@ impl Rule for ServerCharsetSpecification {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -49,7 +48,7 @@ impl Rule for ServerCharsetSpecification {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -70,7 +69,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerCharsetSpecification;
         let (_client, _state) = make_test_context();
-        let conn = make_test_conn();
         let mut tx = crate::test_helpers::make_test_transaction();
         if !content_type.is_empty() {
             tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -82,8 +80,7 @@ mod tests {
             });
         }
 
-        let violation =
-            rule.check_transaction(&tx, &conn, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_clear_site_data.rs
+++ b/src/rules/server_clear_site_data.rs
@@ -85,7 +85,6 @@ impl Rule for ServerClearSiteData {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -171,9 +170,7 @@ fn extract_path_from_resource(resource: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{
-        make_test_config_with_enabled_paths_rules, make_test_conn, make_test_context,
-    };
+    use crate::test_helpers::{make_test_config_with_enabled_paths_rules, make_test_context};
     use rstest::rstest;
 
     #[rstest]
@@ -194,7 +191,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerClearSiteData;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
         let cfg =
             make_test_config_with_enabled_paths_rules(&[("server_clear_site_data", &config_paths)]);
 
@@ -205,7 +201,7 @@ mod tests {
             headers: crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice()),
         });
 
-        let violation = rule.check_transaction(&tx, &conn, &state, &cfg);
+        let violation = rule.check_transaction(&tx, &state, &cfg);
 
         if expect_violation {
             let Some(v) = violation else {

--- a/src/rules/server_content_type_present.rs
+++ b/src/rules/server_content_type_present.rs
@@ -20,7 +20,6 @@ impl Rule for ServerContentTypePresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -71,7 +70,7 @@ impl Rule for ServerContentTypePresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -95,7 +94,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerContentTypePresent;
         let (_client, _state) = make_test_context();
-        let conn = make_test_conn();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -103,8 +101,7 @@ mod tests {
             headers: crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice()),
         });
 
-        let violation =
-            rule.check_transaction(&tx, &conn, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_etag_or_last_modified.rs
+++ b/src/rules/server_etag_or_last_modified.rs
@@ -20,7 +20,6 @@ impl Rule for ServerEtagOrLastModified {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -46,21 +45,19 @@ impl Rule for ServerEtagOrLastModified {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
 
     #[test]
     fn check_response_200_missing_headers() -> anyhow::Result<()> {
         let rule = ServerEtagOrLastModified;
         let (_client, _state) = make_test_context();
         let status = 200;
-        let conn = make_test_conn();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
             status,
             headers: crate::test_helpers::make_headers_from_pairs(&[]),
         });
-        let violation =
-            rule.check_transaction(&tx, &conn, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
         assert!(violation.is_some());
         assert_eq!(
             violation.map(|v| v.message),
@@ -74,14 +71,13 @@ mod tests {
         let rule = ServerEtagOrLastModified;
         let (_client, _state) = make_test_context();
         let status = 200;
-        let conn = make_test_conn();
+
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
             status,
             headers: crate::test_helpers::make_headers_from_pairs(&[("etag", "\"12345\"")]),
         });
-        let violation =
-            rule.check_transaction(&tx, &conn, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
         assert!(violation.is_none());
         Ok(())
     }
@@ -91,7 +87,6 @@ mod tests {
         let rule = ServerEtagOrLastModified;
         let (_client, _state) = make_test_context();
         let status = 200;
-        let conn = make_test_conn();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
             status,
@@ -100,8 +95,7 @@ mod tests {
                 "Wed, 21 Oct 2015 07:28:00 GMT",
             )]),
         });
-        let violation =
-            rule.check_transaction(&tx, &conn, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
         assert!(violation.is_none());
         Ok(())
     }
@@ -111,14 +105,12 @@ mod tests {
         let rule = ServerEtagOrLastModified;
         let (_client, _state) = make_test_context();
         let status = 404;
-        let conn = make_test_conn();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
             status,
             headers: crate::test_helpers::make_headers_from_pairs(&[]),
         });
-        let violation =
-            rule.check_transaction(&tx, &conn, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
         assert!(violation.is_none());
     }
 }

--- a/src/rules/server_no_body_for_1xx_204_304.rs
+++ b/src/rules/server_no_body_for_1xx_204_304.rs
@@ -20,7 +20,6 @@ impl Rule for ServerNoBodyFor1xx204304 {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -73,7 +72,7 @@ impl Rule for ServerNoBodyFor1xx204304 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -92,7 +91,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerNoBodyFor1xx204304;
         let (_client, state) = make_test_context();
-        let conn = make_test_conn();
         // Provide an explicit config with severity set to 'error' so tests assert correctly
         let mut cfg = crate::config::Config::default();
         let mut table = toml::map::Map::new();
@@ -112,7 +110,7 @@ mod tests {
             headers: crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice()),
         });
 
-        let violation = rule.check_transaction(&tx, &conn, &state, &cfg);
+        let violation = rule.check_transaction(&tx, &state, &cfg);
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_response_405_allow.rs
+++ b/src/rules/server_response_405_allow.rs
@@ -20,7 +20,6 @@ impl Rule for ServerResponse405Allow {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -40,7 +39,7 @@ impl Rule for ServerResponse405Allow {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_conn, make_test_context};
+    use crate::test_helpers::make_test_context;
     use rstest::rstest;
 
     #[rstest]
@@ -56,15 +55,13 @@ mod tests {
         let rule = ServerResponse405Allow;
         let (_client, state) = make_test_context();
 
-        let conn = make_test_conn();
         use crate::test_helpers::make_test_transaction_with_response;
         let header_pairs: Vec<(&str, &str)> = match header {
             Some((k, v)) => vec![(k, v)],
             None => vec![],
         };
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation =
-            rule.check_transaction(&tx, &conn, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_x_content_type_options.rs
+++ b/src/rules/server_x_content_type_options.rs
@@ -60,7 +60,6 @@ impl Rule for ServerXContentTypeOptions {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _conn: &crate::connection::ConnectionMetadata,
         _state: &StateStore,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
@@ -108,7 +107,7 @@ impl Rule for ServerXContentTypeOptions {
 mod tests {
     use super::*;
     use crate::test_helpers::{
-        enable_rule, make_test_config_with_content_types, make_test_conn, make_test_context,
+        enable_rule, make_test_config_with_content_types, make_test_context,
     };
     use rstest::rstest;
 
@@ -128,7 +127,6 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerXContentTypeOptions;
         let (_client, _state) = make_test_context();
-        let conn = make_test_conn();
         let cfg = make_test_config_with_content_types(&content_types);
 
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -137,7 +135,7 @@ mod tests {
             headers: crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice()),
         });
 
-        let violation = rule.check_transaction(&tx, &conn, &_state, &cfg);
+        let violation = rule.check_transaction(&tx, &_state, &cfg);
 
         if expect_violation {
             assert!(violation.is_some());
@@ -242,7 +240,6 @@ mod tests {
         let rule = ServerXContentTypeOptions;
         let (_client, _state) = make_test_context();
         let status = 200;
-        let conn = make_test_conn();
         let mut cfg = crate::config::Config::default();
         let mut table = toml::map::Map::new();
         table.insert("enabled".to_string(), toml::Value::Boolean(true));
@@ -264,7 +261,7 @@ mod tests {
             )]),
         });
 
-        let violation = rule.check_transaction(&tx, &conn, &_state, &cfg);
+        let violation = rule.check_transaction(&tx, &_state, &cfg);
         assert!(violation.is_some());
         Ok(())
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -118,11 +118,7 @@ impl StateStore {
     }
 
     /// Record a new connection establishment.
-    pub fn record_connection(
-        &self,
-        client: &ClientIdentifier,
-        _conn_metadata: &crate::connection::ConnectionMetadata,
-    ) {
+    pub fn record_connection(&self, client: &ClientIdentifier) {
         if let Ok(mut stats) = self.stats.write() {
             let entry = stats.entry(client.clone()).or_default();
             entry.connection_count += 1;
@@ -392,14 +388,13 @@ mod tests {
     fn track_connection_efficiency() -> anyhow::Result<()> {
         let store = StateStore::new(300);
         let client = make_client();
-        let conn = crate::connection::ConnectionMetadata::new("127.0.0.1:12345".parse()?);
 
         // Initial state
         assert_eq!(store.get_connection_count(&client), 0);
         assert!(store.get_connection_efficiency(&client).is_none());
 
         // Record connection
-        store.record_connection(&client, &conn);
+        store.record_connection(&client);
         assert_eq!(store.get_connection_count(&client), 1);
 
         // 0 requests, 1 connection -> efficiency 0.0
@@ -424,7 +419,7 @@ mod tests {
         assert_eq!(store.get_connection_efficiency(&client), Some(2.0));
 
         // Record another connection
-        store.record_connection(&client, &conn);
+        store.record_connection(&client);
 
         // 2 requests, 2 connections -> efficiency 1.0
         assert_eq!(store.get_connection_efficiency(&client), Some(1.0));

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -7,7 +7,7 @@
 use crate::state::{ClientIdentifier, StateStore};
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::HeaderMap;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr};
 
 /// Create a test client identifier with standard test values
 #[cfg(test)]
@@ -22,15 +22,6 @@ pub fn make_test_client() -> ClientIdentifier {
 #[cfg(test)]
 pub fn make_test_context() -> (ClientIdentifier, StateStore) {
     (make_test_client(), StateStore::new(300))
-}
-
-/// Create a test connection metadata with standard test address
-#[cfg(test)]
-pub fn make_test_conn() -> crate::connection::ConnectionMetadata {
-    crate::connection::ConnectionMetadata::new(SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-        12345,
-    ))
 }
 
 /// Create a HeaderMap from a slice of (key, value) pairs for use in tests


### PR DESCRIPTION
Information the rules need, such as the client information, were previously included in the HttpTransaction. The ConnectionMetadata now can remain only internally, simplifying the rule interface.
