### PR TITLE
refactor(rules): migrate all rules to Rule::check

### DIFF
--- a/src/rules/client_accept_encoding_present.rs
+++ b/src/rules/client_accept_encoding_present.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientAcceptEncodingPresent;
 
 impl Rule for ClientAcceptEncodingPresent {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_accept_encoding_present"
@@ -18,12 +18,14 @@ impl Rule for ClientAcceptEncodingPresent {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.headers.contains_key("accept-encoding") {
             Some(Violation {
                 rule: self.id().into(),
@@ -51,10 +53,11 @@ mod tests {
         } else {
             crate::test_helpers::make_test_transaction()
         };
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if header_present {
             assert!(violation.is_none());

--- a/src/rules/client_accept_ranges_on_partial_content.rs
+++ b/src/rules/client_accept_ranges_on_partial_content.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientAcceptRangesOnPartialContent;
 
 impl Rule for ClientAcceptRangesOnPartialContent {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_accept_ranges_on_partial_content"
@@ -18,12 +18,14 @@ impl Rule for ClientAcceptRangesOnPartialContent {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests that contain a UTF-8 Range header we can parse.
         let range_val = crate::helpers::headers::get_header_str(&tx.request.headers, "range")?;
         // Only treat the header as having a unit if it includes a '=' delimiter (e.g. 'bytes=0-499')
@@ -130,7 +132,7 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = ClientAcceptRangesOnPartialContent;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("range", range_val)]);
@@ -145,7 +147,7 @@ mod tests {
             None => crate::transaction_history::TransactionHistory::empty(),
         };
 
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(&tx, &history, &cfg, &crate::rules::RuleConfigEngine::new());
         if expect_violation {
             assert!(v.is_some());
         } else {
@@ -157,7 +159,7 @@ mod tests {
     #[test]
     fn invalid_accept_ranges_token_reports_violation() {
         let rule = ClientAcceptRangesOnPartialContent;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut p = make_prev_resp(200, Some("x@bad"));
         p.request.uri = crate::test_helpers::make_test_transaction()
             .request
@@ -168,10 +170,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-1")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -181,14 +184,15 @@ mod tests {
     #[test]
     fn no_previous_response_does_nothing() -> anyhow::Result<()> {
         let rule = ClientAcceptRangesOnPartialContent;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-1")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -211,7 +215,7 @@ mod tests {
     #[test]
     fn non_utf8_accept_ranges_treated_as_missing_reports_violation() -> anyhow::Result<()> {
         let rule = ClientAcceptRangesOnPartialContent;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         // Create a previous response 206 with non-UTF8 Accept-Ranges header
         let mut p = make_prev_resp(206, None);
@@ -237,10 +241,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-1")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -251,7 +256,7 @@ mod tests {
     #[test]
     fn non_utf8_range_with_accept_ranges_present_is_lenient() -> anyhow::Result<()> {
         let rule = ClientAcceptRangesOnPartialContent;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         // Previous response advertises 'bytes' in Accept-Ranges
         let mut p = make_prev_resp(200, Some("bytes"));
@@ -267,10 +272,11 @@ mod tests {
         hm.insert("range", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Be lenient: if the request Range header is non-utf8, do not raise a violation when Accept-Ranges was present
         assert!(v.is_none());
@@ -280,7 +286,7 @@ mod tests {
     #[test]
     fn non_utf8_range_with_previous_206_is_lenient() -> anyhow::Result<()> {
         let rule = ClientAcceptRangesOnPartialContent;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         // Create a previous 206 response with no Accept-Ranges header
         let mut p = make_prev_resp(206, None);
@@ -296,10 +302,11 @@ mod tests {
         hm.insert("range", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // If Range header itself is not valid UTF-8, the rule should not emit a misleading violation about Accept-Ranges
         assert!(v.is_none());

--- a/src/rules/client_cache_respect.rs
+++ b/src/rules/client_cache_respect.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientCacheRespect;
 
 impl Rule for ClientCacheRespect {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_cache_respect"
@@ -18,12 +18,14 @@ impl Rule for ClientCacheRespect {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Use the previous transaction passed by the linter (if any)
         let previous_tx = history.previous()?;
         let resp = previous_tx.response.as_ref()?;
@@ -112,8 +114,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(req_headers_pairs.as_slice());
         let history = crate::queries::by_resource::by_resource(&store, &client, resource);
-        let violation =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let violation = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
 
         if expect_violation {
             assert!(violation.is_some());
@@ -147,8 +153,12 @@ mod tests {
         tx.request.uri = resource.to_string();
 
         let history = crate::queries::by_resource::by_resource(&store, &client, resource);
-        let violation =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let violation = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
 
         assert!(violation.is_none());
         Ok(())

--- a/src/rules/client_expect_header_valid.rs
+++ b/src/rules/client_expect_header_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientExpectHeaderValid;
 
 impl Rule for ClientExpectHeaderValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_expect_header_valid"
@@ -18,12 +18,14 @@ impl Rule for ClientExpectHeaderValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check request headers
         for hv in tx.request.headers.get_all("Expect").iter() {
             let s = match hv.to_str() {
@@ -166,10 +168,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ClientExpectHeaderValid;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&[("expect", value)]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
@@ -195,10 +198,11 @@ mod tests {
         hm.insert("Expect", HeaderValue::from_str("a=b/c")?);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -217,10 +221,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -238,10 +243,11 @@ mod tests {
 
         // Should report a violation due to invalid 'a/b' token
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
         Ok(())
@@ -256,10 +262,11 @@ mod tests {
         hm.insert("Expect", HeaderValue::from_static("100-Continue=param"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/client_host_header.rs
+++ b/src/rules/client_host_header.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 pub struct ClientHostHeader;
 
 impl Rule for ClientHostHeader {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_host_header"
@@ -19,12 +19,14 @@ impl Rule for ClientHostHeader {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let host_values = tx.request.headers.get_all("host");
         let host_count = host_values.iter().count();
         if host_count == 0 {
@@ -77,7 +79,7 @@ impl Rule for ClientHostHeader {
             match crate::helpers::ipv6::parse_bracketed_ipv6(s) {
                 Some((_inner, port_opt)) => {
                     if let Some(port) = port_opt {
-                        return self.validate_port(port, config);
+                        return self.validate_port(port, &config);
                     }
                     return None;
                 }
@@ -124,7 +126,7 @@ impl Rule for ClientHostHeader {
         // Single colon — interpret as host:port and validate the port
         if let Some(idx) = s.rfind(':') {
             let port = &s[idx + 1..];
-            return self.validate_port(port, config);
+            return self.validate_port(port, &config);
         }
 
         None
@@ -206,10 +208,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ClientHostHeader;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&header_pairs);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -230,10 +233,11 @@ mod tests {
             ("host", "example.com"),
             ("host", "other.example.com"),
         ]);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         assert_eq!(
@@ -256,10 +260,11 @@ mod tests {
         hm.insert("host", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         assert!(violation.is_some());
@@ -289,10 +294,11 @@ mod tests {
             "example.com:999999999999999999999",
         )]);
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         let v = violation.unwrap();

--- a/src/rules/client_patch_method_content_type_match.rs
+++ b/src/rules/client_patch_method_content_type_match.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct ClientPatchMethodContentTypeMatch;
 
 impl Rule for ClientPatchMethodContentTypeMatch {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_patch_method_content_type_match"
@@ -20,12 +20,14 @@ impl Rule for ClientPatchMethodContentTypeMatch {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to PATCH requests
         if !tx.request.method.eq_ignore_ascii_case("PATCH") {
             return None;
@@ -202,7 +204,7 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         // Build current PATCH request
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -224,7 +226,7 @@ mod tests {
             Some(p) => crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             None => crate::transaction_history::TransactionHistory::empty(),
         };
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(&tx, &history, &cfg, &crate::rules::RuleConfigEngine::new());
         if expect_violation {
             assert!(v.is_some());
         } else {
@@ -236,7 +238,7 @@ mod tests {
     #[test]
     fn multiple_accept_patch_fields_are_merged() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "PATCH".into();
@@ -261,10 +263,11 @@ mod tests {
         prev.request.uri = tx.request.uri.clone();
         prev.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -273,7 +276,7 @@ mod tests {
     #[test]
     fn malformed_accept_patch_reports_violation() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("badmedia"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -288,10 +291,11 @@ mod tests {
             "application/example-patch+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -302,7 +306,7 @@ mod tests {
     #[test]
     fn trailing_comma_in_accept_patch_is_violation() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("application/json,"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -315,10 +319,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -329,7 +334,7 @@ mod tests {
     #[test]
     fn bad_and_good_accept_patch_accepts_if_one_valid() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("badmedia, application/merge-patch+json"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -344,10 +349,11 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -356,7 +362,7 @@ mod tests {
     #[test]
     fn wildcard_accept_patch_matches_type_star() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("application/*"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -371,10 +377,11 @@ mod tests {
             "application/example+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -383,7 +390,7 @@ mod tests {
     #[test]
     fn accept_patch_with_params_is_accepted() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("application/merge-patch+json; version=1"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -398,10 +405,11 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -410,7 +418,7 @@ mod tests {
     #[test]
     fn star_star_accept_patch_matches_any() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("*/*"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -425,10 +433,11 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -437,7 +446,7 @@ mod tests {
     #[test]
     fn whitespace_only_accept_patch_reports_violation() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("   "));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -452,10 +461,11 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // whitespace-only header triggers empty token detection and thus a violation
         assert!(v.is_some());
@@ -465,7 +475,7 @@ mod tests {
     #[test]
     fn request_content_type_non_utf8_is_treated_as_missing() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("application/merge-patch+json"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -481,10 +491,11 @@ mod tests {
         hm.insert("content-type", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -493,7 +504,7 @@ mod tests {
     #[test]
     fn malformed_request_content_type_is_ignored_and_no_violation() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut prev = make_prev_with_accept_patch(Some("application/merge-patch+json"));
         prev.request.uri = crate::test_helpers::make_test_transaction()
@@ -506,10 +517,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "bad")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // malformed Content-Type is delegated to other rules; this rule should not emit a violation
         assert!(v.is_none());
@@ -519,7 +531,7 @@ mod tests {
     #[test]
     fn non_utf8_accept_patch_is_violation() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         use hyper::header::HeaderValue;
         use hyper::HeaderMap;
 
@@ -541,10 +553,11 @@ mod tests {
             "application/example-patch+json",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -561,7 +574,7 @@ mod tests {
     #[test]
     fn non_patch_requests_are_ignored() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
@@ -569,10 +582,11 @@ mod tests {
         let mut prev = make_prev_with_accept_patch(Some("application/merge-patch+json"));
         prev.request.uri = tx.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -581,7 +595,7 @@ mod tests {
     #[test]
     fn previous_without_response_is_ignored() -> anyhow::Result<()> {
         let rule = ClientPatchMethodContentTypeMatch;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "PATCH".into();
@@ -594,10 +608,11 @@ mod tests {
         let mut prev = crate::test_helpers::make_test_transaction();
         prev.request.uri = tx.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/client_prefer_header_and_preference_applied.rs
+++ b/src/rules/client_prefer_header_and_preference_applied.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientPreferHeaderAndPreferenceApplied;
 
 impl Rule for ClientPreferHeaderAndPreferenceApplied {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_prefer_header_and_preference_applied"
@@ -18,12 +18,14 @@ impl Rule for ClientPreferHeaderAndPreferenceApplied {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only meaningful when request includes Prefer and response is present
         let saw_prefer = tx
             .request
@@ -86,7 +88,7 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = ClientPreferHeaderAndPreferenceApplied;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
 
@@ -103,10 +105,11 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -121,7 +124,7 @@ mod tests {
         use hyper::header::HeaderValue;
 
         let rule = ClientPreferHeaderAndPreferenceApplied;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers =
@@ -135,10 +138,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // treat non-utf8 header as present -> no violation from this rule
         assert!(v.is_none());
@@ -157,7 +161,7 @@ mod tests {
         use hyper::header::HeaderValue;
 
         let rule = ClientPreferHeaderAndPreferenceApplied;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         // non-utf8 Prefer header should be ignored and not cause a missing Preference-Applied warning
@@ -165,10 +169,11 @@ mod tests {
         hm.insert("prefer", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -177,7 +182,7 @@ mod tests {
     #[test]
     fn multiple_prefer_headers_some_empty_some_valid() -> anyhow::Result<()> {
         let rule = ClientPreferHeaderAndPreferenceApplied;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
@@ -185,10 +190,11 @@ mod tests {
             ("Prefer", "respond-async"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -197,15 +203,16 @@ mod tests {
     #[test]
     fn empty_prefer_header_only_is_ignored() -> anyhow::Result<()> {
         let rule = ClientPreferHeaderAndPreferenceApplied;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("Prefer", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/client_range_header_syntax_valid.rs
+++ b/src/rules/client_range_header_syntax_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientRangeHeaderSyntaxValid;
 
 impl Rule for ClientRangeHeaderSyntaxValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_range_header_syntax_valid"
@@ -18,12 +18,14 @@ impl Rule for ClientRangeHeaderSyntaxValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use hyper::header::RANGE;
 
         let hdrs = tx.request.headers.get_all(RANGE);
@@ -158,10 +160,11 @@ mod tests {
         tx.request.headers.insert("range", value.parse()?);
 
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -189,10 +192,11 @@ mod tests {
             .append("range", "items=0-1".parse::<HeaderValue>()?);
 
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -202,10 +206,11 @@ mod tests {
     fn header_absent_no_violation() -> anyhow::Result<()> {
         let tx = make_test_transaction();
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -219,10 +224,11 @@ mod tests {
         tx.request.headers.insert("range", bad);
 
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/client_request_method_token_valid.rs
+++ b/src/rules/client_request_method_token_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientRequestMethodTokenValid;
 
 impl Rule for ClientRequestMethodTokenValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_request_method_token_valid"
@@ -18,12 +18,14 @@ impl Rule for ClientRequestMethodTokenValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let m = tx.request.method.as_str();
 
         // Validate token characters per RFC token (tchar) and uppercase requirement using shared helpers
@@ -81,10 +83,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.method = method.as_str().to_string();
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -105,10 +108,11 @@ mod tests {
         let mut tx = make_test_transaction();
         tx.request.method = "get".to_string();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -117,10 +121,11 @@ mod tests {
         // Invalid character should be reported with char in message
         let mut tx2 = make_test_transaction();
         tx2.request.method = "G@T".to_string();
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         let msg2 = v2.unwrap().message;

--- a/src/rules/client_request_origin_header_present_for_cors.rs
+++ b/src/rules/client_request_origin_header_present_for_cors.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientRequestOriginHeaderPresentForCors;
 
 impl Rule for ClientRequestOriginHeaderPresentForCors {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_request_origin_header_present_for_cors"
@@ -18,12 +18,14 @@ impl Rule for ClientRequestOriginHeaderPresentForCors {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let headers = &req.headers;
 
@@ -87,9 +89,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{
-        make_headers_from_pairs, make_test_rule_config, make_test_transaction,
-    };
+    use crate::test_helpers::{make_headers_from_pairs, make_test_transaction};
 
     #[rstest]
     fn preflight_without_origin_is_violation() {
@@ -98,10 +98,11 @@ mod tests {
         tx.request.method = "OPTIONS".into();
         tx.request.headers = make_headers_from_pairs(&[("access-control-request-method", "POST")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing Origin"));
@@ -117,10 +118,11 @@ mod tests {
             ("origin", "https://example.com"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -135,10 +137,11 @@ mod tests {
             ("origin", "http:///bad"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Origin header invalid"));
@@ -151,10 +154,11 @@ mod tests {
         tx.request.uri = "http://other.example/resource".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -170,10 +174,11 @@ mod tests {
         tx.request.uri = "http://example.com/resource".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/client_request_target_form_checks.rs
+++ b/src/rules/client_request_target_form_checks.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientRequestTargetFormChecks;
 
 impl Rule for ClientRequestTargetFormChecks {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_request_target_form_checks"
@@ -18,12 +18,14 @@ impl Rule for ClientRequestTargetFormChecks {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let method = tx.request.method.as_str();
         let target = tx.request.uri.as_str();
 
@@ -97,15 +99,13 @@ mod tests {
         tx.request.method = method.into();
         tx.request.uri = uri.into();
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/client_request_target_no_fragment.rs
+++ b/src/rules/client_request_target_no_fragment.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientRequestTargetNoFragment;
 
 impl Rule for ClientRequestTargetNoFragment {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_request_target_no_fragment"
@@ -18,12 +18,14 @@ impl Rule for ClientRequestTargetNoFragment {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if tx.request.uri.contains('#') {
             return Some(Violation {
                 rule: self.id().into(),
@@ -52,15 +54,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.uri = uri.to_string();
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/client_request_uri_percent_encoding_valid.rs
+++ b/src/rules/client_request_uri_percent_encoding_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientRequestUriPercentEncodingValid;
 
 impl Rule for ClientRequestUriPercentEncodingValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_request_uri_percent_encoding_valid"
@@ -18,12 +18,14 @@ impl Rule for ClientRequestUriPercentEncodingValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let s = tx.request.uri.as_str();
         if let Some(msg) = crate::helpers::uri::check_percent_encoding(s) {
             return Some(Violation {
@@ -57,15 +59,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.uri = uri.to_string();
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/client_request_version_method_validity.rs
+++ b/src/rules/client_request_version_method_validity.rs
@@ -26,7 +26,7 @@ use crate::rules::Rule;
 pub struct ClientRequestVersionMethodValidity;
 
 impl Rule for ClientRequestVersionMethodValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_request_version_method_validity"
@@ -36,12 +36,14 @@ impl Rule for ClientRequestVersionMethodValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let method = tx.request.method.as_str();
 
         // Determine whether the request seems to include a body by looking at
@@ -109,11 +111,12 @@ mod tests {
     ) {
         let rule = ClientRequestVersionMethodValidity;
         let tx = make_tx_with_req(method, headers);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -127,11 +130,12 @@ mod tests {
     fn invalid_content_length_is_ignored() {
         let rule = ClientRequestVersionMethodValidity;
         let tx = make_tx_with_req("GET", vec![("content-length", "not-a-number")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -141,11 +145,12 @@ mod tests {
         let rule = ClientRequestVersionMethodValidity;
         let huge = "9".repeat(100);
         let tx = make_tx_with_req("GET", vec![("content-length", huge.as_str())]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -155,19 +160,21 @@ mod tests {
         let rule = ClientRequestVersionMethodValidity;
         let tx_empty = make_tx_with_req("GET", vec![("content-length", "")]);
         let tx_space = make_tx_with_req("GET", vec![("content-length", "   ")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v_empty = rule.check_transaction(
+        let v_empty = rule.check(
             &tx_empty,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_empty.is_none());
 
-        let v_space = rule.check_transaction(
+        let v_space = rule.check(
             &tx_space,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_space.is_none());
     }
@@ -175,24 +182,26 @@ mod tests {
     #[test]
     fn violation_messages_are_informative() {
         let rule = ClientRequestVersionMethodValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let tx = make_tx_with_req("GET", vec![("content-length", "10")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("GET request"));
 
         let tx2 = make_tx_with_req("TRACE", vec![("transfer-encoding", "chunked")]);
         let v2 = rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v2.message.contains("TRACE request"));

--- a/src/rules/client_sec_websocket_headers_consistency.rs
+++ b/src/rules/client_sec_websocket_headers_consistency.rs
@@ -9,7 +9,7 @@ use base64::Engine;
 pub struct ClientSecWebsocketHeadersConsistency;
 
 impl Rule for ClientSecWebsocketHeadersConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_sec_websocket_headers_consistency"
@@ -19,12 +19,14 @@ impl Rule for ClientSecWebsocketHeadersConsistency {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only consider WebSocket handshake requests: GET method and Upgrade includes 'websocket'
         if tx.request.method != "GET" {
             return None;
@@ -186,12 +188,12 @@ mod tests {
     ) {
         let rule = ClientSecWebsocketHeadersConsistency;
         let tx = make_ws_request(headers);
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert_eq!(v.is_some(), expect_violation);
     }
@@ -203,13 +205,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("upgrade", "websocket")]);
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -219,13 +221,13 @@ mod tests {
         // Upgrade: h2
         let tx = make_ws_request(vec![("upgrade", "h2"), ("connection", "Upgrade")]);
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -239,12 +241,12 @@ mod tests {
             ("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="),
         ]);
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Connection: Upgrade"));
@@ -258,12 +260,12 @@ mod tests {
             ("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="),
         ]);
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Sec-WebSocket-Version"));
@@ -279,13 +281,13 @@ mod tests {
             ("sec-websocket-key", " dGhlIHNhbXBsZSBub25jZQ== "),
         ]);
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -315,12 +317,12 @@ mod tests {
         tx.request.headers = hm;
 
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Sec-WebSocket-Key"));
@@ -338,13 +340,13 @@ mod tests {
         tx.request.headers = hm;
 
         let rule = ClientSecWebsocketHeadersConsistency;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }

--- a/src/rules/client_user_agent_present.rs
+++ b/src/rules/client_user_agent_present.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ClientUserAgentPresent;
 
 impl Rule for ClientUserAgentPresent {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "client_user_agent_present"
@@ -18,12 +18,14 @@ impl Rule for ClientUserAgentPresent {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.headers.contains_key("user-agent") {
             Some(Violation {
                 rule: self.id().into(),
@@ -52,10 +54,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ClientUserAgentPresent;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&header_pairs);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_accept_and_content_type_negotiation.rs
+++ b/src/rules/message_accept_and_content_type_negotiation.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAcceptAndContentTypeNegotiation;
 
 impl Rule for MessageAcceptAndContentTypeNegotiation {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_accept_and_content_type_negotiation"
@@ -18,12 +18,14 @@ impl Rule for MessageAcceptAndContentTypeNegotiation {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check when request has Accept and response has Content-Type
         let accept = crate::helpers::headers::get_header_str(&tx.request.headers, "accept");
         let resp = match &tx.response {
@@ -139,7 +141,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         if let Some(a) = accept {
@@ -150,10 +154,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", ct)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -188,7 +193,9 @@ mod tests {
     fn invalid_response_content_type_parsing_is_ignored() {
         // If the response Content-Type cannot be parsed, the rule conservatively does nothing
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers =
@@ -197,10 +204,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -209,7 +217,9 @@ mod tests {
     fn invalid_accept_member_is_ignored_but_may_cause_violation() {
         // An invalid media-range in Accept is ignored; if it is the only member, the response may be unacceptable
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers =
@@ -217,10 +227,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/plain")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -229,17 +240,20 @@ mod tests {
     fn star_in_accept_is_treated_as_invalid_member() {
         // A literal '*' is invalid per media-range syntax and is ignored; without other members this leads to violation
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("accept", "*")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/plain")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -248,7 +262,9 @@ mod tests {
     fn invalid_q_value_is_ignored_and_does_not_make_member_unacceptable() {
         // If q value is malformed, we conservatively treat the member as acceptable unless q parses to 0
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers =
@@ -256,10 +272,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/plain")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -268,7 +285,9 @@ mod tests {
     fn empty_q_value_is_ignored_and_member_is_accepted() {
         // q= with empty RHS should not make member unacceptable
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers =
@@ -276,10 +295,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -287,14 +307,17 @@ mod tests {
     #[test]
     fn no_response_is_ignored() {
         let rule = MessageAcceptAndContentTypeNegotiation;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_and_content_type_negotiation",
+        ]);
 
         let tx = crate::test_helpers::make_test_transaction();
         // tx.response is None
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_accept_encoding_parameter_validity.rs
+++ b/src/rules/message_accept_encoding_parameter_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAcceptEncodingParameterValidity;
 
 impl Rule for MessageAcceptEncodingParameterValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_accept_encoding_parameter_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageAcceptEncodingParameterValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // This rule validates `Accept-Encoding` header parameters (q-values and param forms) in requests.
         for hv in tx.request.headers.get_all("accept-encoding").iter() {
             if let Ok(val) = hv.to_str() {
@@ -147,7 +149,9 @@ mod tests {
     #[case(Some("gzip;q=0.1234"), true)]
     fn check_request_cases(#[case] ae: Option<&str>, #[case] expect_violation: bool) {
         let rule = MessageAcceptEncodingParameterValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_encoding_parameter_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = ae {
@@ -155,10 +159,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -186,13 +191,16 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("accept-encoding", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_encoding_parameter_validity",
+        ]);
 
         // Non-UTF8 header values should be considered a violation by this rule
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -217,7 +225,9 @@ mod tests {
     #[case(Some("gzip;param=bad@val"), true)]
     fn check_additional_parameter_cases(#[case] ae: Option<&str>, #[case] expect_violation: bool) {
         let rule = MessageAcceptEncodingParameterValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_encoding_parameter_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = ae {
@@ -225,10 +235,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -250,7 +261,9 @@ mod tests {
     #[test]
     fn multiple_header_fields_are_checked() {
         let rule = MessageAcceptEncodingParameterValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_encoding_parameter_validity",
+        ]);
 
         use hyper::header::HeaderValue;
         let mut headers = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -260,10 +273,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_accept_header_media_type_syntax.rs
+++ b/src/rules/message_accept_header_media_type_syntax.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAcceptHeaderMediaTypeSyntax;
 
 impl Rule for MessageAcceptHeaderMediaTypeSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_accept_header_media_type_syntax"
@@ -18,12 +18,14 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate a single Accept-like header value (media-range list)
         let check_val = |hdr: &str, val: &str| -> Option<Violation> {
             for member in crate::helpers::headers::parse_list_header(val) {
@@ -219,7 +221,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageAcceptHeaderMediaTypeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_header_media_type_syntax",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = accept {
@@ -237,10 +241,11 @@ mod tests {
             }
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -269,16 +274,19 @@ mod tests {
     #[test]
     fn check_accept_in_response() -> anyhow::Result<()> {
         let rule = MessageAcceptHeaderMediaTypeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_header_media_type_syntax",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept", "text/html; q=1.0000")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_accept_language_weight_validity.rs
+++ b/src/rules/message_accept_language_weight_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAcceptLanguageWeightValidity;
 
 impl Rule for MessageAcceptLanguageWeightValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_accept_language_weight_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageAcceptLanguageWeightValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Accept-Language header value (may contain comma-separated members)
         let validate_value = |hdr_value: &str| -> Option<Violation> {
             for member in crate::helpers::headers::parse_list_header(hdr_value) {
@@ -152,7 +154,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = al {
@@ -160,10 +164,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -192,12 +197,15 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("accept-language", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -206,7 +214,9 @@ mod tests {
     #[test]
     fn multiple_header_fields_are_checked() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         use hyper::header::HeaderValue;
         let mut headers = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -216,10 +226,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -227,16 +238,19 @@ mod tests {
     #[test]
     fn response_header_invalid_q_reports_violation() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;q=1.0000")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -250,12 +264,15 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("accept-language", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -264,17 +281,20 @@ mod tests {
     #[test]
     fn other_param_quoted_string_valid_and_invalid() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         // valid quoted-string
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;foo=\"ok\"")]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -285,10 +305,11 @@ mod tests {
             "en;foo=\"unterminated",
         )]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -296,15 +317,18 @@ mod tests {
     #[test]
     fn invalid_param_name_reports_violation() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;b@d=1")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -312,15 +336,18 @@ mod tests {
     #[test]
     fn param_without_value_reports_violation() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;param")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -328,15 +355,18 @@ mod tests {
     #[test]
     fn wildcard_with_q_ok() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "*;q=0.5")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -344,15 +374,18 @@ mod tests {
     #[test]
     fn uppercase_q_parameter_name_is_accepted() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;Q=0.5")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -360,7 +393,9 @@ mod tests {
     #[test]
     fn multiple_header_fields_all_valid_no_violation() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         use hyper::header::HeaderValue;
         let mut headers = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -370,10 +405,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -381,7 +417,9 @@ mod tests {
     #[test]
     fn quoted_string_with_escaped_quote_valid() {
         let rule = MessageAcceptLanguageWeightValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_language_weight_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // quoted-string with escaped quote: "a\"b"
@@ -389,10 +427,11 @@ mod tests {
             "accept-language",
             "en;foo=\"a\\\"b\"",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_accept_ranges_and_206_consistency.rs
+++ b/src/rules/message_accept_ranges_and_206_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAcceptRangesAnd206Consistency;
 
 impl Rule for MessageAcceptRangesAnd206Consistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_accept_ranges_and_206_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageAcceptRangesAnd206Consistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -115,7 +117,9 @@ mod tests {
     ) -> anyhow::Result<()> {
         // input: (status, Option<(content-range-unit, accept-ranges-value)>)
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         let tx = match input {
             Some((status, maybe)) => {
@@ -136,10 +140,11 @@ mod tests {
             None => crate::test_helpers::make_test_transaction(),
         };
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for input={:?}", input);
@@ -157,7 +162,9 @@ mod tests {
     #[test]
     fn accept_ranges_case_insensitive_and_multiple_values_are_accepted() -> anyhow::Result<()> {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         // uppercase Accept-Ranges matches lowercase Content-Range
         let tx1 = crate::test_helpers::make_test_transaction_with_response(
@@ -165,10 +172,11 @@ mod tests {
             &[("content-range", "bytes 0-0/1"), ("accept-ranges", "BYTES")],
         );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -181,10 +189,11 @@ mod tests {
             ],
         );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -194,16 +203,19 @@ mod tests {
     #[test]
     fn invalid_token_in_accept_ranges_is_reported() {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         let tx = crate::test_helpers::make_test_transaction_with_response(
             206,
             [("accept-ranges", "x@bad")].as_slice(),
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -213,7 +225,9 @@ mod tests {
     #[test]
     fn multiple_accept_ranges_fields_are_combined_and_checked() -> anyhow::Result<()> {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         // Two separate header fields that together advertise the needed unit
         use hyper::header::HeaderValue;
@@ -230,10 +244,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -242,7 +257,9 @@ mod tests {
     #[test]
     fn accept_ranges_none_in_any_field_reports_violation() -> anyhow::Result<()> {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         use hyper::header::HeaderValue;
         let mut tx = crate::test_helpers::make_test_transaction_with_response(206, &[]);
@@ -258,10 +275,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -270,7 +288,9 @@ mod tests {
     #[test]
     fn multiple_accept_ranges_fields_invalid_token_reports_violation() -> anyhow::Result<()> {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         use hyper::header::HeaderValue;
         let mut tx = crate::test_helpers::make_test_transaction_with_response(206, &[]);
@@ -285,10 +305,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -297,7 +318,9 @@ mod tests {
     #[test]
     fn all_accept_ranges_fields_non_utf8_treated_as_missing() -> anyhow::Result<()> {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         use hyper::header::HeaderValue;
         let mut tx = crate::test_helpers::make_test_transaction_with_response(206, &[]);
@@ -312,10 +335,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -324,7 +348,9 @@ mod tests {
     #[test]
     fn non_utf8_accept_ranges_treated_as_missing() -> anyhow::Result<()> {
         let rule = MessageAcceptRangesAnd206Consistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_ranges_and_206_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(206, &[]);
         use hyper::header::HeaderValue;
@@ -338,10 +364,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_access_control_allow_credentials_when_origin.rs
+++ b/src/rules/message_access_control_allow_credentials_when_origin.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAccessControlAllowCredentialsWhenOrigin;
 
 impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_access_control_allow_credentials_when_origin"
@@ -18,12 +18,14 @@ impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -101,7 +103,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[rstest]
     #[case(Some("*"), Some("true"), true)]
@@ -127,10 +129,11 @@ mod tests {
             tx = crate::test_helpers::make_test_transaction_with_response(200, &pairs);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?} & {:?}", acao, acc);
@@ -165,10 +168,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -194,10 +198,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -207,10 +212,11 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageAccessControlAllowCredentialsWhenOrigin;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -222,10 +228,11 @@ mod tests {
             200,
             &[("access-control-allow-credentials", "true")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -240,10 +247,11 @@ mod tests {
                 ("access-control-allow-credentials", "true"),
             ],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -258,10 +266,11 @@ mod tests {
                 ("access-control-allow-credentials", "TRUE"),
             ],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -276,10 +285,11 @@ mod tests {
                 ("access-control-allow-credentials", "  true  "),
             ],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -307,10 +317,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -325,10 +336,11 @@ mod tests {
                 ("access-control-allow-credentials", "1"),
             ],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_access_control_allow_origin_valid.rs
+++ b/src/rules/message_access_control_allow_origin_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAccessControlAllowOriginValid;
 
 impl Rule for MessageAccessControlAllowOriginValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_access_control_allow_origin_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageAccessControlAllowOriginValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -102,16 +104,17 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[test]
     fn no_response_no_violation() {
         let rule = MessageAccessControlAllowOriginValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -123,10 +126,11 @@ mod tests {
             200,
             &[("content-type", "text/plain")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -142,10 +146,11 @@ mod tests {
             200,
             &[("access-control-allow-origin", val)],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -162,10 +167,11 @@ mod tests {
             200,
             &[("access-control-allow-origin", "https://a, https://b")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("single value"));
@@ -192,10 +198,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple"));
@@ -208,10 +215,11 @@ mod tests {
             200,
             &[("access-control-allow-origin", "example.com")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid origin"));
@@ -238,10 +246,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));

--- a/src/rules/message_age_header_numeric.rs
+++ b/src/rules/message_age_header_numeric.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAgeHeaderNumeric;
 
 impl Rule for MessageAgeHeaderNumeric {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_age_header_numeric"
@@ -18,12 +18,14 @@ impl Rule for MessageAgeHeaderNumeric {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
         let resp = match &tx.response {
             Some(r) => r,
@@ -78,10 +80,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageAgeHeaderNumeric;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -101,10 +104,11 @@ mod tests {
         let rule = MessageAgeHeaderNumeric;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("age", "120, 240")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -129,10 +133,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -144,10 +149,11 @@ mod tests {
     fn no_response_no_violation() -> anyhow::Result<()> {
         let rule = MessageAgeHeaderNumeric;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -163,10 +169,11 @@ mod tests {
     fn violation_message_meaningful() -> anyhow::Result<()> {
         let rule = MessageAgeHeaderNumeric;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[("age", "bad")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_allow_header_method_tokens.rs
+++ b/src/rules/message_allow_header_method_tokens.rs
@@ -9,7 +9,7 @@ use hyper::HeaderMap;
 pub struct MessageAllowHeaderMethodTokens;
 
 impl Rule for MessageAllowHeaderMethodTokens {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_allow_header_method_tokens"
@@ -19,12 +19,14 @@ impl Rule for MessageAllowHeaderMethodTokens {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &HeaderMap| -> Option<Violation> {
             for hv in headers.get_all("allow").iter() {
                 let allow_str = match hv.to_str() {
@@ -84,7 +86,7 @@ mod tests {
 
     fn check_allow_header_helper(allow_value: &str, is_response: bool) -> Option<Violation> {
         use crate::http_transaction::ResponseInfo;
-        use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+        use crate::test_helpers::make_test_transaction;
         use hyper::header::HeaderValue;
 
         let rule = MessageAllowHeaderMethodTokens;
@@ -113,10 +115,11 @@ mod tests {
             HeaderValue::from_str(allow_value).unwrap(),
         );
 
-        rule.check_transaction(
+        rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -196,16 +199,17 @@ mod tests {
     #[test]
     fn test_no_allow_header_returns_none() {
         // If there's no Allow header at all, the rule should pass
-        use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+        use crate::test_helpers::make_test_transaction;
 
         let rule = MessageAllowHeaderMethodTokens;
         let tx = make_test_transaction();
 
         // Transaction has no Allow header
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/message_auth_scheme_iana_registered.rs
+++ b/src/rules/message_auth_scheme_iana_registered.rs
@@ -62,7 +62,7 @@ fn parse_allowed_config(
 pub struct MessageAuthSchemeIanaRegistered;
 
 impl Rule for MessageAuthSchemeIanaRegistered {
-    type Config = AuthSchemeConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_auth_scheme_iana_registered"
@@ -80,12 +80,14 @@ impl Rule for MessageAuthSchemeIanaRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         // Helper to check a single scheme token against allowed list
         let check_scheme =
             |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {
@@ -178,16 +180,26 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn make_cfg() -> AuthSchemeConfig {
-        AuthSchemeConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "basic".to_string(),
-                "bearer".to_string(),
-                "digest".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_auth_scheme_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![
+                        toml::Value::String("basic".into()),
+                        toml::Value::String("bearer".into()),
+                        toml::Value::String("digest".into()),
+                    ]),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -206,10 +218,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("www-authenticate", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -234,10 +247,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("authorization", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -279,10 +293,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("www-authenticate", " realm=\"x\"")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -308,10 +323,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -334,10 +350,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -352,10 +369,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Basic")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Authorization header"));
@@ -462,10 +480,11 @@ mod tests {
             "Basic realm=\"x\", NewScheme abc=",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -491,10 +510,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -510,10 +530,11 @@ mod tests {
             "bAsIc realm=\"x\"",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -539,10 +560,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -558,10 +580,11 @@ mod tests {
             "bAsIc QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -583,18 +606,17 @@ mod tests {
                 t
             }),
         );
-        let parsed = parse_allowed_config(&cfgt, "message_auth_scheme_iana_registered")?;
-
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
             "www-authenticate",
             "Basic realm=\"x\"",
         )]);
 
-        let v = MessageAuthSchemeIanaRegistered.check_transaction(
+        let v = MessageAuthSchemeIanaRegistered.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &parsed,
+            &cfgt,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_authorization_credentials_present.rs
+++ b/src/rules/message_authorization_credentials_present.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageAuthorizationCredentialsPresent;
 
 impl Rule for MessageAuthorizationCredentialsPresent {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_authorization_credentials_present"
@@ -18,12 +18,14 @@ impl Rule for MessageAuthorizationCredentialsPresent {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             match hv.to_str() {
                 Ok(s) => {
@@ -78,10 +80,11 @@ mod tests {
                 .append("authorization", HeaderValue::from_str(h)?);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -103,10 +106,11 @@ mod tests {
             HeaderValue::from_bytes(b"Bearer \xff").unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -129,10 +133,11 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Basic"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_basic_auth_base64_validity.rs
+++ b/src/rules/message_basic_auth_base64_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageBasicAuthBase64Validity;
 
 impl Rule for MessageBasicAuthBase64Validity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_basic_auth_base64_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageBasicAuthBase64Validity {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             match hv.to_str() {
                 Ok(s) => {
@@ -85,10 +87,11 @@ mod tests {
                 .append("authorization", HeaderValue::from_str(h)?);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header '{:?}'", header);
@@ -113,10 +116,11 @@ mod tests {
             HeaderValue::from_str(&format!("Basic {}", enc)).unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("control"));
@@ -134,10 +138,11 @@ mod tests {
             HeaderValue::from_static("Basic not-base64"),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -149,10 +154,11 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Basic"));
         let rule = MessageBasicAuthBase64Validity;
-        let v1 = rule.check_transaction(
+        let v1 = rule.check(
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
         assert!(v1.unwrap().message.contains("missing credentials"));
@@ -161,10 +167,11 @@ mod tests {
         tx2.request
             .headers
             .append("authorization", HeaderValue::from_static("Basic "));
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2.unwrap().message.contains("missing credentials"));
@@ -178,10 +185,11 @@ mod tests {
             HeaderValue::from_bytes(b"Basic \xff").unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -198,10 +206,11 @@ mod tests {
             HeaderValue::from_str(&format!("basic {}", enc)).unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -217,10 +226,11 @@ mod tests {
             HeaderValue::from_str(&format!("Basic {}", enc)).unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_bearer_token_format_validity.rs
+++ b/src/rules/message_bearer_token_format_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageBearerTokenFormatValidity;
 
 impl Rule for MessageBearerTokenFormatValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_bearer_token_format_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageBearerTokenFormatValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             let s = match hv.to_str() {
                 Ok(s) => s,
@@ -91,10 +93,11 @@ mod tests {
                 .append("authorization", HeaderValue::from_str(h)?);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -121,10 +124,11 @@ mod tests {
             HeaderValue::from_bytes(b"Bearer \xff").unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -155,10 +159,11 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("bearer abc123"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -178,10 +183,11 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Bearer a b"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -197,10 +203,11 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Bearer ab=c"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -218,10 +225,11 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Bearer =abc"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_cache_control_and_pragma_consistency.rs
+++ b/src/rules/message_cache_control_and_pragma_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCacheControlAndPragmaConsistency;
 
 impl Rule for MessageCacheControlAndPragmaConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cache_control_and_pragma_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageCacheControlAndPragmaConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check requests: Pragma: no-cache vs Cache-Control: only-if-cached contradiction
         for hv in tx.request.headers.get_all("pragma").iter() {
             let s = match hv.to_str() {
@@ -88,7 +90,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // Build headers map and append values so both headers can coexist
@@ -107,10 +111,11 @@ mod tests {
         }
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -125,16 +130,19 @@ mod tests {
     #[test]
     fn response_with_pragma_reports_violation() {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("pragma", "no-cache")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Pragma"));
@@ -144,7 +152,9 @@ mod tests {
     fn non_utf8_pragma_is_ignored() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let bad = HeaderValue::from_bytes(&[0xff])?;
@@ -153,10 +163,11 @@ mod tests {
         tx.request.headers = hm;
 
         // Non-UTF8 values are ignored by this consistency rule; syntax/token rules should report encoding problems.
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -165,7 +176,9 @@ mod tests {
     #[test]
     fn request_multiple_cache_control_headers_detection() -> anyhow::Result<()> {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -183,10 +196,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -195,7 +209,9 @@ mod tests {
     #[test]
     fn request_non_no_cache_pragma_no_violation() {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -206,10 +222,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -217,16 +234,19 @@ mod tests {
     #[test]
     fn response_non_no_cache_pragma_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("pragma", "foo")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -235,7 +255,9 @@ mod tests {
     #[test]
     fn pragma_with_multiple_members_triggers_on_no_cache() {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -249,10 +271,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -260,7 +283,9 @@ mod tests {
     #[test]
     fn multiple_pragma_headers_trigger_on_response() {
         let rule = MessageCacheControlAndPragmaConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_cache_control_and_pragma_consistency",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -268,10 +293,11 @@ mod tests {
         hm.append("pragma", hyper::header::HeaderValue::from_static("bar"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_cache_control_directive_validity.rs
+++ b/src/rules/message_cache_control_directive_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCacheControlDirectiveValidity;
 
 impl Rule for MessageCacheControlDirectiveValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cache_control_directive_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageCacheControlDirectiveValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Apply to both request and response messages
         for header_val in tx.request.headers.get_all("cache-control").iter() {
             if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
@@ -237,10 +239,11 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", value);
@@ -266,10 +269,11 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_resp(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", value);
@@ -286,10 +290,11 @@ mod tests {
             ("cache-control", "no-cache"),
             ("cache-control", "max-age=60"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -304,10 +309,11 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("cache-control", bad);
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -317,10 +323,11 @@ mod tests {
     fn whitespace_only_request_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("   ");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -333,10 +340,11 @@ mod tests {
     fn whitespace_only_response_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_resp("   ");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -349,10 +357,11 @@ mod tests {
     fn private_unterminated_quoted_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("private=\"unterminated");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -367,10 +376,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("cache-control", ",max-age=1")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -403,10 +413,11 @@ mod tests {
     fn foo_empty_value_allowed() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -416,10 +427,11 @@ mod tests {
     fn foo_quoted_value_allowed() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=\"bar\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -429,10 +441,11 @@ mod tests {
     fn directive_value_invalid_token() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=bad@val");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -442,10 +455,11 @@ mod tests {
     fn max_age_too_large_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("max-age=18446744073709551616");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -455,10 +469,11 @@ mod tests {
     fn empty_directive_name_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("=bar");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -468,10 +483,11 @@ mod tests {
     fn private_quoted_empty_field_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("private=\"field1,,field3\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -481,10 +497,11 @@ mod tests {
     fn private_quoted_invalid_field_char_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("private=\"field1,bad@field\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -506,10 +523,11 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -519,10 +537,11 @@ mod tests {
     fn whitespace_around_name_value_accepted() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req(" max-age = 3600 ");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -532,10 +551,11 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -545,10 +565,11 @@ mod tests {
     fn multiple_directives_unquoted_comma_accepted() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=bar,baz");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_cache_control_token_valid.rs
+++ b/src/rules/message_cache_control_token_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCacheControlTokenValid;
 
 impl Rule for MessageCacheControlTokenValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cache_control_token_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageCacheControlTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Apply to both request and response messages
         for header_val in tx.request.headers.get_all("cache-control").iter() {
             if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
@@ -167,10 +169,11 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -190,10 +193,11 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_resp(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -212,10 +216,11 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("cache-control", bad);
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -229,10 +234,11 @@ mod tests {
             ("cache-control", "no-cache"),
             ("cache-control", "max-age=60"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -246,10 +252,11 @@ mod tests {
             ("cache-control", "no-cache"),
             ("cache-control", "max-age=60"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -259,10 +266,11 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -272,10 +280,11 @@ mod tests {
     fn quoted_value_unterminated_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req("foo=\"unterminated");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -285,10 +294,11 @@ mod tests {
     fn empty_directive_value_is_accepted() -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req("foo=");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -303,10 +313,11 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("cache-control", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -318,10 +329,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("cache-control", ",max-age=1")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_caching_directive_interaction.rs
+++ b/src/rules/message_caching_directive_interaction.rs
@@ -14,7 +14,7 @@ use crate::rules::Rule;
 pub struct MessageCachingDirectiveInteraction;
 
 impl Rule for MessageCachingDirectiveInteraction {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_caching_directive_interaction"
@@ -24,12 +24,14 @@ impl Rule for MessageCachingDirectiveInteraction {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to check a single HeaderMap for contradictions
         let check_headers = |hdrs: &hyper::HeaderMap| -> Option<Violation> {
             use crate::helpers::headers::split_commas_respecting_quotes;
@@ -177,12 +179,15 @@ mod tests {
     #[case("s-maxage=60, s-maxage=30", true)]
     fn request_cases(#[case] val: &str, #[case] expect_violation: bool) {
         let rule = MessageCachingDirectiveInteraction;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
         let tx = make_req(val);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", val);
@@ -200,12 +205,15 @@ mod tests {
     #[case("s-maxage=60, s-maxage=30", true)]
     fn response_cases(#[case] val: &str, #[case] expect_violation: bool) {
         let rule = MessageCachingDirectiveInteraction;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
         let tx = make_resp(val);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", val);
@@ -223,11 +231,14 @@ mod tests {
         hm.insert("cache-control", bad);
         tx.request.headers = hm;
         let rule = MessageCachingDirectiveInteraction;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -236,11 +247,14 @@ mod tests {
     fn empty_member_is_violation() {
         let rule = MessageCachingDirectiveInteraction;
         let tx = make_req(",max-age=1");
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -249,11 +263,14 @@ mod tests {
     fn quoted_max_age_zero_no_violation() {
         let rule = MessageCachingDirectiveInteraction;
         let tx = make_req("no-cache, max-age=\"0\"");
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -262,16 +279,19 @@ mod tests {
     fn multiple_header_fields_combined_reports_violation() {
         use hyper::header::HeaderValue;
         let rule = MessageCachingDirectiveInteraction;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
         hm.append("cache-control", HeaderValue::from_static("no-store"));
         hm.append("cache-control", HeaderValue::from_static("public"));
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -280,11 +300,14 @@ mod tests {
     fn conflicting_max_age_values_reports_violation() {
         let rule = MessageCachingDirectiveInteraction;
         let tx = make_req("max-age=60, max-age=\"30\"");
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -293,11 +316,14 @@ mod tests {
     fn no_cache_control_header_no_violation() {
         let rule = MessageCachingDirectiveInteraction;
         let tx = crate::test_helpers::make_test_transaction();
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_caching_directive_interaction",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_charset_iana_registered.rs
+++ b/src/rules/message_charset_iana_registered.rs
@@ -63,7 +63,7 @@ fn parse_allowed_config(
 pub struct MessageCharsetIanaRegistered;
 
 impl Rule for MessageCharsetIanaRegistered {
-    type Config = CharsetConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_charset_iana_registered"
@@ -81,12 +81,14 @@ impl Rule for MessageCharsetIanaRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         use crate::helpers::headers::parse_media_type;
 
         let check_header = |which: &str, val: &str| -> Option<Violation> {
@@ -206,16 +208,26 @@ mod tests {
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
-    fn make_cfg() -> CharsetConfig {
-        CharsetConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "utf-8".to_string(),
-                "iso-8859-1".to_string(),
-                "us-ascii".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_charset_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![
+                        toml::Value::String("utf-8".into()),
+                        toml::Value::String("iso-8859-1".into()),
+                        toml::Value::String("us-ascii".into()),
+                    ]),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -241,10 +253,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -273,10 +286,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -378,10 +392,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -395,10 +410,11 @@ mod tests {
             "content-type",
             "text/plain; CHARSET = UTF-8",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -413,10 +429,11 @@ mod tests {
             "content-type",
             "text/plain; charset",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -431,10 +448,11 @@ mod tests {
             "content-type",
             "text/plain; charset",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -449,10 +467,11 @@ mod tests {
             "content-type",
             "text/plain; charset=utf-8;",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -466,10 +485,11 @@ mod tests {
             "content-type",
             "text/plain; charset=utf-8; charset=unknown-charset",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -524,10 +544,11 @@ mod tests {
             .headers
             .insert("content-type", bad);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_compression_and_transfer_encoding_consistency.rs
+++ b/src/rules/message_compression_and_transfer_encoding_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCompressionAndTransferEncodingConsistency;
 
 impl Rule for MessageCompressionAndTransferEncodingConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_compression_and_transfer_encoding_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses
         let resp = match &tx.response {
             Some(r) => r,
@@ -128,11 +130,14 @@ mod tests {
     ) {
         let tx = make_tx_with_headers(ce, te);
         let rule = MessageCompressionAndTransferEncodingConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_compression_and_transfer_encoding_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -163,11 +168,14 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = MessageCompressionAndTransferEncodingConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_compression_and_transfer_encoding_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -195,11 +203,14 @@ mod tests {
         );
 
         let rule = MessageCompressionAndTransferEncodingConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_compression_and_transfer_encoding_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Non-UTF8 content-encoding should be ignored and not cause a panic or violation
         assert!(v.is_none());
@@ -209,11 +220,14 @@ mod tests {
     fn overlapping_multiple_tokens_message_contains_both_sorted() {
         let tx = make_tx_with_headers(Some("gzip, br"), Some("br, gzip"));
         let rule = MessageCompressionAndTransferEncodingConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_compression_and_transfer_encoding_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_conditional_headers_consistency.rs
+++ b/src/rules/message_conditional_headers_consistency.rs
@@ -16,7 +16,7 @@ use crate::rules::Rule;
 pub struct MessageConditionalHeadersConsistency;
 
 impl Rule for MessageConditionalHeadersConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_conditional_headers_consistency"
@@ -26,12 +26,14 @@ impl Rule for MessageConditionalHeadersConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         let req = &tx.request;
 
@@ -117,10 +119,11 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -138,10 +141,11 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -156,10 +160,11 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-range", "\"a\"")]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("without Range"));
@@ -174,10 +179,11 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("MUST not contain a weak"));
@@ -197,10 +203,11 @@ mod tests {
         tx.request.headers = hm;
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -215,10 +222,11 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -233,10 +241,11 @@ mod tests {
         )]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("only defined for GET/HEAD"));
@@ -252,10 +261,11 @@ mod tests {
         )]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -270,10 +280,11 @@ mod tests {
         )]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -288,10 +299,11 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_connection_header_tokens_valid.rs
+++ b/src/rules/message_connection_header_tokens_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageConnectionHeaderTokensValid;
 
 impl Rule for MessageConnectionHeaderTokensValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_connection_header_tokens_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageConnectionHeaderTokensValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &hyper::HeaderMap| -> Option<Violation> {
             for hv in headers.get_all(hyper::header::CONNECTION).iter() {
                 let s = match hv.to_str() {
@@ -100,10 +102,11 @@ mod tests {
         }
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
@@ -142,10 +145,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
@@ -169,10 +173,11 @@ mod tests {
         tx.request.headers = hm;
 
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
         Ok(())
@@ -193,10 +198,11 @@ mod tests {
 
         // Should report a violation due to invalid 'a/b' token
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
         Ok(())
@@ -210,10 +216,11 @@ mod tests {
         tx.request.headers = hyper::HeaderMap::new();
 
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
         Ok(())
@@ -233,10 +240,11 @@ mod tests {
         tx.request.headers = hm;
 
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
         Ok(())

--- a/src/rules/message_connection_upgrade.rs
+++ b/src/rules/message_connection_upgrade.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageConnectionUpgrade;
 
 impl Rule for MessageConnectionUpgrade {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_connection_upgrade"
@@ -18,12 +18,14 @@ impl Rule for MessageConnectionUpgrade {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request headers
         if let Some(msg) = check_connection_upgrade_map(&tx.request.headers) {
             return Some(Violation {
@@ -88,10 +90,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -114,10 +117,11 @@ mod tests {
         let status = 101; // Switching Protocols
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_content_disposition_parameter_validity.rs
+++ b/src/rules/message_content_disposition_parameter_validity.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct MessageContentDispositionParameterValidity;
 
 impl Rule for MessageContentDispositionParameterValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_disposition_parameter_validity"
@@ -20,12 +20,14 @@ impl Rule for MessageContentDispositionParameterValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check_value = |hdr_name: &str, val: &str| -> Option<Violation> {
             let s = val.trim();
             if s.is_empty() {
@@ -317,15 +319,16 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", value);
@@ -342,14 +345,15 @@ mod tests {
             "content-disposition",
             "form-data; name=\"x\"; filename=example.png",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -363,14 +367,15 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -390,14 +395,15 @@ mod tests {
             "content-disposition",
             "attachment; param=\"unterminated",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -410,14 +416,15 @@ mod tests {
             "content-disposition",
             "attachment; size=\"12a\"",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -431,14 +438,15 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -460,14 +468,15 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -480,14 +489,15 @@ mod tests {
             "content-disposition",
             "attachment; ; filename=a",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -500,14 +510,15 @@ mod tests {
             "content-disposition",
             "attachment; filename*=UTF-8''",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -520,14 +531,15 @@ mod tests {
             "content-disposition",
             "attachment; title=\"a\\\"b\"",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -540,15 +552,16 @@ mod tests {
             "content-disposition",
             "attachment; filename*=UTF-8''%zz",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("filename* extended value invalid"));
@@ -562,15 +575,16 @@ mod tests {
             "content-disposition",
             "attachment; title*=UTF-8''hello@world",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("extended parameter 'title*' invalid"));
@@ -584,14 +598,15 @@ mod tests {
             "content-disposition",
             "attachment; size=\"unterminated",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -604,14 +619,15 @@ mod tests {
             "content-disposition",
             "form-data; filename=bad@name",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_parameter_validity",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_content_disposition_token_valid.rs
+++ b/src/rules/message_content_disposition_token_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentDispositionTokenValid;
 
 impl Rule for MessageContentDispositionTokenValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_disposition_token_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageContentDispositionTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Content-Disposition header value
         let check_value = |hdr_name: &str, val: &str| -> Option<Violation> {
             // Trim whitespace and split off parameters
@@ -117,15 +119,16 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_token_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", value);
@@ -142,14 +145,15 @@ mod tests {
             "content-disposition",
             "form-data; name=\"x\"",
         )]);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_token_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -163,14 +167,15 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_token_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -185,14 +190,15 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_token_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -216,14 +222,15 @@ mod tests {
             trailers: None,
         });
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_token_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -235,14 +242,15 @@ mod tests {
             200,
             &[("content-disposition", "   ")],
         );
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_content_disposition_token_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_content_encoding_and_type_consistency.rs
+++ b/src/rules/message_content_encoding_and_type_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentEncodingAndTypeConsistency;
 
 impl Rule for MessageContentEncodingAndTypeConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_encoding_and_type_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageContentEncodingAndTypeConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a Content-Encoding-like header value (comma-separated members).
         // This helper validates members in `val` and updates `seen` with found codings so duplicates
         // across multiple header fields can be detected when `seen` is shared between calls.
@@ -151,10 +153,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -181,10 +184,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -211,10 +215,11 @@ mod tests {
             HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         let v = violation.unwrap();
@@ -229,10 +234,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip, ")]);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }
@@ -244,10 +250,11 @@ mod tests {
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "*")]);
-        let v1 = rule.check_transaction(
+        let v1 = rule.check(
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
 
@@ -255,10 +262,11 @@ mod tests {
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx2.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "*")]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
@@ -274,10 +282,11 @@ mod tests {
         hm.append("content-encoding", HeaderValue::from_static("gzip"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -291,10 +300,11 @@ mod tests {
         hm.append("content-encoding", HeaderValue::from_static("gzip"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -323,10 +333,11 @@ mod tests {
         // part but its token before the ';' is empty -> triggers the rule
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip,;,br")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -341,10 +352,11 @@ mod tests {
             .headers
             .append("content-encoding", HeaderValue::from_bytes(&[0xff])?);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -362,10 +374,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_content_encoding_iana_registered.rs
+++ b/src/rules/message_content_encoding_iana_registered.rs
@@ -64,7 +64,7 @@ fn parse_allowed_config(
 pub struct MessageContentEncodingIanaRegistered;
 
 impl Rule for MessageContentEncodingIanaRegistered {
-    type Config = ContentEncodingConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_encoding_iana_registered"
@@ -82,12 +82,14 @@ impl Rule for MessageContentEncodingIanaRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         // Helper to check a single header value against allowed list
         let check_value = |hdr_name: &str, val: &str, allowed: &Vec<String>| -> Option<Violation> {
             for part in crate::helpers::headers::parse_list_header(val) {
@@ -148,17 +150,27 @@ mod tests {
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
-    fn make_cfg() -> ContentEncodingConfig {
-        ContentEncodingConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "gzip".to_string(),
-                "br".to_string(),
-                "deflate".to_string(),
-                "zstd".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_content_encoding_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![
+                        toml::Value::String("gzip".into()),
+                        toml::Value::String("br".into()),
+                        toml::Value::String("deflate".into()),
+                        toml::Value::String("zstd".into()),
+                    ]),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -183,10 +195,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -216,10 +229,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -409,10 +423,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x!bad")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -438,10 +453,11 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -450,10 +466,11 @@ mod tests {
         let mut hm2 = hyper::HeaderMap::new();
         hm2.insert("accept-encoding", HeaderValue::from_bytes(b"\xff").unwrap());
         tx2.request.headers = hm2;
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -477,16 +494,15 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&full_cfg, "message_content_encoding_iana_registered")?;
-
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", "x-custom;q=0.5")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &parsed,
+            &full_cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -512,16 +528,15 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&full_cfg, "message_content_encoding_iana_registered")?;
-
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x-custom")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &parsed,
+            &full_cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -536,20 +551,22 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip, ")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", "gzip, ")]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
         Ok(())
@@ -564,10 +581,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip; param=1")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -576,39 +594,55 @@ mod tests {
     #[test]
     fn iana_registry_entries_are_accepted() -> anyhow::Result<()> {
         let rule = MessageContentEncodingIanaRegistered;
-        let cfg = ContentEncodingConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "aes128gcm",
-                "br",
-                "compress",
-                "dcb",
-                "dcz",
-                "deflate",
-                "exi",
-                "gzip",
-                "identity",
-                "pack200-gzip",
-                "x-compress",
-                "x-gzip",
-                "zstd",
-            ]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
-        };
+        let codings: Vec<String> = vec![
+            "aes128gcm",
+            "br",
+            "compress",
+            "dcb",
+            "dcz",
+            "deflate",
+            "exi",
+            "gzip",
+            "identity",
+            "pack200-gzip",
+            "x-compress",
+            "x-gzip",
+            "zstd",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_content_encoding_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(
+                        codings
+                            .iter()
+                            .map(|s| toml::Value::String(s.clone()))
+                            .collect(),
+                    ),
+                );
+                t
+            }),
+        );
 
-        for coding in &cfg.allowed {
+        for coding in &codings {
             // response
             let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
             tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(
                 &[("content-encoding", coding.as_str())],
             );
-            let v = rule.check_transaction(
+            let v = rule.check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(
                 v.is_none(),
@@ -622,10 +656,11 @@ mod tests {
                 "accept-encoding",
                 coding.as_str(),
             )]);
-            let v2 = rule.check_transaction(
+            let v2 = rule.check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(
                 v2.is_none(),
@@ -663,20 +698,30 @@ mod tests {
     #[test]
     fn unrecognized_content_coding_message_and_severity() -> anyhow::Result<()> {
         let rule = MessageContentEncodingIanaRegistered;
-        let cfg = ContentEncodingConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-            allowed: vec!["gzip".to_string()],
-        };
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_content_encoding_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("error".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![toml::Value::String("gzip".into())]),
+                );
+                t
+            }),
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x-foo")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -698,10 +743,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x@bad")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_content_length.rs
+++ b/src/rules/message_content_length.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentLength;
 
 impl Rule for MessageContentLength {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_length"
@@ -18,12 +18,14 @@ impl Rule for MessageContentLength {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &hyper::HeaderMap| -> Option<Violation> {
             match crate::helpers::headers::validate_content_length(headers) {
                 Ok(_) => None,
@@ -96,10 +98,11 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_headers(&[("content-length", value)]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "value '{}' expected violation", value);
@@ -129,10 +132,11 @@ mod tests {
             &[("content-length", value)],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "response value '{}' expected violation", value);
@@ -160,10 +164,11 @@ mod tests {
         let pairs: Vec<(&str, &str)> = values.iter().map(|v| ("content-length", *v)).collect();
         let tx = crate::test_helpers::make_test_transaction_with_headers(&pairs);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -193,10 +198,11 @@ mod tests {
             trailers: None,
         });
 
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -225,10 +231,11 @@ mod tests {
         hm.insert(hyper::header::CONTENT_LENGTH, bad_value);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));

--- a/src/rules/message_content_length_vs_transfer_encoding.rs
+++ b/src/rules/message_content_length_vs_transfer_encoding.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentLengthVsTransferEncoding;
 
 impl Rule for MessageContentLengthVsTransferEncoding {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_length_vs_transfer_encoding"
@@ -18,12 +18,14 @@ impl Rule for MessageContentLengthVsTransferEncoding {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request headers
         if tx.request.headers.contains_key("content-length")
             && tx.request.headers.contains_key("transfer-encoding")
@@ -72,10 +74,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -100,10 +103,11 @@ mod tests {
         let status = 200;
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_content_location_and_uri_consistency.rs
+++ b/src/rules/message_content_location_and_uri_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentLocationAndUriConsistency;
 
 impl Rule for MessageContentLocationAndUriConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_location_and_uri_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageContentLocationAndUriConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -167,12 +169,15 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = make_tx_with_req_uri(req_uri, status, headers);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -185,15 +190,18 @@ mod tests {
     #[test]
     fn bad_percent_encoding_reports_violation() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             200,
             &[("content-location", "/bad%2G")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));
@@ -202,15 +210,18 @@ mod tests {
     #[test]
     fn whitespace_in_value_reports_violation() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             200,
             &[("content-location", "/a b")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not contain whitespace"));
@@ -219,7 +230,9 @@ mod tests {
     #[test]
     fn non_utf8_header_value_is_violation() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.insert(
@@ -227,10 +240,11 @@ mod tests {
             HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -238,15 +252,18 @@ mod tests {
     #[test]
     fn empty_value_reports_violation() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             200,
             &[("content-location", "")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -254,12 +271,15 @@ mod tests {
     #[test]
     fn fragment_in_content_location_is_ignored_for_matching() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = make_tx_with_req_uri("/foo", 200, &[("content-location", "/foo#frag")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -267,12 +287,15 @@ mod tests {
     #[test]
     fn trailing_slash_mismatch_reports_violation() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = make_tx_with_req_uri("/foo", 200, &[("content-location", "/foo/")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -280,16 +303,19 @@ mod tests {
     #[test]
     fn origin_case_insensitive_match() {
         let rule = MessageContentLocationAndUriConsistency;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_location_and_uri_consistency",
+        ]);
         let tx = make_tx_with_req_uri(
             "http://EXAMPLE.com/foo",
             200,
             &[("content-location", "http://example.com/foo")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_content_md5_vs_digest_preference.rs
+++ b/src/rules/message_content_md5_vs_digest_preference.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentMd5VsDigestPreference;
 
 impl Rule for MessageContentMd5VsDigestPreference {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_md5_vs_digest_preference"
@@ -18,12 +18,14 @@ impl Rule for MessageContentMd5VsDigestPreference {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to check a header map for both Content-Digest and Content-MD5
         let check_map = |which: &str, headers: &hyper::HeaderMap| -> Option<Violation> {
             let has_new = headers.get_all("content-digest").iter().next().is_some();
@@ -63,7 +65,9 @@ mod tests {
     #[test]
     fn both_headers_in_request_reports_violation() {
         let rule = MessageContentMd5VsDigestPreference;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_md5_vs_digest_preference",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
@@ -71,10 +75,11 @@ mod tests {
             ("content-md5", "dGVzdA=="),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -85,7 +90,9 @@ mod tests {
     #[test]
     fn both_headers_in_response_reports_violation() {
         let rule = MessageContentMd5VsDigestPreference;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_md5_vs_digest_preference",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[
@@ -93,10 +100,11 @@ mod tests {
             ("content-md5", "dGVzdA=="),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -104,7 +112,9 @@ mod tests {
     #[test]
     fn only_content_digest_is_ok() {
         let rule = MessageContentMd5VsDigestPreference;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_md5_vs_digest_preference",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -112,10 +122,11 @@ mod tests {
             "sha-256=:\tdGVzdA==:",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -124,16 +135,19 @@ mod tests {
     fn only_content_md5_is_ok_for_this_specific_rule() {
         // Content-MD5 alone is handled by the digest header syntax rule for deprecation. This rule only flags when both are present.
         let rule = MessageContentMd5VsDigestPreference;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_md5_vs_digest_preference",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-md5", "dGVzdA==")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -141,7 +155,9 @@ mod tests {
     #[test]
     fn non_utf8_content_md5_but_content_digest_present_reports_violation() {
         let rule = MessageContentMd5VsDigestPreference;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_md5_vs_digest_preference",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         // Insert non-utf8 for content-md5
@@ -157,10 +173,11 @@ mod tests {
             HeaderValue::from_static("sha-256=:\tdGVzdA==:"),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -175,7 +192,9 @@ mod tests {
     #[test]
     fn request_precedence_over_response() {
         let rule = MessageContentMd5VsDigestPreference;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_md5_vs_digest_preference",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
@@ -187,10 +206,11 @@ mod tests {
             ("content-md5", "dGVzdA=="),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_content_security_policy_and_frame_options_consistency.rs
+++ b/src/rules/message_content_security_policy_and_frame_options_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentSecurityPolicyAndFrameOptionsConsistency;
 
 impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_security_policy_and_frame_options_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
         let resp = match &tx.response {
             Some(r) => r,
@@ -248,11 +250,11 @@ mod tests {
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
-    fn make_cfg() -> crate::rules::RuleConfig {
-        crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_cfg() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_severity(
+            "message_content_security_policy_and_frame_options_consistency",
+            "warn",
+        )
     }
 
     #[rstest]
@@ -272,10 +274,11 @@ mod tests {
             ("x-frame-options", xfo),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -310,10 +313,11 @@ mod tests {
         headers.insert("x-frame-options", bad);
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -331,10 +335,11 @@ mod tests {
         ]);
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not match"));
@@ -374,10 +379,11 @@ mod tests {
             ("x-frame-options", "ALLOW-FROM https://a"),
         ]);
         tx.response.as_mut().unwrap().headers = headers;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -393,10 +399,11 @@ mod tests {
             ("x-frame-options", "DENY"),
         ]);
         // since the directive is malformed (no members) we treat as absent and no violation
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -415,10 +422,11 @@ mod tests {
         headers.append("x-frame-options", "DENY".parse().unwrap());
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -433,10 +441,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "ALLOW-FROM https://example/"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -451,10 +460,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "UNKNOWN https://example"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -472,10 +482,11 @@ mod tests {
             ("x-frame-options", "ALLOW-FROM http://example"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -490,10 +501,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://a"),
             ("x-frame-options", "ALLOW-FROM"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -508,10 +520,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors 'none'"),
             ("x-frame-options", "ALLOW-FROM https://example"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -528,10 +541,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://EXample"),
             ("x-frame-options", "ALLOW-FROM https://example"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -549,10 +563,11 @@ mod tests {
             ),
             ("x-frame-options", "ALLOW-FROM https://example"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -567,10 +582,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "SAMEORIGIN"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -588,10 +604,11 @@ mod tests {
         ]);
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -609,10 +626,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "allow-from https://example"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -645,10 +663,11 @@ mod tests {
             ("x-frame-options", "SAMEORIGIN"),
         ]);
         // report-only policies should not affect framing enforcement -> ignore
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -663,10 +682,11 @@ mod tests {
             ("content-security-policy", "frame-ancestors 'self'"),
             ("x-frame-options", "SAMEORIGIN"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -684,10 +704,11 @@ mod tests {
         headers.insert("content-security-policy", bad);
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -702,10 +723,11 @@ mod tests {
             "content-security-policy",
             "frame-ancestors https://example",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_content_transfer_encoding_valid.rs
+++ b/src/rules/message_content_transfer_encoding_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentTransferEncodingValid;
 
 impl Rule for MessageContentTransferEncodingValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_transfer_encoding_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageContentTransferEncodingValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Allowed encodings per RFC 2045 §6
         let allowed = ["7bit", "8bit", "binary", "quoted-printable", "base64"];
 
@@ -118,7 +120,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageContentTransferEncodingValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_transfer_encoding_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(v) = hdr {
@@ -126,10 +130,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -142,7 +147,9 @@ mod tests {
     #[test]
     fn non_utf8_header_values_are_ignored() -> anyhow::Result<()> {
         let rule = MessageContentTransferEncodingValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_transfer_encoding_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -152,10 +159,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -164,16 +172,19 @@ mod tests {
     #[test]
     fn request_header_valid_and_request_scoped_is_checked() -> anyhow::Result<()> {
         let rule = MessageContentTransferEncodingValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_transfer_encoding_valid",
+        ]);
 
         // valid request header should not produce a violation
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", "8bit")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -183,10 +194,11 @@ mod tests {
             "content-transfer-encoding",
             "xcodec",
         )]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         Ok(())
@@ -196,16 +208,19 @@ mod tests {
     fn empty_header_value_is_violation_and_multiple_headers_with_one_invalid_is_reported(
     ) -> anyhow::Result<()> {
         let rule = MessageContentTransferEncodingValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_transfer_encoding_valid",
+        ]);
 
         // empty header value
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", " ")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
@@ -214,10 +229,11 @@ mod tests {
             ("content-transfer-encoding", "base64"),
             ("content-transfer-encoding", "x-bad"),
         ]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         Ok(())

--- a/src/rules/message_content_type_iana_registered.rs
+++ b/src/rules/message_content_type_iana_registered.rs
@@ -64,7 +64,7 @@ fn parse_allowed_config(
 pub struct MessageContentTypeIanaRegistered;
 
 impl Rule for MessageContentTypeIanaRegistered {
-    type Config = ContentTypeConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_type_iana_registered"
@@ -82,12 +82,14 @@ impl Rule for MessageContentTypeIanaRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         let check_media_type =
             |hdr_name: &str, val: &str, allowed: &Vec<String>| -> Option<Violation> {
                 // Parse media-type; if it fails, let other rules (well-formed) report it.
@@ -156,17 +158,27 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn make_cfg() -> ContentTypeConfig {
-        ContentTypeConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "text/plain".to_string(),
-                "application/json".to_string(),
-                "image/*".to_string(),
-                "+json".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_content_type_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![
+                        toml::Value::String("text/plain".into()),
+                        toml::Value::String("application/json".into()),
+                        toml::Value::String("image/*".into()),
+                        toml::Value::String("+json".into()),
+                    ]),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -190,10 +202,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -221,10 +234,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -241,10 +255,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -252,20 +267,30 @@ mod tests {
     #[test]
     fn wildcard_allowed_accepts_any() {
         let rule = MessageContentTypeIanaRegistered;
-        let cfg = ContentTypeConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec!["*/*".to_string()],
-        };
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_content_type_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![toml::Value::String("*/*".into())]),
+                );
+                t
+            }),
+        );
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-type",
             "application/vnd.unknown",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -302,10 +327,11 @@ mod tests {
         tx1.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -315,10 +341,11 @@ mod tests {
             "application/ld+json",
         )]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -332,10 +359,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/x-custom")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -452,10 +480,11 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -467,10 +496,11 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx2.request.headers = hm2;
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }

--- a/src/rules/message_content_type_well_formed.rs
+++ b/src/rules/message_content_type_well_formed.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageContentTypeWellFormed;
 
 impl Rule for MessageContentTypeWellFormed {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_content_type_well_formed"
@@ -18,16 +18,18 @@ impl Rule for MessageContentTypeWellFormed {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request Content-Type
         if let Some(hv) = tx.request.headers.get("content-type") {
             if let Ok(s) = hv.to_str() {
-                if let Some(v) = check_content_type("request", s, config) {
+                if let Some(v) = check_content_type("request", s, &config) {
                     return Some(v);
                 }
             }
@@ -37,7 +39,7 @@ impl Rule for MessageContentTypeWellFormed {
         if let Some(resp) = &tx.response {
             if let Some(hv) = resp.headers.get("content-type") {
                 if let Ok(s) = hv.to_str() {
-                    if let Some(v) = check_content_type("response", s, config) {
+                    if let Some(v) = check_content_type("response", s, &config) {
                         return Some(v);
                     }
                 }
@@ -227,16 +229,19 @@ mod tests {
     #[rstest]
     fn request_and_response_integration() -> anyhow::Result<()> {
         let rule = MessageContentTypeWellFormed;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_content_type_well_formed",
+        ]);
 
         // request invalid
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
@@ -245,10 +250,11 @@ mod tests {
             200,
             &[("content-type", "text")],
         );
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
@@ -262,15 +268,17 @@ mod tests {
             200,
             &[("content-type", "application/json")],
         );
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
-        let v4 = rule.check_transaction(
+        let v4 = rule.check(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_none());
         assert!(v4.is_none());

--- a/src/rules/message_cookie_attribute_consistency.rs
+++ b/src/rules/message_cookie_attribute_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCookieAttributeConsistency;
 
 impl Rule for MessageCookieAttributeConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cookie_attribute_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageCookieAttributeConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -271,10 +273,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = MessageCookieAttributeConsistency;
-        rule.check_transaction(
+        rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -349,10 +352,11 @@ mod tests {
             .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
 
         let rule = MessageCookieAttributeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -430,10 +434,11 @@ mod tests {
             .append("set-cookie", HeaderValue::from_static("=bad; Secure"));
 
         let rule = MessageCookieAttributeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_cookie_domain_validity.rs
+++ b/src/rules/message_cookie_domain_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCookieDomainValidity;
 
 impl Rule for MessageCookieDomainValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cookie_domain_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageCookieDomainValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -97,10 +99,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = MessageCookieDomainValidity;
-        rule.check_transaction(
+        rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -149,10 +152,11 @@ mod tests {
         });
 
         let rule = MessageCookieDomainValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -196,10 +200,11 @@ mod tests {
             .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
 
         let rule = MessageCookieDomainValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_cookie_path_validity.rs
+++ b/src/rules/message_cookie_path_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCookiePathValidity;
 
 impl Rule for MessageCookiePathValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cookie_path_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageCookiePathValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -91,10 +93,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = MessageCookiePathValidity;
-        rule.check_transaction(
+        rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -177,10 +180,11 @@ mod tests {
         });
 
         let rule = MessageCookiePathValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -206,10 +210,11 @@ mod tests {
         });
 
         let rule = MessageCookiePathValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -254,10 +259,11 @@ mod tests {
     fn check_missing_response() {
         let tx = crate::test_helpers::make_test_transaction();
         let rule = MessageCookiePathValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_cross_origin_embedder_policy_valid.rs
+++ b/src/rules/message_cross_origin_embedder_policy_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCrossOriginEmbedderPolicyValid;
 
 impl Rule for MessageCrossOriginEmbedderPolicyValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cross_origin_embedder_policy_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageCrossOriginEmbedderPolicyValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // COEP is a response-only header per spec; ignore requests
         let resp = if let Some(resp) = &tx.response {
             resp
@@ -92,7 +94,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[rstest]
     #[case(Some("require-corp"), false)]
@@ -113,10 +115,11 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -134,10 +137,11 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageCrossOriginEmbedderPolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -163,10 +167,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -196,10 +201,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -234,10 +240,11 @@ mod tests {
             200,
             &[("cross-origin-embedder-policy", "require-corp ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -250,10 +257,11 @@ mod tests {
             &[("cross-origin-embedder-policy", "unsafe-none")],
         );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not enable cross-origin isolation"));
@@ -271,10 +279,11 @@ mod tests {
             )],
         );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));
@@ -301,10 +310,11 @@ mod tests {
             200,
             &[("cross-origin-embedder-policy", "CrEdEntIalLess")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "expected no violation for mixed-case value");
 

--- a/src/rules/message_cross_origin_opener_policy_valid.rs
+++ b/src/rules/message_cross_origin_opener_policy_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCrossOriginOpenerPolicyValid;
 
 impl Rule for MessageCrossOriginOpenerPolicyValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cross_origin_opener_policy_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageCrossOriginOpenerPolicyValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // COOP is a response-only header per spec; ignore requests
         let resp = if let Some(resp) = &tx.response {
             resp
@@ -90,7 +92,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[rstest]
     #[case(Some("same-origin"), false)]
@@ -111,10 +113,11 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -132,10 +135,11 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageCrossOriginOpenerPolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -160,10 +164,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -193,10 +198,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -231,10 +237,11 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", "same-origin ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -247,10 +254,11 @@ mod tests {
             &[("cross-origin-opener-policy", "other")],
         );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("unsupported value"));
@@ -265,10 +273,11 @@ mod tests {
             &[("cross-origin-opener-policy", "same-origin, unsafe-none")],
         );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));
@@ -281,10 +290,11 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", " same-origin-allow-popups ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_cross_origin_resource_policy_valid.rs
+++ b/src/rules/message_cross_origin_resource_policy_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageCrossOriginResourcePolicyValid;
 
 impl Rule for MessageCrossOriginResourcePolicyValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_cross_origin_resource_policy_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageCrossOriginResourcePolicyValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // CORP is a response-only header per spec; ignore requests
         let resp = if let Some(resp) = &tx.response {
             resp
@@ -95,7 +97,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[rstest]
     #[case(Some("same-site"), false)]
@@ -116,10 +118,11 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -137,10 +140,11 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageCrossOriginResourcePolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -165,10 +169,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -198,10 +203,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -236,10 +242,11 @@ mod tests {
             200,
             &[("cross-origin-resource-policy", "same-origin ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -252,10 +259,11 @@ mod tests {
             &[("cross-origin-resource-policy", "other")],
         );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("unsupported value"));
@@ -270,10 +278,11 @@ mod tests {
             &[("cross-origin-resource-policy", "same-origin, cross-origin")],
         );
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));

--- a/src/rules/message_date_and_time_headers_consistency.rs
+++ b/src/rules/message_date_and_time_headers_consistency.rs
@@ -9,7 +9,7 @@ use crate::rules::Rule;
 pub struct MessageDateAndTimeHeadersConsistency;
 
 impl Rule for MessageDateAndTimeHeadersConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_date_and_time_headers_consistency"
@@ -19,12 +19,14 @@ impl Rule for MessageDateAndTimeHeadersConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use chrono::Duration;
 
         // Tolerate some small clock skew when comparing dates
@@ -214,10 +216,11 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&h);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -238,10 +241,11 @@ mod tests {
             ("last-modified", "Wed, 21 Oct 2015 07:30:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -258,10 +262,11 @@ mod tests {
             ("sunset", "Wed, 21 Oct 2015 07:27:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -278,10 +283,11 @@ mod tests {
             ("if-modified-since", "Wed, 21 Oct 2015 07:30:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -300,10 +306,11 @@ mod tests {
         hm.insert("date", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -318,10 +325,11 @@ mod tests {
             ("sunset", "not-a-date"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -343,10 +351,11 @@ mod tests {
         hm.insert("last-modified", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -365,10 +374,11 @@ mod tests {
         hm.insert("if-modified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -383,10 +393,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("date", "not-a-date")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -403,10 +414,11 @@ mod tests {
             "Tue, 01 Jan 2030 00:00:00 GMT",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -423,10 +435,11 @@ mod tests {
         hm.insert("date", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -443,10 +456,11 @@ mod tests {
             ("last-modified", "not-a-date"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Parse error for Last-Modified should be ignored by this rule (other rule will report)
         assert!(v.is_none());
@@ -462,10 +476,11 @@ mod tests {
             ("if-modified-since", "not-a-date"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Parse error for If-Modified-Since should be ignored by this rule (other rule will report)
         assert!(v.is_none());
@@ -481,10 +496,11 @@ mod tests {
             "Wed, 21 Oct 2015 07:30:00 GMT",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Without a Date header to compare against, the rule should not produce a violation
         assert!(v.is_none());
@@ -505,10 +521,11 @@ mod tests {
         hm.insert("sunset", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;

--- a/src/rules/message_digest_auth_validity.rs
+++ b/src/rules/message_digest_auth_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageDigestAuthValidity;
 
 impl Rule for MessageDigestAuthValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_digest_auth_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageDigestAuthValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             match hv.to_str() {
                 Ok(s) => {
@@ -207,7 +209,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(h) = header {
@@ -216,10 +220,11 @@ mod tests {
                 .append("authorization", h.parse().unwrap());
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -232,7 +237,9 @@ mod tests {
     #[test]
     fn invalid_param_name_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -242,10 +249,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -256,7 +264,9 @@ mod tests {
     #[test]
     fn lowercase_scheme_is_accepted() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -266,10 +276,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -278,7 +289,9 @@ mod tests {
     #[test]
     fn parse_params_missing_value_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -288,10 +301,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -307,10 +321,11 @@ mod tests {
             "authorization",
             hyper::header::HeaderValue::from_bytes(b"Digest \xff").unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -319,7 +334,9 @@ mod tests {
     #[test]
     fn required_param_quoted_empty_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -329,10 +346,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -346,7 +364,9 @@ mod tests {
     #[test]
     fn quoted_string_with_escaped_quote_is_accepted() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // username contains an escaped quote inside the quoted-string which is valid
@@ -355,10 +375,11 @@ mod tests {
             "Digest username=\"Mu\\\"fasa\", realm=\"test\", nonce=\"abc\", uri=\"/\", response=\"d\"".parse().unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -367,7 +388,9 @@ mod tests {
     #[test]
     fn invalid_quoted_string_reports_specific_message() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // username quoted-string missing closing quote should trigger quoted-string validation error
@@ -378,10 +401,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -409,17 +433,20 @@ mod tests {
     #[test]
     fn digest_scheme_with_whitespace_but_no_params_reports_invalid_params() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request
             .headers
             .append("authorization", "Digest    ".parse().unwrap());
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -431,17 +458,20 @@ mod tests {
     #[test]
     fn digest_scheme_without_params_reports_missing_parameters_message() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request
             .headers
             .append("authorization", "Digest".parse().unwrap());
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -452,7 +482,9 @@ mod tests {
     #[test]
     fn invalid_response_value_token_char_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -462,10 +494,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -478,7 +511,9 @@ mod tests {
     #[test]
     fn invalid_quoted_string_extra_chars_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // username quoted-string followed by extra chars should trigger quoted-string validation error
@@ -489,10 +524,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -505,7 +541,9 @@ mod tests {
     #[test]
     fn duplicate_param_last_empty_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // username appears twice; last one is empty -> should trigger missing/empty required param
@@ -516,10 +554,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -533,7 +572,9 @@ mod tests {
     #[test]
     fn multiple_authorization_headers_one_invalid_triggers_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // add a Basic header first, then an invalid Digest (empty response)
@@ -547,10 +588,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -564,7 +606,9 @@ mod tests {
     #[test]
     fn multiple_digest_headers_one_invalid_after_valid_triggers_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // first a valid Digest, then an invalid Digest (empty response)
@@ -581,10 +625,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -593,7 +638,9 @@ mod tests {
     #[test]
     fn multiple_digest_headers_all_valid_no_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -609,10 +656,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -621,17 +669,20 @@ mod tests {
     #[test]
     fn empty_authorization_header_ignored() {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         // An empty Authorization value should be ignored
         tx.request
             .headers
             .append("authorization", "".parse().unwrap());
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -639,7 +690,9 @@ mod tests {
     #[test]
     fn unquoted_username_with_space_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
@@ -649,10 +702,11 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -661,7 +715,9 @@ mod tests {
     #[test]
     fn quoted_string_ends_with_escape_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
             "authorization",
@@ -669,10 +725,11 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -687,7 +744,9 @@ mod tests {
     #[test]
     fn required_param_unquoted_empty_reports_violation() -> anyhow::Result<()> {
         let rule = MessageDigestAuthValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_auth_validity",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers.append(
             "authorization",
@@ -695,10 +754,11 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_digest_header_syntax.rs
+++ b/src/rules/message_digest_header_syntax.rs
@@ -9,7 +9,7 @@ use base64::Engine;
 pub struct MessageDigestHeaderSyntax;
 
 impl Rule for MessageDigestHeaderSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_digest_header_syntax"
@@ -19,12 +19,14 @@ impl Rule for MessageDigestHeaderSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Shared parser for comma-separated key=value members
         let parse_key_value_members = |value: &str,
                                        empty_member_msg: &str,
@@ -531,12 +533,15 @@ mod tests {
     fn request_want_digest_cases(#[case] value: &str, #[case] expect_violation: bool) {
         let rule = MessageDigestHeaderSyntax;
         let tx = make_req_want_digest(value);
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -554,11 +559,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("want-digest", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -568,11 +576,14 @@ mod tests {
     fn want_digest_empty_member_is_violation() {
         let rule = MessageDigestHeaderSyntax;
         let tx = make_req_want_digest("sha-256=, , sha-512");
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -583,11 +594,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("want-digest", "SHA-256")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -603,11 +617,14 @@ mod tests {
         hm.append("want-digest", HeaderValue::from_static("SHA-256"));
         hm.append("want-digest", HeaderValue::from_static("sha-256"));
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -633,12 +650,15 @@ mod tests {
     fn request_digest_cases(#[case] value: &str, #[case] expect_violation: bool) {
         let rule = MessageDigestHeaderSyntax;
         let tx = make_req_digest(value);
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -653,12 +673,15 @@ mod tests {
     fn response_digest_cases(#[case] value: &str, #[case] expect_violation: bool) {
         let rule = MessageDigestHeaderSyntax;
         let tx = make_resp_digest(value);
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -671,11 +694,14 @@ mod tests {
     fn empty_header_absent_returns_none() {
         let rule = MessageDigestHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -689,11 +715,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("digest", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -714,11 +743,14 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -730,11 +762,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA@1=YWJj")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -745,11 +780,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA-256=YWJj")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -763,11 +801,14 @@ mod tests {
             200,
             &[("content-digest", "sha-256=:dGVzdA==:")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -779,11 +820,14 @@ mod tests {
             200,
             &[("content-digest", "sha-256=:not-base64!:")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -795,11 +839,14 @@ mod tests {
             200,
             &[("digest", "SHA-256=YWJj")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -814,11 +861,14 @@ mod tests {
             "content-digest",
             "sha-256=:not-base64!:",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -833,11 +883,14 @@ mod tests {
             "content-digest",
             "sha-256=:dGVzdA==:,",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -849,11 +902,14 @@ mod tests {
             200,
             &[("want-content-digest", "sha-512=3, sha-256=10")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -865,11 +921,14 @@ mod tests {
             200,
             &[("want-content-digest", "sha-256=20")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -881,11 +940,14 @@ mod tests {
         tx.request
             .headers
             .append("want-content-digest", "sha-256=20".parse().unwrap());
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -897,12 +959,15 @@ mod tests {
             200,
             &[("content-md5", "dGVzdA==")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
         // Add a simple check that presence of header yields a violation via our rule: we will add handling next
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -914,11 +979,14 @@ mod tests {
             200,
             &[("repr-digest", "sha-256=:dGVzdA==:")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -930,11 +998,14 @@ mod tests {
             200,
             &[("repr-digest", "sha-256=:not-base64!:")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -947,11 +1018,14 @@ mod tests {
             "repr-digest",
             "sha-256=:not-base64!:",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -963,11 +1037,14 @@ mod tests {
             200,
             &[("want-repr-digest", "sha-512=0, sha-256=10")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -979,11 +1056,14 @@ mod tests {
             200,
             &[("want-repr-digest", "sha-256=20")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -997,11 +1077,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("content-digest", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1029,11 +1112,14 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1045,11 +1131,14 @@ mod tests {
             200,
             &[("want-content-digest", "sha-256=abc")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1063,11 +1152,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("repr-digest", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1089,11 +1181,14 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1115,11 +1210,14 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1132,11 +1230,14 @@ mod tests {
             200,
             &[("want-content-digest", "sha-256")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1151,11 +1252,14 @@ mod tests {
         hm.append("digest", HeaderValue::from_static("SHA-256=YWJj"));
         hm.append("digest", HeaderValue::from_static("SHA-256=not-base64!"));
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1177,11 +1281,14 @@ mod tests {
     ) {
         let rule = MessageDigestHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -1210,11 +1317,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("content-digest", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1236,11 +1346,14 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1262,11 +1375,14 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1279,11 +1395,14 @@ mod tests {
             200,
             &[("want-repr-digest", "sha-256")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1302,11 +1421,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append(header, bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1324,11 +1446,14 @@ mod tests {
     fn want_field_cases(#[case] header: &str, #[case] value: &str, #[case] expect_violation: bool) {
         let rule = MessageDigestHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -1354,11 +1479,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-md5", "dGVzdA==")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1372,11 +1500,14 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("content-md5", bad);
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1392,11 +1523,14 @@ mod tests {
         hm.append("content-md5", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1415,11 +1549,14 @@ mod tests {
             HeaderValue::from_static("sha-256=:dGVzdA==:"),
         );
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Since legacy Digest is checked first, we expect a violation about Digest being obsoleted
         assert!(v.is_some());
@@ -1436,11 +1573,14 @@ mod tests {
             "digest",
             "SHA-256=YWJj,,SHA-512=ZGVm",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1456,11 +1596,14 @@ mod tests {
     ) {
         let rule = MessageDigestHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -1484,11 +1627,14 @@ mod tests {
             HeaderValue::from_static("sha-256=:not-base64!:"),
         );
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1499,11 +1645,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA-256=YWJj,")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1517,11 +1666,14 @@ mod tests {
             "Content-Digest",
             "sha-256=:dGVzdA==:",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1542,11 +1694,14 @@ mod tests {
             HeaderValue::from_static("sha-512=:dGVzdA==:"),
         );
         req.request.headers = hm_req;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let vreq = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let vreq = rule.check(
             &req,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(vreq.is_none());
 
@@ -1569,10 +1724,11 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let vresp = rule.check_transaction(
+        let vresp = rule.check(
             &resp_tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(vresp.is_none());
     }
@@ -1584,11 +1740,14 @@ mod tests {
             200,
             &[("repr-digest", " sha-256 = :dGVzdA==: ")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1596,17 +1755,20 @@ mod tests {
     #[test]
     fn want_field_space_around_equals_accepted_and_missing_equals_in_multi_is_violation() {
         let rule = MessageDigestHeaderSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
 
         // space around equals accepted
         let tx_ok = crate::test_helpers::make_test_transaction_with_response(
             200,
             &[("want-content-digest", "sha-512 = 2")],
         );
-        let v_ok = rule.check_transaction(
+        let v_ok = rule.check(
             &tx_ok,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_ok.is_none());
 
@@ -1615,10 +1777,11 @@ mod tests {
             200,
             &[("want-content-digest", "sha-512=3, sha-256")],
         );
-        let v_bad = rule.check_transaction(
+        let v_bad = rule.check(
             &tx_bad,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_bad.is_some());
         let msg = v_bad.unwrap().message;
@@ -1632,11 +1795,14 @@ mod tests {
             200,
             &[("content-digest", "sha-256:dGVzdA==:")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1650,11 +1816,14 @@ mod tests {
             200,
             &[("want-content-digest", "sha-256=3, ,sha-512=5")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1663,11 +1832,14 @@ mod tests {
     fn want_digest_invalid_char_reports_invalid_char_in_message() {
         let rule = MessageDigestHeaderSyntax;
         let tx = make_req_want_digest("sha@1");
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1681,11 +1853,14 @@ mod tests {
             200,
             &[("content-digest", "sha-256=:")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1700,11 +1875,14 @@ mod tests {
             200,
             &[("want-content-digest", "sha@1=5")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1718,11 +1896,14 @@ mod tests {
             200,
             &[("content-md5", "dGVzdA==")],
         );
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1733,11 +1914,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA-256=YWJj,")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_digest_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_early_data_header_safe_method.rs
+++ b/src/rules/message_early_data_header_safe_method.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageEarlyDataHeaderSafeMethod;
 
 impl Rule for MessageEarlyDataHeaderSafeMethod {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_early_data_header_safe_method"
@@ -19,12 +19,14 @@ impl Rule for MessageEarlyDataHeaderSafeMethod {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Early-Data is defined as a request header (RFC 8470). If present and equal to '1',
         // it should only be used with safe methods (GET, HEAD, OPTIONS, TRACE).
         // A request may include multiple Early-Data header fields. Per RFC 8470, any
@@ -76,7 +78,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) {
         let rule = MessageEarlyDataHeaderSafeMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_early_data_header_safe_method",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = method.to_string();
@@ -84,10 +88,11 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("early-data", h)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -129,7 +134,9 @@ mod tests {
     #[test]
     fn multiple_header_instances_with_one_1_reports_violation() {
         let rule = MessageEarlyDataHeaderSafeMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_early_data_header_safe_method",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "POST".to_string();
@@ -139,10 +146,11 @@ mod tests {
         hm.append("early-data", "1".parse::<HeaderValue>().unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -150,7 +158,9 @@ mod tests {
     #[test]
     fn non_utf8_header_value_is_ignored() {
         let rule = MessageEarlyDataHeaderSafeMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_early_data_header_safe_method",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "POST".to_string();
@@ -160,10 +170,11 @@ mod tests {
         hm.append("early-data", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_etag_syntax.rs
+++ b/src/rules/message_etag_syntax.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct MessageEtagSyntax;
 
 impl Rule for MessageEtagSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_etag_syntax"
@@ -20,12 +20,14 @@ impl Rule for MessageEtagSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -105,15 +107,13 @@ mod tests {
             });
         }
 
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "warn");
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for value={:?}", value);
@@ -146,10 +146,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -174,10 +175,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_expires_and_cache_control_consistency.rs
+++ b/src/rules/message_expires_and_cache_control_consistency.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 pub struct MessageExpiresAndCacheControlConsistency;
 
 impl Rule for MessageExpiresAndCacheControlConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_expires_and_cache_control_consistency"
@@ -23,12 +23,14 @@ impl Rule for MessageExpiresAndCacheControlConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -161,7 +163,7 @@ impl Rule for MessageExpiresAndCacheControlConsistency {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction_with_response};
+    use crate::test_helpers::make_test_transaction_with_response;
     use rstest::rstest;
 
     #[rstest]
@@ -188,11 +190,14 @@ mod tests {
 
         let tx = make_test_transaction_with_response(200, &headers);
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for headers={:?}", headers);
@@ -227,11 +232,14 @@ mod tests {
             ],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -244,11 +252,14 @@ mod tests {
             &[("cache-control", "max-age=60"), ("expires", "not-a-date")],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // invalid Expires is left to other rules; this rule returns None
         assert!(v.is_none());
@@ -266,11 +277,14 @@ mod tests {
             ],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -290,11 +304,14 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // non-UTF8 cache-control means cc_present stays false -> no violation
         assert!(v.is_none());
@@ -312,11 +329,14 @@ mod tests {
             ],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -338,11 +358,14 @@ mod tests {
             &[("cache-control", "no-cache"), ("expires", &expires)],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "got {:?}", v);
         Ok(())
@@ -380,11 +403,14 @@ mod tests {
             ],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -404,11 +430,14 @@ mod tests {
             &[("cache-control", "no-store"), ("expires", &expires)],
         );
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -478,11 +507,14 @@ mod tests {
         );
 
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -499,11 +531,14 @@ mod tests {
         hm.insert("expires", bad);
         tx.response.as_mut().unwrap().headers = hm;
         let rule = MessageExpiresAndCacheControlConsistency;
-        let cfg = make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_expires_and_cache_control_consistency",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // non-UTF8 expires means has_expires stays false -> no violation
         assert!(v.is_none());

--- a/src/rules/message_extension_headers_registered.rs
+++ b/src/rules/message_extension_headers_registered.rs
@@ -62,7 +62,7 @@ fn parse_allowed_config(
 pub struct MessageExtensionHeadersRegistered;
 
 impl Rule for MessageExtensionHeadersRegistered {
-    type Config = ExtensionHeadersConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_extension_headers_registered"
@@ -80,12 +80,14 @@ impl Rule for MessageExtensionHeadersRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         // Helper to check headers map against allowed set
         let check_map = |headers: &hyper::HeaderMap| -> Option<Violation> {
             for (name, _val) in headers.iter() {
@@ -126,15 +128,27 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn make_cfg_with_allowed(allowed: Vec<&str>) -> ExtensionHeadersConfig {
-        ExtensionHeadersConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: allowed
-                .into_iter()
-                .map(|s| s.to_ascii_lowercase())
-                .collect(),
-        }
+    fn make_cfg_with_allowed(allowed: Vec<&str>) -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_extension_headers_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(
+                        allowed
+                            .into_iter()
+                            .map(|s| toml::Value::String(s.to_string()))
+                            .collect(),
+                    ),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -163,10 +177,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&header_pairs);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -190,10 +205,11 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -296,10 +312,11 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("x-unknown", "v")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -342,10 +359,11 @@ mod tests {
         let cfg = make_cfg_with_allowed(vec!["x-custom"]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("X-CUSTOM", "1")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -358,10 +376,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-a", "1"), ("x-b", "2")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_form_data_content_disposition_valid.rs
+++ b/src/rules/message_form_data_content_disposition_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageFormDataContentDispositionValid;
 
 impl Rule for MessageFormDataContentDispositionValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_form_data_content_disposition_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageFormDataContentDispositionValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper that checks a single header value
         let check_value = |_hdr: &str, val: &str| -> Option<Violation> {
             let s = val.trim();
@@ -178,7 +180,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = cd {
@@ -186,10 +190,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", cd);
@@ -209,7 +214,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(v) = cd {
@@ -217,10 +224,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", cd);
@@ -234,17 +242,20 @@ mod tests {
     fn non_utf8_header_is_reported() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -253,17 +264,20 @@ mod tests {
     #[test]
     fn quoted_empty_name_reports_violation() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-disposition",
             "form-data; name=\"\"",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -271,17 +285,20 @@ mod tests {
     #[test]
     fn quoted_whitespace_name_reports_violation() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-disposition",
             "form-data; name=\"   \"",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -289,17 +306,20 @@ mod tests {
     #[test]
     fn malformed_quoted_name_reports_violation() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-disposition",
             "form-data; name=\"unterminated",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -308,17 +328,20 @@ mod tests {
     fn request_non_utf8_header_is_reported() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -327,15 +350,18 @@ mod tests {
     #[test]
     fn form_data_without_params_reports_missing_name() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "form-data")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -343,17 +369,20 @@ mod tests {
     #[test]
     fn case_insensitive_disposition_and_param_name_is_accepted() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-disposition",
             "Form-Data; NAME=User",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -361,15 +390,18 @@ mod tests {
     #[test]
     fn empty_disposition_type_is_ignored() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "; name=user")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -377,15 +409,18 @@ mod tests {
     #[test]
     fn form_data_with_trailing_semicolon_reports_missing_name() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "form-data;")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -394,7 +429,9 @@ mod tests {
     fn multiple_content_disposition_all_valid_is_ok() {
         use hyper::header::HeaderValue;
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers.append(
@@ -406,10 +443,11 @@ mod tests {
             HeaderValue::from_static("form-data; name=\"b\""),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -417,15 +455,18 @@ mod tests {
     #[test]
     fn empty_header_value_is_ignored() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -433,17 +474,20 @@ mod tests {
     #[test]
     fn malformed_param_without_eq_is_ignored_by_this_rule() {
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-disposition",
             "form-data; badparam",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Although a parameter is present, the absence of a 'name' parameter should still be
         // treated as a violation for 'form-data' dispositions.
@@ -454,7 +498,9 @@ mod tests {
     fn multiple_content_disposition_headers_one_invalid_reports_violation() {
         use hyper::header::HeaderValue;
         let rule = MessageFormDataContentDispositionValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_form_data_content_disposition_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         // append a valid and an invalid header
@@ -467,10 +513,11 @@ mod tests {
             HeaderValue::from_static("form-data; filename=example.txt"),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_forwarded_header_validity.rs
+++ b/src/rules/message_forwarded_header_validity.rs
@@ -9,7 +9,7 @@ use std::net::IpAddr;
 pub struct MessageForwardedHeaderValidity;
 
 impl Rule for MessageForwardedHeaderValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_forwarded_header_validity"
@@ -19,12 +19,14 @@ impl Rule for MessageForwardedHeaderValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Forwarded element (one comma-separated member)
         let validate_element = |elem: &str| -> Option<Violation> {
             if elem.is_empty() {
@@ -430,10 +432,11 @@ mod tests {
     fn valid_forwarded_simple_for_ipv4() {
         let tx = make_tx_with_forwarded("for=192.0.2.43");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -442,10 +445,11 @@ mod tests {
     fn valid_forwarded_for_ipv6_bracketed() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1]\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -454,10 +458,11 @@ mod tests {
     fn valid_forwarded_with_port() {
         let tx = make_tx_with_forwarded("for=198.51.100.17:1234;proto=https;by=203.0.113.5");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -466,10 +471,11 @@ mod tests {
     fn invalid_forwarded_empty_element() {
         let tx = make_tx_with_forwarded(", ;for=192.0.2.43");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Leading empty list members and stray semicolons are ignored by header parsing; consider this valid
         assert!(v.is_none());
@@ -479,10 +485,11 @@ mod tests {
     fn invalid_forwarded_missing_eq() {
         let tx = make_tx_with_forwarded("for");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -491,10 +498,11 @@ mod tests {
     fn invalid_forwarded_bad_ipv4() {
         let tx = make_tx_with_forwarded("for=999.999.999.999");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -503,10 +511,11 @@ mod tests {
     fn invalid_forwarded_bad_ipv6_brackets() {
         let tx = make_tx_with_forwarded("for=[2001:db8::zzz]");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -515,10 +524,11 @@ mod tests {
     fn invalid_forwarded_bad_port() {
         let tx = make_tx_with_forwarded("for=192.0.2.1:99999");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -532,10 +542,11 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("forwarded", bad);
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -548,10 +559,11 @@ mod tests {
             &[("forwarded", "for=192.0.2.4, proto=https")],
         );
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -560,10 +572,11 @@ mod tests {
     fn invalid_forwarded_obfuscated_token_invalid_char() {
         let tx = make_tx_with_forwarded("for=obf@bad");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -572,10 +585,11 @@ mod tests {
     fn invalid_forwarded_proto_token_char() {
         let tx = make_tx_with_forwarded("proto=ht@tp");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -584,10 +598,11 @@ mod tests {
     fn invalid_forwarded_host_with_large_port() {
         let tx = make_tx_with_forwarded("host=example.com:99999");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -596,10 +611,11 @@ mod tests {
     fn invalid_forwarded_host_missing_bracket() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -608,10 +624,11 @@ mod tests {
     fn invalid_forwarded_for_unterminated_quoted_ipv6() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -620,10 +637,11 @@ mod tests {
     fn forwarded_by_unknown_is_ok() {
         let tx = make_tx_with_forwarded("by=unknown");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -632,10 +650,11 @@ mod tests {
     fn forwarded_for_obfuscated_token_ok() {
         let tx = make_tx_with_forwarded("for=x-foo");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -644,10 +663,11 @@ mod tests {
     fn unknown_param_value_invalid_token_char() {
         let tx = make_tx_with_forwarded("foo=bad@value");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -659,10 +679,11 @@ mod tests {
             &[("forwarded", "for=999.999.999.999")],
         );
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -674,10 +695,11 @@ mod tests {
             &[("forwarded", "foo=bad@value")],
         );
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -686,10 +708,11 @@ mod tests {
     fn valid_forwarded_quoted_ipv6_with_port() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1]:1234\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -698,10 +721,11 @@ mod tests {
     fn invalid_forwarded_quoted_ipv6_empty_inside() {
         let tx = make_tx_with_forwarded("for=\"[]\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -710,10 +734,11 @@ mod tests {
     fn invalid_forwarded_quoted_ipv6_bad_port_syntax() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1]x\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -722,10 +747,11 @@ mod tests {
     fn valid_forwarded_host_with_port_regname() {
         let tx = make_tx_with_forwarded("host=example.com:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -734,10 +760,11 @@ mod tests {
     fn invalid_forwarded_host_invalid_char() {
         let tx = make_tx_with_forwarded("host=exa mple");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -746,10 +773,11 @@ mod tests {
     fn unknown_param_quoted_string_ok() {
         let tx = make_tx_with_forwarded("foo=\"bar baz\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -762,10 +790,11 @@ mod tests {
             ("forwarded", "for=999.999.999.999"),
         ]);
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -774,10 +803,11 @@ mod tests {
     fn unknown_param_token_ok() {
         let tx = make_tx_with_forwarded("foo=bar");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -786,10 +816,11 @@ mod tests {
     fn invalid_forwarded_ipv6_port_non_numeric() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1]:x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -798,10 +829,11 @@ mod tests {
     fn invalid_forwarded_ipv6_port_empty() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1]:");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -810,10 +842,11 @@ mod tests {
     fn invalid_forwarded_host_bracketed_port_non_numeric() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]:notnum");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -822,10 +855,11 @@ mod tests {
     fn valid_forwarded_host_bracketed_with_port() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -834,10 +868,11 @@ mod tests {
     fn valid_forwarded_obfuscated_with_port() {
         let tx = make_tx_with_forwarded("for=x-foo:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -846,10 +881,11 @@ mod tests {
     fn invalid_forwarded_obfuscated_token_with_port_invalid_char() {
         let tx = make_tx_with_forwarded("for=obf@bad:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -858,10 +894,11 @@ mod tests {
     fn quoted_unknown_ok() {
         let tx = make_tx_with_forwarded("for=\"unknown\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -870,10 +907,11 @@ mod tests {
     fn invalid_forwarded_bare_ipv6_no_brackets() {
         let tx = make_tx_with_forwarded("for=2001:db8::1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -882,10 +920,11 @@ mod tests {
     fn invalid_param_name_invalid_token_char() {
         let tx = make_tx_with_forwarded("@=1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -894,10 +933,11 @@ mod tests {
     fn invalid_forwarded_empty_value() {
         let tx = make_tx_with_forwarded("foo=");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -906,10 +946,11 @@ mod tests {
     fn invalid_forwarded_proto_quoted_with_space_is_violation() {
         let tx = make_tx_with_forwarded("proto=\"ht tp\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -918,10 +959,11 @@ mod tests {
     fn unknown_param_quoted_with_escaped_quote_ok() {
         let tx = make_tx_with_forwarded("foo=\"a\\\"b\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -930,10 +972,11 @@ mod tests {
     fn invalid_forwarded_host_with_port_and_space() {
         let tx = make_tx_with_forwarded("host=exa mple:80");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -942,10 +985,11 @@ mod tests {
     fn invalid_forwarded_empty_param_name() {
         let tx = make_tx_with_forwarded("=value");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -959,10 +1003,11 @@ mod tests {
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.append("forwarded", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -972,10 +1017,11 @@ mod tests {
     fn unknown_param_quoted_with_semicolon_ok() {
         let tx = make_tx_with_forwarded("foo=\"a;b\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -984,10 +1030,11 @@ mod tests {
     fn invalid_forwarded_for_missing_closing_bracket() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -996,10 +1043,11 @@ mod tests {
     fn invalid_forwarded_for_non_colon_after_bracket() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1]x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1008,10 +1056,11 @@ mod tests {
     fn invalid_forwarded_host_non_colon_after_bracket() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1020,10 +1069,11 @@ mod tests {
     fn invalid_forwarded_empty_header_value() {
         let tx = make_tx_with_forwarded("");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Empty header value is ignored by header parsing; considered valid
         assert!(v.is_none());
@@ -1033,10 +1083,11 @@ mod tests {
     fn invalid_forwarded_quoted_string_extra_chars() {
         let tx = make_tx_with_forwarded("foo=\"bar\"x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1045,10 +1096,11 @@ mod tests {
     fn invalid_forwarded_empty_quoted_for() {
         let tx = make_tx_with_forwarded("for=\"\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -1059,10 +1111,11 @@ mod tests {
     fn valid_forwarded_quoted_ipv4_with_port() {
         let tx = make_tx_with_forwarded("for=\"192.0.2.1:8080\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1071,10 +1124,11 @@ mod tests {
     fn forwarded_extra_semicolon_ignored() {
         let tx = make_tx_with_forwarded("for=192.0.2.1; ;proto=https");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1083,10 +1137,11 @@ mod tests {
     fn valid_forwarded_host_ipv4_with_port() {
         let tx = make_tx_with_forwarded("host=192.0.2.1:80");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1095,10 +1150,11 @@ mod tests {
     fn valid_forwarded_host_bracketed_no_port() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1107,10 +1163,11 @@ mod tests {
     fn forwarded_host_empty_port_is_accepted() {
         let tx = make_tx_with_forwarded("host=example.com:");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Empty port after ':' is accepted (treated as absent) by the implementation
         assert!(v.is_none());
@@ -1120,10 +1177,11 @@ mod tests {
     fn invalid_forwarded_host_with_at() {
         let tx = make_tx_with_forwarded("host=user@host");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1140,10 +1198,11 @@ mod tests {
                 let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
                 hm.append("forwarded", bad);
                 tx.request.headers = hm;
-                let v = rule.check_transaction(
+                let v = rule.check(
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
-                    &crate::test_helpers::make_test_rule_config(),
+                    &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                    &crate::rules::RuleConfigEngine::new(),
                 );
                 assert!(v.is_some());
             }
@@ -1159,10 +1218,11 @@ mod tests {
     fn invalid_forwarded_host_empty_brackets() {
         let tx = make_tx_with_forwarded("host=[]");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1171,10 +1231,11 @@ mod tests {
     fn invalid_forwarded_ipv4_port_non_numeric() {
         let tx = make_tx_with_forwarded("for=192.0.2.1:xyz");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_from_header_email_syntax.rs
+++ b/src/rules/message_from_header_email_syntax.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageFromHeaderEmailSyntax;
 
 impl Rule for MessageFromHeaderEmailSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_from_header_email_syntax"
@@ -19,12 +19,14 @@ impl Rule for MessageFromHeaderEmailSyntax {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
 
         for hv in req.headers.get_all("from").iter() {
@@ -85,15 +87,16 @@ mod tests {
     fn check_from_header(#[case] from: &str, #[case] expect_violation: bool) {
         let rule = MessageFromHeaderEmailSyntax;
         let tx = make_tx_with_from(from);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_from_header_email_syntax",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", from);
@@ -114,15 +117,16 @@ mod tests {
         );
         tx.request.headers = headers;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_from_header_email_syntax",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));

--- a/src/rules/message_header_field_names_token.rs
+++ b/src/rules/message_header_field_names_token.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageHeaderFieldNamesToken;
 
 impl Rule for MessageHeaderFieldNamesToken {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_header_field_names_token"
@@ -18,16 +18,18 @@ impl Rule for MessageHeaderFieldNamesToken {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // token characters per RFC token (tchar) - use shared helper
         // Check request headers
         for (k, _v) in tx.request.headers.iter() {
-            if let Some(v) = check_header_name(k.as_str(), config) {
+            if let Some(v) = check_header_name(k.as_str(), &config) {
                 return Some(v);
             }
         }
@@ -35,7 +37,7 @@ impl Rule for MessageHeaderFieldNamesToken {
         // Check response headers if present
         if let Some(resp) = &tx.response {
             for (k, _v) in resp.headers.iter() {
-                if let Some(v) = check_header_name(k.as_str(), config) {
+                if let Some(v) = check_header_name(k.as_str(), &config) {
                     return Some(v);
                 }
             }
@@ -95,10 +97,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -132,10 +135,11 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_http2_pseudo_headers_validity.rs
+++ b/src/rules/message_http2_pseudo_headers_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageHttp2PseudoHeadersValidity;
 
 impl Rule for MessageHttp2PseudoHeadersValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_http2_pseudo_headers_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageHttp2PseudoHeadersValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate request-related pseudo-header semantics using canonical transaction fields.
         // Many capture formats do not retain raw HTTP/2 pseudo-header names in the HeaderMap (they are
         // represented as `RequestInfo.method` and `RequestInfo.uri` in the canonical transaction). Validate
@@ -254,10 +256,11 @@ mod tests {
         tx.request.method = method.to_string();
         tx.request.uri = uri.to_string();
         let rule = MessageHttp2PseudoHeadersValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -280,10 +283,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         let rule = MessageHttp2PseudoHeadersValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -316,10 +320,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "1http://example.com/".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid scheme"));
@@ -330,10 +337,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/bad%2G".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));
@@ -344,10 +354,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/foo bar".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("contains whitespace"));
@@ -358,10 +371,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -375,10 +391,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("malformed bracketed IPv6"));
@@ -389,10 +408,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:abc".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("port invalid"));
@@ -403,10 +425,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:70000".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("port out of range"));
@@ -417,10 +442,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("port invalid"));
@@ -431,10 +459,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "user:pass@example.com".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not include userinfo"));
@@ -445,10 +476,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1]:443".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -458,10 +492,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "::1".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must be bracketed"));
@@ -472,10 +509,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "fe80::1:80".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must be bracketed"));
@@ -486,10 +526,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com/path".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -499,10 +542,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/ok%20here".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -512,10 +558,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GE€T".into();
         tx.request.uri = "/".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid token"));
@@ -524,10 +573,13 @@ mod tests {
     #[test]
     fn response_status_low_out_of_range_is_violation() {
         let tx = crate::test_helpers::make_test_transaction_with_response(99, &[]);
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("3-digit"));
@@ -538,10 +590,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "https:///path".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -555,10 +610,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "http://user:pass@example.com/path".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not include userinfo"));
@@ -569,10 +627,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "OPTIONS".into();
         tx.request.uri = "*".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -582,10 +643,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "*".into();
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Asterisk ('*')"));
@@ -594,10 +658,13 @@ mod tests {
     #[test]
     fn response_status_out_of_range_is_violation() {
         let tx = crate::test_helpers::make_test_transaction_with_response(700, &[]);
-        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
+        let v = MessageHttp2PseudoHeadersValidity.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "message_http2_pseudo_headers_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("3-digit"));

--- a/src/rules/message_http3_host_authority_consistency.rs
+++ b/src/rules/message_http3_host_authority_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageHttp3HostAuthorityConsistency;
 
 impl Rule for MessageHttp3HostAuthorityConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_http3_host_authority_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageHttp3HostAuthorityConsistency {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions.
         if tx.request.version != "HTTP/3" {
             return None;
@@ -110,10 +112,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host(uri, Some(host));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -149,10 +152,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host(uri, Some(host));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -171,10 +175,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://example.com/path", None);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -185,10 +190,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("/path", Some("example.com"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -200,10 +206,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://example.com/path", Some(""));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not be empty"));
@@ -214,10 +221,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://example.com/path", Some("  "));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not be empty"));
@@ -232,10 +240,11 @@ mod tests {
             make_h3_transaction_with_uri_and_host("https://example.com/path", Some("other.com"));
         tx.request.version = "HTTP/1.1".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -247,10 +256,11 @@ mod tests {
             make_h3_transaction_with_uri_and_host("https://example.com/path", Some("other.com"));
         tx.request.version = "HTTP/2.0".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -268,10 +278,11 @@ mod tests {
         tx.request.headers = hyper::HeaderMap::new();
         tx.request.headers.insert("host", bad);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF-8"));
@@ -288,10 +299,11 @@ mod tests {
             Some("  example.com  "),
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -303,10 +315,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("example.com:443", Some("example.com:443"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -317,10 +330,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("example.com:443", Some("other.com:443"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("inconsistent"));
@@ -331,10 +345,11 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://[::1]/path", Some("[::1]"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -346,10 +361,11 @@ mod tests {
         let tx =
             make_h3_transaction_with_uri_and_host("https://example.com./path", Some("example.com"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("inconsistent"));
@@ -362,10 +378,11 @@ mod tests {
         let tx =
             make_h3_transaction_with_uri_and_host("https://example.com?q=1", Some("example.com"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -376,10 +393,11 @@ mod tests {
         let tx =
             make_h3_transaction_with_uri_and_host("https://example.com#frag", Some("example.com"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_http3_no_connection_header.rs
+++ b/src/rules/message_http3_no_connection_header.rs
@@ -17,7 +17,7 @@ const FORBIDDEN_HEADERS: &[&str] = &[
 pub struct MessageHttp3NoConnectionHeader;
 
 impl Rule for MessageHttp3NoConnectionHeader {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_http3_no_connection_header"
@@ -27,12 +27,14 @@ impl Rule for MessageHttp3NoConnectionHeader {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions.
         if tx.request.version != "HTTP/3" {
             return None;
@@ -158,10 +160,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[(header_name, header_value)]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(header_name));
@@ -174,10 +177,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept", "text/html")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -197,10 +201,11 @@ mod tests {
         let rule = MessageHttp3NoConnectionHeader;
         let tx = make_h3_transaction_with_response(200, &[(header_name, header_value)]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(header_name));
@@ -211,10 +216,11 @@ mod tests {
         let rule = MessageHttp3NoConnectionHeader;
         let tx = make_h3_transaction_with_response(200, &[("content-type", "text/html")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -227,10 +233,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "trailers")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -241,10 +248,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "gzip")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("TE header"));
@@ -256,10 +264,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "Trailers")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -271,10 +280,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers, gzip")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("TE header"));
@@ -290,10 +300,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("connection", "keep-alive")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -306,10 +317,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("connection", "keep-alive")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -322,10 +334,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("accept", "*/*")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -338,10 +351,11 @@ mod tests {
         let rule = MessageHttp3NoConnectionHeader;
         let tx = make_h3_transaction_with_response(200, &[("te", "trailers")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("request-only"));
@@ -364,10 +378,11 @@ mod tests {
         tx.request.version = "HTTP/3".into();
         // Response version stays HTTP/1.1 (upstream)
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -382,10 +397,11 @@ mod tests {
             .expect("should construct non-utf8 header");
         tx.request.headers.insert("te", bad);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF-8"));
@@ -399,10 +415,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Empty TE is not a violation (parse_list_header filters empty tokens)
         assert!(v.is_none());
@@ -417,10 +434,11 @@ mod tests {
             ("te", "gzip"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         // Forbidden header check runs first

--- a/src/rules/message_http3_pseudo_headers_validity.rs
+++ b/src/rules/message_http3_pseudo_headers_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageHttp3PseudoHeadersValidity;
 
 impl Rule for MessageHttp3PseudoHeadersValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_http3_pseudo_headers_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions.
         if tx.request.version != "HTTP/3" {
             return None;
@@ -173,10 +175,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = "".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":method"));
@@ -188,10 +191,11 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = "   ".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":method"));
@@ -206,10 +210,11 @@ mod tests {
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com/path".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -223,10 +228,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -240,10 +246,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":path"));
@@ -258,10 +265,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -276,10 +284,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Asterisk"));
@@ -299,10 +308,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Asterisk"));
@@ -318,10 +328,11 @@ mod tests {
         tx.request.uri = "/resource".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -335,10 +346,11 @@ mod tests {
         tx.request.uri = "https://example.com/path".into();
         tx.request.headers = hyper::HeaderMap::new(); // no Host needed
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -351,10 +363,11 @@ mod tests {
         tx.request.uri = "*".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -369,10 +382,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -384,10 +398,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -400,10 +415,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "   ".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -419,10 +435,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -436,10 +453,11 @@ mod tests {
         tx.request.uri = "/ws".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("extended CONNECT"));
@@ -454,10 +472,11 @@ mod tests {
         tx.request.uri = "*".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -473,10 +492,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com:443")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -490,10 +510,11 @@ mod tests {
         tx.request.uri = "example.com:443".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -505,10 +526,11 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(200, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -518,10 +540,11 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(0, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -532,10 +555,11 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(600, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -552,10 +576,11 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(status, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -573,10 +598,11 @@ mod tests {
         tx.request.version = version.into();
         tx.request.method = "".into(); // would be a violation for HTTP/3
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -591,10 +617,11 @@ mod tests {
         tx.request.version = "HTTP/3".into();
         // Response version stays HTTP/1.1 — status 0 should not be flagged.
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -609,10 +636,11 @@ mod tests {
         tx.request.uri = "https://example.com/".into();
         tx.response = None;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -643,10 +671,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1]:443".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -661,10 +690,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "https://example.com/ws".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -680,10 +710,11 @@ mod tests {
             ("content-type", "application/json"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -695,10 +726,11 @@ mod tests {
         tx.request.method = "HEAD".into();
         tx.request.uri = "https://example.com/resource".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -708,10 +740,11 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(99, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -727,10 +760,11 @@ mod tests {
         tx.request.uri = "/resource".into();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("host", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -742,10 +776,11 @@ mod tests {
         tx.request.method = "DELETE".into();
         tx.request.uri = "https://example.com/resource/42".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -761,10 +796,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":path"));
@@ -779,10 +815,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -795,10 +832,11 @@ mod tests {
         tx.request.method = "connect".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -810,10 +848,11 @@ mod tests {
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com:8443/path".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -824,10 +863,11 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(100, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -846,10 +886,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -862,10 +903,11 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -880,10 +922,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":path"));
@@ -900,10 +943,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -919,10 +963,11 @@ mod tests {
             ("content-type", "application/json"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -935,10 +980,11 @@ mod tests {
         tx.request.uri = "/resource/1".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));

--- a/src/rules/message_http_version_syntax_valid.rs
+++ b/src/rules/message_http_version_syntax_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageHttpVersionSyntaxValid;
 
 impl Rule for MessageHttpVersionSyntaxValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_http_version_syntax_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageHttpVersionSyntaxValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request version token (now required)
         if let Some(msg) = check_version_token(&tx.request.version) {
             return Some(Violation {
@@ -84,7 +86,6 @@ fn check_version_token(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::make_test_rule_config;
 
     #[test]
     fn valid_versions_pass() {
@@ -99,10 +100,11 @@ mod tests {
         });
 
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -112,10 +114,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "http/1.1".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Request HTTP-version invalid"));
@@ -126,19 +129,21 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/11.0".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.version = "HTTP/1.10".into();
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
     }
@@ -155,10 +160,11 @@ mod tests {
             trailers: None,
         });
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -168,10 +174,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -181,10 +188,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1.x".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -194,10 +202,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1.1.1".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -215,10 +224,11 @@ mod tests {
             trailers: None,
         });
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Response HTTP-version invalid"));
@@ -229,10 +239,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1.".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -242,10 +253,11 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction();
         let rule = MessageHttpVersionSyntaxValid;
         // make_test_transaction defaults version to "HTTP/1.1"
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -262,10 +274,11 @@ mod tests {
             trailers: None,
         });
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_if_match_etag_syntax.rs
+++ b/src/rules/message_if_match_etag_syntax.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct MessageIfMatchEtagSyntax;
 
 impl Rule for MessageIfMatchEtagSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_if_match_etag_syntax"
@@ -20,12 +20,14 @@ impl Rule for MessageIfMatchEtagSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         for hv in tx.request.headers.get_all("if-match").iter() {
             let s = match hv.to_str() {
@@ -88,15 +90,16 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", hv)]);
         }
 
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_if_match_etag_syntax",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -122,10 +125,11 @@ mod tests {
         hm.insert("if-match", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -145,10 +149,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -161,10 +166,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", ",")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -181,10 +187,11 @@ mod tests {
         hm.append("if-match", HeaderValue::from_static("\"b\""));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -202,10 +209,11 @@ mod tests {
         hm.append("if-match", HeaderValue::from_static("b"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_if_modified_since_date_format.rs
+++ b/src/rules/message_if_modified_since_date_format.rs
@@ -9,7 +9,7 @@ use crate::rules::Rule;
 pub struct MessageIfModifiedSinceDateFormat;
 
 impl Rule for MessageIfModifiedSinceDateFormat {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_if_modified_since_date_format"
@@ -19,12 +19,14 @@ impl Rule for MessageIfModifiedSinceDateFormat {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         for hv in tx.request.headers.get_all("if-modified-since").iter() {
             let s = match hv.to_str() {
@@ -81,10 +83,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", h)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -106,10 +109,11 @@ mod tests {
         hm.insert("if-modified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -122,10 +126,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -147,10 +152,11 @@ mod tests {
         hm.append("if-modified-since", HeaderValue::from_static("not-a-date"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -174,10 +180,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Using multiple valid headers is acceptable (validate each); no violation expected if all valid
         assert!(v.is_none());

--- a/src/rules/message_if_none_match_etag_syntax.rs
+++ b/src/rules/message_if_none_match_etag_syntax.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct MessageIfNoneMatchEtagSyntax;
 
 impl Rule for MessageIfNoneMatchEtagSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_if_none_match_etag_syntax"
@@ -20,12 +20,14 @@ impl Rule for MessageIfNoneMatchEtagSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         for hv in tx.request.headers.get_all("if-none-match").iter() {
             let s = match hv.to_str() {
@@ -89,15 +91,16 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-none-match", hv)]);
         }
 
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_if_none_match_etag_syntax",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -123,10 +126,11 @@ mod tests {
         hm.insert("if-none-match", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -146,10 +150,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -163,10 +168,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", ",")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -183,10 +189,11 @@ mod tests {
         hm.append("if-none-match", HeaderValue::from_static("\"b\""));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -204,10 +211,11 @@ mod tests {
         hm.append("if-none-match", HeaderValue::from_static("b"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_if_unmodified_since_date_format.rs
+++ b/src/rules/message_if_unmodified_since_date_format.rs
@@ -9,7 +9,7 @@ use crate::rules::Rule;
 pub struct MessageIfUnmodifiedSinceDateFormat;
 
 impl Rule for MessageIfUnmodifiedSinceDateFormat {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_if_unmodified_since_date_format"
@@ -19,12 +19,14 @@ impl Rule for MessageIfUnmodifiedSinceDateFormat {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to requests only
         for hv in tx.request.headers.get_all("if-unmodified-since").iter() {
             let s = match hv.to_str() {
@@ -82,10 +84,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-unmodified-since", h)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -107,10 +110,11 @@ mod tests {
         hm.insert("if-unmodified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -123,10 +127,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-unmodified-since", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -151,10 +156,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -178,10 +184,11 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Using multiple valid headers is acceptable (validate each); no violation expected if all valid
         assert!(v.is_none());

--- a/src/rules/message_language_tag_format_valid.rs
+++ b/src/rules/message_language_tag_format_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageLanguageTagFormatValid;
 
 impl Rule for MessageLanguageTagFormatValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_language_tag_format_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageLanguageTagFormatValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate language-tag tokens according to helpers::language
         let check_tag = |hdr: &str, tag: &str| -> Option<Violation> {
             if let Err(e) = crate::helpers::language::validate_language_tag(tag) {
@@ -113,7 +115,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageLanguageTagFormatValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_language_tag_format_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = cl {
@@ -121,10 +125,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -142,7 +147,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageLanguageTagFormatValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_language_tag_format_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(v) = cl {
@@ -150,10 +157,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -187,7 +195,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageLanguageTagFormatValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_language_tag_format_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(v) = al {
@@ -195,10 +205,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -211,16 +222,19 @@ mod tests {
     #[test]
     fn check_content_language_in_request() -> anyhow::Result<()> {
         let rule = MessageLanguageTagFormatValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_language_tag_format_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-language", "en, fr")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_link_header_validity.rs
+++ b/src/rules/message_link_header_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageLinkHeaderValidity;
 
 impl Rule for MessageLinkHeaderValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_link_header_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageLinkHeaderValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers (Link is meaningful on responses / 103 Early Hints)
         let resp = match &tx.response {
             Some(r) => r,
@@ -236,7 +238,9 @@ mod tests {
     #[case(Some(("Link", "<https://example.com/>; bad@=1")), true)]
     fn check_link_cases(#[case] header: Option<(&str, &str)>, #[case] expect_violation: bool) {
         let rule = MessageLinkHeaderValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_link_header_validity",
+        ]);
 
         let tx = if let Some(h) = header {
             make_resp_with_header(200, h)
@@ -244,10 +248,11 @@ mod tests {
             crate::test_helpers::make_test_transaction()
         };
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -264,23 +269,27 @@ mod tests {
     #[test]
     fn early_hints_requires_preload_and_as() {
         let rule = MessageLinkHeaderValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_link_header_validity",
+        ]);
 
         // 103 with preload but missing as
         let tx = make_resp_with_header(103, ("Link", "<https://example.com/>; rel=preload"));
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
         // 103 with no rel -> violation
         let tx2 = make_resp_with_header(103, ("Link", "<https://example.com/>; title=\"x\""));
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
     }
@@ -288,7 +297,9 @@ mod tests {
     #[test]
     fn additional_edge_cases_report_meaningful_messages() {
         let rule = MessageLinkHeaderValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_link_header_validity",
+        ]);
 
         // Non-UTF8 header
         use hyper::header::HeaderValue;
@@ -297,70 +308,77 @@ mod tests {
         hm.append("link", bad);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
 
         // Trailing comma -> empty member
         let tx2 = make_resp_with_header(200, ("Link", "<https://example/>; rel=next,"));
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2.unwrap().message.contains("empty member"));
 
         // Missing closing '>'
         let tx3 = make_resp_with_header(200, ("Link", "<https://example.com/; rel=next"));
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         assert!(v3.unwrap().message.contains("missing closing"));
 
         // Missing value for param
         let tx4 = make_resp_with_header(200, ("Link", "<https://example/>; rel"));
-        let v4 = rule.check_transaction(
+        let v4 = rule.check(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
         assert!(v4.unwrap().message.contains("missing '=' or value"));
 
         // Invalid quoted-string
         let tx5 = make_resp_with_header(200, ("Link", "<https://example/>; title=\"unterminated"));
-        let v5 = rule.check_transaction(
+        let v5 = rule.check(
             &tx5,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v5.is_some());
         assert!(v5.unwrap().message.contains("quoted-string"));
 
         // Invalid token char in param value
         let tx6 = make_resp_with_header(200, ("Link", "<https://example/>; as=bad@val"));
-        let v6 = rule.check_transaction(
+        let v6 = rule.check(
             &tx6,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v6.is_some());
         assert!(v6.unwrap().message.contains("invalid character"));
 
         // rel contains invalid char
         let tx7 = make_resp_with_header(200, ("Link", "<https://example/>; rel=bad@rel"));
-        let v7 = rule.check_transaction(
+        let v7 = rule.check(
             &tx7,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v7.is_some());
         let msg7 = v7.unwrap().message;
@@ -387,23 +405,27 @@ mod tests {
     #[test]
     fn additional_positive_and_multi_header_cases() {
         let rule = MessageLinkHeaderValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_link_header_validity",
+        ]);
 
         // rel with multiple types (space-separated) should be OK
         let tx = make_resp_with_header(200, ("Link", "<https://example/>; rel=next prev"));
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
         // quoted-string title with escaped quote is accepted
         let tx2 = make_resp_with_header(200, ("Link", "<https://example/>; title=\"a\\\"b\""));
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
 
@@ -412,19 +434,21 @@ mod tests {
             200,
             ("Link", "<https://example/>; rel=preload; as=\"script\""),
         );
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_none());
 
         // trailing semicolon ignored
         let tx4 = make_resp_with_header(200, ("Link", "<https://example/>; rel=next;"));
-        let v4 = rule.check_transaction(
+        let v4 = rule.check(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_none());
 
@@ -440,10 +464,11 @@ mod tests {
                 .parse::<HeaderValue>()
                 .unwrap(),
         );
-        let vm = rule.check_transaction(
+        let vm = rule.check(
             &txm,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(vm.is_some());
     }

--- a/src/rules/message_max_forwards_numeric.rs
+++ b/src/rules/message_max_forwards_numeric.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageMaxForwardsNumeric;
 
 impl Rule for MessageMaxForwardsNumeric {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_max_forwards_numeric"
@@ -19,12 +19,14 @@ impl Rule for MessageMaxForwardsNumeric {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         for val in tx.request.headers.get_all("max-forwards").iter() {
             let s = match val.to_str() {
@@ -77,10 +79,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(hdrs);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -111,10 +114,11 @@ mod tests {
         hm.insert("max-forwards", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_media_type_suffix_validity.rs
+++ b/src/rules/message_media_type_suffix_validity.rs
@@ -59,7 +59,7 @@ fn parse_allowed_config(
 }
 
 impl Rule for MessageMediaTypeSuffixValidity {
-    type Config = MessageMediaTypeSuffixConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_media_type_suffix_validity"
@@ -77,12 +77,14 @@ impl Rule for MessageMediaTypeSuffixValidity {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         let check_media = |hdr_name: &str, val: &str| -> Option<Violation> {
             let parsed = match crate::helpers::headers::parse_media_type(val) {
                 Ok(p) => p,
@@ -158,20 +160,30 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn make_cfg() -> MessageMediaTypeSuffixConfig {
-        MessageMediaTypeSuffixConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "json".to_string(),
-                "xml".to_string(),
-                "ber".to_string(),
-                "der".to_string(),
-                "fastinfoset".to_string(),
-                "wbxml".to_string(),
-                "exi".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_media_type_suffix_validity".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![
+                        toml::Value::String("json".into()),
+                        toml::Value::String("xml".into()),
+                        toml::Value::String("ber".into()),
+                        toml::Value::String("der".into()),
+                        toml::Value::String("fastinfoset".into()),
+                        toml::Value::String("wbxml".into()),
+                        toml::Value::String("exi".into()),
+                    ]),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -181,10 +193,11 @@ mod tests {
             &[("content-type", "application/ld+json")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -196,10 +209,11 @@ mod tests {
             &[("content-type", "application/vnd.example+unknown")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("+unknown"));
@@ -213,10 +227,11 @@ mod tests {
             "application/vnd.foo+xml; q=0.8, application/bar+nope",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("+nope"));
@@ -229,10 +244,11 @@ mod tests {
             &[("content-type", "application/foo+")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty structured suffix"));
@@ -245,10 +261,11 @@ mod tests {
             &[("content-type", "application/ld+JSON")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -260,10 +277,11 @@ mod tests {
             &[("content-type", "text")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -276,10 +294,11 @@ mod tests {
             "application/vnd.foo+unknown",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("+unknown"));
@@ -293,10 +312,11 @@ mod tests {
             "application/example+JSON",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -309,10 +329,11 @@ mod tests {
             "application/vnd.foo+JSON; q=0.8, text/html",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_multipart_boundary_syntax.rs
+++ b/src/rules/message_multipart_boundary_syntax.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageMultipartBoundarySyntax;
 
 impl Rule for MessageMultipartBoundarySyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_multipart_boundary_syntax"
@@ -18,16 +18,18 @@ impl Rule for MessageMultipartBoundarySyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request Content-Type
         if let Some(hv) = tx.request.headers.get("content-type") {
             if let Ok(s) = hv.to_str() {
-                if let Some(v) = check_multipart_boundary("request", s, config) {
+                if let Some(v) = check_multipart_boundary("request", s, &config) {
                     return Some(v);
                 }
             }
@@ -37,7 +39,7 @@ impl Rule for MessageMultipartBoundarySyntax {
         if let Some(resp) = &tx.response {
             if let Some(hv) = resp.headers.get("content-type") {
                 if let Ok(s) = hv.to_str() {
-                    if let Some(v) = check_multipart_boundary("response", s, config) {
+                    if let Some(v) = check_multipart_boundary("response", s, &config) {
                         return Some(v);
                     }
                 }
@@ -242,7 +244,9 @@ mod tests {
     #[case(Some("multipart/mixed; boundary=\"abc \""), true)]
     #[case(None, false)]
     fn multipart_boundary_cases(#[case] header: Option<&str>, #[case] expect_violation: bool) {
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_multipart_boundary_syntax",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(h) = header {
@@ -250,10 +254,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", h)]);
         }
 
-        let v = MessageMultipartBoundarySyntax.check_transaction(
+        let v = MessageMultipartBoundarySyntax.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}", header);
@@ -267,16 +272,19 @@ mod tests {
         }
 
         // Also test response
-        let cfg2 = crate::test_helpers::make_test_rule_config();
+        let cfg2 = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_multipart_boundary_syntax",
+        ]);
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(h) = header {
             tx2.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", h)]);
         }
-        let v2 = MessageMultipartBoundarySyntax.check_transaction(
+        let v2 = MessageMultipartBoundarySyntax.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg2,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v2.is_some(), "expected violation for response {:?}", header);
@@ -293,31 +301,37 @@ mod tests {
     #[test]
     fn parse_media_type_error_no_violation() {
         // malformed Content-Type that fails parse_media_type should not cause this rule to run
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_multipart_boundary_syntax",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "not-a-media-type")]);
-        let v = MessageMultipartBoundarySyntax.check_transaction(
+        let v = MessageMultipartBoundarySyntax.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
 
     #[test]
     fn quoted_string_unterminated_reports_violation() {
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_multipart_boundary_syntax",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         // boundary quoted-string not terminated
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-type",
             "multipart/mixed; boundary=\"unfinished",
         )]);
-        let v = MessageMultipartBoundarySyntax.check_transaction(
+        let v = MessageMultipartBoundarySyntax.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -326,33 +340,39 @@ mod tests {
 
     #[test]
     fn non_multipart_ignored() {
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_multipart_boundary_syntax",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-type",
             "text/plain; boundary=abc",
         )]);
-        let v = MessageMultipartBoundarySyntax.check_transaction(
+        let v = MessageMultipartBoundarySyntax.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
 
     #[test]
     fn quoted_string_invalid_char_reports_violation() {
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_multipart_boundary_syntax",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction();
         // $ is not permitted in bchars set
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-type",
             "multipart/mixed; boundary=\"bad$\"",
         )]);
-        let v = MessageMultipartBoundarySyntax.check_transaction(
+        let v = MessageMultipartBoundarySyntax.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_multipart_content_type_and_body_consistency.rs
+++ b/src/rules/message_multipart_content_type_and_body_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageMultipartContentTypeAndBodyConsistency;
 
 impl Rule for MessageMultipartContentTypeAndBodyConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_multipart_content_type_and_body_consistency"
@@ -18,19 +18,21 @@ impl Rule for MessageMultipartContentTypeAndBodyConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request body when Content-Type is multipart
         if let Some(hv) = tx.request.headers.get("content-type") {
             if let Ok(s) = hv.to_str() {
                 if let Some(boundary) = crate::helpers::headers::extract_multipart_boundary(s) {
                     if let Some(b) = &tx.request_body {
                         if let Some(v) =
-                            check_body_contains_boundary("request", &boundary, b.as_ref(), config)
+                            check_body_contains_boundary("request", &boundary, b.as_ref(), &config)
                         {
                             return Some(v);
                         }
@@ -49,7 +51,7 @@ impl Rule for MessageMultipartContentTypeAndBodyConsistency {
                                 "response",
                                 &boundary,
                                 b.as_ref(),
-                                config,
+                                &config,
                             ) {
                                 return Some(v);
                             }
@@ -121,10 +123,11 @@ mod tests {
             b"--abc\r\nContent-Type: text/plain\r\n\r\nhi\r\n--abc--\r\n",
         ));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -137,10 +140,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("--abc"));
@@ -154,10 +158,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--abc\r\nPart\r\n--abc\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing terminating boundary"));
@@ -171,10 +176,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -186,10 +192,11 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=abc")],
         );
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -203,10 +210,11 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"--xyz\r\nfoo\r\n--xyz--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -219,10 +227,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--a b\r\nx\r\n--a b--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -235,10 +244,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -252,10 +262,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -265,10 +276,11 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=\"unterminated")],
         );
         tx2.response_body = Some(Bytes::from_static(b"no boundaries"));
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -282,10 +294,11 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -302,10 +315,11 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"--xyz\r\nPart\r\n--xyz\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("terminating boundary"));
@@ -320,10 +334,11 @@ mod tests {
         // body contains only the final boundary marker
         tx.response_body = Some(Bytes::from_static(b"--abc--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -337,10 +352,11 @@ mod tests {
         // unescaped boundary is: a"b
         tx.response_body = Some(Bytes::from_static(b"--a\"b\r\nx\r\n--a\"b--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -358,10 +374,11 @@ mod tests {
             b"--gc0pJq0M:08jU534c0p\r\npart\r\n--gc0pJq0M:08jU534c0p--\r\n",
         ));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -374,10 +391,11 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"\x00\x01--bin\x02--bin--\x03"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_origin_isolated_header_validity.rs
+++ b/src/rules/message_origin_isolated_header_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageOriginIsolatedHeaderValidity;
 
 impl Rule for MessageOriginIsolatedHeaderValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_origin_isolated_header_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageOriginIsolatedHeaderValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = if let Some(r) = &tx.response {
             r
         } else {
@@ -99,11 +101,14 @@ mod tests {
             );
         }
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_origin_isolated_header_validity",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -132,10 +137,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Origin-Isolation"));
@@ -156,10 +162,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -180,10 +187,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         let msg = v.unwrap().message;
         assert!(msg.contains("non-ASCII") || msg.contains("control"));
@@ -197,10 +205,11 @@ mod tests {
             200,
             &[("origin-isolation", "?0")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("?0"));
@@ -213,10 +222,11 @@ mod tests {
             200,
             &[("origin-isolation", "?1, ?1")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("single value"));
@@ -226,10 +236,11 @@ mod tests {
     fn no_response_returns_none() {
         let rule = MessageOriginIsolatedHeaderValidity;
         let tx = crate::test_helpers::make_test_transaction(); // no response set
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_permissions_policy_directives_valid.rs
+++ b/src/rules/message_permissions_policy_directives_valid.rs
@@ -9,7 +9,7 @@ use crate::rules::Rule;
 pub struct MessagePermissionsPolicyDirectivesValid;
 
 impl Rule for MessagePermissionsPolicyDirectivesValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_permissions_policy_directives_valid"
@@ -19,12 +19,14 @@ impl Rule for MessagePermissionsPolicyDirectivesValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only inspect responses (server header)
         let resp = match &tx.response {
             Some(r) => r,
@@ -252,7 +254,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(v) = hdr {
@@ -260,10 +264,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}: got none", hdr);
@@ -281,7 +286,9 @@ mod tests {
     #[test]
     fn non_utf8_is_violation() -> anyhow::Result<()> {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -291,10 +298,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -326,7 +334,9 @@ mod tests {
     #[test]
     fn empty_directive_is_reported() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -334,10 +344,11 @@ mod tests {
             ",geolocation=(self)",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty directive"));
@@ -346,16 +357,19 @@ mod tests {
     #[test]
     fn empty_value_is_reported() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "geolocation=")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("has empty value"));
@@ -364,7 +378,9 @@ mod tests {
     #[test]
     fn numeric_values_are_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -372,10 +388,11 @@ mod tests {
             "geolocation=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("numeric value"));
@@ -384,7 +401,9 @@ mod tests {
     #[test]
     fn unterminated_inner_list_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -392,10 +411,11 @@ mod tests {
             "geolocation=(self",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("unterminated inner-list"));
@@ -404,7 +424,9 @@ mod tests {
     #[test]
     fn empty_inner_list_member_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -412,10 +434,11 @@ mod tests {
             "geolocation=(self  )",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty inner-list"));
@@ -424,7 +447,9 @@ mod tests {
     #[test]
     fn invalid_quoted_string_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -432,10 +457,11 @@ mod tests {
             "geolocation=\"abc",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid quoted-string"));
@@ -444,7 +470,9 @@ mod tests {
     #[test]
     fn invalid_token_like_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -452,10 +480,11 @@ mod tests {
             "geolocation=1abc",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid token value"));
@@ -464,7 +493,9 @@ mod tests {
     #[test]
     fn empty_parameter_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -472,10 +503,11 @@ mod tests {
             "geolocation=(self);",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty parameter"));
@@ -484,7 +516,9 @@ mod tests {
     #[test]
     fn invalid_bare_parameter_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -492,10 +526,11 @@ mod tests {
             "geolocation=(self);123",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid bare parameter"));
@@ -504,7 +539,9 @@ mod tests {
     #[test]
     fn invalid_parameter_value_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -512,10 +549,11 @@ mod tests {
             "geolocation=(self);foo=!",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid parameter 'foo'"));
@@ -524,7 +562,9 @@ mod tests {
     #[test]
     fn report_to_quoted_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -532,10 +572,11 @@ mod tests {
             "geolocation=(self);report-to=\"endpoint\"",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -544,7 +585,9 @@ mod tests {
     fn feature_part_params_ignored() {
         // a semicolon before the '=' with its own '=' makes the member malformed and should be rejected
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -552,10 +595,11 @@ mod tests {
             "geolocation;meta=1=(self)",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -563,7 +607,9 @@ mod tests {
     #[test]
     fn decimal_number_value_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -571,10 +617,11 @@ mod tests {
             "geolocation=1.2",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("numeric value"));
@@ -583,7 +630,9 @@ mod tests {
     #[test]
     fn byte_sequence_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -591,10 +640,11 @@ mod tests {
             "geolocation=:YWJj:",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("byte-sequence"));
@@ -603,7 +653,9 @@ mod tests {
     #[test]
     fn param_with_number_value_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -611,10 +663,11 @@ mod tests {
             "geolocation=(self);foo=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -622,7 +675,9 @@ mod tests {
     #[test]
     fn bare_param_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -630,10 +685,11 @@ mod tests {
             "geolocation=(self);foo",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -641,7 +697,9 @@ mod tests {
     #[test]
     fn param_with_quoted_value_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -649,10 +707,11 @@ mod tests {
             "geolocation=(self);foo=\"bar\"",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -660,7 +719,9 @@ mod tests {
     #[test]
     fn token_with_special_chars_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -668,10 +729,11 @@ mod tests {
             "geolocation=feat:sub/1.2-_",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -679,7 +741,9 @@ mod tests {
     #[test]
     fn star_param_name_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -687,10 +751,11 @@ mod tests {
             "geolocation=(self);*=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -698,7 +763,9 @@ mod tests {
     #[test]
     fn invalid_param_name_uppercase_is_rejected() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -706,10 +773,11 @@ mod tests {
             "geolocation=(self);Foo=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid parameter 'Foo'"));
@@ -719,16 +787,19 @@ mod tests {
     fn feature_starting_with_digit_is_accepted() {
         // feature identifiers may start with a digit per our conservative validation
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "1geo=(self)")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -736,16 +807,19 @@ mod tests {
     #[test]
     fn empty_header_value_is_violation() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -757,7 +831,9 @@ mod tests {
     #[test]
     fn param_name_with_dot_underscore_star_is_ok() {
         let rule = MessagePermissionsPolicyDirectivesValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_permissions_policy_directives_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -765,10 +841,11 @@ mod tests {
             "geolocation=(self);a.b_c*=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_pragma_token_valid.rs
+++ b/src/rules/message_pragma_token_valid.rs
@@ -11,7 +11,7 @@ use crate::rules::Rule;
 pub struct MessagePragmaTokenValid;
 
 impl Rule for MessagePragmaTokenValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_pragma_token_valid"
@@ -21,12 +21,14 @@ impl Rule for MessagePragmaTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate request headers
         for header_val in tx.request.headers.get_all("pragma").iter() {
             if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
@@ -162,10 +164,11 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessagePragmaTokenValid;
         let tx = make_req(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -192,10 +195,11 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessagePragmaTokenValid;
         let tx = make_resp(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -219,10 +223,11 @@ mod tests {
     fn trailing_comma_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("no-cache,");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -231,10 +236,11 @@ mod tests {
     fn directive_name_invalid_char_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("n@me=1");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -243,10 +249,11 @@ mod tests {
     fn token_value_invalid_char_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=ba@d");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -255,10 +262,11 @@ mod tests {
     fn quoted_value_unterminated_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=\"unterminated");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -267,10 +275,11 @@ mod tests {
     fn empty_directive_value_is_accepted() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -279,10 +288,11 @@ mod tests {
     fn list_with_invalid_middle_member_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("no-cache, bad@name=1, max-age=0");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -296,10 +306,11 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("pragma", bad);
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -309,10 +320,11 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -332,10 +344,11 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -345,10 +358,11 @@ mod tests {
     fn empty_directive_value_in_response_is_accepted() {
         let rule = MessagePragmaTokenValid;
         let tx = make_resp("foo=");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -360,10 +374,11 @@ mod tests {
             ("pragma", "no-cache"),
             ("pragma", "foo=bar"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_prefer_header_valid.rs
+++ b/src/rules/message_prefer_header_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessagePreferHeaderValid;
 
 impl Rule for MessagePreferHeaderValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_prefer_header_valid"
@@ -18,12 +18,14 @@ impl Rule for MessagePreferHeaderValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to requests only
         let req = &tx.request;
 
@@ -212,10 +214,11 @@ mod tests {
     fn check_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessagePreferHeaderValid;
         let tx = make_req(value);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -239,10 +242,11 @@ mod tests {
             ("prefer", "respond-async, wait=100"),
             ("prefer", "handling=lenient"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -259,10 +263,11 @@ mod tests {
         hm.insert("prefer", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -273,10 +278,11 @@ mod tests {
         // A member that starts with a semicolon or is empty should trigger an empty preference token violation
         let rule = MessagePreferHeaderValid;
         let tx = make_req(";foo");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -288,20 +294,22 @@ mod tests {
     fn invalid_token_char_messages_include_char() -> anyhow::Result<()> {
         let rule = MessagePreferHeaderValid;
         let tx = make_req("f@o=1");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
         assert!(msg.contains("'@'"));
 
         let tx2 = make_req("return=minimal; foo=bad@");
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         let msg2 = v2.unwrap().message;

--- a/src/rules/message_preference_applied_header_valid.rs
+++ b/src/rules/message_preference_applied_header_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessagePreferenceAppliedHeaderValid;
 
 impl Rule for MessagePreferenceAppliedHeaderValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_preference_applied_header_valid"
@@ -18,12 +18,14 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only meaningful when a response is present
         let resp = match &tx.response {
             Some(r) => r,
@@ -222,10 +224,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[(parts2[0].trim(), parts2[1].trim())]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -255,10 +258,11 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff]).expect("should construct non-utf8 header");
         hm.insert("preference-applied", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -269,10 +273,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -285,10 +290,11 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo=\"bar\"")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=\"bar\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -301,10 +307,11 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "f@o")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("'@'"));
@@ -317,10 +324,11 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=bad@")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -335,10 +343,11 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo=\"bar\"")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=\"bar")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("quoted-string error"));
@@ -352,10 +361,11 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=bar")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_priority_header_syntax.rs
+++ b/src/rules/message_priority_header_syntax.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessagePriorityHeaderSyntax;
 
 impl Rule for MessagePriorityHeaderSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_priority_header_syntax"
@@ -18,12 +18,14 @@ impl Rule for MessagePriorityHeaderSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request
         if let Some(hv) = tx.request.headers.get_all("priority").iter().next() {
             if hv.to_str().is_err() {
@@ -243,11 +245,14 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessagePriorityHeaderSyntax;
         let tx = make_tx_with_req(value);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", value);
@@ -273,11 +278,14 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessagePriorityHeaderSyntax;
         let tx = make_tx_with_resp(value);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -291,11 +299,14 @@ mod tests {
     fn violation_message_is_meaningful() {
         let rule = MessagePriorityHeaderSyntax;
         let tx = make_tx_with_req("u=8");
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -305,54 +316,61 @@ mod tests {
     #[test]
     fn params_and_edge_cases() {
         let rule = MessagePriorityHeaderSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
 
         // valid parameter on urgency
         let tx1 = make_tx_with_req("u=3;foo=bar");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // empty parameter name is ignored (tolerant) per structured-field-like handling
         let tx2 = make_tx_with_req("u=3;;i");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // empty member between commas
         let tx3 = make_tx_with_req("u=1, ,i");
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         assert!(v3.unwrap().message.contains("empty member"));
 
         // param key uppercase -> violation
         let tx4 = make_tx_with_req("u=1;X=1");
-        let v4 = rule.check_transaction(
+        let v4 = rule.check(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
         assert!(v4.unwrap().message.contains("invalid parameter key"));
 
         // param with empty value
         let tx5 = make_tx_with_req("u=1;foo=");
-        let v5 = rule.check_transaction(
+        let v5 = rule.check(
             &tx5,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v5.is_some());
         if let Some(v) = v5 {
@@ -367,30 +385,33 @@ mod tests {
         // unknown key with token-like value is accepted
         let tx6 = make_tx_with_req("x=token/value");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx6,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // i=?0 accepted
         let tx7 = make_tx_with_req("i=?0");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx7,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // explicit boolean on unknown key accepted
         let tx8 = make_tx_with_req("y=?1");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx8,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -398,34 +419,39 @@ mod tests {
     #[test]
     fn more_edge_cases_to_increase_coverage() {
         let rule = MessagePriorityHeaderSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
 
         // unknown key with invalid boolean -> violation
         let tx2 = make_tx_with_req("x=?2");
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2.unwrap().message.contains("invalid boolean value"));
 
         // invalid member key (starts with digit)
         let tx3 = make_tx_with_req("1=3");
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         assert!(v3.unwrap().message.contains("invalid member key"));
 
         // invalid numeric with leading plus -> violation, reported as "invalid value"
         let tx4 = make_tx_with_req("x=+1");
-        let v4 = rule.check_transaction(
+        let v4 = rule.check(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
         let msg = v4.unwrap().message;
@@ -434,10 +460,11 @@ mod tests {
         // star key accepted
         let tx5 = make_tx_with_req("*=5");
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx5,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -451,11 +478,14 @@ mod tests {
         hm.append("priority", bad);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -492,11 +522,14 @@ mod tests {
             .unwrap()
             .headers
             .append("priority", bad);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_priority_header_syntax",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));

--- a/src/rules/message_problem_details_structure.rs
+++ b/src/rules/message_problem_details_structure.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageProblemDetailsStructure;
 
 impl Rule for MessageProblemDetailsStructure {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_problem_details_structure"
@@ -18,12 +18,14 @@ impl Rule for MessageProblemDetailsStructure {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -149,10 +151,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for hdr={:?}", hdr);
@@ -182,10 +185,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Problem Details response"));
@@ -206,10 +210,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -229,10 +234,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -253,10 +259,11 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b""));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -277,10 +284,11 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b"{}"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -301,10 +309,11 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b"{\"type\":\"x\"}"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -325,10 +334,11 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b"not json"));
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_range_and_content_range_consistency.rs
+++ b/src/rules/message_range_and_content_range_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageRangeAndContentRangeConsistency;
 
 impl Rule for MessageRangeAndContentRangeConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_range_and_content_range_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageRangeAndContentRangeConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -156,10 +158,11 @@ mod tests {
             .insert("range", "bytes=0-499".parse().unwrap());
 
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -171,10 +174,11 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing Content-Range"));
@@ -190,10 +194,11 @@ mod tests {
             .headers
             .insert("range", "bytes=5-3".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -205,10 +210,11 @@ mod tests {
             &[("content-range", "bytes 0-1/10")],
         );
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -230,10 +236,11 @@ mod tests {
             .headers
             .insert("range", "bytes=0-499".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -246,10 +253,11 @@ mod tests {
             &[("content-range", "bytes */1234")],
         );
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx_ok,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -257,18 +265,20 @@ mod tests {
             416,
             &[("content-range", "bytes 0-0/1234")],
         );
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx_bad,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
         let tx_missing = crate::test_helpers::make_test_transaction_with_response(416, &[]);
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx_missing,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
     }
@@ -283,10 +293,11 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not use '*'"));
@@ -302,10 +313,11 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));

--- a/src/rules/message_referer_uri_valid.rs
+++ b/src/rules/message_referer_uri_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageRefererUriValid;
 
 impl Rule for MessageRefererUriValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_referer_uri_valid"
@@ -19,12 +19,14 @@ impl Rule for MessageRefererUriValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
 
         for hv in req.headers.get_all("referer").iter() {
@@ -98,15 +100,16 @@ mod tests {
     fn check_referer_header(#[case] referer: &str, #[case] expect_violation: bool) {
         let rule = MessageRefererUriValid;
         let tx = make_tx_with_referer(referer);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_referer_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", referer);
@@ -127,15 +130,16 @@ mod tests {
         );
         tx.request.headers = headers;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_referer_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -148,15 +152,16 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("referer", "1http://ex")]);
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_referer_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid scheme"));
@@ -169,15 +174,16 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("referer", "ht!tp://ex")]);
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_referer_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid character"));
@@ -191,14 +197,15 @@ mod tests {
         headers.append("referer", "bad%ZZ".parse().unwrap());
         tx.request.headers = headers;
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_referer_uri_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));

--- a/src/rules/message_refresh_header_syntax_valid.rs
+++ b/src/rules/message_refresh_header_syntax_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageRefreshHeaderSyntaxValid;
 
 impl Rule for MessageRefreshHeaderSyntaxValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_refresh_header_syntax_valid"
@@ -19,12 +19,14 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -153,10 +155,11 @@ mod tests {
     fn cases(#[case] hdrs: &[(&str, &str)], #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageRefreshHeaderSyntaxValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, hdrs);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}", hdrs);
@@ -185,10 +188,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -204,10 +208,11 @@ mod tests {
             &[("refresh", "5"), ("refresh", "10; url=/x")],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -221,10 +226,11 @@ mod tests {
             &[("refresh", "5"), ("refresh", "bad")],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -235,10 +241,11 @@ mod tests {
         let rule = MessageRefreshHeaderSyntaxValid;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("refresh", "   ")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -252,10 +259,11 @@ mod tests {
         let rule = MessageRefreshHeaderSyntaxValid;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("refresh", "5;")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -269,10 +277,11 @@ mod tests {
             200,
             &[("refresh", "5; url=/a,b")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -286,10 +295,11 @@ mod tests {
             200,
             &[("refresh", "5; url=/in valid")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -300,10 +310,11 @@ mod tests {
             200,
             &[("refresh", "5; url=/x%G1")],
         );
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         let msg2 = v2.unwrap().message;
@@ -314,10 +325,11 @@ mod tests {
             200,
             &[("refresh", "5; url=1http://example/")],
         );
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         let msg3 = v3.unwrap().message;

--- a/src/rules/message_request_body_length_accuracy.rs
+++ b/src/rules/message_request_body_length_accuracy.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageRequestBodyLengthAccuracy;
 
 impl Rule for MessageRequestBodyLengthAccuracy {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_request_body_length_accuracy"
@@ -18,12 +18,14 @@ impl Rule for MessageRequestBodyLengthAccuracy {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
 
         // If any Content-Length header(s) are present, validate each value and compare
@@ -126,10 +128,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -147,10 +150,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -169,10 +173,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -191,10 +196,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -212,10 +218,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -238,10 +245,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -267,10 +275,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -291,10 +300,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -315,10 +325,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("too large"));
@@ -341,10 +352,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -362,10 +374,11 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_response_body_length_accuracy.rs
+++ b/src/rules/message_response_body_length_accuracy.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageResponseBodyLengthAccuracy;
 
 impl Rule for MessageResponseBodyLengthAccuracy {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_response_body_length_accuracy"
@@ -18,12 +18,14 @@ impl Rule for MessageResponseBodyLengthAccuracy {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -128,10 +130,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -148,10 +151,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -169,10 +173,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -190,10 +195,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -210,10 +216,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -235,10 +242,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -263,10 +271,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -286,10 +295,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -306,10 +316,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -326,10 +337,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -352,10 +364,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "overflowing Content-Length should be reported");
         let msg = v.unwrap().message;
@@ -378,10 +391,11 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),

--- a/src/rules/message_retry_after_date_or_delay.rs
+++ b/src/rules/message_retry_after_date_or_delay.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageRetryAfterDateOrDelay;
 
 impl Rule for MessageRetryAfterDateOrDelay {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_retry_after_date_or_delay"
@@ -18,12 +18,14 @@ impl Rule for MessageRetryAfterDateOrDelay {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
         let resp = match &tx.response {
             Some(r) => r,
@@ -86,10 +88,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageRetryAfterDateOrDelay;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -125,10 +128,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -138,10 +142,11 @@ mod tests {
     fn no_response_no_violation() -> anyhow::Result<()> {
         let rule = MessageRetryAfterDateOrDelay;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -160,10 +165,11 @@ mod tests {
             503,
             &[("retry-after", "bad")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -190,10 +196,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -208,10 +215,11 @@ mod tests {
             503,
             &[("retry-after", "120, 240")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_sec_fetch_dest_value_valid.rs
+++ b/src/rules/message_sec_fetch_dest_value_valid.rs
@@ -14,7 +14,7 @@ use crate::rules::Rule;
 pub struct MessageSecFetchDestValueValid;
 
 impl Rule for MessageSecFetchDestValueValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_sec_fetch_dest_value_valid"
@@ -24,12 +24,14 @@ impl Rule for MessageSecFetchDestValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-dest").iter().count();
@@ -128,7 +130,9 @@ mod tests {
     #[case(None, false)]
     fn sec_fetch_dest_cases(#[case] header: Option<&str>, #[case] expect_violation: bool) {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = header {
@@ -136,10 +140,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -165,11 +170,14 @@ mod tests {
         hm.insert("sec-fetch-dest", bad);
         tx.request.headers = hm;
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -178,16 +186,19 @@ mod tests {
     #[test]
     fn invalid_token_char_reports_violation() {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "b@d")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -197,16 +208,19 @@ mod tests {
     #[test]
     fn whitespace_around_value_is_accepted() {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", " image ")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -217,17 +231,20 @@ mod tests {
     #[test]
     fn multiple_header_fields_first_valid_second_invalid() {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let tx = crate::test_helpers::make_test_transaction_with_headers(&[
             ("sec-fetch-dest", "image"),
             ("sec-fetch-dest", "invalid"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for multiple header fields");
         let msg = v.unwrap().message;
@@ -237,17 +254,20 @@ mod tests {
     #[test]
     fn multiple_header_fields_both_invalid_reports_violation() {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let tx = crate::test_helpers::make_test_transaction_with_headers(&[
             ("sec-fetch-dest", "bad1"),
             ("sec-fetch-dest", "bad2"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -258,16 +278,19 @@ mod tests {
     #[test]
     fn unrecognized_value_reports_unrecognized_message() {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "bogus")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for unrecognized token");
         let msg = v.unwrap().message;
@@ -278,16 +301,19 @@ mod tests {
     #[test]
     fn comma_in_value_reports_invalid_token_char() {
         let rule = MessageSecFetchDestValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_dest_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "image,script")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for comma-separated value");
         let msg = v.unwrap().message;

--- a/src/rules/message_sec_fetch_mode_value_valid.rs
+++ b/src/rules/message_sec_fetch_mode_value_valid.rs
@@ -11,7 +11,7 @@ use crate::rules::Rule;
 pub struct MessageSecFetchModeValueValid;
 
 impl Rule for MessageSecFetchModeValueValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_sec_fetch_mode_value_valid"
@@ -21,12 +21,14 @@ impl Rule for MessageSecFetchModeValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-mode").iter().count();
@@ -104,7 +106,9 @@ mod tests {
     #[case(None, false)]
     fn sec_fetch_mode_cases(#[case] header: Option<&str>, #[case] expect_violation: bool) {
         let rule = MessageSecFetchModeValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = header {
@@ -112,10 +116,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -141,11 +146,14 @@ mod tests {
         hm.insert("sec-fetch-mode", bad);
         tx.request.headers = hm;
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -154,16 +162,19 @@ mod tests {
     #[test]
     fn invalid_token_char_reports_violation() {
         let rule = MessageSecFetchModeValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", "b@d")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -176,7 +187,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchModeValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -184,10 +197,11 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("invalid"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-Mode"));
@@ -199,7 +213,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchModeValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -207,10 +223,11 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-Mode"));
@@ -222,7 +239,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchModeValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -230,10 +249,11 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("bad2"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-Mode"));
@@ -242,16 +262,19 @@ mod tests {
     #[test]
     fn whitespace_around_value_is_accepted() {
         let rule = MessageSecFetchModeValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_mode_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", " same-origin ")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),

--- a/src/rules/message_sec_fetch_site_value_valid.rs
+++ b/src/rules/message_sec_fetch_site_value_valid.rs
@@ -11,7 +11,7 @@ use crate::rules::Rule;
 pub struct MessageSecFetchSiteValueValid;
 
 impl Rule for MessageSecFetchSiteValueValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_sec_fetch_site_value_valid"
@@ -21,12 +21,14 @@ impl Rule for MessageSecFetchSiteValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-site").iter().count();
@@ -103,7 +105,9 @@ mod tests {
     #[case(None, false)]
     fn sec_fetch_site_cases(#[case] header: Option<&str>, #[case] expect_violation: bool) {
         let rule = MessageSecFetchSiteValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = header {
@@ -111,10 +115,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -140,12 +145,15 @@ mod tests {
         hm.insert("sec-fetch-site", bad);
         tx.request.headers = hm;
 
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
         // get_header_str will return None for non-utf8 and this rule treats non-UTF8 as violation
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -154,16 +162,19 @@ mod tests {
     #[test]
     fn invalid_token_char_reports_violation() {
         let rule = MessageSecFetchSiteValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", "b@d")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -173,16 +184,19 @@ mod tests {
     #[test]
     fn whitespace_around_value_is_accepted() {
         let rule = MessageSecFetchSiteValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", " same-origin ")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -196,7 +210,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchSiteValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -205,10 +221,11 @@ mod tests {
         tx.request.headers = hm;
 
         // Multiple header fields are always a violation (potential header injection)
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for multiple header fields");
         let msg = v.unwrap().message;
@@ -225,7 +242,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchSiteValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -233,10 +252,11 @@ mod tests {
         hm.append("sec-fetch-site", HeaderValue::from_static("bad2"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -250,7 +270,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchSiteValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_site_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -258,10 +280,11 @@ mod tests {
         hm.append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),

--- a/src/rules/message_sec_fetch_user_value_valid.rs
+++ b/src/rules/message_sec_fetch_user_value_valid.rs
@@ -11,7 +11,7 @@ use crate::rules::Rule;
 pub struct MessageSecFetchUserValueValid;
 
 impl Rule for MessageSecFetchUserValueValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_sec_fetch_user_value_valid"
@@ -21,12 +21,14 @@ impl Rule for MessageSecFetchUserValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-user").iter().count();
         if count == 0 {
@@ -91,7 +93,9 @@ mod tests {
     #[case(None, false)]
     fn sec_fetch_user_cases(#[case] header: Option<&str>, #[case] expect_violation: bool) {
         let rule = MessageSecFetchUserValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = header {
@@ -99,10 +103,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -119,16 +124,19 @@ mod tests {
     #[test]
     fn false_serialization_reports_violation() {
         let rule = MessageSecFetchUserValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unrecognized Sec-Fetch-User"));
@@ -137,16 +145,19 @@ mod tests {
     #[test]
     fn structured_boolean_with_suffix_reports_violation() {
         let rule = MessageSecFetchUserValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?1;param")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unrecognized Sec-Fetch-User"));
@@ -155,16 +166,19 @@ mod tests {
     #[test]
     fn comma_separated_single_field_reports_violation() {
         let rule = MessageSecFetchUserValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?1,?1")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unrecognized Sec-Fetch-User"));
@@ -173,16 +187,19 @@ mod tests {
     #[test]
     fn whitespace_only_header_reports_violation() {
         let rule = MessageSecFetchUserValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "   ")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("is empty"));
@@ -194,7 +211,9 @@ mod tests {
         use hyper::HeaderMap;
 
         let rule = MessageSecFetchUserValueValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = HeaderMap::new();
@@ -202,10 +221,11 @@ mod tests {
         hm.append("sec-fetch-user", HeaderValue::from_static("?1"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-User"));
@@ -223,11 +243,14 @@ mod tests {
         hm.insert("sec-fetch-user", bad);
         tx.request.headers = hm;
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_sec_fetch_user_value_valid",
+        ]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));

--- a/src/rules/message_server_header_product_valid.rs
+++ b/src/rules/message_server_header_product_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageServerHeaderProductValid;
 
 impl Rule for MessageServerHeaderProductValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_server_header_product_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageServerHeaderProductValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check_value = |hdr: &str, val: &str| -> Option<Violation> {
             // Strip top-level parenthesized comments (allowed in Server values)
             let no_comments = match crate::helpers::headers::strip_comments(val) {
@@ -140,7 +142,9 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageServerHeaderProductValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_server_header_product_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut resp = crate::test_helpers::make_test_transaction_with_response(200, &[]);
@@ -150,10 +154,11 @@ mod tests {
         }
         tx.response = resp.response;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -166,17 +171,20 @@ mod tests {
     #[test]
     fn multiple_server_fields_checked() -> anyhow::Result<()> {
         let rule = MessageServerHeaderProductValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_server_header_product_valid",
+        ]);
 
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[("server", "nginx/1.18.0")]);
         hm.append("server", HeaderValue::from_static("Bad@Srv/1.0"));
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -185,17 +193,20 @@ mod tests {
     #[test]
     fn non_utf8_header_value_is_reported() -> anyhow::Result<()> {
         let rule = MessageServerHeaderProductValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_server_header_product_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.insert("server", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -204,16 +215,19 @@ mod tests {
     #[test]
     fn unterminated_comment_reports_violation() -> anyhow::Result<()> {
         let rule = MessageServerHeaderProductValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_server_header_product_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "Bad (unbalanced")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -222,16 +236,19 @@ mod tests {
     #[test]
     fn server_only_comments_is_reported() -> anyhow::Result<()> {
         let rule = MessageServerHeaderProductValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_server_header_product_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "(Apache)")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -240,16 +257,19 @@ mod tests {
     #[test]
     fn comment_before_product_is_accepted() -> anyhow::Result<()> {
         let rule = MessageServerHeaderProductValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_server_header_product_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "(test) nginx/1.18.0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_strict_transport_security_validity.rs
+++ b/src/rules/message_strict_transport_security_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageStrictTransportSecurityValidity;
 
 impl Rule for MessageStrictTransportSecurityValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_strict_transport_security_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageStrictTransportSecurityValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applicable to responses
         let resp = match &tx.response {
             Some(r) => r,
@@ -234,15 +236,16 @@ mod tests {
     fn cases(#[case] val: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp(val);
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         let got = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some();
         assert_eq!(got, expect_violation, "value: {}", val);
@@ -267,15 +270,16 @@ mod tests {
             trailers: None,
         });
         let rule = MessageStrictTransportSecurityValidity;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -284,15 +288,16 @@ mod tests {
     fn empty_value_is_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -301,15 +306,16 @@ mod tests {
     fn trailing_semicolon_reports_empty_directive() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=1;");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -318,15 +324,16 @@ mod tests {
     fn unknown_directive_with_bad_quoted_string_reports_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=1; foo=\"unterminated");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -335,15 +342,16 @@ mod tests {
     fn unknown_directive_with_invalid_token_value_reports_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=1; bar=bad@val");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -352,15 +360,16 @@ mod tests {
     fn unknown_directive_with_quoted_string_is_ok() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=1; foo=\"valid\"");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -369,15 +378,16 @@ mod tests {
     fn max_age_empty_value_is_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -386,15 +396,16 @@ mod tests {
     fn max_age_without_equals_is_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -403,15 +414,16 @@ mod tests {
     fn max_age_quoted_is_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=\"3600\"");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -420,15 +432,16 @@ mod tests {
     fn directive_name_with_invalid_char_is_violation() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("ma x=1");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -437,15 +450,16 @@ mod tests {
     fn unknown_directive_with_token_value_is_ok() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=1; foo=bar");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -454,15 +468,16 @@ mod tests {
     fn include_subdomains_case_insensitive_is_ok() {
         let rule = MessageStrictTransportSecurityValidity;
         let tx = make_resp("max-age=1; IncludeSubDomains");
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -483,15 +498,16 @@ mod tests {
             trailers: None,
         });
         let rule = MessageStrictTransportSecurityValidity;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_strict_transport_security_validity",
+            "warn",
+        );
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }

--- a/src/rules/message_structured_headers_validity.rs
+++ b/src/rules/message_structured_headers_validity.rs
@@ -62,7 +62,7 @@ fn parse_headers_config(
 }
 
 impl Rule for MessageStructuredHeadersValidity {
-    type Config = MessageStructuredHeadersConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_structured_headers_validity"
@@ -80,12 +80,14 @@ impl Rule for MessageStructuredHeadersValidity {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_headers_config(cfg, self.id()).ok()?;
         for hdr in &config.headers {
             // Request
             for hv in tx.request.headers.get_all(hdr.as_str()).iter() {
@@ -344,12 +346,27 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn make_cfg_with_headers(headers: &[&str]) -> MessageStructuredHeadersConfig {
-        MessageStructuredHeadersConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            headers: headers.iter().map(|s| s.to_string()).collect(),
-        }
+    fn make_cfg_with_headers(headers: &[&str]) -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_structured_headers_validity".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "headers".into(),
+                    toml::Value::Array(
+                        headers
+                            .iter()
+                            .map(|s| toml::Value::String(s.to_string()))
+                            .collect(),
+                    ),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -419,10 +436,11 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // header.to_str() will error and we expect a violation reporting invalid utf-8
         assert!(v.is_some());
@@ -488,10 +506,11 @@ mod tests {
             200,
             &[("x-struct", "\"unterminated")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -863,10 +882,11 @@ mod tests {
             hyper::header::HeaderValue::from_static("\"unterminated"),
         );
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vi) = v {
@@ -889,10 +909,11 @@ mod tests {
         if let Some(resp) = &mut tx.response {
             resp.headers = rh;
         }
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vi) = v {

--- a/src/rules/message_sunset_and_deprecation_consistency.rs
+++ b/src/rules/message_sunset_and_deprecation_consistency.rs
@@ -9,7 +9,7 @@ use chrono::TimeZone;
 pub struct MessageSunsetAndDeprecationConsistency;
 
 impl Rule for MessageSunsetAndDeprecationConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_sunset_and_deprecation_consistency"
@@ -20,12 +20,14 @@ impl Rule for MessageSunsetAndDeprecationConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only applies to responses
         let resp = match &tx.response {
             Some(r) => r,
@@ -122,10 +124,11 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(v) = &v {
             eprintln!(
@@ -147,10 +150,11 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -168,10 +172,11 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -186,17 +191,19 @@ mod tests {
             crate::test_helpers::make_test_transaction_with_response(200, &[("deprecation", "@0")]);
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -221,10 +228,11 @@ mod tests {
         });
 
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -243,10 +251,11 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -258,10 +267,11 @@ mod tests {
             &[("sunset", "not-a-date"), ("deprecation", "@0")],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -280,10 +290,11 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -300,10 +311,11 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -319,10 +331,11 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -339,10 +352,11 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -359,10 +373,11 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -385,10 +400,11 @@ mod tests {
 
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config()
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }

--- a/src/rules/message_te_header_constraints.rs
+++ b/src/rules/message_te_header_constraints.rs
@@ -9,7 +9,7 @@ use crate::rules::Rule;
 pub struct MessageTeHeaderConstraints;
 
 impl Rule for MessageTeHeaderConstraints {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_te_header_constraints"
@@ -19,12 +19,14 @@ impl Rule for MessageTeHeaderConstraints {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // TE should not appear in responses
         if let Some(resp) = &tx.response {
             if let Some(val) = crate::helpers::headers::get_header_str(&resp.headers, "te") {
@@ -190,10 +192,10 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageTeHeaderConstraints;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_te_header_constraints",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some((k, v)) = te_hdr {
@@ -209,10 +211,11 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation but got none");
@@ -225,19 +228,20 @@ mod tests {
     #[test]
     fn te_in_response_is_violation() -> anyhow::Result<()> {
         let rule = MessageTeHeaderConstraints;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_te_header_constraints",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -257,10 +261,10 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageTeHeaderConstraints;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_te_header_constraints",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some((k, v)) = te_hdr {
@@ -276,10 +280,11 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation but got none");
@@ -306,10 +311,10 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageTeHeaderConstraints;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_te_header_constraints",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some((k, v)) = te_hdr {
@@ -325,10 +330,11 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation but got none");

--- a/src/rules/message_timing_allow_origin_validity.rs
+++ b/src/rules/message_timing_allow_origin_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageTimingAllowOriginValidity;
 
 impl Rule for MessageTimingAllowOriginValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_timing_allow_origin_validity"
@@ -18,12 +18,14 @@ impl Rule for MessageTimingAllowOriginValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -101,16 +103,17 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[test]
     fn no_response_no_violation() {
         let rule = MessageTimingAllowOriginValidity;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -122,10 +125,11 @@ mod tests {
             200,
             &[("content-type", "text/plain")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -142,10 +146,11 @@ mod tests {
             200,
             &[("timing-allow-origin", val)],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -176,10 +181,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -193,10 +199,11 @@ mod tests {
             200,
             &[("timing-allow-origin", "https://a,  ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -213,10 +220,11 @@ mod tests {
             200,
             &[("timing-allow-origin", " ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty"));
@@ -229,10 +237,11 @@ mod tests {
             200,
             &[("timing-allow-origin", "https://[::1]:8080")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -244,10 +253,11 @@ mod tests {
             200,
             &[("timing-allow-origin", "*, https://example.com")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -259,10 +269,11 @@ mod tests {
             200,
             &[("timing-allow-origin", "NULL")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -274,10 +285,11 @@ mod tests {
             200,
             &[("timing-allow-origin", "https:///foo")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid origin"));
@@ -301,10 +313,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),

--- a/src/rules/message_trailer_fields_validity.rs
+++ b/src/rules/message_trailer_fields_validity.rs
@@ -58,7 +58,7 @@ const PROHIBITED_TRAILER_FIELDS: &[&str] = &[
 pub struct MessageTrailerFieldsValidity;
 
 impl Rule for MessageTrailerFieldsValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_trailer_fields_validity"
@@ -68,18 +68,20 @@ impl Rule for MessageTrailerFieldsValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request trailers.
         if let Some(ref trailers) = tx.request.trailers {
             let declared = collect_declared_trailers(&tx.request.headers);
             let conn_val =
                 crate::helpers::headers::get_header_str(&tx.request.headers, "connection");
-            if let Some(v) = check_trailers(self.id(), config, trailers, &declared, conn_val) {
+            if let Some(v) = check_trailers(self.id(), &config, trailers, &declared, conn_val) {
                 return Some(v);
             }
         }
@@ -89,7 +91,7 @@ impl Rule for MessageTrailerFieldsValidity {
             if let Some(ref trailers) = resp.trailers {
                 let declared = collect_declared_trailers(&resp.headers);
                 let conn_val = crate::helpers::headers::get_header_str(&resp.headers, "connection");
-                if let Some(v) = check_trailers(self.id(), config, trailers, &declared, conn_val) {
+                if let Some(v) = check_trailers(self.id(), &config, trailers, &declared, conn_val) {
                     return Some(v);
                 }
             }
@@ -203,14 +205,15 @@ fn check_trailers(
 mod tests {
     use super::*;
     use crate::test_helpers::{
-        make_headers_from_pairs, make_test_rule_config, make_test_transaction,
-        make_test_transaction_with_response,
+        make_headers_from_pairs, make_test_transaction, make_test_transaction_with_response,
     };
     use crate::transaction_history::TransactionHistory;
     use rstest::rstest;
 
-    fn cfg() -> crate::rules::RuleConfig {
-        make_test_rule_config()
+    fn cfg() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_trailer_fields_validity",
+        ])
     }
 
     fn empty_history() -> TransactionHistory {
@@ -264,7 +267,12 @@ mod tests {
         );
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(
             v.is_some(),
             "expected violation for prohibited trailer '{field}'"
@@ -291,7 +299,12 @@ mod tests {
         );
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(
             v.is_some(),
             "expected violation for prohibited request trailer '{field}'"
@@ -309,7 +322,12 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -321,7 +339,12 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -331,7 +354,12 @@ mod tests {
     fn no_trailers_no_violation() {
         let rule = MessageTrailerFieldsValidity;
         let tx = make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -339,7 +367,12 @@ mod tests {
     fn request_only_no_trailers_no_violation() {
         let rule = MessageTrailerFieldsValidity;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -353,7 +386,12 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -367,7 +405,12 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -380,7 +423,12 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -392,7 +440,12 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -406,7 +459,12 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -421,7 +479,12 @@ mod tests {
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
         // No Trailer header → declared is empty → undeclared check skipped
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -435,7 +498,12 @@ mod tests {
         trailers.insert("content-length", "42".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("prohibited"));
     }
@@ -450,7 +518,12 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("hop-by-hop"));
     }
@@ -464,7 +537,12 @@ mod tests {
         trailers.insert("x-req-hop", "value".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("hop-by-hop"));
     }
@@ -477,7 +555,12 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("hop-by-hop"));
     }
@@ -490,7 +573,12 @@ mod tests {
         trailers.insert("x-other", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -504,7 +592,12 @@ mod tests {
         trailers.insert("transfer-encoding", "chunked".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         // Should say "prohibited", not "hop-by-hop", since static check runs first.
         assert!(v.unwrap().message.contains("prohibited"));
@@ -527,7 +620,12 @@ mod tests {
         resp_trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("host"));
     }
@@ -554,7 +652,12 @@ mod tests {
         trailers.insert("x-signature", "sig".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -566,7 +669,12 @@ mod tests {
         let mut tx = make_test_transaction_with_response(200, &[("trailer", "x-checksum")]);
         tx.response.as_mut().unwrap().trailers = Some(hyper::HeaderMap::new());
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -582,7 +690,12 @@ mod tests {
         trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -598,7 +711,12 @@ mod tests {
         trailers.insert("etag", "\"abc\"".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -610,7 +728,12 @@ mod tests {
         trailers.insert("server-timing", "db;dur=53".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -623,7 +746,12 @@ mod tests {
         trailers.insert("transfer-encoding", "chunked".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("prohibited"));
     }
@@ -638,7 +766,12 @@ mod tests {
         trailers.insert("x-extra", "extra".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -660,7 +793,12 @@ mod tests {
         trailers.insert("content-type", "text/plain".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("prohibited"));
     }
@@ -678,7 +816,12 @@ mod tests {
         resp_trailers.insert("content-length", "99".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("authorization"));
     }
@@ -696,7 +839,12 @@ mod tests {
         resp_trailers.insert("date", "Sat, 01 Jan 2026 00:00:00 GMT".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("date"));
     }
@@ -714,7 +862,12 @@ mod tests {
         trailers.insert("server-timing", "total;dur=100".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = rule.check(
+            &tx,
+            &empty_history(),
+            &cfg(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 

--- a/src/rules/message_trailer_headers_valid.rs
+++ b/src/rules/message_trailer_headers_valid.rs
@@ -9,7 +9,7 @@ use crate::rules::Rule;
 pub struct MessageTrailerHeadersValid;
 
 impl Rule for MessageTrailerHeadersValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_trailer_headers_valid"
@@ -19,12 +19,14 @@ impl Rule for MessageTrailerHeadersValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Cache Connection header nomination once for both request and response checks
         let connection_val =
             crate::helpers::headers::get_header_str(&tx.request.headers, "connection").or_else(
@@ -122,20 +124,21 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         // Response case
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", trailer_val)]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -162,10 +165,11 @@ mod tests {
                     ("connection", "Keep-Alive"),
                     ("trailer", "Keep-Alive"),
                 ]);
-            let v2 = rule.check_transaction(
+            let v2 = rule.check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(
                 v2.is_some(),
@@ -179,19 +183,20 @@ mod tests {
     #[test]
     fn trailer_empty_member_is_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -200,17 +205,18 @@ mod tests {
     #[test]
     fn request_trailer_valid_is_ok() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("trailer", "ETag")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -219,18 +225,19 @@ mod tests {
     #[test]
     fn request_trailer_invalid_token_reports_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "bad token")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -239,19 +246,20 @@ mod tests {
     #[test]
     fn invalid_token_violation_message_includes_char_and_member() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "bad token")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("invalid character"));
@@ -262,19 +270,20 @@ mod tests {
     #[test]
     fn hop_by_hop_violation_message_includes_header_name() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "Transfer-Encoding")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("nominate") || v.message.contains("hop-by-hop"));
@@ -285,20 +294,21 @@ mod tests {
     #[test]
     fn request_trailer_connection_nominated_reports_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
             ("connection", "Keep-Alive"),
             ("trailer", "Keep-Alive"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -308,20 +318,21 @@ mod tests {
     fn non_utf8_trailer_is_violation() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.append("trailer", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -331,20 +342,21 @@ mod tests {
     fn request_non_utf8_trailer_is_violation() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = hyper::HeaderMap::new();
         hm.append("trailer", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -353,10 +365,10 @@ mod tests {
     #[test]
     fn request_trailer_response_connection_nominated_reports_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
@@ -364,10 +376,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "Keep-Alive")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -376,20 +389,21 @@ mod tests {
     #[test]
     fn request_trailer_lowercase_token_matches_connection_case_insensitive() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
             ("connection", "Keep-Alive"),
             ("trailer", "keep-alive"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -398,17 +412,18 @@ mod tests {
     #[test]
     fn response_trailer_whitespace_only_is_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "   ")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -417,16 +432,17 @@ mod tests {
     #[test]
     fn request_trailer_whitespace_only_is_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("trailer", "   ")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -436,19 +452,20 @@ mod tests {
     fn multiple_trailer_header_fields_iterated_reports_violation() -> anyhow::Result<()> {
         use hyper::header::HeaderValue;
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.append("trailer", HeaderValue::from_static("ETag"));
         hm.append("trailer", HeaderValue::from_static("bad token"));
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -457,17 +474,18 @@ mod tests {
     #[test]
     fn trailer_nominates_trailer_itself_is_violation() -> anyhow::Result<()> {
         let rule = MessageTrailerHeadersValid;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "message_trailer_headers_valid",
+            "warn",
+        );
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "trailer")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_transfer_coding_iana_registered.rs
+++ b/src/rules/message_transfer_coding_iana_registered.rs
@@ -61,7 +61,7 @@ fn parse_allowed_config(
 pub struct MessageTransferCodingIanaRegistered;
 
 impl Rule for MessageTransferCodingIanaRegistered {
-    type Config = TransferCodingConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_transfer_coding_iana_registered"
@@ -79,12 +79,14 @@ impl Rule for MessageTransferCodingIanaRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         // check a list-style header value (Transfer-Encoding or TE) against allowed list
         let check_value = |hdr_name: &str, val: &str, allowed: &[String]| -> Option<Violation> {
             for part in crate::helpers::headers::parse_list_header(val) {
@@ -149,16 +151,26 @@ mod tests {
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
-    fn make_cfg() -> TransferCodingConfig {
-        TransferCodingConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "chunked".to_string(),
-                "gzip".to_string(),
-                "deflate".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_transfer_coding_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![
+                        toml::Value::String("chunked".into()),
+                        toml::Value::String("gzip".into()),
+                        toml::Value::String("deflate".into()),
+                    ]),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -181,10 +193,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -212,10 +225,11 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -234,10 +248,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x@bad")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -261,10 +276,11 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -272,10 +288,11 @@ mod tests {
         let mut hm2 = hyper::HeaderMap::new();
         hm2.insert("te", HeaderValue::from_bytes(b"\xff").unwrap());
         tx2.request.headers = hm2;
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -410,16 +427,15 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&full_cfg, "message_transfer_coding_iana_registered")?;
-
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "x-custom;q=0.5")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &parsed,
+            &full_cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -445,16 +461,15 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&full_cfg, "message_transfer_coding_iana_registered")?;
-
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x-custom")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &parsed,
+            &full_cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -463,20 +478,30 @@ mod tests {
     #[test]
     fn unrecognized_transfer_coding_message_and_severity() -> anyhow::Result<()> {
         let rule = MessageTransferCodingIanaRegistered;
-        let cfg = TransferCodingConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-            allowed: vec!["chunked".to_string()],
-        };
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "message_transfer_coding_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("error".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(vec![toml::Value::String("chunked".into())]),
+                );
+                t
+            }),
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x-foo")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -540,10 +565,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -575,10 +601,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers, x-custom")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -596,10 +623,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x@bad")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_transfer_encoding_chunked_final.rs
+++ b/src/rules/message_transfer_encoding_chunked_final.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageTransferEncodingChunkedFinal;
 
 impl Rule for MessageTransferEncodingChunkedFinal {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_transfer_encoding_chunked_final"
@@ -18,12 +18,14 @@ impl Rule for MessageTransferEncodingChunkedFinal {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &hyper::HeaderMap| -> Option<Violation> {
             let mut codings: Vec<String> = Vec::new();
             for hv in headers.get_all(hyper::header::TRANSFER_ENCODING).iter() {
@@ -100,10 +102,11 @@ mod tests {
             value,
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "request '{}' expected violation", value);
@@ -120,10 +123,11 @@ mod tests {
 
         let tx = crate::test_helpers::make_test_transaction();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -145,10 +149,11 @@ mod tests {
             &[("transfer-encoding", value)],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "response '{}' expected violation", value);
@@ -169,10 +174,11 @@ mod tests {
             ("transfer-encoding", "gzip"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -188,10 +194,11 @@ mod tests {
         hm.insert(hyper::header::TRANSFER_ENCODING, bad_value);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none()); // Rule skips invalid UTF-8 headers
         Ok(())

--- a/src/rules/message_user_agent_token_valid.rs
+++ b/src/rules/message_user_agent_token_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageUserAgentTokenValid;
 
 impl Rule for MessageUserAgentTokenValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_user_agent_token_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageUserAgentTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check_value = |hdr: &str, val: &str| -> Option<Violation> {
             // Strip comments (e.g., parentheses) before token parsing
             let no_comments = match crate::helpers::headers::strip_comments(val) {
@@ -154,17 +156,20 @@ mod tests {
         #[case] expect_violation: bool,
     ) -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         if let Some(v) = ua {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("user-agent", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -177,17 +182,20 @@ mod tests {
     #[test]
     fn user_agent_product_and_version_invalid_chars_are_reported() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         // invalid character in product
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "A@gen/1.0")]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
 
@@ -196,10 +204,11 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent/1@0")]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
 
@@ -209,7 +218,9 @@ mod tests {
     #[test]
     fn multiple_user_agent_fields_are_checked() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         // one good and one bad header -> violation
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[("user-agent", "curl/7.68.0")]);
@@ -217,10 +228,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = hm;
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
 
@@ -230,17 +242,20 @@ mod tests {
     #[test]
     fn non_utf8_header_value_is_reported() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.insert("user-agent", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -249,16 +264,19 @@ mod tests {
     #[test]
     fn response_user_agent_is_validated() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Bad/UA!")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -267,17 +285,20 @@ mod tests {
     #[test]
     fn response_multiple_user_agent_fields_are_checked() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[("user-agent", "curl/7.68.0")]);
         hm.append("user-agent", HeaderValue::from_static("Bad@UA/1.0"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -286,17 +307,20 @@ mod tests {
     #[test]
     fn response_non_utf8_header_value_is_reported() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.insert("user-agent", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -308,16 +332,19 @@ mod tests {
     #[test]
     fn empty_product_token_from_whitespace_is_reported() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent  /1.0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -329,15 +356,18 @@ mod tests {
     #[test]
     fn invalid_char_messages_include_char() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "A@gen/1.0")]);
-        let v1 = rule.check_transaction(
+        let v1 = rule.check(
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
         if let Some(violation) = v1 {
@@ -347,10 +377,11 @@ mod tests {
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent/1@0")]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         if let Some(violation) = v2 {
@@ -362,7 +393,9 @@ mod tests {
     #[test]
     fn user_agent_only_comments_is_reported() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(
@@ -370,10 +403,11 @@ mod tests {
             "(compatible; something)",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -390,16 +424,19 @@ mod tests {
     #[test]
     fn user_agent_unmatched_parentheses_is_reported() -> anyhow::Result<()> {
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent (unclosed")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -412,16 +449,19 @@ mod tests {
     fn user_agent_unbalanced_comment_reports_violation() -> anyhow::Result<()> {
         // moved from helper tests: ensure unbalanced parenthesized comment in User-Agent is reported
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent (incomplete")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -432,16 +472,19 @@ mod tests {
         // Escaped parentheses should not be treated as comment delimiters; they will be preserved
         // by strip_comments and then validated for token characters by the rule.
         let rule = MessageUserAgentTokenValid;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_user_agent_token_valid",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent\\(1.0\\)")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // Parentheses are not allowed in token syntax, so we expect a violation, but the parser should
         // not treat them as comment delimiters (i.e., no parse error about unmatched comment).

--- a/src/rules/message_via_header_syntax_valid.rs
+++ b/src/rules/message_via_header_syntax_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageViaHeaderSyntaxValid;
 
 impl Rule for MessageViaHeaderSyntaxValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_via_header_syntax_valid"
@@ -18,12 +18,14 @@ impl Rule for MessageViaHeaderSyntaxValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use hyper::HeaderMap;
 
         // Helper to validate Via headers in a HeaderMap (reduces duplication)
@@ -46,12 +48,12 @@ impl Rule for MessageViaHeaderSyntaxValid {
             None
         }
 
-        if let Some(err) = check_headers(&tx.request.headers, config) {
+        if let Some(err) = check_headers(&tx.request.headers, &config) {
             return Some(err);
         }
 
         if let Some(resp) = &tx.response {
-            if let Some(err) = check_headers(&resp.headers, config) {
+            if let Some(err) = check_headers(&resp.headers, &config) {
                 return Some(err);
             }
         }
@@ -241,10 +243,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("via", "1.1 example.com")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -254,10 +257,11 @@ mod tests {
     fn check_response_header_invalid() -> anyhow::Result<()> {
         let rule = MessageViaHeaderSyntaxValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[("via", "1.1")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -298,10 +302,11 @@ mod tests {
         hm.insert("via", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_warning_header_syntax.rs
+++ b/src/rules/message_warning_header_syntax.rs
@@ -171,7 +171,7 @@ fn check_warning_value_str(val: &str) -> Option<String> {
 pub struct MessageWarningHeaderSyntax;
 
 impl Rule for MessageWarningHeaderSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_warning_header_syntax"
@@ -181,12 +181,14 @@ impl Rule for MessageWarningHeaderSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check response headers
         if let Some(resp) = &tx.response {
             for hv in resp.headers.get_all("Warning").iter() {
@@ -261,10 +263,11 @@ mod tests {
             make_test_transaction()
         };
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header {:?}", header);
@@ -289,10 +292,11 @@ mod tests {
             .unwrap()
             .headers
             .append("Warning", HeaderValue::from_bytes(&[0xff]).unwrap());
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -311,10 +315,11 @@ mod tests {
                 .parse::<hyper::header::HeaderValue>()
                 .unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -324,10 +329,11 @@ mod tests {
             "Warning",
             "110-\"bad\"".parse::<hyper::header::HeaderValue>().unwrap(),
         );
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2
@@ -365,10 +371,11 @@ mod tests {
         let rule = MessageWarningHeaderSyntax;
 
         let tx = make_test_transaction_with_response(200, &[("Warning", header)]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(expect_msg) = expect {
@@ -385,10 +392,11 @@ mod tests {
             .headers
             .insert("Warning", HeaderValue::from_static(""));
         let rule = MessageWarningHeaderSyntax;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -401,10 +409,11 @@ mod tests {
             &[("Warning", "214 host \"ok\", ,214 host \"bad\"")],
         );
         let rule = MessageWarningHeaderSyntax;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty member"));
@@ -421,10 +430,11 @@ mod tests {
             )],
         );
         let rule = MessageWarningHeaderSyntax;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -460,10 +470,11 @@ mod tests {
             .unwrap()
             .headers
             .append("Warning", HeaderValue::from_static("110 - \"Stale\""));
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -474,10 +485,11 @@ mod tests {
         let rule = MessageWarningHeaderSyntax;
 
         let tx = make_test_transaction_with_response(200, &[("Warning", "110-\"bad\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Missing space after warn-code"));
@@ -497,10 +509,11 @@ mod tests {
             "Warning",
             HeaderValue::from_bytes(b"214 host \"abc\\\"").unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_well_known_uri_format.rs
+++ b/src/rules/message_well_known_uri_format.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageWellKnownUriFormat;
 
 impl Rule for MessageWellKnownUriFormat {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_well_known_uri_format"
@@ -18,12 +18,14 @@ impl Rule for MessageWellKnownUriFormat {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let path = crate::helpers::uri::extract_path_from_request_target(&tx.request.uri)?;
 
         // Well-known URIs MUST be under the path prefix `/.well-known/` per RFC 8615.
@@ -66,22 +68,24 @@ mod tests {
     fn valid_well_known_paths_are_ok() {
         let rule = MessageWellKnownUriFormat;
         let mut tx = make_tx_with_uri("/.well-known/openid-configuration");
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_well_known_uri_format",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
         tx = make_tx_with_uri("https://example.com/.well-known/security.txt");
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -92,14 +96,15 @@ mod tests {
     fn missing_slash_reports_violation(#[case] uri: &str, #[case] _desc: &str) {
         let rule = MessageWellKnownUriFormat;
         let tx = make_tx_with_uri(uri);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_well_known_uri_format",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -110,14 +115,15 @@ mod tests {
     fn not_at_root_reports_violation() {
         let rule = MessageWellKnownUriFormat;
         let tx = make_tx_with_uri("/foo/.well-known/abc");
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_well_known_uri_format",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -128,14 +134,15 @@ mod tests {
     fn unrelated_paths_do_not_trigger() {
         let rule = MessageWellKnownUriFormat;
         let tx = make_tx_with_uri("/foo/bar");
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_well_known_uri_format",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -144,14 +151,15 @@ mod tests {
     fn absolute_form_without_path_does_not_trigger() {
         let rule = MessageWellKnownUriFormat;
         let tx = make_tx_with_uri("https://example.com");
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "message_well_known_uri_format",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_www_authenticate_challenge_syntax.rs
+++ b/src/rules/message_www_authenticate_challenge_syntax.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageWwwAuthenticateChallengeSyntax;
 
 impl Rule for MessageWwwAuthenticateChallengeSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_www_authenticate_challenge_syntax"
@@ -18,12 +18,14 @@ impl Rule for MessageWwwAuthenticateChallengeSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers; ignore non-UTF8 header values
         if let Some(resp) = &tx.response {
             for hv in resp.headers.get_all("www-authenticate").iter() {
@@ -81,12 +83,15 @@ mod tests {
     #[case("Basic realm=\"unfinished", true)]
     fn check_www_authenticate_cases(#[case] val: &str, #[case] expect_violation: bool) {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = make_resp(val);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "val='{}' expected violation", val);
@@ -98,7 +103,9 @@ mod tests {
     #[test]
     fn non_utf8_header_values_are_ignored() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -108,10 +115,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -119,15 +127,18 @@ mod tests {
     #[test]
     fn parameter_before_scheme_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "error=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -139,15 +150,18 @@ mod tests {
     #[test]
     fn trailing_empty_parameter_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=\"x\", ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(vv) = v {
             assert!(
@@ -161,15 +175,18 @@ mod tests {
     #[test]
     fn multiple_challenges_and_token68_ok() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=\"a\", NewScheme abcdef=")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -184,15 +201,18 @@ mod tests {
     #[test]
     fn invalid_auth_param_name_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic re@alm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name"));
@@ -201,15 +221,18 @@ mod tests {
     #[test]
     fn invalid_auth_param_value_token_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=abc@")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(vv) = v {
             assert!(
@@ -233,15 +256,18 @@ mod tests {
     #[test]
     fn auth_param_name_empty_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic =\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name is empty"));
@@ -250,15 +276,18 @@ mod tests {
     #[test]
     fn invalid_quoted_string_reports_message() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=\"unfinished")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let vv = v.unwrap();
@@ -270,15 +299,18 @@ mod tests {
     #[test]
     fn quoted_string_with_extra_chars_reports_invalid() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic a=\"good\"extra")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let vv = v.unwrap();
@@ -290,15 +322,18 @@ mod tests {
     #[test]
     fn consecutive_commas_produce_empty_param_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=\"x\", , error=\"y\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(vv) = v {
             assert!(
@@ -312,16 +347,19 @@ mod tests {
     #[test]
     fn challenge_missing_auth_scheme_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         // member starts with whitespace -> missing scheme
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", " realm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing auth-scheme"));
@@ -330,15 +368,18 @@ mod tests {
     #[test]
     fn empty_member_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", ",")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty"));
@@ -347,7 +388,9 @@ mod tests {
     #[test]
     fn multiple_header_fields_checked() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.append(
@@ -359,10 +402,11 @@ mod tests {
             hyper::header::HeaderValue::from_static("NewScheme abc="),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -370,7 +414,9 @@ mod tests {
     #[test]
     fn invalid_among_multiple_headers_reports_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.append(
@@ -382,10 +428,11 @@ mod tests {
             hyper::header::HeaderValue::from_static("Basic realm=\"x\""),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -393,15 +440,18 @@ mod tests {
     #[test]
     fn empty_auth_param_value_is_violation() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vv) = v {
@@ -412,16 +462,19 @@ mod tests {
     #[test]
     fn quoted_string_with_escaped_quote_is_accepted() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         // realm with escaped quote inside quoted-string
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=\"a\\\"b\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -429,15 +482,18 @@ mod tests {
     #[test]
     fn realm_token_unquoted_is_accepted() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic realm=token123")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -445,15 +501,18 @@ mod tests {
     #[test]
     fn token68_with_common_chars_is_accepted() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "NewScheme abc+/.=-_123")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -461,16 +520,19 @@ mod tests {
     #[test]
     fn first_part_invalid_but_rhs_is_quoted_reports_invalid_name() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         // left side contains '/', RHS starts with '"' -> should be parsed as auth-param and reported
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "New abc/def=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name"));
@@ -479,16 +541,19 @@ mod tests {
     #[test]
     fn first_part_invalid_treated_as_token68_if_rhs_not_quoted() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         // left contains invalid char '/', RHS does not start with '"' -> treat as token68
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "New abc/def=xyz")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -496,15 +561,18 @@ mod tests {
     #[test]
     fn non_common_scheme_trailing_eq_accepted_as_token68() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "NonCommon abc=")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -512,15 +580,18 @@ mod tests {
     #[test]
     fn common_scheme_trailing_eq_reports_missing_value() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "Basic abc=")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vv) = v {
@@ -531,15 +602,18 @@ mod tests {
     #[test]
     fn suspicious_single_token_after_scheme_is_violation_for_non_token68() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "NewScheme realm")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("suspicious single token"));
@@ -548,15 +622,18 @@ mod tests {
     #[test]
     fn first_invalid_with_comma_parses_as_auth_param_and_reports_name() {
         let rule = MessageWwwAuthenticateChallengeSyntax;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_www_authenticate_challenge_syntax",
+        ]);
         let tx = crate::test_helpers::make_test_transaction_with_response(
             401,
             &[("www-authenticate", "New abc/def=\"x\", realm=\"y\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name"));

--- a/src/rules/message_x_forwarded_consistency.rs
+++ b/src/rules/message_x_forwarded_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct MessageXForwardedConsistency;
 
 impl Rule for MessageXForwardedConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "message_x_forwarded_consistency"
@@ -18,12 +18,14 @@ impl Rule for MessageXForwardedConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use crate::helpers::headers::parse_list_header;
 
         let check_xff = |val: &str| -> Option<Violation> {
@@ -226,10 +228,11 @@ mod tests {
             tx.request.headers =
                 crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-for", v)]);
         }
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -245,10 +248,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-for", "not-an-ip")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
@@ -256,10 +260,11 @@ mod tests {
             200,
             &[("x-forwarded-proto", "https")],
         );
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -280,10 +285,11 @@ mod tests {
             tx.request.headers =
                 crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-proto", v)]);
         }
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -310,10 +316,11 @@ mod tests {
             tx.request.headers =
                 crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", v)]);
         }
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -333,10 +340,11 @@ mod tests {
         let mut hm = tx.request.headers.clone();
         hm.append("x-forwarded-for", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -348,10 +356,11 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx2.response.as_mut().unwrap().headers = hm2;
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -362,10 +371,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-proto", "https, ftp")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid X-Forwarded-Proto"));
@@ -377,10 +387,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-for", "*")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -405,10 +416,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", ":80")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -423,10 +435,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "example.com:")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -437,10 +450,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "[::1]:notnum")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -456,10 +470,11 @@ mod tests {
             "x-forwarded-host",
             "example.com/extra",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -471,10 +486,11 @@ mod tests {
             200,
             &[("x-forwarded-host", "user@host")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -487,10 +503,11 @@ mod tests {
             "x-forwarded-for",
             "203.0.113.195,bogus,198.51.100.17",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid X-Forwarded-For"));
@@ -502,10 +519,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "[::zz]:8080")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid IPv6 literal"));
@@ -517,10 +535,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "exa mple.com")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -531,10 +550,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "[::1]:70000")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid port"));
@@ -546,10 +566,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-proto", "https,:")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -562,10 +583,11 @@ mod tests {
             "x-forwarded-host",
             "example\t.com:80",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -576,10 +598,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "user@host:80")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid host"));

--- a/src/rules/semantic_cache_coherence.rs
+++ b/src/rules/semantic_cache_coherence.rs
@@ -18,7 +18,7 @@ use crate::rules::Rule;
 pub struct SemanticCacheCoherence;
 
 impl Rule for SemanticCacheCoherence {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_cache_coherence"
@@ -30,12 +30,14 @@ impl Rule for SemanticCacheCoherence {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -120,20 +122,22 @@ mod tests {
     #[test]
     fn no_violation_without_history() {
         let rule = SemanticCacheCoherence;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp_tx(
             "https://example.com/foo",
             200,
             &[("date", "Wed, 21 Oct 2015 07:28:00 GMT")],
         );
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(&tx, &history, &cfg, &crate::rules::RuleConfigEngine::new())
+            .is_none());
     }
 
     #[test]
     fn increasing_date_ok() {
         let rule = SemanticCacheCoherence;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let prev = make_resp_tx(
             "https://example.com/foo",
             200,
@@ -146,13 +150,20 @@ mod tests {
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&curr, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &curr,
+                &history,
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn out_of_order_date_flagged() {
         let rule = SemanticCacheCoherence;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let prev = make_resp_tx(
             "https://example.com/foo",
             200,
@@ -165,7 +176,12 @@ mod tests {
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&curr, &history, &cfg);
+        let v = rule.check(
+            &curr,
+            &history,
+            &cfg,
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("appears stale"));
     }
@@ -173,7 +189,7 @@ mod tests {
     #[test]
     fn last_modified_decrease_flagged() {
         let rule = SemanticCacheCoherence;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let prev = make_resp_tx(
             "https://example.com/foo",
             200,
@@ -186,19 +202,31 @@ mod tests {
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&curr, &history, &cfg);
+        let v = rule.check(
+            &curr,
+            &history,
+            &cfg,
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
     #[test]
     fn no_time_headers_no_violation() {
         let rule = SemanticCacheCoherence;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let prev = make_resp_tx("https://example.com/foo", 200, &[]);
         let mut curr = make_resp_tx("https://example.com/foo", 200, &[]);
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&curr, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &curr,
+                &history,
+                &cfg,
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]

--- a/src/rules/semantic_head_response_headers_match_get.rs
+++ b/src/rules/semantic_head_response_headers_match_get.rs
@@ -63,7 +63,7 @@ fn parse_headers_config(
 pub struct SemanticHeadResponseHeadersMatchGet;
 
 impl Rule for SemanticHeadResponseHeadersMatchGet {
-    type Config = SemanticHeadResponseHeadersMatchGetConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_head_response_headers_match_get"
@@ -81,11 +81,12 @@ impl Rule for SemanticHeadResponseHeadersMatchGet {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         // Only applies to HEAD responses with a previous GET on the same URI
         if !tx.request.method.eq_ignore_ascii_case("HEAD") {
@@ -111,6 +112,10 @@ impl Rule for SemanticHeadResponseHeadersMatchGet {
             Some(r) => r,
             None => return None,
         };
+
+        // Parse config only after the cheap method/response/history guards above —
+        // non-HEAD transactions (the common case) skip the allocation entirely.
+        let config = parse_headers_config(cfg, self.id()).ok()?;
 
         // For each configured header, enforce presence/value equivalence between GET and HEAD
         for name in &config.headers {
@@ -263,15 +268,27 @@ mod tests {
         tx
     }
 
-    fn make_cfg_with_headers(headers: Vec<&str>) -> SemanticHeadResponseHeadersMatchGetConfig {
-        SemanticHeadResponseHeadersMatchGetConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            headers: headers
-                .into_iter()
-                .map(|s| s.to_ascii_lowercase())
-                .collect(),
-        }
+    fn make_cfg_with_headers(headers: Vec<&str>) -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "semantic_head_response_headers_match_get".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "headers".into(),
+                    toml::Value::Array(
+                        headers
+                            .into_iter()
+                            .map(|s| toml::Value::String(s.to_string()))
+                            .collect(),
+                    ),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[test]
@@ -290,10 +307,11 @@ mod tests {
         // ensure URIs match
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type", "content-length"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -305,10 +323,11 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing header"));
@@ -321,10 +340,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("x-foo", "bar")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["x-foo"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -340,10 +360,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("content-length", "5")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -356,10 +377,11 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -371,10 +393,11 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -383,10 +406,11 @@ mod tests {
     fn no_previous_does_nothing() {
         let rule = SemanticHeadResponseHeadersMatchGet;
         let head = make_head_with_headers(&[("etag", "\"v1\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -399,10 +423,11 @@ mod tests {
         // different URIs
         head.request.uri = "/other".parse().unwrap();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -415,10 +440,11 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -442,10 +468,11 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // prev had non-utf8 'etag' -> treated as present -> HEAD missing it should be a violation
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -481,10 +508,11 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // Both present but non-UTF8 -> rule should be lenient and not report a violation
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -496,10 +524,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -588,10 +617,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v2\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Header 'etag' value differs"));
@@ -605,10 +635,11 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // 'x-foo' is not in the configured headers list -> should be ignored
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -620,10 +651,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("transfer-encoding", "chunked")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -635,10 +667,11 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -650,10 +683,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("content-length", "5")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -665,10 +699,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "accept, accept-encoding")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -680,10 +715,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "a, c")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Vary"));
@@ -699,10 +735,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -726,10 +763,11 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // presence detected, but values are not compared when one side is non-UTF8
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -741,10 +779,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\""), ("content-type", "text/html")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("content-type"));
@@ -757,10 +796,11 @@ mod tests {
         let mut head = make_head_with_headers(&[("accept-encoding", "deflate, gzip")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["accept-encoding"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -837,10 +877,11 @@ mod tests {
         head.response = None;
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -853,10 +894,11 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // validate_content_length on prev will error -> rule must be lenient
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -868,10 +910,11 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/semantic_options_method_capabilities.rs
+++ b/src/rules/semantic_options_method_capabilities.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct SemanticOptionsMethodCapabilities;
 
 impl Rule for SemanticOptionsMethodCapabilities {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_options_method_capabilities"
@@ -18,12 +18,14 @@ impl Rule for SemanticOptionsMethodCapabilities {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only care about OPTIONS requests with a final response
         if !tx.request.method.eq_ignore_ascii_case("OPTIONS") {
             return None;
@@ -90,11 +92,12 @@ mod tests {
     ) {
         let rule = SemanticOptionsMethodCapabilities;
         let tx = make_opts_tx(status, header);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for status {}", status);
@@ -112,12 +115,13 @@ mod tests {
     fn violation_message_is_informative() {
         let rule = SemanticOptionsMethodCapabilities;
         let tx = make_opts_tx(200, None);
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Allow"));
@@ -127,11 +131,14 @@ mod tests {
     fn non_options_request_is_ignored() {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = SemanticOptionsMethodCapabilities.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "semantic_options_method_capabilities",
+        ]);
+        let v = SemanticOptionsMethodCapabilities.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -149,11 +156,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "OPTIONS".into();
         tx.response = None;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),

--- a/src/rules/semantic_origin_matching_for_cors.rs
+++ b/src/rules/semantic_origin_matching_for_cors.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct SemanticOriginMatchingForCors;
 
 impl Rule for SemanticOriginMatchingForCors {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_origin_matching_for_cors"
@@ -18,12 +18,14 @@ impl Rule for SemanticOriginMatchingForCors {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let headers = &req.headers;
 
@@ -143,18 +145,18 @@ mod tests {
     use rstest::rstest;
 
     use crate::test_helpers::{
-        make_headers_from_pairs, make_test_rule_config, make_test_transaction,
-        make_test_transaction_with_response,
+        make_headers_from_pairs, make_test_transaction, make_test_transaction_with_response,
     };
 
     #[rstest]
     fn no_origin_header_ignored() {
         let rule = SemanticOriginMatchingForCors;
         let tx = make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -165,10 +167,11 @@ mod tests {
         let mut tx = make_test_transaction();
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         // response has no ACAO
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -181,10 +184,11 @@ mod tests {
             &[("access-control-allow-origin", "https://example.com")],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -195,10 +199,11 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "*")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -215,10 +220,11 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("'*' is not allowed"));
@@ -233,10 +239,11 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not match request Origin"));
@@ -248,10 +255,11 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -268,10 +276,11 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("'*' is not allowed"));
@@ -286,10 +295,11 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://a")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));
@@ -313,10 +323,11 @@ mod tests {
             trailers: None,
         });
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Multiple Access-Control-Allow-Origin"));
@@ -328,10 +339,11 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "NULL")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -341,10 +353,11 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "NULL")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -355,10 +368,11 @@ mod tests {
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "*")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "bad://")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         // The helper now returns a generic message for missing authority,

--- a/src/rules/semantic_patch_partial_update.rs
+++ b/src/rules/semantic_patch_partial_update.rs
@@ -13,7 +13,7 @@ use crate::rules::Rule;
 pub struct SemanticPatchPartialUpdate;
 
 impl Rule for SemanticPatchPartialUpdate {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_patch_partial_update"
@@ -23,12 +23,14 @@ impl Rule for SemanticPatchPartialUpdate {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.method.eq_ignore_ascii_case("PATCH") {
             return None;
         }
@@ -151,11 +153,12 @@ mod tests {
     ) {
         let rule = SemanticPatchPartialUpdate;
         let tx = make_tx_with_req(headers);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -180,11 +183,12 @@ mod tests {
             HeaderValue::from_bytes(b"text/plain\xFF").unwrap(),
         );
         tx.request.body_length = Some(1);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // rule should not produce a violation; malformed header handled elsewhere
         assert!(v.is_none());
@@ -196,11 +200,12 @@ mod tests {
         let mut tx = make_tx_with_req(vec![]);
         tx.request.method = "PATCH".into();
         tx.request.body_length = Some(5);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -214,11 +219,12 @@ mod tests {
         let mut tx = make_tx_with_req(vec![]);
         tx.request.method = "PATCH".into();
         tx.request_body = Some(Bytes::from("hello"));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),

--- a/src/rules/semantic_post_creates_resource.rs
+++ b/src/rules/semantic_post_creates_resource.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct SemanticPostCreatesResource;
 
 impl Rule for SemanticPostCreatesResource {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_post_creates_resource"
@@ -18,12 +18,14 @@ impl Rule for SemanticPostCreatesResource {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only consider POST requests with a response
         if !tx.request.method.eq_ignore_ascii_case("POST") {
             return None;
@@ -100,11 +102,12 @@ mod tests {
     ) {
         let rule = SemanticPostCreatesResource;
         let tx = make_tx(status, headers);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for status {}", status);
@@ -122,11 +125,12 @@ mod tests {
     fn location_header_case_insensitive() {
         let rule = SemanticPostCreatesResource;
         let tx = make_tx(200, vec![("Location", "/new")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -142,11 +146,12 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -160,11 +165,12 @@ mod tests {
         // create headers with two Location lines; header-map will collapse but still
         // presence is what matters
         let tx = make_tx(200, vec![("location", "/a"), ("location", "/b")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -177,12 +183,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(201, &[]);
         tx.request.method = "PUT".to_string();
         let rule = SemanticPostCreatesResource;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }

--- a/src/rules/semantic_status_code_semantics.rs
+++ b/src/rules/semantic_status_code_semantics.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct SemanticStatusCodeSemantics;
 
 impl Rule for SemanticStatusCodeSemantics {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_status_code_semantics"
@@ -18,12 +18,14 @@ impl Rule for SemanticStatusCodeSemantics {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -91,10 +93,11 @@ mod tests {
     fn missing_www_on_401_reports_violation() {
         let rule = SemanticStatusCodeSemantics;
         let tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("WWW-Authenticate"));
@@ -104,10 +107,11 @@ mod tests {
     fn missing_proxy_on_407_reports_violation() {
         let rule = SemanticStatusCodeSemantics;
         let tx = crate::test_helpers::make_test_transaction_with_response(407, &[]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Proxy-Authenticate"));
@@ -120,10 +124,11 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -135,10 +140,11 @@ mod tests {
             200,
             &[("www-authenticate", "Basic realm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-401"));
@@ -152,10 +158,11 @@ mod tests {
             401,
             &[("WWW-AUTHENTICATE", "Basic realm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -171,10 +178,11 @@ mod tests {
             HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -192,10 +200,11 @@ mod tests {
             401,
             &[("proxy-authenticate", "Basic realm=\"proxy\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -212,10 +221,11 @@ mod tests {
                 ("www-authenticate", "Basic realm=\"x\""),
             ],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("WWW-Authenticate"));
@@ -228,10 +238,11 @@ mod tests {
             200,
             &[("proxy-authenticate", "Basic realm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Proxy-Authenticate"));

--- a/src/rules/semantic_trace_method_echo.rs
+++ b/src/rules/semantic_trace_method_echo.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct SemanticTraceMethodEcho;
 
 impl Rule for SemanticTraceMethodEcho {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "semantic_trace_method_echo"
@@ -18,12 +18,14 @@ impl Rule for SemanticTraceMethodEcho {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.method.eq_ignore_ascii_case("TRACE") {
             return None;
         }
@@ -157,10 +159,11 @@ mod tests {
     fn non_trace_request_is_ignored() {
         let rule = SemanticTraceMethodEcho;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -173,10 +176,11 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "chunked")]);
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("MUST NOT include content"));
@@ -190,10 +194,11 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("content-length", "1")]);
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Content-Length 1"));
@@ -206,10 +211,11 @@ mod tests {
         tx.request.body_length = Some(4);
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("captured request body"));
@@ -222,10 +228,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-length", "0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -237,10 +244,11 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-length", "abc")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -260,10 +268,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -281,10 +290,11 @@ mod tests {
         });
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("message/http"));
@@ -308,10 +318,11 @@ mod tests {
         });
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("message/http"));
@@ -333,10 +344,11 @@ mod tests {
         });
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("should be message/http"));
@@ -355,10 +367,11 @@ mod tests {
         });
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("is invalid"));
@@ -376,10 +389,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -400,10 +414,11 @@ mod tests {
         });
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_rule_config(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("message/http"));
@@ -424,10 +439,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -447,10 +463,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -467,10 +484,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_200_vs_204_body_consistency.rs
+++ b/src/rules/server_200_vs_204_body_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct Server200Vs204BodyConsistency;
 
 impl Rule for Server200Vs204BodyConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_200_vs_204_body_consistency"
@@ -18,12 +18,14 @@ impl Rule for Server200Vs204BodyConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -130,12 +132,13 @@ mod tests {
             }
         }
 
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -164,11 +167,12 @@ mod tests {
     fn no_response_returns_none() -> anyhow::Result<()> {
         let rule = Server200Vs204BodyConsistency;
         let tx = crate::test_helpers::make_test_transaction();
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -178,12 +182,13 @@ mod tests {
     fn violation_message_for_content_length_zero() -> anyhow::Result<()> {
         let rule = Server200Vs204BodyConsistency;
         let tx = make_tx_with_response(200, "GET", &[("content-length", "0")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .expect("expected violation");
         assert!(v.message.contains("Content-Length: 0"));
@@ -198,12 +203,13 @@ mod tests {
         if let Some(resp) = tx.response.as_mut() {
             resp.body_length = Some(0);
         }
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .expect("expected violation");
         assert!(v.message.contains("captured length 0"));
@@ -239,11 +245,12 @@ mod tests {
             trailers: None,
         });
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/server_3xx_vs_request_method.rs
+++ b/src/rules/server_3xx_vs_request_method.rs
@@ -13,7 +13,7 @@ use crate::rules::Rule;
 pub struct Server3xxVsRequestMethod;
 
 impl Rule for Server3xxVsRequestMethod {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_3xx_vs_request_method"
@@ -23,12 +23,14 @@ impl Rule for Server3xxVsRequestMethod {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses
         let resp = match &tx.response {
             Some(r) => r,
@@ -94,12 +96,13 @@ mod tests {
     #[test]
     fn post_301_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -111,12 +114,13 @@ mod tests {
     #[test]
     fn post_302_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -124,12 +128,13 @@ mod tests {
     #[test]
     fn post_303_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(303, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -138,12 +143,13 @@ mod tests {
     fn post_200_with_location_is_ignored() {
         // Non-3xx status codes should be ignored even if a Location header is present
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(200, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "non-3xx status should be ignored");
     }
@@ -151,12 +157,13 @@ mod tests {
     #[test]
     fn post_307_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(307, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -164,12 +171,13 @@ mod tests {
     #[test]
     fn get_301_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "GET", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -177,12 +185,13 @@ mod tests {
     #[test]
     fn post_301_without_location_is_ignored() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "POST", false);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -190,12 +199,13 @@ mod tests {
     #[test]
     fn lower_case_method_post_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "post", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -204,16 +214,17 @@ mod tests {
     fn non_utf8_location_still_counts() {
         use hyper::header::HeaderValue;
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = make_tx(301, "POST", true);
         // Replace location header with a non-UTF8 value; presence alone should trigger the rule
         let mut hm = hyper::HeaderMap::new();
         hm.insert("location", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -221,13 +232,14 @@ mod tests {
     #[test]
     fn options_and_trace_are_treated_as_safe() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         for m in &["OPTIONS", "TRACE"] {
             let tx = make_tx(301, m, true);
-            let v = rule.check_transaction(
+            let v = rule.check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(v.is_none(), "method {} should be treated as safe", m);
         }
@@ -244,12 +256,13 @@ mod tests {
     #[test]
     fn post_300_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(300, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -257,12 +270,13 @@ mod tests {
     #[test]
     fn post_308_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(308, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -270,12 +284,13 @@ mod tests {
     #[test]
     fn head_301_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "HEAD", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -283,12 +298,13 @@ mod tests {
     #[test]
     fn put_301_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "PUT", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -296,12 +312,13 @@ mod tests {
     #[test]
     fn patch_301_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "PATCH", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -309,12 +326,13 @@ mod tests {
     #[test]
     fn delete_301_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "DELETE", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -322,13 +340,14 @@ mod tests {
     #[test]
     fn empty_method_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = make_tx(301, "POST", true);
         tx.request.method = "".to_string();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -337,16 +356,17 @@ mod tests {
     fn multiple_location_headers_count() {
         use hyper::header::HeaderValue;
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = make_tx(301, "POST", false);
         let mut hm = hyper::HeaderMap::new();
         hm.append("location", HeaderValue::from_static("/first"));
         hm.append("location", HeaderValue::from_static("/second"));
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -355,15 +375,16 @@ mod tests {
     fn empty_location_value_counts() {
         use hyper::header::HeaderValue;
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = make_tx(301, "POST", false);
         let mut hm = hyper::HeaderMap::new();
         hm.insert("location", HeaderValue::from_static(""));
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -372,12 +393,13 @@ mod tests {
     fn no_response_is_ignored() {
         // If there's no response, rule should return None
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = crate::test_helpers::make_test_transaction(); // no response
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -385,13 +407,13 @@ mod tests {
     #[test]
     fn post_302_violation_message_and_severity() {
         let rule = Server3xxVsRequestMethod;
-        let mut cfg = crate::test_helpers::make_test_rule_config();
-        cfg.severity = crate::lint::Severity::Error;
+        let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         let tx = make_tx(302, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -403,12 +425,13 @@ mod tests {
     #[test]
     fn connect_301_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "CONNECT", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -421,12 +444,13 @@ mod tests {
     #[test]
     fn options_mixed_case_treated_as_safe() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "oPtIoNs", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "mixed-case OPTIONS should be treated as safe");
     }
@@ -434,12 +458,13 @@ mod tests {
     #[test]
     fn trace_mixed_case_treated_as_safe() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "TrAcE", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "mixed-case TRACE should be treated as safe");
     }
@@ -447,12 +472,13 @@ mod tests {
     #[test]
     fn connect_302_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "CONNECT", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -463,12 +489,13 @@ mod tests {
     #[test]
     fn put_302_with_location_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "PUT", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -479,12 +506,13 @@ mod tests {
     #[test]
     fn post_304_with_location_is_ok() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(304, "POST", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -495,12 +523,13 @@ mod tests {
     #[test]
     fn connect_lowercase_reports_violation() {
         let rule = Server3xxVsRequestMethod;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "connect", true);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),

--- a/src/rules/server_accept_ranges_values_valid.rs
+++ b/src/rules/server_accept_ranges_values_valid.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct ServerAcceptRangesValuesValid;
 
 impl Rule for ServerAcceptRangesValuesValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_accept_ranges_values_valid"
@@ -20,12 +20,14 @@ impl Rule for ServerAcceptRangesValuesValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -100,15 +102,16 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_accept_ranges_values_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -132,10 +135,11 @@ mod tests {
     fn missing_response_returns_none() {
         let rule = ServerAcceptRangesValuesValid;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_alt_svc_h3_advertisement_valid.rs
+++ b/src/rules/server_alt_svc_h3_advertisement_valid.rs
@@ -13,7 +13,7 @@ pub struct ServerAltSvcH3AdvertisementValid;
 const MAX_REASONABLE_MA: u64 = 365 * 24 * 3600;
 
 impl Rule for ServerAltSvcH3AdvertisementValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_alt_svc_h3_advertisement_valid"
@@ -23,12 +23,14 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("alt-svc").iter() {
@@ -83,7 +85,7 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
                 }
 
                 // Parse parameters looking for `ma`
-                if let Some(v) = check_h3_ma_param(self.id(), config, params_str) {
+                if let Some(v) = check_h3_ma_param(self.id(), &config, params_str) {
                     return Some(v);
                 }
             }
@@ -221,15 +223,16 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_alt_svc_h3_advertisement_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -250,12 +253,13 @@ mod tests {
             200,
             &[("alt-svc", "h3-29=\":443\"")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("h3-29"));
@@ -269,12 +273,13 @@ mod tests {
             200,
             &[("alt-svc", "h3=\":443\"; ma=0")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("ma=0"));
@@ -287,12 +292,13 @@ mod tests {
             200,
             &[("alt-svc", "h3=\":443\"; ma=99999999")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("unreasonably large"));
@@ -305,12 +311,13 @@ mod tests {
             200,
             &[("alt-svc", "h3=\":443\"; ma=abc")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("non-numeric"));
@@ -321,10 +328,11 @@ mod tests {
     fn missing_response_returns_none() {
         let rule = ServerAltSvcH3AdvertisementValid;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -336,11 +344,12 @@ mod tests {
             200,
             &[("alt-svc", "h2=\":443\""), ("alt-svc", "h3-29=\":443\"")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -352,11 +361,12 @@ mod tests {
             200,
             &[("alt-svc", "h2=\":443\"; ma=0")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -368,12 +378,13 @@ mod tests {
             200,
             &[("alt-svc", "h3=\":443\"; ma=")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("no value"));
@@ -397,10 +408,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -417,11 +429,12 @@ mod tests {
             200,
             &[("alt-svc", "h3example.com:443")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -433,11 +446,12 @@ mod tests {
             200,
             &[("alt-svc", "=\":443\"")],
         );
-        let config = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_alt_svc_header_syntax.rs
+++ b/src/rules/server_alt_svc_header_syntax.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct ServerAltSvcHeaderSyntax;
 
 impl Rule for ServerAltSvcHeaderSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_alt_svc_header_syntax"
@@ -20,12 +20,14 @@ impl Rule for ServerAltSvcHeaderSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -205,15 +207,16 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_alt_svc_header_syntax",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -232,10 +235,11 @@ mod tests {
         let rule = ServerAltSvcHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -258,10 +262,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_alt_svc_protocol_iana_registered.rs
+++ b/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -62,7 +62,7 @@ fn parse_allowed_config(
 pub struct ServerAltSvcProtocolIanaRegistered;
 
 impl Rule for ServerAltSvcProtocolIanaRegistered {
-    type Config = AltSvcProtocolConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_alt_svc_protocol_iana_registered"
@@ -80,12 +80,14 @@ impl Rule for ServerAltSvcProtocolIanaRegistered {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_allowed_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -153,18 +155,27 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    fn make_cfg() -> AltSvcProtocolConfig {
-        AltSvcProtocolConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-            allowed: vec![
-                "h2".to_string(),
-                "h3".to_string(),
-                "h2c".to_string(),
-                "ws".to_string(),
-                "wss".to_string(),
-            ],
-        }
+    fn make_cfg() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        cfg.rules.insert(
+            "server_alt_svc_protocol_iana_registered".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "allowed".into(),
+                    toml::Value::Array(
+                        ["h2", "h3", "h2c", "ws", "wss"]
+                            .iter()
+                            .map(|p| toml::Value::String(p.to_string()))
+                            .collect(),
+                    ),
+                );
+                t
+            }),
+        );
+        cfg
     }
 
     #[rstest]
@@ -188,10 +199,11 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -216,10 +228,11 @@ mod tests {
                 ("alt-svc", "xproto=example.com:443"),
             ],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -236,10 +249,11 @@ mod tests {
             200,
             &[("alt-svc", "h2example.com:443")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         // syntax rule will report missing '='; this rule should be conservative and not panic or report
         assert!(v.is_none());
@@ -264,10 +278,11 @@ mod tests {
         });
 
         let cfg = make_cfg();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_authentication_challenge_validity.rs
+++ b/src/rules/server_authentication_challenge_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerAuthenticationChallengeValidity;
 
 impl Rule for ServerAuthenticationChallengeValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_authentication_challenge_validity"
@@ -18,12 +18,14 @@ impl Rule for ServerAuthenticationChallengeValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers; ignore non-UTF8 header values
         if let Some(resp) = &tx.response {
             use std::collections::{HashMap, HashSet};
@@ -111,12 +113,13 @@ mod tests {
     #[test]
     fn single_challenge_no_violation() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp("Basic realm=\"example\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -124,12 +127,13 @@ mod tests {
     #[test]
     fn multiple_schemes_same_realm_is_violation() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp("Basic realm=\"a\", NewAuth realm=\"a\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let vv = v.unwrap();
@@ -139,12 +143,13 @@ mod tests {
     #[test]
     fn different_realms_no_violation() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp("Basic realm=\"a\", NewAuth realm=\"b\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -152,7 +157,7 @@ mod tests {
     #[test]
     fn multiple_header_fields_checked() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         let mut hm = hyper::HeaderMap::new();
         hm.append(
@@ -164,10 +169,11 @@ mod tests {
             hyper::header::HeaderValue::from_static("NewAuth realm=\"a\""),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -175,13 +181,14 @@ mod tests {
     #[test]
     fn quoted_and_unquoted_realm_match_is_violation() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // Basic realm="a" and NewAuth realm=a -> should be treated equal
         let tx = make_resp("Basic realm=\"a\", NewAuth realm=a");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -189,7 +196,7 @@ mod tests {
     #[test]
     fn non_utf8_header_values_are_ignored() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -199,10 +206,11 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -210,13 +218,14 @@ mod tests {
     #[test]
     fn quoted_with_escaped_quote_matches() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // realm with escaped quote inside quoted-string
         let tx = make_resp("Basic realm=\"a\\\"b\", NewAuth realm=\"a\\\"b\"");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -224,13 +233,14 @@ mod tests {
     #[test]
     fn missing_realm_among_challenges_is_not_violation() {
         let rule = ServerAuthenticationChallengeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // NewAuth has no realm, Basic has realm a
         let tx = make_resp("Basic realm=\"a\", NewAuth");
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_cache_control_present.rs
+++ b/src/rules/server_cache_control_present.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerCacheControlPresent;
 
 impl Rule for ServerCacheControlPresent {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_cache_control_present"
@@ -18,12 +18,14 @@ impl Rule for ServerCacheControlPresent {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if let Some(resp) = &tx.response {
             if resp.status == 200 && !resp.headers.contains_key("cache-control") {
                 return Some(Violation {
@@ -60,10 +62,11 @@ mod tests {
             Some((k, v)) => make_test_transaction_with_response(status, &[(k, v)]),
             None => make_test_transaction_with_response(status, &[]),
         };
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/server_charset_specification.rs
+++ b/src/rules/server_charset_specification.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerCharsetSpecification;
 
 impl Rule for ServerCharsetSpecification {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_charset_specification"
@@ -18,12 +18,14 @@ impl Rule for ServerCharsetSpecification {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -94,10 +96,11 @@ mod tests {
             });
         }
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/server_clear_site_data.rs
+++ b/src/rules/server_clear_site_data.rs
@@ -80,7 +80,7 @@ paths = ["/logout"]"#
 }
 
 impl Rule for ServerClearSiteData {
-    type Config = ClearSiteDataConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_clear_site_data"
@@ -98,11 +98,12 @@ impl Rule for ServerClearSiteData {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         // Only check successful responses
         let Some(resp) = &tx.response else {
@@ -112,6 +113,10 @@ impl Rule for ServerClearSiteData {
         if !(200..300).contains(&status) {
             return None;
         }
+
+        // Parse config only after the cheap response/status guards — non-2xx
+        // responses (redirects, errors) skip the paths allocation entirely.
+        let config = parse_paths_config(cfg, self.id()).ok()?;
 
         // Check if the current resource path matches any configured path
         let resource_path = extract_path_from_resource(&tx.request.uri);
@@ -194,11 +199,12 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerClearSiteData;
 
-        let config = super::ClearSiteDataConfig {
-            enabled: true,
-            paths: config_paths.iter().map(|s| s.to_string()).collect(),
-            severity: crate::lint::Severity::Warn,
-        };
+        let mut config = crate::config::Config::default();
+        crate::test_helpers::enable_rule_with_paths(
+            &mut config,
+            "server_clear_site_data",
+            &config_paths,
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.uri = format!("http://test.com{}", resource_path);
@@ -211,10 +217,11 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -367,15 +374,17 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerClearSiteData;
         let tx = crate::test_helpers::make_test_transaction();
-        let config = super::ClearSiteDataConfig {
-            enabled: true,
-            paths: vec!["/logout".to_string()],
-            severity: crate::lint::Severity::Warn,
-        };
-        let violation = rule.check_transaction(
+        let mut config = crate::config::Config::default();
+        crate::test_helpers::enable_rule_with_paths(
+            &mut config,
+            "server_clear_site_data",
+            &["/logout"],
+        );
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_content_security_policy_validity.rs
+++ b/src/rules/server_content_security_policy_validity.rs
@@ -14,7 +14,7 @@ use crate::rules::Rule;
 pub struct ServerContentSecurityPolicyValidity;
 
 impl Rule for ServerContentSecurityPolicyValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_content_security_policy_validity"
@@ -24,12 +24,14 @@ impl Rule for ServerContentSecurityPolicyValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
         let resp = match &tx.response {
             Some(r) => r,
@@ -238,11 +240,11 @@ mod tests {
     use hyper::header::HeaderValue;
     use rstest::rstest;
 
-    fn make_cfg() -> crate::rules::RuleConfig {
-        crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_cfg() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_severity(
+            "server_content_security_policy_validity",
+            "warn",
+        )
     }
 
     #[rstest]
@@ -264,10 +266,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-security-policy", h)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header '{:?}'", header);
@@ -292,10 +295,11 @@ mod tests {
             "def@ult-src 'self'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid character"));
@@ -312,10 +316,11 @@ mod tests {
             "default-src 'self'; ",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("empty directive"));
@@ -332,10 +337,11 @@ mod tests {
             "default-src 'self",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Unterminated"));
@@ -352,10 +358,11 @@ mod tests {
             "default-src ''",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty single-quoted"));
@@ -381,10 +388,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers = headers;
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("not valid UTF-8"));
@@ -401,10 +409,11 @@ mod tests {
             "script-src nonce-",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty nonce value"));
@@ -421,10 +430,11 @@ mod tests {
             "script-src sha256-",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -447,10 +457,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers = headers;
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid character"));
@@ -472,10 +483,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-security-policy", "   ")]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("MUST not be empty"));
@@ -492,10 +504,11 @@ mod tests {
             "default-src 'self';;;script-src 'self'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("empty directive"));
@@ -512,10 +525,11 @@ mod tests {
             "script-src nonce-abc def",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -532,10 +546,11 @@ mod tests {
             "script-src 'nonce-abc def'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid nonce value") || v.message.contains("Unterminated"));
@@ -552,10 +567,11 @@ mod tests {
             "script-src 'nonce-'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty nonce value"));
@@ -572,10 +588,11 @@ mod tests {
             "script-src sha256-abc",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -592,10 +609,11 @@ mod tests {
             "script-src 'sha256-'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -612,10 +630,11 @@ mod tests {
             "script-src sha384-abc",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -632,10 +651,11 @@ mod tests {
             "script-src 'sha512-'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -652,10 +672,11 @@ mod tests {
             "script-src sha512-abc",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -672,10 +693,11 @@ mod tests {
             "script-src 'sha256-abc' https://example.com",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -691,10 +713,11 @@ mod tests {
             "script-src 'sha384-abc' https://example.com",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -710,10 +733,11 @@ mod tests {
             "script-src 'sha512-abc' https://example.com",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -729,10 +753,11 @@ mod tests {
             "script-src 'nonce-abc' 'sha256-abc' 'sha384-abc' 'sha512-abc' default-src 'self'",
         )]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -748,10 +773,11 @@ mod tests {
             "script-src 'sha384-'",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -767,10 +793,11 @@ mod tests {
             "script-src sha384-",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -786,10 +813,11 @@ mod tests {
             "script-src sha512-",
         )]);
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -800,10 +828,11 @@ mod tests {
         let rule = ServerContentSecurityPolicyValidity;
         let cfg = make_cfg();
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_content_type_present.rs
+++ b/src/rules/server_content_type_present.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerContentTypePresent;
 
 impl Rule for ServerContentTypePresent {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_content_type_present"
@@ -18,12 +18,14 @@ impl Rule for ServerContentTypePresent {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -104,10 +106,11 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -126,10 +129,11 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerContentTypePresent;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_deprecation_header_syntax.rs
+++ b/src/rules/server_deprecation_header_syntax.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerDeprecationHeaderSyntax;
 
 impl Rule for ServerDeprecationHeaderSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_deprecation_header_syntax"
@@ -18,12 +18,14 @@ impl Rule for ServerDeprecationHeaderSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
         let resp = match &tx.response {
             Some(r) => r,
@@ -109,10 +111,11 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerDeprecationHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -143,10 +146,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -168,10 +172,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -186,10 +191,11 @@ mod tests {
             200,
             &[("deprecation", "   @1688169599   ")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -202,10 +208,11 @@ mod tests {
             200,
             &[("deprecation", "@abc")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -219,10 +226,11 @@ mod tests {
         let rule = ServerDeprecationHeaderSyntax;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("deprecation", "@")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -235,10 +243,11 @@ mod tests {
             200,
             &[("deprecation", "@-1")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -251,10 +260,11 @@ mod tests {
             200,
             &[("deprecation", "TRUE")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -266,10 +276,11 @@ mod tests {
     fn no_response_no_violation() {
         let rule = ServerDeprecationHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_etag_or_last_modified.rs
+++ b/src/rules/server_etag_or_last_modified.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerEtagOrLastModified;
 
 impl Rule for ServerEtagOrLastModified {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_etag_or_last_modified"
@@ -18,12 +18,14 @@ impl Rule for ServerEtagOrLastModified {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -70,10 +72,11 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -91,10 +94,11 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerEtagOrLastModified;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_http3_status_code_validity.rs
+++ b/src/rules/server_http3_status_code_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerHttp3StatusCodeValidity;
 
 impl Rule for ServerHttp3StatusCodeValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_http3_status_code_validity"
@@ -18,12 +18,14 @@ impl Rule for ServerHttp3StatusCodeValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 connections.
         if tx.request.version != "HTTP/3" {
             return None;
@@ -120,10 +122,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(101, &[("upgrade", "websocket")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         let v = v.expect("should be a violation");
         assert_eq!(v.rule, "server_http3_status_code_validity");
@@ -137,10 +140,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(101, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("101"));
@@ -156,10 +160,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(status, headers);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -171,10 +176,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(100, &[("content-length", "0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         let v = v.expect("should be a violation");
         assert_eq!(v.rule, "server_http3_status_code_validity");
@@ -187,10 +193,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(103, &[("content-length", "42")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -208,10 +215,11 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("message body"));
@@ -225,10 +233,11 @@ mod tests {
             resp.body_length = Some(0);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -246,10 +255,11 @@ mod tests {
             )]));
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("trailer"));
@@ -268,10 +278,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(status, &[]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -286,10 +297,11 @@ mod tests {
             &[("upgrade", "websocket")],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -305,10 +317,11 @@ mod tests {
         tx.request.version = "HTTP/3".into();
         // response.version stays HTTP/1.1
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -321,10 +334,11 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/3".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -337,10 +351,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(199, &[("content-length", "0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("199"));
@@ -352,10 +367,11 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(200, &[("content-length", "42")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -370,10 +386,11 @@ mod tests {
             resp.body_length = Some(100);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -389,10 +406,11 @@ mod tests {
             )]));
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -408,10 +426,11 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -426,10 +445,11 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("101"));
@@ -445,10 +465,11 @@ mod tests {
             resp.body_length = None;
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -462,10 +483,11 @@ mod tests {
             crate::test_helpers::make_test_transaction_with_response(101, &[("upgrade", "h2c")]);
         tx.request.version = "HTTP/2.0".into();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -480,10 +502,11 @@ mod tests {
             resp.body_length = Some(5);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("102"));
@@ -500,10 +523,11 @@ mod tests {
             resp.trailers = Some(hyper::HeaderMap::new());
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("trailer"));
@@ -524,10 +548,11 @@ mod tests {
             )]));
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("trailer"));

--- a/src/rules/server_keep_alive_timeout_reasonable.rs
+++ b/src/rules/server_keep_alive_timeout_reasonable.rs
@@ -57,7 +57,7 @@ fn parse_keep_alive_config(
 pub struct ServerKeepAliveTimeoutReasonable;
 
 impl Rule for ServerKeepAliveTimeoutReasonable {
-    type Config = ServerKeepAliveConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_keep_alive_timeout_reasonable"
@@ -75,12 +75,14 @@ impl Rule for ServerKeepAliveTimeoutReasonable {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_keep_alive_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -191,21 +193,17 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let cfg_arc = boxed
-            .downcast::<ServerKeepAliveConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
-
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         if let Some(v) = hv {
             tx.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&[("keep-alive", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &*cfg_arc,
+            &full_cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}: got {:?}", hv, v);
@@ -241,15 +239,11 @@ mod tests {
                 t
             }),
         );
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let cfg_arc = boxed
-            .downcast::<ServerKeepAliveConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
-
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &*cfg_arc,
+            &full_cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_last_modified_rfc1123_format.rs
+++ b/src/rules/server_last_modified_rfc1123_format.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerLastModifiedRfc1123Format;
 
 impl Rule for ServerLastModifiedRfc1123Format {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_last_modified_rfc1123_format"
@@ -18,12 +18,14 @@ impl Rule for ServerLastModifiedRfc1123Format {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -76,10 +78,11 @@ mod tests {
             });
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -110,10 +113,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_location_header_uri_valid.rs
+++ b/src/rules/server_location_header_uri_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerLocationHeaderUriValid;
 
 impl Rule for ServerLocationHeaderUriValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_location_header_uri_valid"
@@ -18,12 +18,14 @@ impl Rule for ServerLocationHeaderUriValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -103,15 +105,16 @@ mod tests {
     fn check_location_header(#[case] loc: &str, #[case] expect_violation: bool) {
         let rule = ServerLocationHeaderUriValid;
         let tx = make_tx_with_loc(loc);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_location_header_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", loc);
@@ -139,15 +142,16 @@ mod tests {
             trailers: None,
         });
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_location_header_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -166,15 +170,16 @@ mod tests {
             trailers: None,
         });
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_location_header_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid scheme"));
@@ -193,15 +198,16 @@ mod tests {
             trailers: None,
         });
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_location_header_uri_valid",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid character"));
@@ -222,14 +228,15 @@ mod tests {
             trailers: None,
         });
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
-        let v = rule.check_transaction(
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_location_header_uri_valid",
+            "warn",
+        );
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));

--- a/src/rules/server_must_revalidate_and_immutable_mismatch.rs
+++ b/src/rules/server_must_revalidate_and_immutable_mismatch.rs
@@ -12,7 +12,7 @@ use crate::rules::Rule;
 pub struct ServerMustRevalidateAndImmutableMismatch;
 
 impl Rule for ServerMustRevalidateAndImmutableMismatch {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_must_revalidate_and_immutable_mismatch"
@@ -22,12 +22,14 @@ impl Rule for ServerMustRevalidateAndImmutableMismatch {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -106,15 +108,16 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "server_must_revalidate_and_immutable_mismatch",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for cc={:?}", cc);
@@ -150,15 +153,16 @@ mod tests {
             .append("cache-control", HeaderValue::from_static("must-revalidate"));
 
         let rule = ServerMustRevalidateAndImmutableMismatch;
-        let cfg = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let cfg = crate::test_helpers::make_test_config_with_severity(
+            "server_must_revalidate_and_immutable_mismatch",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -186,10 +190,11 @@ mod tests {
             .insert("cache-control", bad);
 
         let rule = ServerMustRevalidateAndImmutableMismatch;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/server_no_body_for_1xx_204_304.rs
+++ b/src/rules/server_no_body_for_1xx_204_304.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerNoBodyFor1xx204304;
 
 impl Rule for ServerNoBodyFor1xx204304 {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_no_body_for_1xx_204_304"
@@ -18,12 +18,14 @@ impl Rule for ServerNoBodyFor1xx204304 {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -115,14 +117,15 @@ mod tests {
             trailers: None,
         });
 
-        let test_rule_config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-        };
-        let violation = rule.check_transaction(
+        let test_rule_config = crate::test_helpers::make_test_config_with_severity(
+            "server_no_body_for_1xx_204_304",
+            "error",
+        );
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &test_rule_config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -143,13 +146,14 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerNoBodyFor1xx204304;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::rules::RuleConfig {
-                enabled: true,
-                severity: crate::lint::Severity::Error,
-            },
+            &crate::test_helpers::make_test_config_with_severity(
+                "server_no_body_for_1xx_204_304",
+                "error",
+            ),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_patch_accept_patch_header.rs
+++ b/src/rules/server_patch_accept_patch_header.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct ServerPatchAcceptPatchHeader;
 
 impl Rule for ServerPatchAcceptPatchHeader {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_patch_accept_patch_header"
@@ -20,12 +20,14 @@ impl Rule for ServerPatchAcceptPatchHeader {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies when the request method is PATCH and a response exists
         if !tx.request.method.eq_ignore_ascii_case("PATCH") {
             return None;
@@ -151,12 +153,13 @@ mod tests {
         let mut tx = tx;
         tx.request.method = method.into();
 
-        let config = crate::test_helpers::make_test_rule_config();
+        let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -203,10 +206,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -233,10 +237,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_priority_and_cacheability_consistency.rs
+++ b/src/rules/server_priority_and_cacheability_consistency.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerPriorityAndCacheabilityConsistency;
 
 impl Rule for ServerPriorityAndCacheabilityConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_priority_and_cacheability_consistency"
@@ -18,12 +18,14 @@ impl Rule for ServerPriorityAndCacheabilityConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -79,10 +81,11 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("priority", "u=3")]);
 
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Priority header"));
@@ -95,10 +98,11 @@ mod tests {
             &[("priority", "u=1"), ("cache-control", "public, max-age=60")],
         );
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -110,10 +114,11 @@ mod tests {
             &[("priority", "u=1"), ("vary", "Accept-Encoding")],
         );
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -122,10 +127,11 @@ mod tests {
     fn no_priority_is_ignored() {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -138,10 +144,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -157,10 +164,11 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -171,10 +179,11 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(503, &[("priority", "u=1")]);
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_problem_details_content_type.rs
+++ b/src/rules/server_problem_details_content_type.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerProblemDetailsContentType;
 
 impl Rule for ServerProblemDetailsContentType {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_problem_details_content_type"
@@ -18,12 +18,14 @@ impl Rule for ServerProblemDetailsContentType {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -107,10 +109,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());

--- a/src/rules/server_quic_transport_parameters.rs
+++ b/src/rules/server_quic_transport_parameters.rs
@@ -15,7 +15,7 @@
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
-use crate::rules::{ProtocolRule, RuleConfig};
+use crate::rules::ProtocolRule;
 
 pub struct ServerQuicTransportParameters;
 
@@ -25,18 +25,20 @@ pub struct ServerQuicTransportParameters;
 const MAX_REASONABLE_IDLE_TIMEOUT_MS: u64 = 600_000;
 
 impl ProtocolRule for ServerQuicTransportParameters {
-    type Config = RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_quic_transport_parameters"
     }
 
-    fn check_event(
+    fn check(
         &self,
         event: &ProtocolEvent,
         _history: &ProtocolEventHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let params = match &event.kind {
             ProtocolEventKind::QuicTransportParams { params } => params,
             _ => return None,
@@ -137,11 +139,10 @@ mod tests {
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
 
-    fn make_config() -> RuleConfig {
-        RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_config() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "server_quic_transport_parameters",
+        ])
     }
 
     fn base_ts() -> DateTime<Utc> {
@@ -175,7 +176,12 @@ mod tests {
     fn reasonable_params_pass() {
         let rule = ServerQuicTransportParameters;
         let evt = make_event(reasonable_params());
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -187,7 +193,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("initial_max_streams_bidi"));
     }
@@ -198,7 +209,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = Some(1);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -208,7 +224,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = None;
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -220,7 +241,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_data = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("initial_max_data"));
     }
@@ -231,7 +257,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_data = None;
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -243,7 +274,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_bidi_local = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -259,7 +295,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_bidi_remote = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -275,7 +316,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_uni = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -291,7 +337,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
     }
@@ -302,7 +353,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = None;
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
     }
@@ -313,7 +369,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(MAX_REASONABLE_IDLE_TIMEOUT_MS + 1);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("excessively large"));
@@ -325,7 +386,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(MAX_REASONABLE_IDLE_TIMEOUT_MS);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -335,7 +401,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(1);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -349,7 +420,12 @@ mod tests {
             connection_id: Uuid::new_v4(),
             kind: ProtocolEventKind::H3StreamOpened { stream_id: 0 },
         };
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -368,7 +444,12 @@ mod tests {
                 payload_length: 10,
             },
         };
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -396,7 +477,12 @@ mod tests {
             initial_max_stream_data_uni: None,
         };
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         // Only max_idle_timeout triggers because None means no timeout
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
@@ -416,7 +502,12 @@ mod tests {
             initial_max_stream_data_uni: Some(0),
         };
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         // First check is initial_max_streams_bidi
         assert!(result.unwrap().message.contains("initial_max_streams_bidi"));

--- a/src/rules/server_redirect_status_and_location_validity.rs
+++ b/src/rules/server_redirect_status_and_location_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerRedirectStatusAndLocationValidity;
 
 impl Rule for ServerRedirectStatusAndLocationValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_redirect_status_and_location_validity"
@@ -18,12 +18,14 @@ impl Rule for ServerRedirectStatusAndLocationValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // If response has a Location header but the status code is not one
         // that normally indicates a redirect or created resource, report it.
         if let Some(resp) = &tx.response {
@@ -69,7 +71,7 @@ mod tests {
         #[case] expect_violation: bool,
     ) {
         let rule = ServerRedirectStatusAndLocationValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         if let Some(l) = loc {
@@ -77,10 +79,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("location", l)]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -103,13 +106,14 @@ mod tests {
     #[test]
     fn no_response_is_ignored() {
         let rule = ServerRedirectStatusAndLocationValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_response_405_allow.rs
+++ b/src/rules/server_response_405_allow.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerResponse405Allow;
 
 impl Rule for ServerResponse405Allow {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_response_405_allow"
@@ -18,12 +18,14 @@ impl Rule for ServerResponse405Allow {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if let Some(resp) = &tx.response {
             if resp.status == 405 && !resp.headers.contains_key("allow") {
                 return Some(Violation {
@@ -61,10 +63,11 @@ mod tests {
             None => vec![],
         };
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/server_response_location_on_redirect.rs
+++ b/src/rules/server_response_location_on_redirect.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerResponseLocationOnRedirect;
 
 impl Rule for ServerResponseLocationOnRedirect {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_response_location_on_redirect"
@@ -18,12 +18,14 @@ impl Rule for ServerResponseLocationOnRedirect {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -88,15 +90,16 @@ mod tests {
     ) {
         let rule = ServerResponseLocationOnRedirect;
         let tx = make_tx(status, loc);
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_response_location_on_redirect",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for status {}", status);
@@ -119,15 +122,16 @@ mod tests {
     fn no_response_returns_none() {
         let rule = ServerResponseLocationOnRedirect;
         let tx = crate::test_helpers::make_test_transaction();
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_response_location_on_redirect",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_retry_after_status_validity.rs
+++ b/src/rules/server_retry_after_status_validity.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerRetryAfterStatusValidity;
 
 impl Rule for ServerRetryAfterStatusValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_retry_after_status_validity"
@@ -18,12 +18,14 @@ impl Rule for ServerRetryAfterStatusValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         resp.headers.get_all("retry-after").iter().next()?;
@@ -67,7 +69,7 @@ mod tests {
         #[case] expect_violation: bool,
     ) {
         let rule = ServerRetryAfterStatusValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         if with_retry_after {
@@ -75,10 +77,11 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("retry-after", "120")]);
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert_eq!(v.is_some(), expect_violation);
     }
@@ -86,12 +89,13 @@ mod tests {
     #[test]
     fn no_response_no_violation() {
         let rule = ServerRetryAfterStatusValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -115,16 +119,17 @@ mod tests {
     #[test]
     fn violation_message_contains_status_and_expected_set() {
         let rule = ServerRetryAfterStatusValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(500, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("retry-after", "60")]);
 
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
+                &crate::rules::RuleConfigEngine::new(),
             )
             .expect("expected violation");
         assert!(v.message.contains("status 500"));

--- a/src/rules/server_server_timing_header_syntax.rs
+++ b/src/rules/server_server_timing_header_syntax.rs
@@ -13,7 +13,7 @@ use crate::rules::Rule;
 pub struct ServerServerTimingHeaderSyntax;
 
 impl Rule for ServerServerTimingHeaderSyntax {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_server_timing_header_syntax"
@@ -23,12 +23,14 @@ impl Rule for ServerServerTimingHeaderSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -268,15 +270,16 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_server_timing_header_syntax",
+            "warn",
+        );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -302,10 +305,11 @@ mod tests {
             ],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -329,10 +333,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -355,10 +360,11 @@ mod tests {
             200,
             &[("Server-Timing", "db;dur=50;dur=abc")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "duplicate params should be ignored");
     }
@@ -370,10 +376,11 @@ mod tests {
             200,
             &[("Server-Timing", "db;=5")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "empty parameter name should be ignored");
     }
@@ -385,10 +392,11 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc=\"abc\"x")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -406,10 +414,11 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -423,10 +432,11 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc=")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -440,10 +450,11 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc=bad@value")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -455,10 +466,11 @@ mod tests {
         let rule = ServerServerTimingHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
         // tx.response is None
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_status_and_caching_semantics.rs
+++ b/src/rules/server_status_and_caching_semantics.rs
@@ -11,7 +11,7 @@ use crate::rules::Rule;
 pub struct ServerStatusAndCachingSemantics;
 
 impl Rule for ServerStatusAndCachingSemantics {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_status_and_caching_semantics"
@@ -21,12 +21,14 @@ impl Rule for ServerStatusAndCachingSemantics {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -110,10 +112,11 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &hdrs);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -141,10 +144,11 @@ mod tests {
         hm.insert("cache-control", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_status_code_valid_range.rs
+++ b/src/rules/server_status_code_valid_range.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerStatusCodeValidRange;
 
 impl Rule for ServerStatusCodeValidRange {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_status_code_valid_range"
@@ -18,12 +18,14 @@ impl Rule for ServerStatusCodeValidRange {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -69,15 +71,16 @@ mod tests {
             trailers: None,
         });
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_status_code_valid_range",
+            "error",
+        );
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -95,15 +98,16 @@ mod tests {
         let rule = ServerStatusCodeValidRange;
         let tx = crate::test_helpers::make_test_transaction();
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Error,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "server_status_code_valid_range",
+            "error",
+        );
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_vary_and_cache_consistency.rs
+++ b/src/rules/server_vary_and_cache_consistency.rs
@@ -14,7 +14,7 @@ use crate::rules::Rule;
 pub struct ServerVaryAndCacheConsistency;
 
 impl Rule for ServerVaryAndCacheConsistency {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_vary_and_cache_consistency"
@@ -24,12 +24,14 @@ impl Rule for ServerVaryAndCacheConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -135,10 +137,11 @@ mod tests {
     ) {
         let rule = ServerVaryAndCacheConsistency;
         let tx = make_tx(vary, cc);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -171,10 +174,11 @@ mod tests {
             .unwrap()
             .headers
             .insert("cache-control", bad);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -207,10 +211,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -221,19 +226,21 @@ mod tests {
 
         // Public (mixed case) should be detected
         let tx = make_tx(Some("*"), Some("Public"));
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
         // MAX-AGE uppercase
         let tx2 = make_tx(Some("*"), Some("MAX-AGE=60"));
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
     }
@@ -258,10 +265,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -271,10 +279,11 @@ mod tests {
         // Vary: * with a non-cacheability extension should not be flagged
         let rule = ServerVaryAndCacheConsistency;
         let tx = make_tx(Some("*"), Some("foo=bar"));
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_vary_header_valid.rs
+++ b/src/rules/server_vary_header_valid.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct ServerVaryHeaderValid;
 
 impl Rule for ServerVaryHeaderValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_vary_header_valid"
@@ -20,12 +20,14 @@ impl Rule for ServerVaryHeaderValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -130,15 +132,13 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let config = crate::rules::RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        };
+        let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "warn");
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -161,10 +161,11 @@ mod tests {
             &[("vary", "Accept-Encoding"), ("vary", "User-Agent")],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -178,10 +179,11 @@ mod tests {
             &[("vary", "*"), ("vary", "Accept-Encoding")],
         );
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -205,10 +207,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -234,10 +237,11 @@ mod tests {
     fn no_response_returns_none() {
         let rule = ServerVaryHeaderValid;
         let tx = crate::test_helpers::make_test_transaction(); // request-only, no response
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_x_content_type_options.rs
+++ b/src/rules/server_x_content_type_options.rs
@@ -60,7 +60,7 @@ fn parse_x_content_type_options_config(
 }
 
 impl Rule for ServerXContentTypeOptions {
-    type Config = XContentTypeOptionsConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_x_content_type_options"
@@ -78,12 +78,14 @@ impl Rule for ServerXContentTypeOptions {
         Ok(std::sync::Arc::new(parsed))
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = parse_x_content_type_options_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -134,11 +136,25 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerXContentTypeOptions;
 
-        let config = super::XContentTypeOptionsConfig {
-            enabled: true,
-            content_types: content_types.iter().map(|s| s.to_string()).collect(),
-            severity: crate::lint::Severity::Warn,
-        };
+        let mut config = crate::config::Config::default();
+        config.rules.insert(
+            "server_x_content_type_options".into(),
+            toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert("enabled".into(), toml::Value::Boolean(true));
+                t.insert("severity".into(), toml::Value::String("warn".into()));
+                t.insert(
+                    "content_types".into(),
+                    toml::Value::Array(
+                        content_types
+                            .iter()
+                            .map(|s| toml::Value::String(s.to_string()))
+                            .collect(),
+                    ),
+                );
+                t
+            }),
+        );
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -150,10 +166,11 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -270,23 +287,21 @@ mod tests {
         let rule = ServerXContentTypeOptions;
 
         let status = 200;
-        let mut cfg = crate::config::Config::default();
+        let mut config = crate::config::Config::default();
         let mut table = toml::map::Map::new();
         table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        table.insert(
+            "severity".to_string(),
+            toml::Value::String("warn".to_string()),
+        );
         table.insert(
             "content_types".to_string(),
             toml::Value::Array(vec![toml::Value::String("text/html".to_string())]),
         );
-        cfg.rules.insert(
+        config.rules.insert(
             "server_x_content_type_options".to_string(),
             toml::Value::Table(table),
         );
-
-        let config = super::XContentTypeOptionsConfig {
-            enabled: true,
-            content_types: vec!["text/html".to_string()],
-            severity: crate::lint::Severity::Warn,
-        };
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.response = Some(crate::http_transaction::ResponseInfo {
@@ -301,10 +316,11 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         Ok(())
@@ -314,15 +330,26 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerXContentTypeOptions;
         let tx = crate::test_helpers::make_test_transaction();
-        let config = super::XContentTypeOptionsConfig {
-            enabled: true,
-            content_types: vec!["text/html".to_string()],
-            severity: crate::lint::Severity::Warn,
-        };
-        let violation = rule.check_transaction(
+        let mut config = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        table.insert(
+            "severity".to_string(),
+            toml::Value::String("warn".to_string()),
+        );
+        table.insert(
+            "content_types".to_string(),
+            toml::Value::Array(vec![toml::Value::String("text/html".to_string())]),
+        );
+        config.rules.insert(
+            "server_x_content_type_options".to_string(),
+            toml::Value::Table(table),
+        );
+        let violation = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_x_frame_options_value_valid.rs
+++ b/src/rules/server_x_frame_options_value_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerXFrameOptionsValueValid;
 
 impl Rule for ServerXFrameOptionsValueValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_x_frame_options_value_valid"
@@ -18,12 +18,14 @@ impl Rule for ServerXFrameOptionsValueValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check response headers
         let resp = match &tx.response {
             Some(r) => r,
@@ -99,7 +101,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[rstest]
     #[case(Some("DENY"), false)]
@@ -134,10 +136,11 @@ mod tests {
                 &[("x-frame-options", h)],
             );
         }
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -174,10 +177,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple X-Frame-Options"));
@@ -204,10 +208,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));

--- a/src/rules/server_x_xss_protection_value_valid.rs
+++ b/src/rules/server_x_xss_protection_value_valid.rs
@@ -8,7 +8,7 @@ use crate::rules::Rule;
 pub struct ServerXXssProtectionValueValid;
 
 impl Rule for ServerXXssProtectionValueValid {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "server_x_xss_protection_value_valid"
@@ -18,12 +18,14 @@ impl Rule for ServerXXssProtectionValueValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -82,7 +84,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction};
+    use crate::test_helpers::make_test_transaction;
 
     #[rstest]
     #[case(Some("0"), false)]
@@ -107,10 +109,11 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -142,10 +145,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple X-XSS-Protection"));
@@ -172,10 +176,11 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -191,10 +196,11 @@ mod tests {
     fn no_response_returns_none() {
         let rule = ServerXXssProtectionValueValid;
         let tx = make_test_transaction(); // no response set
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -203,10 +209,11 @@ mod tests {
     fn response_without_header_returns_none() {
         let rule = ServerXXssProtectionValueValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -218,10 +225,11 @@ mod tests {
             200,
             &[("x-xss-protection", "1")],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -236,10 +244,11 @@ mod tests {
             200,
             &[("x-xss-protection", val)],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -254,10 +263,11 @@ mod tests {
             200,
             &[("x-xss-protection", val)],
         );
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;

--- a/src/rules/stateful_101_switching_protocols.rs
+++ b/src/rules/stateful_101_switching_protocols.rs
@@ -21,7 +21,7 @@ use crate::rules::Rule;
 pub struct Stateful101SwitchingProtocols;
 
 impl Rule for Stateful101SwitchingProtocols {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_101_switching_protocols"
@@ -31,12 +31,14 @@ impl Rule for Stateful101SwitchingProtocols {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // ── Check: HTTP traffic after a prior 101 on the same connection ──
@@ -207,12 +209,14 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -226,12 +230,14 @@ mod tests {
             &[("upgrade", "h2c"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -245,12 +251,14 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -264,12 +272,14 @@ mod tests {
             &[],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -283,12 +293,14 @@ mod tests {
         ]);
         tx.response = None;
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -299,12 +311,14 @@ mod tests {
     fn unsolicited_101_no_upgrade_in_request() {
         let tx = make_upgrade_tx("HTTP/1.1", &[], 101, &[("upgrade", "websocket")]);
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("did not include an Upgrade header"));
@@ -321,12 +335,14 @@ mod tests {
             &[("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing required Upgrade header"));
@@ -343,12 +359,14 @@ mod tests {
             &[("upgrade", "h2c"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("was not offered by the client"));
@@ -365,12 +383,14 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/1.0"));
@@ -387,12 +407,14 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/2"));
@@ -407,12 +429,14 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/2"));
@@ -429,12 +453,14 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/3"));
@@ -463,8 +489,16 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(&current, &history, &cfg).unwrap();
+        let v = rule
+            .check(
+                &current,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
+            )
+            .unwrap();
         assert!(v.message.contains("HTTP traffic after 101"));
     }
 
@@ -481,8 +515,16 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        assert!(rule.check_transaction(&current, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &current,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     // ── Violation: multiple offered protocols, server picks one ──
@@ -496,12 +538,14 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -515,12 +559,14 @@ mod tests {
             &[("upgrade", "IRC/6.9"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("was not offered"));
@@ -537,12 +583,14 @@ mod tests {
             &[("upgrade", " websocket "), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -565,12 +613,14 @@ mod tests {
             ("connection", "Upgrade"),
         ]);
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -584,12 +634,14 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("no protocol tokens"));
@@ -604,12 +656,14 @@ mod tests {
             &[("upgrade", " , , "), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("no protocol tokens"));
@@ -624,12 +678,14 @@ mod tests {
             &[("upgrade", "TLS/1.0"), ("connection", "Upgrade")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("was not offered"));
@@ -648,8 +704,16 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        assert!(rule.check_transaction(&current, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &current,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_101_switching_protocols"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]

--- a/src/rules/stateful_103_early_hints_before_final.rs
+++ b/src/rules/stateful_103_early_hints_before_final.rs
@@ -11,7 +11,7 @@ use crate::rules::Rule;
 pub struct Stateful103EarlyHintsBeforeFinal;
 
 impl Rule for Stateful103EarlyHintsBeforeFinal {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_103_early_hints_before_final"
@@ -21,12 +21,14 @@ impl Rule for Stateful103EarlyHintsBeforeFinal {
         crate::rules::RuleScope::Server
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses with status 103
         let resp = match &tx.response {
             Some(r) => r,
@@ -79,7 +81,6 @@ mod tests {
     #[test]
     fn early_hints_103_after_final_is_reported() {
         let rule = Stateful103EarlyHintsBeforeFinal;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         prev.request.uri = "/x".to_string();
@@ -89,10 +90,13 @@ mod tests {
         tx.request.uri = "/x".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_103_early_hints_before_final",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -102,7 +106,6 @@ mod tests {
     #[test]
     fn early_hints_103_after_final_different_uri_is_ignored() {
         let rule = Stateful103EarlyHintsBeforeFinal;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         prev.request.uri = "/a".to_string();
@@ -112,10 +115,13 @@ mod tests {
         tx.request.uri = "/b".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_103_early_hints_before_final",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -123,7 +129,6 @@ mod tests {
     #[test]
     fn early_hints_103_before_final_is_allowed() {
         let rule = Stateful103EarlyHintsBeforeFinal;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = crate::test_helpers::make_test_transaction_with_response(103, &[]);
         prev.request.uri = "/r".to_string();
@@ -133,10 +138,13 @@ mod tests {
         tx.request.uri = "/r".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_103_early_hints_before_final",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -169,7 +177,6 @@ mod tests {
     #[test]
     fn previous_without_response_is_ignored() {
         let rule = Stateful103EarlyHintsBeforeFinal;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         // previous transaction exists but has no response -> rule should ignore
         let mut prev = crate::test_helpers::make_test_transaction();
@@ -180,10 +187,13 @@ mod tests {
         tx.request.uri = "/z".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_103_early_hints_before_final",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/stateful_authentication_failure_loop.rs
+++ b/src/rules/stateful_authentication_failure_loop.rs
@@ -10,7 +10,7 @@ use crate::rules::Rule;
 pub struct StatefulAuthenticationFailureLoop;
 
 impl Rule for StatefulAuthenticationFailureLoop {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_authentication_failure_loop"
@@ -20,12 +20,14 @@ impl Rule for StatefulAuthenticationFailureLoop {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
         if resp.status != 401 {
             return None;
@@ -67,7 +69,6 @@ mod tests {
     #[test]
     fn test_auth_loop_detected() {
         let rule = StatefulAuthenticationFailureLoop;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         tx.request.uri = "https://example.com/protected".to_string();
@@ -84,7 +85,14 @@ mod tests {
         // supply history newest-first; tx3 is most recent
         let history = crate::transaction_history::TransactionHistory::new(vec![tx3, tx2, tx1]);
 
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_authentication_failure_loop",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("4 consecutive"));
     }
@@ -92,7 +100,6 @@ mod tests {
     #[test]
     fn test_auth_loop_broken_by_200() {
         let rule = StatefulAuthenticationFailureLoop;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
 
@@ -104,7 +111,14 @@ mod tests {
         // put newest transaction first (tx4) to satisfy TransactionHistory
         let history = crate::transaction_history::TransactionHistory::new(vec![tx4, tx3, tx2, tx1]);
 
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_authentication_failure_loop",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         // Only 2 consecutive 401s before the 200, so no loop
         assert!(v.is_none());
     }
@@ -112,7 +126,6 @@ mod tests {
     #[test]
     fn test_non_401_ignored() {
         let rule = StatefulAuthenticationFailureLoop;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let tx1 = crate::test_helpers::make_test_transaction_with_response(401, &[]);
@@ -122,7 +135,14 @@ mod tests {
         // newest-first history
         let history = crate::transaction_history::TransactionHistory::new(vec![tx3, tx2, tx1]);
 
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_authentication_failure_loop",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 

--- a/src/rules/stateful_cache_validation_chain.rs
+++ b/src/rules/stateful_cache_validation_chain.rs
@@ -31,7 +31,7 @@ use crate::rules::Rule;
 pub struct StatefulCacheValidationChain;
 
 impl Rule for StatefulCacheValidationChain {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_cache_validation_chain"
@@ -41,12 +41,14 @@ impl Rule for StatefulCacheValidationChain {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let has_inm = req.headers.contains_key("if-none-match");
         let has_ims = req.headers.contains_key("if-modified-since");
@@ -193,10 +195,13 @@ mod tests {
     fn non_conditional_request_is_ok() {
         let rule = StatefulCacheValidationChain;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -207,10 +212,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -222,10 +230,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "*")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -237,10 +248,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -252,10 +266,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -267,10 +284,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "W/\"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -282,10 +302,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "W/\"b\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -297,10 +320,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "*")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -312,10 +338,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -328,10 +357,13 @@ mod tests {
         // first token wrong, second token correct
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -343,10 +375,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -360,10 +395,13 @@ mod tests {
             ("if-none-match", "\"a\""),
             ("if-modified-since", "Thu, 02 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -379,10 +417,13 @@ mod tests {
             "if-modified-since",
             "wed, 01 Jan 2020 00:00:00 GMT",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -396,10 +437,13 @@ mod tests {
             ("if-none-match", "\"a\""),
             ("if-modified-since", "Wed, 01 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -413,10 +457,13 @@ mod tests {
             "if-modified-since",
             "Thu, 02 Jan 2020 00:00:00 GMT",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -428,10 +475,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", "not-a-date")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -446,10 +496,13 @@ mod tests {
             "if-modified-since",
             "Thu, 02 Jan 2020 00:00:00 GMT",
         )]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -463,10 +516,13 @@ mod tests {
             ("if-none-match", "\"b\""),
             ("if-modified-since", "Thu, 02 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -480,10 +536,13 @@ mod tests {
             ("if-none-match", "\"a\""),
             ("if-modified-since", "Thu, 02 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -497,10 +556,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev2, prev1]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cache_validation_chain",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/stateful_conditional_request_handling.rs
+++ b/src/rules/stateful_conditional_request_handling.rs
@@ -15,7 +15,7 @@ use crate::rules::Rule;
 pub struct StatefulConditionalRequestHandling;
 
 impl Rule for StatefulConditionalRequestHandling {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_conditional_request_handling"
@@ -25,12 +25,14 @@ impl Rule for StatefulConditionalRequestHandling {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies when request contains one or more conditional headers
         let req = &tx.request;
         let has_inm = req.headers.get("if-none-match").is_some();
@@ -172,10 +174,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("no previous response recorded"));
@@ -190,10 +195,13 @@ mod tests {
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let prev_empty = make_prev_with_headers(&[]);
-        let v1 = rule.check_transaction(
+        let v1 = rule.check(
             &tx1,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
 
@@ -203,10 +211,13 @@ mod tests {
             "if-modified-since",
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
@@ -214,10 +225,13 @@ mod tests {
         let mut tx3 = crate::test_helpers::make_test_transaction();
         tx3.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-match", "\"a\"")]);
-        let v3 = rule.check_transaction(
+        let v3 = rule.check(
             &tx3,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
 
@@ -227,10 +241,13 @@ mod tests {
             "if-unmodified-since",
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
-        let v4 = rule.check_transaction(
+        let v4 = rule.check(
             &tx4,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
     }
@@ -245,10 +262,13 @@ mod tests {
         let prev = make_prev_with_headers(&[("etag", "\"a\"")]);
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -259,10 +279,13 @@ mod tests {
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
         let prev2 = make_prev_with_headers(&[("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")]);
-        let v2 = rule.check_transaction(
+        let v2 = rule.check(
             &tx2,
             &crate::transaction_history::TransactionHistory::new(vec![prev2.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -279,10 +302,13 @@ mod tests {
 
         let rule = StatefulConditionalRequestHandling;
         // previous satisfies validator check
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("consider returning 304"));
@@ -303,10 +329,13 @@ mod tests {
         let prev = make_prev_with_headers(&[("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")]);
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("consider returning 304"));
@@ -324,10 +353,13 @@ mod tests {
 
         let rule = StatefulConditionalRequestHandling;
         // response ETag doesn't match request conditional -> allowed
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -342,10 +374,13 @@ mod tests {
         let prev = crate::test_helpers::make_test_transaction();
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_conditional_request_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v

--- a/src/rules/stateful_cookie_domain_matching.rs
+++ b/src/rules/stateful_cookie_domain_matching.rs
@@ -21,7 +21,7 @@ use crate::rules::Rule;
 pub struct StatefulCookieDomainMatching;
 
 impl Rule for StatefulCookieDomainMatching {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_cookie_domain_matching"
@@ -31,12 +31,14 @@ impl Rule for StatefulCookieDomainMatching {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
         let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
         if cookie_headers.is_empty() {
@@ -167,28 +169,43 @@ mod tests {
     #[test]
     fn no_violation_without_history() {
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn valid_cookie_allowed() {
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/foo", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn domain_mismatch_flagged() {
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx(
             "https://example.com/",
@@ -198,7 +215,14 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_domain_matching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("different domain"));
     }
@@ -206,7 +230,6 @@ mod tests {
     #[test]
     fn domain_mismatch_but_value_matches_valid_cookie_not_flagged() {
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev1 = make_resp_tx(
             "https://example.com/",
@@ -222,19 +245,34 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn path_mismatch_flagged() {
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/private"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_domain_matching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid for path"));
     }
@@ -242,10 +280,18 @@ mod tests {
     #[test]
     fn no_cookie_header_ignored() {
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let tx = make_tx_with_req("https://example.com/", None);
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
@@ -253,7 +299,6 @@ mod tests {
         // history has a cookie with same name but different value for another
         // domain; sending a different value should not trigger.
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx(
             "https://example.com/",
@@ -263,27 +308,43 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=2"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn http_scheme_valid_cookie() {
         // non-secure cookie should still be allowed over plain HTTP when domain/path match
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("http://example.com/", Some("a=1; Path=/"), Some(ts));
         let mut tx = make_tx_with_req("http://example.com/foo", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn secure_cookie_over_http_not_flagged() {
         // scheme logic should ensure secure cookies are simply ignored by this rule
         let rule = StatefulCookieDomainMatching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx(
             "https://example.com/",
@@ -293,7 +354,16 @@ mod tests {
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_domain_matching"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]

--- a/src/rules/stateful_cookie_lifecycle.rs
+++ b/src/rules/stateful_cookie_lifecycle.rs
@@ -15,7 +15,7 @@ use crate::rules::Rule;
 pub struct StatefulCookieLifecycle;
 
 impl Rule for StatefulCookieLifecycle {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_cookie_lifecycle"
@@ -27,12 +27,14 @@ impl Rule for StatefulCookieLifecycle {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
         let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
         if cookie_headers.is_empty() {
@@ -248,60 +250,96 @@ mod tests {
     #[test]
     fn no_violation_without_history() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_lifecycle"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn unrelated_cookie_ignored() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = chrono::Utc::now();
         // history contains a cookie named a
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("b=2"));
         tx.timestamp = ts + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_lifecycle"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn secure_cookie_over_https_ok() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = chrono::Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Secure"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
     #[test]
     fn cookie_sent_within_lifetime() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Max-Age=60"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(30);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_lifecycle"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn expired_cookie_sent_flagged() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Max-Age=1"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("expired or removed"));
     }
@@ -309,7 +347,6 @@ mod tests {
     #[test]
     fn stale_value_flagged() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev1 = make_resp_tx("https://example.com/", Some("a=1; Max-Age=60"), Some(ts));
         let prev2 = make_resp_tx(
@@ -321,7 +358,14 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(20);
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("value"));
     }
@@ -329,13 +373,19 @@ mod tests {
     #[test]
     fn secure_cookie_over_http_flagged() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Secure"), Some(ts));
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Secure cookie"));
     }
@@ -348,7 +398,6 @@ mod tests {
         // plain HTTP; the rule should *not* report a secure-over-http
         // violation (the sent pair doesn't actually match the secure cookie).
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev_secure = make_resp_tx(
             "https://example.com/",
@@ -366,7 +415,14 @@ mod tests {
             prev_nonsecure.clone(),
             prev_secure.clone(),
         ]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(
             v.is_none(),
             "should not flag secure cookie if sent value is different"
@@ -376,13 +432,19 @@ mod tests {
     #[test]
     fn path_mismatch_flagged() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/private"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid for path"));
     }
@@ -391,13 +453,19 @@ mod tests {
     fn path_prefix_boundary_flagged() {
         // /foo should not match /foobar
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/foo"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/foobar", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid for path"));
     }
@@ -405,7 +473,6 @@ mod tests {
     #[test]
     fn domain_mismatch_ignored() {
         let rule = StatefulCookieLifecycle;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let prev = make_resp_tx(
             "https://example.com/",
@@ -415,7 +482,14 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_cookie_lifecycle",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         // request to other.com should not be influenced by cookie from example.com
         assert!(
             v.is_none(),

--- a/src/rules/stateful_cookie_same_site_enforcement.rs
+++ b/src/rules/stateful_cookie_same_site_enforcement.rs
@@ -17,7 +17,7 @@ use crate::rules::Rule;
 pub struct StatefulCookieSameSiteEnforcement;
 
 impl Rule for StatefulCookieSameSiteEnforcement {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_cookie_same_site_enforcement"
@@ -27,12 +27,14 @@ impl Rule for StatefulCookieSameSiteEnforcement {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
         let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
         if cookie_headers.is_empty() {
@@ -159,9 +161,7 @@ impl Rule for StatefulCookieSameSiteEnforcement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{
-        make_headers_from_pairs, make_test_rule_config, make_test_transaction,
-    };
+    use crate::test_helpers::{make_headers_from_pairs, make_test_transaction};
     use chrono::Utc;
     use hyper::header::HeaderValue;
 
@@ -204,19 +204,26 @@ mod tests {
     #[test]
     fn no_violation_without_history() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let mut tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn request_without_cookie_header_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let mut tx = make_test_transaction();
         tx.request.uri = "https://example.com/".to_string();
         tx.request
@@ -227,13 +234,21 @@ mod tests {
             Some("a=1; SameSite=Strict"),
             Some(Utc::now()),
         )]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn fetch_site_none_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -244,13 +259,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("none"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn fetch_site_invalid_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -261,13 +284,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("invalid"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn unrelated_cookie_does_not_report() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         // history sets cookie b; request sends cookie a
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
@@ -279,13 +310,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn secure_cookie_over_http_ignored_for_samesite() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "http://example.com/",
@@ -297,13 +336,21 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         // even though cross-site, the secure cookie should not match because of scheme
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn strict_cookie_cross_site_reports() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         // history sets a Strict cookie
         let ts = Utc::now();
         let htx = make_resp_tx(
@@ -316,13 +363,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]
     fn lax_cookie_cross_site_non_nav_reports() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -337,13 +392,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("cors"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]
     fn lax_cookie_cross_site_nav_get_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -358,13 +421,21 @@ mod tests {
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.method = "GET".parse().unwrap();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn lax_cookie_cross_site_nav_head_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -379,13 +450,21 @@ mod tests {
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.method = "HEAD".parse().unwrap();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn none_cookie_cross_site_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -396,13 +475,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn unspecified_treated_as_lax() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -416,16 +503,33 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("cors"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]
     fn missing_fetch_site_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let tx = make_tx_with_req("https://example.com/", Some("a=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
@@ -438,7 +542,6 @@ mod tests {
     #[test]
     fn same_site_context_allows_strict() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -449,13 +552,21 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("same-site"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn mismatched_cookie_value_does_not_report() {
         let rule = StatefulCookieSameSiteEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
             "https://example.com/",
@@ -466,6 +577,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_cookie_same_site_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 }

--- a/src/rules/stateful_digest_auth_nonce_handling.rs
+++ b/src/rules/stateful_digest_auth_nonce_handling.rs
@@ -31,7 +31,7 @@ use crate::rules::Rule;
 pub struct StatefulDigestAuthNonceHandling;
 
 impl Rule for StatefulDigestAuthNonceHandling {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_digest_auth_nonce_handling"
@@ -41,12 +41,14 @@ impl Rule for StatefulDigestAuthNonceHandling {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about client-side requests with Digest Authorization
         for hv in tx.request.headers.get_all("authorization").iter() {
             let s = match hv.to_str() {
@@ -301,11 +303,13 @@ mod tests {
     fn no_challenge_before_auth_is_reported() {
         let nonce1 = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(
+        let v = StatefulDigestAuthNonceHandling.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -322,8 +326,14 @@ mod tests {
                 &make_challenge(&nonce1, Some("o1"), None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o2")));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("opaque does not match"));
     }
@@ -336,8 +346,14 @@ mod tests {
                 &make_challenge(&nonce1, Some("o1"), None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing opaque"));
     }
@@ -347,11 +363,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Basic abc")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(
+        let v = StatefulDigestAuthNonceHandling.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -363,11 +381,13 @@ mod tests {
             "authorization",
             "Digest realm=\"r\"",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(
+        let v = StatefulDigestAuthNonceHandling.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -380,11 +400,13 @@ mod tests {
             "authorization",
             "Digest bogus=\"x\", =bad",
         )]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(
+        let v = StatefulDigestAuthNonceHandling.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -404,8 +426,14 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev_request, prev_challenge]);
         let tx = tx_req_with_auth(&auth2);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("nonce-count did not increase"));
     }
@@ -421,8 +449,14 @@ mod tests {
             )]);
         // client correctly uses same nonce but wrong nc
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000005"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must reset nc"));
     }
@@ -437,8 +471,14 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev_request, prev_challenge]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000002"), Some("o1")));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -451,8 +491,14 @@ mod tests {
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("nonce differs"));
     }
@@ -466,8 +512,14 @@ mod tests {
             )]);
         // request omits opaque entirely
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing opaque"));
     }
@@ -482,8 +534,14 @@ mod tests {
             )]);
         // client uses different nonce entirely
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v
             .unwrap()
@@ -499,8 +557,14 @@ mod tests {
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, None, None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -512,8 +576,14 @@ mod tests {
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("GARBAGE"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid nc"));
     }
@@ -527,8 +597,14 @@ mod tests {
                 &make_challenge(&nonce1, None, Some("true")),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         let msg = v.unwrap().message;
         assert!(msg.contains("nonce differs"), "got message: {}", msg);
@@ -543,8 +619,14 @@ mod tests {
             )]);
         // correct reset
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -559,8 +641,14 @@ mod tests {
         );
         let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -572,8 +660,14 @@ mod tests {
                 &make_challenge(&nonce, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce, None, None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -589,8 +683,14 @@ mod tests {
         );
         let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -608,8 +708,14 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
         let nonce = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(&tx, &history, &cfg);
+        let v = StatefulDigestAuthNonceHandling.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         // no digest challenge seen -> violation for missing challenge
         assert!(v.is_some());
         assert!(v
@@ -623,11 +729,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Digest")]);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(
+        let v = StatefulDigestAuthNonceHandling.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -642,11 +750,13 @@ mod tests {
             HeaderValue::from_bytes(&[0xff, 0xff]).unwrap(),
         );
         tx.request.headers = headers;
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = StatefulDigestAuthNonceHandling.check_transaction(
+        let v = StatefulDigestAuthNonceHandling.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_digest_auth_nonce_handling",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/stateful_http3_goaway_semantics.rs
+++ b/src/rules/stateful_http3_goaway_semantics.rs
@@ -12,23 +12,25 @@
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
-use crate::rules::{ProtocolRule, RuleConfig};
+use crate::rules::ProtocolRule;
 
 pub struct StatefulHttp3GoawaySemantics;
 
 impl ProtocolRule for StatefulHttp3GoawaySemantics {
-    type Config = RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_http3_goaway_semantics"
     }
 
-    fn check_event(
+    fn check(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         match &event.kind {
             // RFC 9114 §5.2: the identifier in a GOAWAY frame MUST NOT
             // increase beyond the value sent in a previous GOAWAY.
@@ -95,11 +97,10 @@ mod tests {
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
 
-    fn make_config() -> RuleConfig {
-        RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_config() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "stateful_http3_goaway_semantics",
+        ])
     }
 
     /// Fixed base timestamp so tests never depend on wall-clock ordering.
@@ -136,7 +137,12 @@ mod tests {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -147,7 +153,12 @@ mod tests {
         let prev = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -158,7 +169,12 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -169,7 +185,12 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(10));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("increased from previous"));
@@ -186,7 +207,12 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, None);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -197,7 +223,12 @@ mod tests {
         let prev = make_goaway(conn, None);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -208,7 +239,12 @@ mod tests {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -219,7 +255,12 @@ mod tests {
         let goaway = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 8);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -230,7 +271,12 @@ mod tests {
         let goaway = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 10);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -241,7 +287,12 @@ mod tests {
         let goaway = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 5);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("stream 5"));
@@ -258,7 +309,12 @@ mod tests {
         let goaway = make_goaway(conn, None);
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -271,7 +327,12 @@ mod tests {
             Uuid::new_v4(),
             ProtocolEventKind::H3StreamClosed { stream_id: 0 },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -289,7 +350,12 @@ mod tests {
                 payload_length: 10,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -322,7 +388,12 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![goaway, stream]);
         // New GOAWAY with id=12 > 10 should fail
         let evt = make_goaway(conn, Some(12));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -346,7 +417,12 @@ mod tests {
         // Stream 3 > goaway id 2 — first event is H3StreamClosed which
         // should be skipped; the goaway at index 1 triggers violation.
         let evt = make_stream_opened(conn, 3);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -371,7 +447,12 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![g1, g2]);
         // New GOAWAY with id=8: compared to most recent (6), 8 > 6 → fail
         let evt = make_goaway(conn, Some(8));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -383,7 +464,12 @@ mod tests {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_goaway(conn, Some(0));
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -395,7 +481,12 @@ mod tests {
         let goaway = make_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -407,7 +498,12 @@ mod tests {
         let goaway = make_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 1);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -419,7 +515,12 @@ mod tests {
         let prev = make_goaway(conn, Some(100));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(0));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 }

--- a/src/rules/stateful_http3_max_push_id.rs
+++ b/src/rules/stateful_http3_max_push_id.rs
@@ -12,23 +12,25 @@
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
-use crate::rules::{ProtocolRule, RuleConfig};
+use crate::rules::ProtocolRule;
 
 pub struct StatefulHttp3MaxPushId;
 
 impl ProtocolRule for StatefulHttp3MaxPushId {
-    type Config = RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_http3_max_push_id"
     }
 
-    fn check_event(
+    fn check(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let current = match &event.kind {
             ProtocolEventKind::H3MaxPushId { push_id } => *push_id,
             _ => return None,
@@ -69,11 +71,8 @@ mod tests {
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
 
-    fn make_config() -> RuleConfig {
-        RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_config() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_enabled_rules(&["stateful_http3_max_push_id"])
     }
 
     fn base_ts() -> DateTime<Utc> {
@@ -105,7 +104,12 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -114,7 +118,12 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 100);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -124,7 +133,12 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, (1u64 << 62) - 1);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -137,7 +151,12 @@ mod tests {
         let prev = make_max_push_id(conn, 5);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 10);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -149,7 +168,12 @@ mod tests {
         let prev = make_max_push_id(conn, 7);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 7);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -162,7 +186,12 @@ mod tests {
         let prev = make_max_push_id(conn, 10);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 4);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         let v = result.expect("expected violation");
         assert_eq!(v.rule, "stateful_http3_max_push_id");
         assert!(v.message.contains("MAX_PUSH_ID 4"));
@@ -177,7 +206,12 @@ mod tests {
         let prev = make_max_push_id(conn, 1);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 0"));
         assert!(v.message.contains("previous 1"));
@@ -190,7 +224,12 @@ mod tests {
         let prev = make_max_push_id(conn, 100);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 99);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -216,7 +255,12 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![g1, g2, g3]);
         // 20 (most recent) == 20 -> OK
         let evt = make_max_push_id(conn, 20);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -238,7 +282,12 @@ mod tests {
         let older = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 50 }, t);
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 8);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -256,7 +305,12 @@ mod tests {
         let older = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 5 }, t);
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 10);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 10"));
         assert!(v.message.contains("previous 20"));
@@ -287,7 +341,12 @@ mod tests {
 
         // New MAX_PUSH_ID = 5 < 10 → violation; settings should be skipped.
         let evt = make_max_push_id(conn, 5);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -307,7 +366,12 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![settings, stream]);
         // No prior MAX_PUSH_ID → first one is accepted at any value.
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -323,7 +387,12 @@ mod tests {
                 settings: vec![(0x06, 4096)],
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -335,7 +404,12 @@ mod tests {
             conn,
             ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -344,7 +418,12 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 });
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -363,7 +442,12 @@ mod tests {
                 payload_length: 10,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -377,17 +461,17 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 5);
 
-        for sev in [
-            crate::lint::Severity::Info,
-            crate::lint::Severity::Warn,
-            crate::lint::Severity::Error,
+        for (sev, sev_str) in [
+            (crate::lint::Severity::Info, "info"),
+            (crate::lint::Severity::Warn, "warn"),
+            (crate::lint::Severity::Error, "error"),
         ] {
-            let cfg = RuleConfig {
-                enabled: true,
-                severity: sev,
-            };
+            let cfg = crate::test_helpers::make_test_config_with_severity(
+                "stateful_http3_max_push_id",
+                sev_str,
+            );
             let v = rule
-                .check_event(&evt, &history, &cfg)
+                .check(&evt, &history, &cfg, &crate::rules::RuleConfigEngine::new())
                 .expect("expected violation");
             assert_eq!(v.severity, sev);
             assert_eq!(v.rule, "stateful_http3_max_push_id");
@@ -412,7 +496,12 @@ mod tests {
         }
         let history = ProtocolEventHistory::new(history_vec);
         let evt = make_max_push_id(conn, 6);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 6"));
         assert!(v.message.contains("previous 7"));
@@ -453,7 +542,12 @@ mod tests {
         let history = ProtocolEventHistory::new(history_vec);
         let evt = make_max_push_id(conn, 14);
         let v = rule
-            .check_event(&evt, &history, &make_config())
+            .check(
+                &evt,
+                &history,
+                &make_config(),
+                &crate::rules::RuleConfigEngine::new(),
+            )
             .expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 14"));
         assert!(v.message.contains("previous 15"));
@@ -469,7 +563,12 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 0);
         let v = rule
-            .check_event(&evt, &history, &make_config())
+            .check(
+                &evt,
+                &history,
+                &make_config(),
+                &crate::rules::RuleConfigEngine::new(),
+            )
             .expect("expected violation");
         // The message should reference RFC 9114 §7.2.7 and the H3_ID_ERROR
         // connection error code so operators can map it to the spec.

--- a/src/rules/stateful_http3_settings_frame.rs
+++ b/src/rules/stateful_http3_settings_frame.rs
@@ -12,7 +12,7 @@
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
-use crate::rules::{ProtocolRule, RuleConfig};
+use crate::rules::ProtocolRule;
 
 pub struct StatefulHttp3SettingsFrame;
 
@@ -27,18 +27,20 @@ const RESERVED_SETTING_IDS: &[u64] = &[
 ];
 
 impl ProtocolRule for StatefulHttp3SettingsFrame {
-    type Config = RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_http3_settings_frame"
     }
 
-    fn check_event(
+    fn check(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let settings = match &event.kind {
             ProtocolEventKind::H3SettingsReceived { settings } => settings,
             _ => return None,
@@ -86,11 +88,8 @@ mod tests {
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
 
-    fn make_config() -> RuleConfig {
-        RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_config() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_enabled_rules(&["stateful_http3_settings_frame"])
     }
 
     fn base_ts() -> DateTime<Utc> {
@@ -129,7 +128,12 @@ mod tests {
                 (0x07, 100),  // SETTINGS_QPACK_BLOCKED_STREAMS
             ],
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -138,7 +142,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -148,7 +157,12 @@ mod tests {
         let conn = Uuid::new_v4();
         // Extension/unknown setting identifiers are allowed.
         let evt = make_settings(conn, vec![(0x33, 1), (0xFF00, 42)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -161,7 +175,12 @@ mod tests {
         let prev = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -173,7 +192,12 @@ mod tests {
         let prev = make_settings(conn, vec![]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -192,7 +216,12 @@ mod tests {
         let closed = make_event_at(conn, ProtocolEventKind::H3StreamClosed { stream_id: 0 }, t);
         let history = ProtocolEventHistory::new(vec![opened, closed]);
         let evt = make_settings(conn, vec![(0x06, 4096)]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -230,7 +259,12 @@ mod tests {
         );
         let history = ProtocolEventHistory::new(vec![opened, prev_settings, transport]);
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
     }
 
@@ -241,7 +275,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x00, 0)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x00"));
     }
@@ -251,7 +290,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x02, 1)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x02"));
     }
@@ -261,7 +305,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x03, 100)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
     }
@@ -271,7 +320,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x04, 65535)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x04"));
     }
@@ -281,7 +335,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x05, 16384)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x05"));
     }
@@ -292,7 +351,12 @@ mod tests {
         let conn = Uuid::new_v4();
         // Mix valid settings with one reserved.
         let evt = make_settings(conn, vec![(0x06, 8192), (0x03, 100), (0x07, 50)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
     }
@@ -305,7 +369,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x01, 4096)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -314,7 +383,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -323,7 +397,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x07, 200)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -333,7 +412,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x08, 1)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -343,7 +427,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x33, 1)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -354,7 +443,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 });
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -366,7 +460,12 @@ mod tests {
             conn,
             ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -375,7 +474,12 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3MaxPushId { push_id: 10 });
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -389,7 +493,12 @@ mod tests {
         let prev = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![(0x02, 1)]); // reserved + duplicate
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = rule.check(
+            &evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }

--- a/src/rules/stateful_immutable_cache_never_stale.rs
+++ b/src/rules/stateful_immutable_cache_never_stale.rs
@@ -30,7 +30,7 @@ use crate::rules::Rule;
 pub struct StatefulImmutableCacheNeverStale;
 
 impl Rule for StatefulImmutableCacheNeverStale {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_immutable_cache_never_stale"
@@ -40,12 +40,14 @@ impl Rule for StatefulImmutableCacheNeverStale {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent prior response with an immutable
         // directive that isn't simultaneously forbidding caching.
         let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
@@ -132,7 +134,7 @@ fn header_has_immutable(headers: &hyper::HeaderMap) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction_with_response};
+    use crate::test_helpers::make_test_transaction_with_response;
     use chrono::Utc;
     use hyper::header::HeaderValue;
 
@@ -190,10 +192,13 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulImmutableCacheNeverStale;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_immutable_cache_never_stale",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -204,7 +209,14 @@ mod tests {
         let prev = make_prev_with_headers(&[("cache-control", "max-age=60")], Utc::now());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_immutable_cache_never_stale",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -221,7 +233,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_immutable_cache_never_stale",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unnecessary revalidation"));
     }
@@ -245,7 +264,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_immutable_cache_never_stale"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -262,7 +288,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_immutable_cache_never_stale"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -275,7 +308,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_immutable_cache_never_stale"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -295,7 +335,14 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_immutable_cache_never_stale",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none(), "unconditional fresh use should not warn");
     }
 
@@ -319,7 +366,14 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // age_val=5, elapsed clamped to 0 -> current_age=5 < freshness(50) => violation
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_immutable_cache_never_stale",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
@@ -337,7 +391,14 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // freshness lifetime zero, so no violation should be reported
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_immutable_cache_never_stale"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 }

--- a/src/rules/stateful_max_age_directive_validity.rs
+++ b/src/rules/stateful_max_age_directive_validity.rs
@@ -31,7 +31,7 @@ use crate::rules::Rule;
 pub struct StatefulMaxAgeDirectiveValidity;
 
 impl Rule for StatefulMaxAgeDirectiveValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_max_age_directive_validity"
@@ -42,12 +42,14 @@ impl Rule for StatefulMaxAgeDirectiveValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate most recent prior response with a usable max-age
         let mut candidate: Option<(&crate::http_transaction::HttpTransaction, i64)> = None;
 
@@ -124,7 +126,7 @@ impl Rule for StatefulMaxAgeDirectiveValidity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction_with_response};
+    use crate::test_helpers::make_test_transaction_with_response;
     use chrono::Utc;
 
     fn make_prev_with_headers(
@@ -151,7 +153,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(30);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -169,7 +178,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(
             v.is_some(),
             "unconditional fetch at exact boundary should warn"
@@ -184,8 +200,15 @@ mod tests {
         tx2.timestamp = base + chrono::Duration::seconds(10);
         let history2 = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(
-            rule.check_transaction(&tx2, &history2, &make_test_rule_config())
-                .is_none(),
+            rule.check(
+                &tx2,
+                &history2,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_max_age_directive_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none(),
             "conditional at boundary should not warn"
         );
     }
@@ -205,7 +228,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("still fresh"));
     }
@@ -225,7 +255,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -242,7 +279,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Stale cached entry"));
     }
@@ -259,7 +303,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -275,7 +326,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -292,7 +350,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(
             v.is_none(),
             "max-age should be ignored when no-cache present"
@@ -314,7 +379,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(30);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some(), "expected violation because still fresh");
     }
 
@@ -338,7 +410,14 @@ mod tests {
         tx.timestamp = base;
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(
             v.is_some(),
             "should flag stale unconditional with age header"
@@ -360,7 +439,14 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
         // age == max-age should be treated as stale; unconditional request
         // should therefore be flagged since validator exists.
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some(), "unconditional fetch at boundary should warn");
 
         // conditional at same moment is appropriate (entry stale) and should NOT trigger a violation
@@ -372,8 +458,15 @@ mod tests {
         tx2.timestamp = base;
         let history2 = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(
-            rule.check_transaction(&tx2, &history2, &make_test_rule_config())
-                .is_none(),
+            rule.check(
+                &tx2,
+                &history2,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_max_age_directive_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none(),
             "conditional at boundary should not warn"
         );
     }
@@ -392,7 +485,14 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // age computed from elapsed clamped to 0 yields fresh state; no violation expected
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_max_age_directive_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 

--- a/src/rules/stateful_must_revalidate_enforcement.rs
+++ b/src/rules/stateful_must_revalidate_enforcement.rs
@@ -34,7 +34,7 @@ use crate::rules::Rule;
 pub struct StatefulMustRevalidateEnforcement;
 
 impl Rule for StatefulMustRevalidateEnforcement {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_must_revalidate_enforcement"
@@ -45,12 +45,14 @@ impl Rule for StatefulMustRevalidateEnforcement {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // find the most recent past response that contained must-revalidate
         let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
         for past in history.iter() {
@@ -154,10 +156,13 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulMustRevalidateEnforcement;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -168,8 +173,14 @@ mod tests {
         let prev = make_prev(200, &[("cache-control", "max-age=60")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -222,8 +233,14 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // current_age should equal age header (5) not negative elapsed
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         // freshness zero and no validator -> no violation
         assert!(v.is_none());
     }
@@ -251,8 +268,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
@@ -281,8 +304,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some(), "equal age should now be treated as stale");
     }
 
@@ -299,8 +328,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
@@ -315,8 +350,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -336,8 +377,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -357,8 +404,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
@@ -379,8 +432,14 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 
@@ -401,8 +460,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some(), "equal age should be considered stale");
     }
 
@@ -422,8 +487,14 @@ mod tests {
         tx.timestamp = base; // no elapsed time
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some(), "max-age=0 should be stale immediately");
     }
 
@@ -443,8 +514,14 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_must_revalidate_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_none());
     }
 

--- a/src/rules/stateful_no_cache_revalidation.rs
+++ b/src/rules/stateful_no_cache_revalidation.rs
@@ -32,7 +32,7 @@ use crate::rules::Rule;
 pub struct StatefulNoCacheRevalidation;
 
 impl Rule for StatefulNoCacheRevalidation {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_no_cache_revalidation"
@@ -44,12 +44,14 @@ impl Rule for StatefulNoCacheRevalidation {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent past response with a no-cache directive.
         let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
         for past in history.iter() {
@@ -123,10 +125,13 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulNoCacheRevalidation;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_no_cache_revalidation",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -177,8 +182,14 @@ mod tests {
         tx.request.uri = "/resource".to_string();
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v =
-            rule.check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_no_cache_revalidation",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("no-cache"));
     }
@@ -197,7 +208,14 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_cache_revalidation"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -213,7 +231,14 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &crate::test_helpers::make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_cache_revalidation"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 

--- a/src/rules/stateful_no_store_enforcement.rs
+++ b/src/rules/stateful_no_store_enforcement.rs
@@ -32,7 +32,7 @@ use crate::rules::Rule;
 pub struct StatefulNoStoreEnforcement;
 
 impl Rule for StatefulNoStoreEnforcement {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_no_store_enforcement"
@@ -43,12 +43,14 @@ impl Rule for StatefulNoStoreEnforcement {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Build maps of validators to a boolean indicating whether the most
         // recent occurrence of that validator came from a no-store response.
         //
@@ -208,7 +210,7 @@ fn header_has_no_store(headers: &hyper::HeaderMap) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction_with_response};
+    use crate::test_helpers::make_test_transaction_with_response;
     use chrono::Utc;
 
     /// Helper creating a previous transaction for the given resource and
@@ -236,13 +238,15 @@ mod tests {
     #[test]
     fn no_violation_without_history() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let tx = crate::test_helpers::make_test_transaction();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -250,20 +254,27 @@ mod tests {
     #[test]
     fn no_violation_if_history_has_no_store_but_request_not_conditional() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(&[("cache-control", "no-store")], &[("etag", "\"a\"")], ts);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn violation_on_if_none_match_matching_no_store() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(&[("cache-control", "no-store")], &[("etag", "\"a\"")], ts);
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -272,7 +283,14 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_no_store_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("ETag"));
     }
@@ -282,7 +300,6 @@ mod tests {
         // a weak validator in history should match a strong one in request and
         // vice versa; normalization makes sure the rule doesn't miss this.
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(&[("cache-control", "no-store")], &[("etag", "W/\"a\"")], ts);
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -291,13 +308,21 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]
     fn violation_on_if_modified_since_matching_no_store() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(
             &[("cache-control", "no-store")],
@@ -312,7 +337,14 @@ mod tests {
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_no_store_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Last-Modified"));
     }
@@ -320,7 +352,6 @@ mod tests {
     #[test]
     fn non_matching_validator_not_flagged() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(&[("cache-control", "no-store")], &[("etag", "\"a\"")], ts);
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -329,7 +360,16 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
@@ -338,7 +378,6 @@ mod tests {
         // non-no-store response, it should no longer be considered
         // prohibited even if an earlier entry had it with no-store.
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev1 = make_prev(&[("cache-control", "no-store")], &[("etag", "\"a\"")], ts);
         let prev2 = make_prev(
@@ -353,14 +392,22 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn later_non_no_store_supersedes_last_modified() {
         // same as above but for Last-Modified
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let lm = "Wed, 21 Oct 2015 07:28:00 GMT";
         let prev1 = make_prev(
@@ -380,7 +427,16 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", lm)]);
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
@@ -399,7 +455,6 @@ mod tests {
     #[test]
     fn multiple_if_none_match_values() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(&[("cache-control", "no-store")], &[("etag", "\"a\"")], ts);
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -409,13 +464,21 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]
     fn multiple_header_fields_for_if_none_match() {
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(&[("cache-control", "no-store")], &[("etag", "\"a\"")], ts);
         let mut tx = crate::test_helpers::make_test_transaction();
@@ -426,14 +489,22 @@ mod tests {
         hm.append("if-none-match", "\"a\"".parse().unwrap());
         tx.request.headers = hm;
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]
     fn last_modified_date_string_inequality() {
         // If dates parse to same instant but differ in formatting we still want a violation.
         let rule = StatefulNoStoreEnforcement;
-        let cfg = make_test_rule_config();
         let ts = Utc::now();
         let prev = make_prev(
             &[("cache-control", "no-store")],
@@ -449,7 +520,16 @@ mod tests {
             "Sun, 06 Nov 1994 08:49:37 GMT",
         )]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_some());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_no_store_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_some());
     }
 
     #[test]

--- a/src/rules/stateful_oauth2_code_flow.rs
+++ b/src/rules/stateful_oauth2_code_flow.rs
@@ -28,7 +28,7 @@ use crate::rules::Rule;
 pub struct StatefulOauth2CodeFlow;
 
 impl Rule for StatefulOauth2CodeFlow {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_oauth2_code_flow"
@@ -39,12 +39,14 @@ impl Rule for StatefulOauth2CodeFlow {
         crate::rules::RuleScope::Client
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req_uri = &tx.request.uri;
         // simple query extraction: portion after '?' if present, ignoring any
         // URI fragment (`#...`) which is not part of the query string.
@@ -141,104 +143,179 @@ mod tests {
     #[test]
     fn auth_request_without_state_flagged() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         let tx = make_tx("https://idp.example.com/authorize?response_type=code&client_id=1");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule.check_transaction(&tx, &history, &cfg).unwrap();
+        let v = rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
+            )
+            .unwrap();
         assert!(v.message.contains("missing or empty state"));
     }
 
     #[test]
     fn auth_request_with_state_ok() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         let tx = make_tx("https://idp.example.com/authorize?response_type=code&state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn callback_without_state_flagged() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         let tx = make_tx("https://app.example.com/callback?code=abc");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule.check_transaction(&tx, &history, &cfg).unwrap();
+        let v = rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
+            )
+            .unwrap();
         assert!(v.message.contains("missing or empty state"));
     }
 
     #[test]
     fn callback_with_unseen_state_flagged() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule.check_transaction(&tx, &history, &cfg).unwrap();
+        let v = rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
+            )
+            .unwrap();
         assert!(v.message.contains("not seen"));
     }
 
     #[test]
     fn callback_with_matching_state_ok() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         // initial auth request earlier in history
         let history = crate::transaction_history::TransactionHistory::new(vec![make_tx(
             "https://idp.example.com/authorize?response_type=code&state=xyz",
         )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn auth_and_callback_without_code_does_not_check_state() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         // a request with state but not response_type=code shouldn't trigger
         let tx = make_tx("https://example.com/foo?state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn auth_and_callback_with_fragments_are_handled() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         // auth request has fragment after query, should still record state
         let history = crate::transaction_history::TransactionHistory::new(vec![make_tx(
             "https://idp.example.com/authorize?response_type=code&state=foo#frag",
         )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=foo#bar");
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn auth_request_fragment_missing_state_flagged() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         let tx = make_tx("https://idp.example.com/authorize?response_type=code#frag");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule.check_transaction(&tx, &history, &cfg).unwrap();
+        let v = rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
+            )
+            .unwrap();
         assert!(v.message.contains("missing or empty state"));
     }
 
     #[test]
     fn empty_state_value_flagged_both_sides() {
         let rule = StatefulOauth2CodeFlow;
-        let cfg = test_helpers::make_test_rule_config();
         // auth request with empty state
         let tx1 = make_tx("https://idp.example.com/authorize?response_type=code&state=");
         let history = crate::transaction_history::TransactionHistory::new(vec![tx1.clone()]);
         // callback with empty state should flag missing or empty
         let tx2 = make_tx("https://app.example.com/callback?code=123&state=");
         let v = rule
-            .check_transaction(
+            .check(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing or empty state"));
-        let v2 = rule.check_transaction(&tx2, &history, &cfg).unwrap();
+        let v2 = rule
+            .check(
+                &tx2,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_oauth2_code_flow",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
+            )
+            .unwrap();
         assert!(v2.message.contains("missing or empty state"));
     }
 

--- a/src/rules/stateful_private_cache_visibility.rs
+++ b/src/rules/stateful_private_cache_visibility.rs
@@ -18,7 +18,7 @@ use crate::rules::Rule;
 pub struct StatefulPrivateCacheVisibility;
 
 impl Rule for StatefulPrivateCacheVisibility {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_private_cache_visibility"
@@ -29,12 +29,14 @@ impl Rule for StatefulPrivateCacheVisibility {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only interested in conditional requests; nothing to do otherwise
         let has_if_none_match = tx.request.headers.contains_key("if-none-match");
         let has_if_modified_since = tx.request.headers.contains_key("if-modified-since");
@@ -175,19 +177,26 @@ mod tests {
     #[test]
     fn no_violation_without_history() {
         let rule = StatefulPrivateCacheVisibility;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_private_cache_visibility"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn same_client_private_not_flagged() {
         let rule = StatefulPrivateCacheVisibility;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let client = crate::test_helpers::make_test_client();
 
@@ -198,13 +207,21 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_private_cache_visibility"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn private_from_other_client_flagged_etag() {
         let rule = StatefulPrivateCacheVisibility;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let client1 = crate::test_helpers::make_test_client();
         let mut client2 = client1.clone();
@@ -217,7 +234,14 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_private_cache_visibility",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Validator '"));
     }
@@ -225,7 +249,6 @@ mod tests {
     #[test]
     fn private_from_other_client_flagged_last_modified() {
         let rule = StatefulPrivateCacheVisibility;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let client1 = crate::test_helpers::make_test_client();
         let mut client2 = client1.clone();
@@ -239,14 +262,20 @@ mod tests {
             .headers
             .append("if-modified-since", lm.parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_private_cache_visibility",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
     #[test]
     fn non_private_from_other_client_not_flagged() {
         let rule = StatefulPrivateCacheVisibility;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let ts = Utc::now();
         let client1 = crate::test_helpers::make_test_client();
         let mut client2 = client1.clone();
@@ -259,6 +288,15 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_private_cache_visibility"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 }

--- a/src/rules/stateful_range_request_and_caching.rs
+++ b/src/rules/stateful_range_request_and_caching.rs
@@ -29,7 +29,7 @@ use crate::rules::Rule;
 pub struct StatefulRangeRequestAndCaching;
 
 impl Rule for StatefulRangeRequestAndCaching {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_range_request_and_caching"
@@ -39,12 +39,14 @@ impl Rule for StatefulRangeRequestAndCaching {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let has_range = req.headers.get("range").is_some();
         if !has_range {
@@ -148,15 +150,17 @@ mod tests {
     #[test]
     fn range_without_if_range_with_no_history_is_ok() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -164,7 +168,6 @@ mod tests {
     #[test]
     fn range_without_if_range_after_partial_reports() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(206, &[("etag", "\"a\"")]);
         prev.request.uri = "/r".to_string();
@@ -176,10 +179,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing If-Range"));
@@ -188,7 +194,6 @@ mod tests {
     #[test]
     fn range_with_matching_if_range_is_ok() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(206, &[("etag", "\"a\"")]);
         prev.request.uri = "/r".to_string();
@@ -202,10 +207,13 @@ mod tests {
             ("if-range", "\"a\""),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -213,7 +221,6 @@ mod tests {
     #[test]
     fn last_modified_validator_matching_if_range_is_ok() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(
             206,
@@ -230,10 +237,13 @@ mod tests {
             ("if-range", "Wed, 21 Oct 2015 07:28:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -241,7 +251,6 @@ mod tests {
     #[test]
     fn last_modified_validator_mismatch_reports() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(
             206,
@@ -258,10 +267,13 @@ mod tests {
             ("if-range", "Wed, 20 Oct 2015 07:28:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not match"));
@@ -270,7 +282,6 @@ mod tests {
     #[test]
     fn range_with_mismatched_if_range_reports() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(206, &[("etag", "\"a\"")]);
         prev.request.uri = "/r".to_string();
@@ -284,10 +295,13 @@ mod tests {
             ("if-range", "\"b\""),
         ]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not match"));
@@ -296,7 +310,6 @@ mod tests {
     #[test]
     fn partial_without_validator_skips() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(206, &[]);
         prev.request.uri = "/r".to_string();
@@ -308,10 +321,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -319,7 +335,6 @@ mod tests {
     #[test]
     fn previous_not_206_ignored() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(200, &[("etag", "\"a\"")]);
         prev.request.uri = "/r".to_string();
@@ -331,10 +346,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -342,7 +360,6 @@ mod tests {
     #[test]
     fn weak_etag_in_prev_does_not_count_as_validator() {
         let rule = StatefulRangeRequestAndCaching;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut prev = make_prev_with_status_and_headers(206, &[("etag", "W/\"weak\"")]);
         prev.request.uri = "/r".to_string();
@@ -354,10 +371,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_range_request_and_caching",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/stateful_redirect_chain_validity.rs
+++ b/src/rules/stateful_redirect_chain_validity.rs
@@ -19,7 +19,7 @@ use crate::rules::Rule;
 pub struct StatefulRedirectChainValidity;
 
 impl Rule for StatefulRedirectChainValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_redirect_chain_validity"
@@ -29,12 +29,14 @@ impl Rule for StatefulRedirectChainValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
             Some(r) => r,
             None => return None,
@@ -156,11 +158,13 @@ mod tests {
     fn detects_circular_redirect_for_equal_path(#[case] req: &str, #[case] loc: &str) {
         let rule = StatefulRedirectChainValidity;
         let tx = make_resp_tx(req, 301, Some(loc));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("circular redirect"));
@@ -171,11 +175,13 @@ mod tests {
         let rule = StatefulRedirectChainValidity;
         // different host should NOT be considered circular
         let tx = make_resp_tx("http://example.com/a", 301, Some("http://other/a"));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -190,11 +196,13 @@ mod tests {
         let mut tx = make_resp_tx("/r", 302, Some("/x"));
         tx.client = crate::test_helpers::make_test_client();
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Repeated redirect"));
@@ -221,11 +229,13 @@ mod tests {
             trailers: None,
         });
 
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -235,11 +245,13 @@ mod tests {
     fn non_redirect_status_with_location_is_ignored() {
         let rule = StatefulRedirectChainValidity;
         let tx = make_resp_tx("/r", 200, Some("/x"));
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         // This rule only inspects redirect/creation status codes — ignore otherwise
         assert!(v.is_none());
@@ -255,12 +267,14 @@ mod tests {
         let mut tx = make_resp_tx("/r", 302, Some("/x"));
         tx.client = crate::test_helpers::make_test_client();
 
-        let cfg = crate::test_helpers::make_test_rule_config();
         // previous had non-redirect status -> should NOT trigger repeated-redirect violation
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -269,11 +283,13 @@ mod tests {
     fn no_location_is_ignored() {
         let rule = StatefulRedirectChainValidity;
         let tx = make_resp_tx("/r", 302, None);
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &cfg,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_redirect_chain_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/stateful_s_max_age_enforcement.rs
+++ b/src/rules/stateful_s_max_age_enforcement.rs
@@ -25,7 +25,7 @@ use crate::rules::Rule;
 pub struct StatefulSMaxAgeEnforcement;
 
 impl Rule for StatefulSMaxAgeEnforcement {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_s_max_age_enforcement"
@@ -36,12 +36,14 @@ impl Rule for StatefulSMaxAgeEnforcement {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent prior response with both s-maxage and a
         // larger max-age value.  s-maxage by itself is not actionable for this
         // check; we need a "real" private freshness lifetime to compare.
@@ -109,7 +111,7 @@ impl Rule for StatefulSMaxAgeEnforcement {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{make_test_rule_config, make_test_transaction_with_response};
+    use crate::test_helpers::make_test_transaction_with_response;
     use chrono::Utc;
 
     fn make_prev_with_headers(
@@ -128,10 +130,13 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulSMaxAgeEnforcement;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = rule.check(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
-            &crate::test_helpers::make_test_rule_config(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_s_max_age_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -150,7 +155,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -169,7 +181,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(6);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
 
         // max-age smaller than s-maxage also irrelevant
@@ -182,7 +201,14 @@ mod tests {
         tx2.timestamp = base + chrono::Duration::seconds(4);
         let history2 = crate::transaction_history::TransactionHistory::new(vec![prev2]);
         assert!(rule
-            .check_transaction(&tx2, &history2, &make_test_rule_config())
+            .check(
+                &tx2,
+                &history2,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -206,7 +232,14 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(20);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check_transaction(&tx, &history, &make_test_rule_config());
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_s_max_age_enforcement",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("s-maxage=10"));
     }
@@ -231,7 +264,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_some());
     }
 
@@ -255,7 +295,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(40);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -277,7 +324,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(20);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 
@@ -303,7 +357,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_some());
     }
 
@@ -330,7 +391,14 @@ mod tests {
         // age clamped to 0, so current_age=0 < s_max_age -> no violation even though
         // the conditional header is present
         assert!(rule
-            .check_transaction(&tx, &history, &make_test_rule_config())
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_s_max_age_enforcement"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
             .is_none());
     }
 

--- a/src/rules/stateful_vary_header_cache_validity.rs
+++ b/src/rules/stateful_vary_header_cache_validity.rs
@@ -35,7 +35,7 @@ use crate::rules::Rule;
 pub struct StatefulVaryHeaderCacheValidity;
 
 impl Rule for StatefulVaryHeaderCacheValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_vary_header_cache_validity"
@@ -46,12 +46,14 @@ impl Rule for StatefulVaryHeaderCacheValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let has_inm = req.headers.contains_key("if-none-match");
         let has_ims = req.headers.contains_key("if-modified-since");
@@ -228,16 +230,23 @@ mod tests {
     #[test]
     fn no_violation_without_conditional() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let tx = make_tx_with_req("https://example.com/foo");
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn inm_wildcard_skips() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -254,13 +263,21 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn mismatch_on_vary_field_triggers() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         // past response had Vary: Accept-Encoding, and request used gzip
         let mut past = make_resp_tx(
@@ -280,7 +297,14 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v
             .unwrap()
@@ -292,7 +316,6 @@ mod tests {
     #[test]
     fn match_on_vary_field_ok() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -309,13 +332,21 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn missing_vary_header_in_past_skips() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx("https://example.com/foo", None, Some("\"etag1\""));
         past.request.headers =
@@ -328,13 +359,21 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn vary_wildcard_ignored() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx("https://example.com/foo", Some("*"), Some("\"etag1\""));
         past.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
@@ -346,13 +385,21 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn case_insensitive_vary_name() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -369,7 +416,14 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("accept-encoding"));
     }
@@ -377,7 +431,6 @@ mod tests {
     #[test]
     fn missing_current_header_is_mismatch() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -394,7 +447,14 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v
             .unwrap()
@@ -406,7 +466,6 @@ mod tests {
     #[test]
     fn multiple_vary_fields_one_mismatch_reports() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -426,7 +485,14 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("x-foo"));
     }
@@ -434,7 +500,6 @@ mod tests {
     #[test]
     fn ims_based_validation_respects_vary() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -450,14 +515,20 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
     }
 
     #[test]
     fn different_validator_skips() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -474,13 +545,21 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(rule
+            .check(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new()
+            )
+            .is_none());
     }
 
     #[test]
     fn weak_etag_matches_and_respects_vary() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         let mut past = make_resp_tx(
             "https://example.com/foo",
@@ -497,7 +576,14 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some());
         assert!(v
             .unwrap()
@@ -509,7 +595,6 @@ mod tests {
     #[test]
     fn finds_match_in_later_history_entry() {
         let rule = StatefulVaryHeaderCacheValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
 
         // first past entry has a different etag
         let mut old = make_resp_tx(
@@ -537,7 +622,14 @@ mod tests {
 
         // newest-first: later matching entry (good) must come first
         let history = crate::transaction_history::TransactionHistory::new(vec![good, old]);
-        let v = rule.check_transaction(&tx, &history, &cfg);
+        let v = rule.check(
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_vary_header_cache_validity",
+            ]),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(v.is_some(), "should inspect later matching entry");
     }
 

--- a/src/rules/stateful_websocket_frame_opcode_sequence.rs
+++ b/src/rules/stateful_websocket_frame_opcode_sequence.rs
@@ -14,23 +14,25 @@
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
-use crate::rules::{ProtocolRule, RuleConfig};
+use crate::rules::ProtocolRule;
 
 pub struct StatefulWebsocketFrameOpcodeSequence;
 
 impl ProtocolRule for StatefulWebsocketFrameOpcodeSequence {
-    type Config = RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_websocket_frame_opcode_sequence"
     }
 
-    fn check_event(
+    fn check(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let (session_id, direction, opcode, payload_length) = match &event.kind {
             ProtocolEventKind::WebSocketFrame {
                 session_id,
@@ -114,11 +116,10 @@ mod tests {
     use chrono::Utc;
     use uuid::Uuid;
 
-    fn make_config() -> RuleConfig {
-        RuleConfig {
-            enabled: true,
-            severity: crate::lint::Severity::Warn,
-        }
+    fn make_config() -> crate::config::Config {
+        crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "stateful_websocket_frame_opcode_sequence",
+        ])
     }
 
     fn make_ws_event(
@@ -148,7 +149,12 @@ mod tests {
         let conn = Uuid::new_v4();
         let session = Uuid::new_v4();
         let evt = make_ws_event(conn, session, MessageDirection::Client, 1, 42);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -158,7 +164,12 @@ mod tests {
         let conn = Uuid::new_v4();
         let session = Uuid::new_v4();
         let evt = make_ws_event(conn, session, MessageDirection::Server, 2, 1024);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -170,7 +181,12 @@ mod tests {
 
         for opcode in [8, 9, 10] {
             let evt = make_ws_event(conn, session, MessageDirection::Client, opcode, 10);
-            let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+            let result = rule.check(
+                &evt,
+                &ProtocolEventHistory::empty(),
+                &make_config(),
+                &crate::rules::RuleConfigEngine::new(),
+            );
             assert!(result.is_none(), "opcode {} should pass", opcode);
         }
     }
@@ -183,7 +199,12 @@ mod tests {
 
         for opcode in [3, 4, 5, 6, 7, 11, 12, 13, 14, 15] {
             let evt = make_ws_event(conn, session, MessageDirection::Client, opcode, 0);
-            let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+            let result = rule.check(
+                &evt,
+                &ProtocolEventHistory::empty(),
+                &make_config(),
+                &crate::rules::RuleConfigEngine::new(),
+            );
             assert!(result.is_some(), "opcode {} should fail", opcode);
             assert!(result.unwrap().message.contains("reserved opcode"));
         }
@@ -197,7 +218,12 @@ mod tests {
 
         // Ping with 126 bytes payload
         let evt = make_ws_event(conn, session, MessageDirection::Client, 9, 126);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("125-byte limit"));
     }
@@ -214,7 +240,12 @@ mod tests {
 
         // Now client sends a Text frame
         let text_evt = make_ws_event(conn, session, MessageDirection::Client, 1, 50);
-        let result = rule.check_event(&text_evt, &history, &make_config());
+        let result = rule.check(
+            &text_evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("after Close"));
     }
@@ -231,7 +262,12 @@ mod tests {
 
         // Server sends a Text frame (different direction — allowed during close handshake)
         let text_evt = make_ws_event(conn, session, MessageDirection::Server, 1, 50);
-        let result = rule.check_event(&text_evt, &history, &make_config());
+        let result = rule.check(
+            &text_evt,
+            &history,
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 
@@ -243,7 +279,12 @@ mod tests {
             connection_id: Uuid::new_v4(),
             kind: ProtocolEventKind::H3GoawayReceived { stream_id: None },
         };
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = rule.check(
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+            &crate::rules::RuleConfigEngine::new(),
+        );
         assert!(result.is_none());
     }
 }

--- a/src/rules/stateful_websocket_handshake_validity.rs
+++ b/src/rules/stateful_websocket_handshake_validity.rs
@@ -22,7 +22,7 @@ use crate::rules::Rule;
 pub struct StatefulWebsocketHandshakeValidity;
 
 impl Rule for StatefulWebsocketHandshakeValidity {
-    type Config = crate::rules::RuleConfig;
+    type Config = ();
 
     fn id(&self) -> &'static str {
         "stateful_websocket_handshake_validity"
@@ -32,12 +32,14 @@ impl Rule for StatefulWebsocketHandshakeValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check_transaction(
+    fn check(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        config: &Self::Config,
+        cfg: &crate::config::Config,
+        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
 
         // Only consider WebSocket handshake requests (GET + Upgrade: websocket)
@@ -218,12 +220,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -241,12 +245,14 @@ mod tests {
             vec![("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing 'Sec-WebSocket-Accept'"));
@@ -269,12 +275,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not match expected"));
@@ -293,12 +301,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing Sec-WebSocket-Key"));
@@ -321,12 +331,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid Sec-WebSocket-Key"));
@@ -350,12 +362,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -377,12 +391,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Expected 101"));
@@ -404,12 +420,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing 'Connection' header"));
@@ -432,12 +450,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v
@@ -452,12 +472,14 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("upgrade", "websocket")]);
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -472,12 +494,14 @@ mod tests {
         ]);
         // response absence doesn't matter since rule should bail early
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -492,12 +516,14 @@ mod tests {
         ]);
         // no response recorded
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         assert!(rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity"
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -519,12 +545,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("required 'Connection: Upgrade' token"));
@@ -546,12 +574,14 @@ mod tests {
             ],
         );
         let rule = StatefulWebsocketHandshakeValidity;
-        let cfg = crate::test_helpers::make_test_rule_config();
         let v = rule
-            .check_transaction(
+            .check(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_websocket_handshake_validity",
+                ]),
+                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing 'Upgrade' header"));

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -87,6 +87,22 @@ pub fn make_test_config_with_enabled_rules(rules: &[&str]) -> crate::config::Con
     cfg
 }
 
+/// Create a configuration with a single rule enabled at the given severity.
+/// `severity` must be one of `"info"`, `"warn"`, `"error"`.
+#[cfg(test)]
+pub fn make_test_config_with_severity(rule_id: &str, severity: &str) -> crate::config::Config {
+    let mut cfg = crate::config::Config::default();
+    let mut table = toml::map::Map::new();
+    table.insert("enabled".to_string(), toml::Value::Boolean(true));
+    table.insert(
+        "severity".to_string(),
+        toml::Value::String(severity.to_string()),
+    );
+    cfg.rules
+        .insert(rule_id.to_string(), toml::Value::Table(table));
+    cfg
+}
+
 /// Validate and build a `RuleConfigEngine` from a configuration.
 /// Panics if the configuration is invalid.
 #[cfg(test)]


### PR DESCRIPTION
Replace every rule's legacy `check_transaction(&Self::Config)` / `check_event(&Self::Config)` override with a `check(&Config, &RuleConfigEngine)` override that parses its config section inline — `parse_rule_config` for the simple rules, the rule's own `parse_*_config` helper for the 13 custom-config rules. Each rule sets `type Config = ()`. The 13 custom-config rules keep their `validate_and_box` override so custom fields (allowed/paths/headers/ timeouts) are still validated at startup.

This builds on the bridge (commit 9514afc): dispatch already routes through `check`, whose default impl delegated to the legacy methods. After this change nothing reads the engine config cache at lint time, clearing the way for #8c to delete `type Config`, `validate_and_box`, `check_transaction`/`check_event`, the config validators, and the `RuleConfigEngine` parameter.

Covers all 184 transaction rules + 5 ProtocolRule rules. Adds the `make_test_config_with_severity` test helper. Two custom-config rules (semantic_head_response_headers_match_get, server_clear_site_data) parse config after their cheap early-return guards to avoid a per-transaction allocation on the common path.
