### PR TITLE
Wire RuleScope into lint dispatch

### DIFF
--- a/src/lint.rs
+++ b/src/lint.rs
@@ -47,43 +47,47 @@ pub fn lint_transaction(
     // Cache origin extraction since it's used by any rule requiring ByOrigin
     let origin = crate::helpers::uri::extract_origin_if_absolute(&tx.request.uri);
 
-    for rule in crate::rules::RULES {
-        if cfg.is_enabled(rule.id()) {
-            let query_type = crate::queries::mapping::get_query_type_for_rule(rule.id());
-
-            let history = match query_type {
-                crate::queries::mapping::QueryType::ByResource => history_by_resource
-                    .get_or_insert_with(|| {
-                        crate::queries::by_resource::by_resource(state, &tx.client, &tx.request.uri)
-                    }),
-                crate::queries::mapping::QueryType::ByOrigin => history_by_origin
-                    .get_or_insert_with(|| {
-                        if let Some(o) = &origin {
-                            crate::queries::by_origin::by_origin(state, &tx.client, o)
-                        } else {
-                            crate::transaction_history::TransactionHistory::empty()
-                        }
-                    }),
-                crate::queries::mapping::QueryType::ByResourceAll => {
-                    history_by_resource_all_clients.get_or_insert_with(|| {
-                        crate::queries::by_resource_all_clients::by_resource_all_clients(
-                            state,
-                            &tx.request.uri,
-                        )
-                    })
-                }
-                crate::queries::mapping::QueryType::ByConnection => history_by_connection
-                    .get_or_insert_with(|| {
-                        if let Some(conn_id) = tx.connection_id {
-                            crate::queries::by_connection::by_connection(state, conn_id)
-                        } else {
-                            crate::transaction_history::TransactionHistory::empty()
-                        }
-                    }),
-            };
-
-            out.extend(rule.check_transaction_erased(tx, history, cfg, engine));
+    // Dispatch only the rules whose scope matches the transaction shape:
+    // `Server` rules are skipped when the response has not been collected yet.
+    // See `Rule::scope` for the contract.
+    for rule in crate::rules::rules_for_scope(tx.response.is_some()) {
+        if !cfg.is_enabled(rule.id()) {
+            continue;
         }
+        let query_type = crate::queries::mapping::get_query_type_for_rule(rule.id());
+
+        let history = match query_type {
+            crate::queries::mapping::QueryType::ByResource => history_by_resource
+                .get_or_insert_with(|| {
+                    crate::queries::by_resource::by_resource(state, &tx.client, &tx.request.uri)
+                }),
+            crate::queries::mapping::QueryType::ByOrigin => {
+                history_by_origin.get_or_insert_with(|| {
+                    if let Some(o) = &origin {
+                        crate::queries::by_origin::by_origin(state, &tx.client, o)
+                    } else {
+                        crate::transaction_history::TransactionHistory::empty()
+                    }
+                })
+            }
+            crate::queries::mapping::QueryType::ByResourceAll => history_by_resource_all_clients
+                .get_or_insert_with(|| {
+                    crate::queries::by_resource_all_clients::by_resource_all_clients(
+                        state,
+                        &tx.request.uri,
+                    )
+                }),
+            crate::queries::mapping::QueryType::ByConnection => history_by_connection
+                .get_or_insert_with(|| {
+                    if let Some(conn_id) = tx.connection_id {
+                        crate::queries::by_connection::by_connection(state, conn_id)
+                    } else {
+                        crate::transaction_history::TransactionHistory::empty()
+                    }
+                }),
+        };
+
+        out.extend(rule.check_transaction_erased(tx, history, cfg, engine));
     }
 
     out
@@ -295,6 +299,42 @@ mod tests {
         });
         // Should use empty history for the ByOrigin None case
         let _violations = lint_transaction(&tx, &cfg, &state, &engine);
+    }
+
+    #[test]
+    fn server_scoped_rules_skipped_on_request_only_transaction() {
+        // Smoke test: confirms `lint_transaction` runs cleanly on a
+        // request-only transaction and that Server-scoped rules don't appear
+        // in the violation list. The actual dispatch-routing invariant
+        // (Server rules excluded from the iterated slice) is asserted by
+        // `rules::tests::rules_for_scope_skips_server_when_no_response` —
+        // this test would also pass by accident if a Server rule self-guarded
+        // on `tx.response.is_none()`, so it carries no load alone.
+        let state = crate::state::StateStore::new(300, 10);
+        let cfg = make_test_config_with_enabled_rules(&[
+            "server_cache_control_present",
+            "client_user_agent_present",
+        ]);
+        let engine = make_test_engine(&cfg);
+        use crate::http_transaction::{HttpTransaction, TimingInfo};
+        let mut tx = HttpTransaction::new(
+            crate::test_helpers::make_test_client(),
+            "GET".to_string(),
+            "http://example/".to_string(),
+        );
+        tx.timing = TimingInfo { duration_ms: 5 };
+        // No tx.response set — this is the request-only path.
+
+        let v = lint_transaction(&tx, &cfg, &state, &engine);
+
+        assert!(
+            v.iter().any(|x| x.rule == "client_user_agent_present"),
+            "client-scoped rule should still run on request-only tx",
+        );
+        assert!(
+            !v.iter().any(|x| x.rule == "server_cache_control_present"),
+            "server-scoped rule must not emit on request-only tx",
+        );
     }
 
     #[test]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -5,7 +5,7 @@
 use crate::lint::Violation;
 use std::any::Any;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 /// Standard configuration for rules
 /// Used as the Config type for non-configurable rules.
@@ -56,6 +56,14 @@ pub trait Rule: Send + Sync {
 
     /// The scope where the rule should be executed. Default is `Both` for
     /// backward compatibility; rules may override for better precision.
+    ///
+    /// The engine partitions rules by scope and dispatches accordingly:
+    /// - `Client` and `Both` rules run on every transaction.
+    /// - `Server` rules run only when `tx.response.is_some()`.
+    ///
+    /// A rule that returns `Server` may therefore assume the response is
+    /// present, but existing implementations still defensively check —
+    /// tightening those is left as follow-up cleanup.
     fn scope(&self) -> RuleScope {
         RuleScope::Both
     }
@@ -734,6 +742,33 @@ pub const RULES: &[&dyn RuleConfigValidator] = &[
     &server_x_xss_protection_value_valid::ServerXXssProtectionValueValid,
 ];
 
+/// `RULES` filtered to those whose scope allows execution on a request-only
+/// transaction (`Client` and `Both`). Built once on first access and preserves
+/// the source order of `RULES`, so dispatch order is stable across the
+/// has-response / no-response cases.
+///
+/// Implementation detail of [`rules_for_scope`]; not part of the public API.
+pub(crate) static REQUEST_ONLY_RULES: LazyLock<Vec<&'static dyn RuleConfigValidator>> =
+    LazyLock::new(|| {
+        RULES
+            .iter()
+            .copied()
+            .filter(|r| !matches!(r.scope(), RuleScope::Server))
+            .collect()
+    });
+
+/// Returns the rule slice the engine should iterate for a transaction with
+/// the given response presence. `Server` rules are excluded when there is no
+/// response; `Client` and `Both` rules run on every transaction. The returned
+/// slice preserves the source order of `RULES`.
+pub fn rules_for_scope(has_response: bool) -> &'static [&'static dyn RuleConfigValidator] {
+    if has_response {
+        RULES
+    } else {
+        &REQUEST_ONLY_RULES
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -751,6 +786,71 @@ mod tests {
             let id = rule.id();
             assert!(!id.is_empty(), "ProtocolRule id should not be empty");
             assert!(ids.insert(id), "Duplicate rule id found: {}", id);
+        }
+    }
+
+    #[test]
+    fn request_only_rules_excludes_server_scope_and_preserves_order() {
+        let server_count = RULES
+            .iter()
+            .filter(|r| matches!(r.scope(), RuleScope::Server))
+            .count();
+        assert_eq!(
+            REQUEST_ONLY_RULES.len(),
+            RULES.len() - server_count,
+            "request-only slice should equal RULES minus the {} server-scoped rules",
+            server_count,
+        );
+
+        // Every rule in REQUEST_ONLY_RULES is non-Server.
+        for rule in REQUEST_ONLY_RULES.iter() {
+            assert_ne!(
+                rule.scope(),
+                RuleScope::Server,
+                "server-scoped rule {} leaked into request-only slice",
+                rule.id(),
+            );
+        }
+
+        // Order preservation: walking RULES and skipping Server entries must
+        // match REQUEST_ONLY_RULES element-for-element.
+        let expected: Vec<&'static str> = RULES
+            .iter()
+            .filter(|r| !matches!(r.scope(), RuleScope::Server))
+            .map(|r| r.id())
+            .collect();
+        let actual: Vec<&'static str> = REQUEST_ONLY_RULES.iter().map(|r| r.id()).collect();
+        assert_eq!(
+            actual, expected,
+            "request-only slice must preserve source order of RULES",
+        );
+    }
+
+    #[test]
+    fn rules_for_scope_returns_full_rules_when_response_present() {
+        // The has-response path must yield the same id sequence as `RULES` —
+        // dispatch order on the production proxy path is unchanged from
+        // pre-partitioning iteration.
+        let with_response: Vec<&'static str> =
+            rules_for_scope(true).iter().map(|r| r.id()).collect();
+        let expected: Vec<&'static str> = RULES.iter().map(|r| r.id()).collect();
+        assert_eq!(with_response, expected);
+    }
+
+    #[test]
+    fn rules_for_scope_skips_server_when_no_response() {
+        let without_response = rules_for_scope(false);
+        for rule in RULES.iter() {
+            let present = without_response.iter().any(|r| r.id() == rule.id());
+            let is_server = matches!(rule.scope(), RuleScope::Server);
+            assert_eq!(
+                present,
+                !is_server,
+                "rule {} (scope {:?}): expected presence in request-only dispatch = {}",
+                rule.id(),
+                rule.scope(),
+                !is_server,
+            );
         }
     }
 


### PR DESCRIPTION
Every rule overrides `Rule::scope()` to declare whether it applies to client traffic, server traffic, or both, but `lint_transaction` ignored the metadata and ran every enabled rule unconditionally. Each rule then re-checked `tx.response.is_some()` defensively — the API was lying about what the engine actually did.

Build a `LazyLock`-backed `REQUEST_ONLY_RULES` slice that filters out `Server`-scoped rules while preserving the source order of `RULES`. A new `rules_for_scope(has_response)` helper returns either `RULES` (when a response is present) or `&REQUEST_ONLY_RULES` (when it is not). The dispatch loop in `lint_transaction` iterates that slice, skipping `Server` rules entirely on request-only paths. Returning `RULES` directly on the has-response path keeps violation order identical to pre-partitioning iteration; only the request-only case is filtered.

Three structural tests guard the contract: that `REQUEST_ONLY_RULES` excludes exactly the `Server`-scoped rules and preserves `RULES`' source order; that `rules_for_scope(true)` yields the same id sequence as `RULES`; and a per-rule presence check that asserts each rule's expected membership in the request-only slice based on its declared scope. A behavioural smoke test in `lint.rs` confirms the integration runs cleanly and is explicitly annotated as a smoke check pointing at the structural assertion that carries the load. The defensive `if let Some(resp)` guards inside existing `Server` rules are left in place — tightening them is independent follow-up work.
