### PR TITLE
Simplify rule interface by replacing state with previous tx

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ impl Rule for MyRuleName {
         "category_my_rule_name"  // Must match filename convention
     }
 
-    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, conn: &crate::connection::ConnectionMetadata, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
+    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, previous: Option<&crate::http_transaction::HttpTransaction>, config: &crate::config::Config) -> Option<Violation> {
         // Return Some(Violation{...}) on failure, None on pass
     }
 
@@ -75,7 +75,7 @@ impl Rule for MyRuleName {
 
 4. **Add tests in same file**: Must cover both violation and non-violation cases. Use `test_helpers`:
 ```rust
-use crate::test_helpers::{make_test_client, make_test_context};
+use crate::test_helpers::{make_test_client};
 ```
 
 5. **Document in `docs/rules/<rule_name>.md`** and link from `docs/rules.md`
@@ -98,7 +98,7 @@ All files must start with license header:
 Use `anyhow::Result` for fallible operations. The proxy is development-only, so fail-fast is acceptable.
 
 ### State Management
-`StateStore` tracks transactions per `(ClientIdentifier, resource)` with configurable TTL. Rules can query previous responses via `state.get_previous()` for stateful analysis like cache validation.
+`StateStore` tracks transactions per `(ClientIdentifier, resource)` with configurable TTL. Rules receive an `Option<&HttpTransaction>` representing the previous transaction for the same client+resource when available; use this for stateful analysis like cache validation.
 
 ### Test Helpers Location
 Shared test utilities are in `src/test_helpers.rs` (only compiled in test cfg).

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ impl Rule for MyRule {
         "category_my_rule_name"
     }
 
-    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
+    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, previous: Option<&crate::http_transaction::HttpTransaction>, config: &crate::config::Config) -> Option<Violation> {
         // Implementation
     }
 }
@@ -92,7 +92,7 @@ impl Rule for ClientHostHeader {
     fn id(&self) -> &'static str { "client_host_header" }
     fn scope(&self) -> crate::rules::RuleScope { crate::rules::RuleScope::Client }
 
-    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, state: &crate::state::StateStore, config: &crate::config::Config) -> Option<Violation> {
+    fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, previous: Option<&crate::http_transaction::HttpTransaction>, config: &crate::config::Config) -> Option<Violation> {
         // Check tx
     }
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -32,9 +32,12 @@ pub fn lint_transaction(
 ) -> Vec<Violation> {
     let mut out = Vec::new();
 
+    // Compute previous transaction (if any) for this client+resource and keep it alive
+    let previous = state.get_previous(&tx.client, &tx.request.uri);
+
     for rule in crate::rules::RULES {
         if cfg.is_enabled(rule.id()) {
-            if let Some(v) = rule.check_transaction(tx, state, cfg) {
+            if let Some(v) = rule.check_transaction(tx, previous.as_ref(), cfg) {
                 out.push(v);
             }
         }

--- a/src/rules/client_user_agent_present.rs
+++ b/src/rules/client_user_agent_present.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct ClientUserAgentPresent;
 
@@ -20,7 +19,7 @@ impl Rule for ClientUserAgentPresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         config: &crate::config::Config,
     ) -> Option<Violation> {
         if !tx.request.headers.contains_key("user-agent") {
@@ -38,7 +37,7 @@ impl Rule for ClientUserAgentPresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -50,11 +49,11 @@ mod tests {
         #[case] expected_message: Option<&str>,
     ) -> anyhow::Result<()> {
         let rule = ClientUserAgentPresent;
-        let (_client, state) = make_test_context();
+
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/message_content_length_vs_transfer_encoding.rs
+++ b/src/rules/message_content_length_vs_transfer_encoding.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct MessageContentLengthVsTransferEncoding;
 
@@ -20,7 +19,7 @@ impl Rule for MessageContentLengthVsTransferEncoding {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         config: &crate::config::Config,
     ) -> Option<Violation> {
         // Check request headers
@@ -54,7 +53,7 @@ impl Rule for MessageContentLengthVsTransferEncoding {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -67,11 +66,11 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageContentLengthVsTransferEncoding;
-        let (_client, state) = make_test_context();
+
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());
@@ -91,11 +90,11 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageContentLengthVsTransferEncoding;
-        let (_client, state) = make_test_context();
+
         let status = 200;
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: ISC
 
 use crate::lint::Violation;
-use crate::state::StateStore;
 
 /// The `Rule` trait defines a single hook that runs on the canonical
 /// `HttpTransaction`. All rules must implement `check_transaction`.
@@ -35,7 +34,7 @@ pub trait Rule: Send + Sync {
     fn check_transaction(
         &self,
         _tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         _config: &crate::config::Config,
     ) -> Option<Violation>;
 }

--- a/src/rules/server_cache_control_present.rs
+++ b/src/rules/server_cache_control_present.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct ServerCacheControlPresent;
 
@@ -20,7 +19,7 @@ impl Rule for ServerCacheControlPresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
         if let Some(resp) = &tx.response {
@@ -39,7 +38,7 @@ impl Rule for ServerCacheControlPresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -53,13 +52,13 @@ mod tests {
         #[case] expected_message: Option<&str>,
     ) -> anyhow::Result<()> {
         let rule = ServerCacheControlPresent;
-        let (_client, state) = make_test_context();
+
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = match header {
             Some((k, v)) => make_test_transaction_with_response(status, &[(k, v)]),
             None => make_test_transaction_with_response(status, &[]),
         };
-        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_charset_specification.rs
+++ b/src/rules/server_charset_specification.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct ServerCharsetSpecification;
 
@@ -20,7 +19,7 @@ impl Rule for ServerCharsetSpecification {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
         let Some(resp) = &tx.response else {
@@ -48,7 +47,7 @@ impl Rule for ServerCharsetSpecification {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -68,7 +67,7 @@ mod tests {
         #[case] expected_message: Option<&str>,
     ) -> anyhow::Result<()> {
         let rule = ServerCharsetSpecification;
-        let (_client, _state) = make_test_context();
+
         let mut tx = crate::test_helpers::make_test_transaction();
         if !content_type.is_empty() {
             tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -80,7 +79,7 @@ mod tests {
             });
         }
 
-        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_content_type_present.rs
+++ b/src/rules/server_content_type_present.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct ServerContentTypePresent;
 
@@ -20,7 +19,7 @@ impl Rule for ServerContentTypePresent {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
         let Some(resp) = &tx.response else {
@@ -70,7 +69,7 @@ impl Rule for ServerContentTypePresent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -93,7 +92,6 @@ mod tests {
         #[case] expected_message: Option<&str>,
     ) -> anyhow::Result<()> {
         let rule = ServerContentTypePresent;
-        let (_client, _state) = make_test_context();
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -101,7 +99,7 @@ mod tests {
             headers: crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice()),
         });
 
-        let violation = rule.check_transaction(&tx, &_state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_no_body_for_1xx_204_304.rs
+++ b/src/rules/server_no_body_for_1xx_204_304.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct ServerNoBodyFor1xx204304;
 
@@ -20,7 +19,7 @@ impl Rule for ServerNoBodyFor1xx204304 {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
         let Some(resp) = &tx.response else {
@@ -72,7 +71,7 @@ impl Rule for ServerNoBodyFor1xx204304 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -90,7 +89,7 @@ mod tests {
         #[case] expected_contains: Option<&str>,
     ) -> anyhow::Result<()> {
         let rule = ServerNoBodyFor1xx204304;
-        let (_client, state) = make_test_context();
+
         // Provide an explicit config with severity set to 'error' so tests assert correctly
         let mut cfg = crate::config::Config::default();
         let mut table = toml::map::Map::new();
@@ -110,7 +109,7 @@ mod tests {
             headers: crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice()),
         });
 
-        let violation = rule.check_transaction(&tx, &state, &cfg);
+        let violation = rule.check_transaction(&tx, None, &cfg);
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/rules/server_response_405_allow.rs
+++ b/src/rules/server_response_405_allow.rs
@@ -4,7 +4,6 @@
 
 use crate::lint::Violation;
 use crate::rules::Rule;
-use crate::state::StateStore;
 
 pub struct ServerResponse405Allow;
 
@@ -20,7 +19,7 @@ impl Rule for ServerResponse405Allow {
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        _state: &StateStore,
+        _previous: Option<&crate::http_transaction::HttpTransaction>,
         _config: &crate::config::Config,
     ) -> Option<Violation> {
         if let Some(resp) = &tx.response {
@@ -39,7 +38,7 @@ impl Rule for ServerResponse405Allow {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_context;
+
     use rstest::rstest;
 
     #[rstest]
@@ -53,7 +52,6 @@ mod tests {
         #[case] expected_message: Option<&str>,
     ) -> anyhow::Result<()> {
         let rule = ServerResponse405Allow;
-        let (_client, state) = make_test_context();
 
         use crate::test_helpers::make_test_transaction_with_response;
         let header_pairs: Vec<(&str, &str)> = match header {
@@ -61,7 +59,7 @@ mod tests {
             None => vec![],
         };
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check_transaction(&tx, &state, &crate::config::Config::default());
+        let violation = rule.check_transaction(&tx, None, &crate::config::Config::default());
 
         if expect_violation {
             assert!(violation.is_some());

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -4,7 +4,7 @@
 
 //! Shared test utilities to reduce duplication across test modules.
 
-use crate::state::{ClientIdentifier, StateStore};
+use crate::state::ClientIdentifier;
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::HeaderMap;
 use std::net::{IpAddr, Ipv4Addr};
@@ -16,12 +16,6 @@ pub fn make_test_client() -> ClientIdentifier {
         IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         "test-agent".to_string(),
     )
-}
-
-/// Create a test client and state store for rule testing
-#[cfg(test)]
-pub fn make_test_context() -> (ClientIdentifier, StateStore) {
-    (make_test_client(), StateStore::new(300))
 }
 
 /// Create a HeaderMap from a slice of (key, value) pairs for use in tests


### PR DESCRIPTION
The only real practical reason for looking at stateful http transactions is to look at a previous request for the same resource.

This implies that in the future we need to properly invalidate and maintain that resource, which is something we'll probably have the semantic awareness to do.

By removing the state from the interface, we make rules simpler.
