### PR TITLE
refactor(rules): drop RuleConfigEngine and the type-erased config trait

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,763 @@
+<!--
+SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+
+SPDX-License-Identifier: ISC
+-->
+
+# lint-http — Architectural Review
+
+## Overview
+
+`lint-http` is a Rust-based forward proxy that intercepts HTTP/1.1, HTTP/2,
+HTTP/3 and WebSocket traffic, runs a catalogue of lint rules over each
+transaction, and appends JSONL captures to disk. The rule catalogue currently
+holds **184 leaf rule modules**: 179 transaction rules registered in the `RULES`
+slice plus 5 protocol-event rules in `PROTOCOL_RULES`. By prefix the rules
+break down as 16 `client_`, 99 `message_`, 8 `semantic_`, 36 `server_`, and
+25 `stateful_`. The source tree is ~80k lines: ~14k of engine / transport /
+helper code and ~66k in the rule modules and their inline tests.
+
+The codebase is organized as:
+
+- A **proxy module tree** (`src/proxy/`) split into `mod.rs`, `http.rs`,
+  `http3.rs`, `connect.rs`, `websocket.rs`, `hop_by_hop.rs`, and
+  `test_support.rs`. Between them they own TCP listening, CONNECT
+  tunneling/MITM, hop-by-hop filtering, body collection, request forwarding,
+  WebSocket relay, and the HTTP/3 (QUIC) accept loop. `proxy/websocket.rs`
+  (~1,250 lines) and `proxy/http.rs` (~1,210 lines) are now the largest proxy
+  units; `src/helpers/headers.rs` (~1,850 lines) is the single largest file.
+- A rule engine (`src/lint.rs`, `src/lint_protocol.rs`, `src/rules/mod.rs`)
+  built around a `Rule` trait with an associated `Config` type, a hand-curated
+  `RULES` slice (179 entries), and a parallel `PROTOCOL_RULES` slice (5
+  entries).
+- A 184-file `src/rules/` directory of leaf rule modules, mirrored by
+  `docs/rules/` (184 per-rule files plus `TEMPLATE.md`) and a hand-maintained
+  `docs/rules.md` index.
+- A bounded, TTL-aware `StateStore` (`src/state.rs`) and `ProtocolEventStore`
+  exposing cross-transaction history, queried indirectly through pre-built
+  `TransactionHistory` / `ProtocolEventHistory` views.
+- A helpers tree (`src/helpers/*`), serde header-map adapters
+  (`src/serde_helpers.rs`), an rcgen-based MITM CA (`src/ca.rs`), and a
+  `CaptureWriter` (`src/capture.rs`) that serializes transactions to a shared
+  JSONL file.
+
+The design has clear strengths: rules are isolated, configurable, and
+well-tested; state is decoupled from rules through pre-queried history views;
+TLS is rust-native; HTTP/3 has dedicated frame-level instrumentation. The
+trade-offs documented below are about scaling the architecture as the rule
+catalogue grows, sharpening boundaries between transport / lint / capture
+concerns, and removing redundancy that has accreted between adjacent
+abstractions.
+
+The improvement entries below are organized by impact tier and tagged with
+**Size** (S / M / L / XL — rough lines-of-change), **Complexity** (Low / Medium
+/ High — coordination cost, blast radius, risk), and **Architectural Gains**
+(what the change buys us beyond the immediate diff).
+
+---
+
+## Guiding principle: rules as a portable library
+
+`src/transaction_history.rs` already declares the architectural intent:
+
+> Rules depend only on `TransactionHistory` (and `HttpTransaction`), never on
+> `StateStore` or the query layer, so the rule crate can be extracted
+> independently in the future.
+
+That extraction (#2) is the long-term goal. Every change in this report should
+preserve or strengthen rule independence — a rule consumed by a CI capture
+linter, a HAR/PCAP analyzer, or a replay harness should not have to know about
+the proxy's transport, its query system, its capture format, or its config
+cache.
+
+When a proposal is tempted to push an engine concern (history queries, state
+storage, capture IO, config caching) into the `Rule` trait, the rule library
+gets dragged along with it. Several Tier 2 proposals below were originally
+drafted that way; the revised forms keep engine concerns *outside* the trait.
+
+The dispatch cleanups (#6–#11) are sequenced to land *before* the workspace
+split (#2) so that the rule crate's public API has no engine-shaped types in
+it by the time the boundary becomes a `Cargo.toml` boundary.
+
+---
+
+## Commit-sizing convention: one atomic commit per step
+
+Every step in the suggested ordering at the bottom of this report corresponds
+to **one atomic commit** that compiles and passes tests on its own. When an
+item from the analysis below is genuinely too large for a single coherent
+commit, it is split into ordered sub-steps (e.g. `#8a`, `#8b`, `#8c`); each
+sub-step is itself an atomic commit. The sub-step decomposition lives next to
+the item description so context stays local.
+
+A few items resist clean splitting because the change cascades through the
+trait surface. Those are kept as single commits in the ordering with their
+size noted honestly — splitting them artificially would produce intermediate
+commits that don't individually compile, which is worse for review than one
+larger but coherent change.
+
+---
+
+## Tier 1 — Structural
+
+### 1. Split `src/proxy.rs` into a `proxy/` module tree — ✅ DONE (commit `1501c66`)
+
+Completed. `src/proxy/` now contains `mod.rs`, `http.rs`, `http3.rs`,
+`connect.rs`, `websocket.rs`, `hop_by_hop.rs`, and `test_support.rs`. Tests
+live alongside their subsystem.
+
+This unblocks the rest of Tier 1 — #3 (streaming bodies) and #4 (writer task)
+can now move per-subsystem instead of touching one 3,800-line file, and the
+proxy crate boundary in #2 has natural module seams to keep.
+
+### 2. Cargo workspace: split into `lint-http-core`, `lint-http-rules`, `lint-http-proxy`
+
+Today this is a single crate; `lib.rs` exposes 19 modules and rules and proxy
+live together. `Cargo.toml` has no `[workspace]`.
+`transaction_history.rs` is already the explicit boundary (its own doc-comment
+notes it exists "so the rule crate can be extracted independently in the
+future").
+
+**Proposed crates:**
+
+- `lint-http-core` — `http_transaction`, `lint`, `transaction_history`,
+  `protocol_event`, `serde_helpers`, `state` (extracted as a trait).
+- `lint-http-rules` — `rules/`, `helpers/`, `queries/`, `lint_protocol` —
+  depends only on `lint-http-core`.
+- `lint-http-proxy` (binary + thin lib) — `proxy/`, `ca`, `capture`,
+  `connection`, `h3_instrument`, `websocket_session`.
+
+- **Size:** L
+- **Complexity:** Medium — needs careful re-export hygiene, visibility audits,
+  and dev-dependency review.
+- **Gains:** Reuses the 184-rule library outside the proxy (e.g. HAR/PCAP
+  analyzers, CI HTTP-fixture linting, postman-style replay), independent
+  versioning, faster incremental builds (rule changes don't rebuild the proxy
+  and vice versa), and a much easier "publish rules to crates.io" story.
+
+### 3. Streaming proxy body pipeline
+
+`handle_http_logic` (`src/proxy/http.rs`) calls `body.collect().await` to fully
+buffer the request body before forwarding, and `resp.into_body().collect().await`
+to fully buffer the response before returning to the client. Both bodies are
+then cloned again — once into the `Full` body that is forwarded, and once held
+as `Bytes` in the transaction.
+
+This breaks several real workflows: large downloads, server-sent events,
+long-poll, chunked CDN responses. Even when bodies are small, holding multiple
+full copies (request and response) per in-flight transaction is wasteful.
+
+**Proposed shape:**
+
+- Stream bodies by default; tee a bounded prefix into a capture buffer
+  (configurable byte cap, e.g. `captures_max_body_bytes`).
+- Compute `body_length` from the streamed total, not from a buffered `Bytes`.
+- Lint rules that need the body (today: very few; mostly content-length /
+  multipart) get a `body_prefix: Option<Bytes>` slice on the transaction
+  alongside the streamed length.
+
+- **Size:** XL
+- **Complexity:** High — touches every error path in `handle_http_logic` plus
+  the H3 stream handler; needs careful trailers handling.
+- **Gains:** Restores correct proxy semantics (SSE, chunked stream), unblocks
+  large-body workloads, removes a memory-amplification bug, decouples capture
+  from forwarding.
+
+### 4. Capture writer: dedicated writer task with bounded mpsc
+
+`CaptureWriter` (`src/capture.rs`) holds an `Arc<Mutex<tokio::fs::File>>` (a
+`tokio::sync::Mutex`). Its `write_line` acquires the mutex, writes the line, and
+**flushes** while still holding the lock. Every concurrent request serializes on
+this mutex and the per-write `flush()`. The async mutex avoids blocking the
+runtime thread, but the per-write fsync barrier and the single shared file
+handle still serialize the capture path — a hidden bottleneck for a proxy.
+
+**Proposed shape:**
+
+```rust
+pub struct CaptureWriter {
+    tx: mpsc::Sender<CaptureRecord>,
+}
+// background task: pull from rx, write batched, flush on idle/timer
+```
+
+- Use `tokio::sync::mpsc` with a bounded queue (drop or backpressure on
+  overflow per a configured policy).
+- Use `BufWriter` + interval-based or size-based flush, not per-line.
+- Provide a `shutdown()` that drains and fsyncs.
+
+- **Size:** M
+- **Complexity:** Medium — backpressure policy is the one design choice that
+  matters; everything else is mechanical.
+- **Gains:** Removes a synchronous fs barrier from the request hot path,
+  isolates IO failures behind a channel boundary, makes the proxy feel "fast"
+  under burst load, and gives a natural place to add capture rotation /
+  compression / streaming endpoints (#13).
+
+### 5. Lossless capture schema (multi-value headers, tagged records, schema version)
+
+`serde_helpers::serialize_headers` collapses `HeaderMap` into a
+`HashMap<String, String>`. Headers that legitimately appear multiple times —
+`Set-Cookie`, `Vary`, `Link`, `Cache-Control`, `Via`, `Forwarded`,
+`WWW-Authenticate` — lose all but one value, and non-UTF-8 values are silently
+dropped by the `v.to_str()` guard. For a tool whose entire purpose is verifying
+HTTP correctness, this is a quiet correctness hazard: a replayed capture can
+pass rules that the live traffic would have failed.
+
+The JSONL also has weak versioning. `WebSocketSession` carries a
+`type: "websocket_session"` discriminator (added via a manual `record_type`
+field), but `HttpTransaction` has none — `load_captures` treats any record
+whose `type` is missing (or equals `http_transaction`) as a transaction and
+skips the rest. There is no `schema_version`.
+
+**Proposed:**
+
+- Serialize headers as `Vec<(String, String)>` (ordered, lossless) or
+  `HashMap<String, Vec<String>>`. Provide a one-shot migrator for the existing
+  format.
+- Wrap top-level capture records in a tagged enum:
+  ```rust
+  #[serde(tag = "type", rename_all = "snake_case")]
+  enum CaptureRecord { HttpTransaction(...), WebsocketSession(...), ... }
+  ```
+- Add `schema_version: u32` (or a `meta` envelope) so future readers can
+  reject / migrate older files cleanly.
+- Decide the policy for non-UTF-8 header bytes: emit base64 with a marker, or
+  fail loud — but stop dropping silently.
+
+- **Size:** M
+- **Complexity:** Medium — touches serde, capture loader, replay/seed paths,
+  and any external tools that consume the JSONL.
+- **Gains:** Correctness of stateful rules over replayed captures, room for
+  schema evolution without ad-hoc heuristics, and an enum that makes capture
+  consumers (dashboards, analyzers) trivial to write.
+
+---
+
+## Tier 2 — Rule Engine
+
+### 6. Wire `RuleScope` into dispatch — ✅ DONE
+
+Implemented as a single-slice filter rather than the originally-proposed
+three-way partition: a `LazyLock`-built `REQUEST_ONLY_RULES` excludes
+`Server`-scoped rules while preserving the source order of `RULES`, and the
+`rules_for_scope(has_response)` helper returns either `RULES` or
+`&REQUEST_ONLY_RULES`. Dispatch in `src/lint.rs` selects with
+`rules_for_scope(tx.response.is_some())`. The simpler shape avoids reordering
+violations on the has-response path and matches the only two dispatch cases
+that actually exist today (`PROTOCOL_RULES` carries no scope yet, so it is
+unchanged).
+
+The `Rule::scope` doc-comment now spells out the engine contract: `Server`
+rules may assume the response is present. The defensive `if let Some(resp)`
+guards inside the server rules become redundant under that contract; removing
+them is left as opportunistic cleanup, not part of this change.
+
+Note: in production `lint_transaction` is only called after response
+collection, so the runtime saving is theoretical for the proxy path. The
+real value lands in #18 (`lint-http lint <captures.jsonl>`) and any other
+non-proxy caller.
+
+### 7. Make stateful rules' query needs explicit — but keep `QueryType` off the `Rule` trait
+
+`src/queries/mapping.rs` is a hardcoded `match rule_id { "stateful_x" =>
+ByOrigin, ... }` with a silent `_ => QueryType::ByResource` default. Adding a
+new stateful rule that needs `ByOrigin` will compile and run, but get the wrong
+history — detectable only via test, if a test exists.
+
+**Rejected fix.** The obvious move — adding `fn query_type(&self) -> QueryType`
+to the `Rule` trait — is rejected on modularity grounds. The vast majority of
+the 184 rules don't need history at all; forcing all of them to import
+`QueryType` and declare an answer pulls the engine's query layer into the rule
+library's public API. A rule reused in a CI capture linter that has no state
+store would still have to satisfy that method.
+
+**Proposed.** Keep the query layer external to the `Rule` trait, but make the
+declaration *exhaustive* and *colocated with rule registration*. Two shapes
+work — the choice depends on how #9 lands:
+
+- **Pair-the-slice.** A separate `STATEFUL_RULES: &[(&dyn Rule, QueryType)]`
+  registry alongside `RULES`, with a test that fails if any rule whose ID
+  begins with `stateful_` (or, better, any rule that opts in via marker)
+  appears in `RULES` but not in `STATEFUL_RULES`. Stateless rules don't change.
+- **Companion trait.** `pub trait StatefulRule: Rule { fn query_type(&self) ->
+  QueryType; }`. The engine iterates two slices. Stateless rules implement only
+  `Rule` and never see `QueryType`.
+
+Either form deletes `queries/mapping.rs` and the silent default. Either keeps
+the stateless majority of rules unaware of the query system.
+
+- **Size:** S
+- **Complexity:** Low.
+- **Gains:** Removes the silent-default failure mode without saddling the
+  `Rule` trait — and any future external rule pack — with engine-level
+  metadata.
+
+### 8. Drop the associated `Config` type and the type-erasure ceremony
+
+Today `Rule` (`src/rules/mod.rs`) has an associated `Config` type. Because that
+prevents `&dyn Rule` from being stored in `RULES`, the codebase carries:
+
+- A second trait, `RuleConfigValidator`, that erases the associated type into
+  `Arc<dyn Any + Send + Sync>`.
+- A `RuleConfigEngine` that holds `HashMap<&'static str, Arc<dyn Any>>` and
+  panics on lookup miss (`"Rule '{}' config not found in cache. This is a
+  bug..."`).
+- A `validate_and_box` method on the public `Rule` trait whose return type is
+  *engine-shaped* (`Arc<dyn Any + Send + Sync>`) — the trait itself leaks
+  the engine's caching strategy.
+- A parallel `ProtocolRuleConfigValidator` for the protocol-event side.
+
+**Rejected alternative.** Returning a single `enum RuleConfig { CacheControl(...),
+CookieLifecycle(...), ... }` would be *worse* than today: every rule's config
+shape becomes part of one closed enum, every external rule pack would have to
+fork that enum, and the rule library can no longer be extended without modifying
+central code. Drop the suggestion.
+
+**Proposed.** Drop the associated type entirely. Rules consume
+`&crate::config::Config` directly and parse their own section internally —
+several non-trivial rules (e.g. `ServerClearSiteData`) already parse a custom
+section in `validate_and_box`:
+
+```rust
+pub trait Rule: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn scope(&self) -> RuleScope { RuleScope::Both }
+    fn validate(&self, _cfg: &Config) -> anyhow::Result<()> { Ok(()) }
+    fn check_transaction(
+        &self,
+        tx: &HttpTransaction,
+        history: &TransactionHistory,
+        config: &Config,
+    ) -> Option<Violation>;
+}
+```
+
+- Each rule's parsed config struct stays private to its module.
+- Rules that want to amortize parsing use a `OnceLock<ParsedConfig>` on
+  themselves; the engine no longer owns a config cache.
+- `validate` returns `()` on success — no boxing, no `Any`, no downcast.
+- `RuleConfigValidator`, `RuleConfigEngine`, the runtime panic path, and the
+  parallel `ProtocolRuleConfigValidator` all delete entirely.
+
+- **Size:** L overall — ~2.5–3 k lines across ~200 files, dominated by
+  mechanical signature changes in the 184 rule files and their tests.
+- **Complexity:** Medium — most of the work is repetitive; the design
+  decisions are small in number.
+- **Gains:** Removes ~200 lines of trait scaffolding and the panic path,
+  shrinks the public `Rule` API to one method plus metadata, and — crucially
+  for #2 — removes the engine-shaped return type (`Arc<dyn Any>`) from the
+  trait so the rule library's public surface no longer leaks the proxy's
+  config-cache implementation.
+
+**Atomic-commit decomposition.**
+
+- **#8a — Add a `check(&self, tx, history, cfg, engine)` method** to `Rule`
+  (and `ProtocolRule`) with a default impl that delegates to the legacy
+  `check_transaction(&Self::Config)` via the engine cache. Engine dispatch
+  switches to call `check` (through the `*_erased` wrappers).
+  `check_transaction` gains an `unreachable!()` default so future rules can
+  skip it. No rule changes; tests unchanged. — ✅ **DONE (commit `9514afc`).**
+- **#8b — Migrate every rule to override `check` directly.** Each rule sets
+  `type Config = ();`, removes its `check_transaction` impl, and provides a
+  `check` impl that takes `cfg: &Config` and parses inline (the custom-config
+  rules call their existing `parse_*_config` helpers from inside `check`). Rule
+  tests migrate from constructing parsed `RuleConfig` / custom-config structs
+  to building a `Config`. Single commit if reviewable as one structural move;
+  can be batched by category (`client_*`, `server_*`, `message_*`,
+  `stateful_*`, `semantic_*`, `protocol`) since each rule's migration is
+  independent thanks to the dual-method trait from #8a. ~2–3 k lines.
+- **#8c — Delete the legacy machinery.** — ✅ **DONE.** Removed `type Config`,
+  `validate_and_box`, the legacy `check_transaction` / `check_event` and their
+  `unreachable!()` defaults, `RuleConfigValidator`, `RuleConfigEngine`,
+  `ProtocolRuleConfigValidator`, and the `engine` parameter that cascaded
+  through `lint_transaction` / `lint_protocol_event` / `Config::load_from_path`
+  / `main.rs` / `Shared` / the proxy submodules. The `check` methods were
+  renamed to `check_transaction` / `check_event` (the legacy names freed). A new
+  object-safe `Rule::validate(&Config) -> Result<()>` replaces `validate_and_box`
+  for startup validation (custom-config rules override it to parse their
+  section); `RULES` / `PROTOCOL_RULES` now store `&dyn Rule` / `&dyn ProtocolRule`
+  directly and `validate_rules` returns `()`.
+
+#8a landed the bridge; #8b did the mechanical per-rule migration; #8c was the
+pure deletion once the bridge had done its job.
+
+### 9. Auto-register rules with `linkme` or `inventory`
+
+`src/rules/mod.rs` has 184 `pub mod ...;` lines, a 179-entry `RULES` slice, and
+a 5-entry `PROTOCOL_RULES` slice, all hand-maintained. There's a test that
+asserts `config_example.toml` contains every registered rule, but nothing
+prevents adding a `pub mod foo;` without registering its struct in `RULES` (or
+vice versa). No `linkme` / `inventory` dependency is present today.
+
+**Proposed:**
+
+- Use `linkme::distributed_slice` (no global ctor on macOS/Windows issue today)
+  or `inventory` to let each rule register itself: `#[lint_http::rule] static
+  RULE: ServerCacheControlPresent = ...;`.
+- Generate the `pub mod` declarations via `build.rs` from directory contents,
+  or move rules into one-file-per-category modules.
+
+- **Size:** M
+- **Complexity:** Medium — needs to be robust on all build targets the project
+  supports (Linux/macOS/Windows already in CI).
+- **Gains:** Adding a rule = create one file. Drop ~370 lines of
+  bookkeeping. Makes external rule packs (#2) realistic.
+
+**Atomic-commit decomposition.**
+
+- **#9a — Wire `linkme` infrastructure.** Add the `linkme` dependency,
+  declare the `#[distributed_slice] static REGISTERED_RULES: [&dyn Rule]`
+  (and the protocol equivalent), and the `#[lint_http::rule]` attribute (or
+  rely on raw `linkme::distributed_slice` registration). The engine still
+  iterates the hand-maintained `RULES` const; the new slice is initially
+  empty and unused. ~80–120 lines.
+- **#9b — Migrate rules to self-register; delete the const.** Every rule
+  file gains a `#[distributed_slice(REGISTERED_RULES)]` registration; the
+  hand-maintained `RULES` slice and the `pub mod ...;` declarations in
+  `mod.rs` go away (modules can be discovered via `build.rs` generating the
+  declarations from the directory listing). Engine swaps to the linkme slice.
+  ~400–600 lines, mostly mechanical 1-line registrations per rule.
+
+### 10. Collapse the lint + record + capture sequence — in the proxy crate, not the rule crate
+
+Across the proxy submodules the sequence
+```rust
+let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state, &shared.engine);
+tx.violations = violations.clone();
+shared.state.record_transaction(&tx);
+let _ = captures.write_transaction(&tx).await;
+```
+appears in **three** places (`proxy/http.rs`, `proxy/websocket.rs`,
+`proxy/http3.rs`). The ordering is load-bearing: state must be recorded
+*after* lint, otherwise the current tx shows up in its own history. That
+invariant is maintained by convention, not by the type system. (The early
+error paths add a secondary duplication via `build_and_write_transaction`.)
+
+**Rejected fix.** The straightforward `lint::Engine { cfg, state,
+rules_engine, captures }` that owns the cycle would *bind the rule library to
+the proxy's IO surface* (state store + capture writer). That breaks #18: a
+`lint-http lint <captures.jsonl>` subcommand that re-runs rules over an
+existing capture file has no proxy, no live state store, and no on-the-fly
+capture writer. If `Engine` insists on owning all four, the rule crate stops
+being usable from a CLI that has only capture files and a config.
+
+**Proposed.**
+
+- Keep `lint_transaction(tx, cfg, history) -> Vec<Violation>` — pure, IO-free,
+  in the rule crate. Untouched.
+- Move the orchestration into the *proxy* crate: a
+  `proxy::TransactionPipeline { state, captures }` that takes a
+  `(HttpTransaction, Vec<Violation>)` and runs record-then-capture in the
+  required order, behind one method call.
+- The three call-sites become `pipeline.commit(tx, lint_transaction(&tx,
+  ...)).await?`. The load-bearing ordering invariant lives in
+  `TransactionPipeline`, not on the rule crate's public surface.
+- Same shape for the protocol-event side.
+
+- **Size:** S–M
+- **Complexity:** Low.
+- **Gains:** One canonical proxy pipeline (no duplicated sequence), a single
+  seam for backpressure (#4) and instrumentation, but the rule library stays
+  usable from a non-proxy caller — exactly what #18 needs.
+
+### 11. Generate per-rule docs from rule metadata
+
+`docs/rules/` has 184 hand-written markdown files (plus `TEMPLATE.md`) mirrored
+against `src/rules/`, with a hand-maintained `docs/rules.md` index. This is a
+documentation-drift trap: rule logic can change without the doc being updated,
+and `config_example.toml` is already kept in sync only via a test assertion.
+There is no test that the markdown matches the rule.
+
+**Proposed:**
+
+- Rule trait gains optional metadata: `fn description(&self) -> &'static str`,
+  `fn rfc_reference(&self) -> Option<&'static str>`,
+  `fn examples(&self) -> &'static [(Compliant | NonCompliant, &'static str)]`.
+- A `cargo run --bin gendocs` (or `xtask`) renders `docs/rules/<id>.md` and
+  `docs/rules.md` from the trait. CI fails if the on-disk docs diverge from
+  what would be regenerated.
+
+**Modularity constraint.** Any types referenced by the metadata — a
+`Compliance::{Compliant, NonCompliant}` enum used by `examples()`, an
+`RfcReference` struct, a `Severity` recommendation type — must live in the
+rule crate alongside the trait, not in a downstream `gendocs` or proxy
+crate. Otherwise external rule packs inherit a docs-tooling dependency just
+to declare metadata. The metadata itself is intrinsic to the rule (unlike
+`QueryType` in #7, which is intrinsic to the engine), so it belongs on the
+trait — but only if its types live there too.
+
+- **Size:** L (one-time tool + per-rule attribute fill-in)
+- **Complexity:** Medium.
+- **Gains:** Single source of truth for what each rule does; dramatically
+  reduces the cost of adding/editing rules; lets the rule library
+  self-describe over an API (e.g., a future `--list-rules --json` CLI).
+
+**Atomic-commit decomposition.**
+
+- **#11a — Add metadata methods to `Rule` / `ProtocolRule` with empty
+  defaults.** `description() -> &'static str { "" }`, `rfc_reference() ->
+  Option<&'static str> { None }`, `examples() -> &'static [Example] { &[] }`.
+  Add the `Compliance` enum and `Example` struct in the rule crate (per the
+  modularity constraint above). No rule changes. ~80–120 lines.
+- **#11b — Add a `gendocs` binary.** `cargo run --bin gendocs` reads each
+  rule's metadata and writes `docs/rules/<id>.md` and `docs/rules.md`.
+  Initially produces near-empty files since defaults are empty. ~150–250
+  lines.
+- **#11c — Fill in per-rule metadata.** Override the metadata methods on
+  every rule with real content. ~1–2 k lines; batchable by category
+  (`client_*`, `server_*`, `message_*`, `stateful_*`, `semantic_*`,
+  `protocol`) if a single commit is too large for review.
+- **#11d — Add CI gate that fails on docs drift.** A test (or workflow
+  step) that runs `gendocs` to a temp directory and `diff`s against
+  `docs/rules/`. ~30 lines + CI config.
+
+---
+
+## Tier 3 — Robustness & Hygiene
+
+### 12. Replace verbose poison-handling with `parking_lot` (or helpers)
+
+`StateStore` (`src/state.rs`) and `ProtocolEventStore` repeat the pattern
+```rust
+match self.store.read() {
+    Ok(g) => ...,
+    Err(_) => { tracing::warn!("... lock poisoned during read"); ... },
+}
+```
+~6–8 times over `std::sync::RwLock`. Tests deliberately poison the locks to
+exercise the recovery paths, padding the file with cases that test
+infrastructure rather than behaviour.
+
+**Proposed:**
+
+- Switch to `parking_lot::RwLock`, which has no poisoning. Drop all the
+  poison-recovery branches and their tests.
+- If `std::sync::RwLock` is preferred, extract a small helper:
+  `fn read_or_warn<T, R>(&self, op: impl FnOnce(&T) -> R) -> Option<R>`.
+
+- **Size:** S
+- **Complexity:** Low.
+- **Gains:** Shrinks `state.rs` (currently ~950 lines), removes test theater,
+  and is marginally faster (parking_lot is faster on contention).
+
+### 13. Live captures stream / control endpoint
+
+The proxy already exposes `/_lint_http/cert`. Adding a Server-Sent-Events or
+WebSocket endpoint at `/_lint_http/stream` that pushes each `CaptureRecord` as
+JSONL would make the dev loop substantially better — no more `tail -f
+captures.jsonl`, and external dashboards become trivial.
+
+This pairs naturally with the writer task in #4: one `mpsc::Sender` feeds disk,
+another (or a `tokio::broadcast`) feeds live subscribers.
+
+- **Size:** M
+- **Complexity:** Low.
+- **Gains:** Significant developer-experience improvement; opens the door to a
+  small TUI/web UI without changes to the rule engine.
+
+### 14. Consolidate the outbound HTTP client + cache the root cert store
+
+Two outbound paths exist:
+- A `LegacyClient` (`hyper-rustls` + native roots) built once at proxy startup
+  (`src/proxy/mod.rs`) for normal forwarding.
+- `connect_upstream_for_upgrade` (`src/proxy/websocket.rs`) builds a fresh
+  `RootCertStore` from `rustls_native_certs::load_native_certs()` on **every**
+  WebSocket-upgrade connection.
+
+The per-request rebuild is pure waste, and the two outbound shapes duplicate
+trust-store and TLS-config construction with no shared home. (Note: the upgrade
+path already degrades gracefully — it returns an `anyhow::Err` when no certs
+load rather than panicking, so the old "startup `expect` panic" concern no
+longer applies.)
+
+**Proposed:**
+
+- Build the `RootCertStore` once in `Shared` and reuse it for both code paths.
+- Wrap the two outbound shapes in a single `Upstream` enum or struct so future
+  features (HTTP/3 outbound, connection pooling tweaks, mTLS) have one home.
+- Optional hardening: fall back to `webpki-roots` with a warn-level log when
+  native trust is unavailable, so a developer tool never hard-fails on a
+  missing platform trust store.
+
+- **Size:** S–M
+- **Complexity:** Low.
+- **Gains:** Removes a per-request rebuild of the trust store and structural
+  duplication between the two outbound paths.
+
+### 15. Connection accept controls + graceful shutdown
+
+`run_proxy_with_limit` (`src/proxy/mod.rs`) accepts unconditionally and spawns a
+task per connection, with no concurrency cap, no graceful shutdown beyond the
+`accept_limit` test counter, and no signal handling (the comment in `main.rs`
+even says "no signal handling here"). A 60-second cleanup interval task runs,
+but nothing drains in-flight work on exit. On burst load, memory and FD
+pressure are unbounded.
+
+**Proposed:**
+
+- A `tokio::sync::Semaphore` bounding live connections (configurable; default
+  generous like 1024).
+- A `CancellationToken` (or `tokio::select!` against `tokio::signal::ctrl_c`)
+  that lets the accept loop and outstanding handlers drain on shutdown,
+  flushing the capture writer before exit.
+- Optional: per-IP rate limit (token bucket) for hardening.
+
+- **Size:** M
+- **Complexity:** Medium.
+- **Gains:** Predictable resource use under load, clean shutdown (no truncated
+  capture lines, no orphaned tokio tasks), and a foundation for an integration
+  test harness that exercises shutdown.
+
+### 16. `Arc<HttpTransaction>` in state to remove deep clones
+
+`StateStore::record_transaction` does `deque.push_front(tx.clone())`, cloning
+the entire transaction (headers, trailers, body bytes) on push, and
+`get_history*` clones again (`.cloned()`) on read. Bodies are `Bytes` (cheap),
+but `HeaderMap` clone is real, and at high `max_history` this matters.
+
+**Proposed:**
+
+- Store `Arc<HttpTransaction>` in the deque. `record_transaction` takes
+  `Arc<HttpTransaction>` (or wraps internally); queries return
+  `Vec<Arc<HttpTransaction>>`.
+- Optionally trim what state holds: rules don't need bodies post-record;
+  storing only headers + small fields would shave more.
+
+- **Size:** S
+- **Complexity:** Low (touches one signature plus query layer).
+- **Gains:** Lower allocation pressure on hot path; modest CPU win; trivial to
+  measure.
+
+---
+
+## Tier 4 — Hygiene
+
+### 17. CLI / packaging polish
+
+Five independent hygiene items collected here. Each is its own atomic commit.
+
+- **#17a — Move `make_temp_captures_path` and `make_temp_config_path`
+  behind `#[cfg(test)]`** (or under a `test-utils` Cargo feature). They're
+  test fixtures currently exposed as `pub` in `lib.rs`. ~10–20 lines.
+- **#17b — Lower `cognitive-complexity-threshold` to clippy default and
+  refactor the offenders.** `clippy.toml` sets the threshold to 30 (twice
+  the default). After #1 and #8 land the offender list shrinks; what's left
+  should be refactored rather than have the budget expanded.
+  ~50–150 lines.
+- **#17c — Reconcile the coverage threshold mismatch.** `.cargo/config.toml`
+  says `--fail-under 95`, `docs/development.md` says "Minimum **90%**".
+  Pick one and update the other. ~5 lines.
+- **#17d — Decide CHANGELOG.md fate.** It says "Three built-in rules" and
+  is otherwise stale (the catalogue is now 184 rules). Either delete it or
+  wire up `git-cliff` / `release-please` to populate it from commit history.
+  ~10–80 lines depending on the choice.
+- **#17e — Audit Cargo.toml feature flags.** `tokio = { features = ["full"] }`
+  and `hyper = { features = ["full"] }` are broad opt-ins. Trim to
+  actually-used features. ~30–80 lines.
+
+- **Size:** S each (collectively still S–M).
+- **Complexity:** Low.
+- **Gains:** Smaller surface area, less drift, faster builds.
+
+### 18. CLI subcommands
+
+The binary takes only `--config` (`src/main.rs`). Useful subcommands fall out
+naturally and each is its own atomic commit.
+
+- **#18a — Clap subcommand scaffold.** Restructure `main.rs` so today's
+  behaviour lives under `lint-http run --config ...`, with `clap` parsing
+  subcommands. No new functionality, just routing. ~80 lines.
+- **#18b — `lint-http lint <captures.jsonl>`.** Re-runs rules over an
+  existing capture file (no proxy). Depends on #5 (lossless capture schema)
+  to round-trip headers correctly and on #8c (engine-free `lint_transaction`)
+  to drive the engine without a `RuleConfigEngine`. ~150–250 lines.
+- **#18c — `lint-http rules list [--format json]`.** Iterates the rule
+  registry and prints id / scope / metadata; depends on #11a. ~80 lines.
+- **#18d — `lint-http gendocs`.** Wires the binary from #11b into the CLI
+  surface. ~30 lines.
+
+- **Size:** M aggregate, S each.
+- **Complexity:** Low.
+- **Gains:** Brings `lint-http` closer to a generic HTTP linter usable in CI
+  pipelines, not just a runtime proxy. This is the single biggest win for
+  positioning the project as a "linter" rather than a "proxy that lints".
+
+---
+
+## Suggested ordering
+
+The center of gravity is **#2** (workspace split into `lint-http-core`,
+`lint-http-rules`, `lint-http-proxy`). Everything below either *enables* that
+split by stripping engine concerns out of the rule trait, or *exploits* it
+once the boundary lands. Land the rule-engine cleanups first so the split
+itself reduces to a `Cargo.toml` exercise plus visibility tightening, not a
+mid-flight redesign.
+
+**Path A — Rule-library hardening.** Each numbered step is one atomic commit
+that compiles and passes tests on its own. Sub-step labels (`8a`, `8b`, …)
+correspond to the decompositions in the relevant item bodies above.
+
+1. ~~**#1** — split `proxy.rs`~~ ✅ done.
+2. ~~**#6** — wire `RuleScope` into dispatch~~ ✅ done.
+3. ~~**#8a** — Add a `check(&self, tx, history, cfg, engine)` method to
+   `Rule`/`ProtocolRule` with a delegating default impl; engine dispatch
+   switches to call it~~ ✅ done (commit `9514afc`).
+4. **#8b** — *(next)* Migrate every rule to override `check` directly (drop
+   `check_transaction`, set `type Config = ()`, parse inline). Tests
+   migrate from passing parsed `RuleConfig` / custom configs to passing a
+   `&Config`. Single bulk commit if reviewable; otherwise batch by category
+   (`client_*`, `server_*`, `message_*`, `stateful_*`, `semantic_*`,
+   `protocol`) — each batch is independently atomic thanks to #8a's bridge.
+5. ~~**#8c** — Delete legacy machinery (`type Config`, `validate_and_box`,
+   legacy `check_transaction`/`check_event`, `RuleConfigValidator`,
+   `RuleConfigEngine`, `ProtocolRuleConfigValidator`, cascading `engine`
+   parameter); rename `check` → `check_transaction`/`check_event`; add
+   object-safe `Rule::validate`.~~ ✅ done.
+6. **#7** — *(next)* Stateful query needs off the trait (pair-the-slice or
+   `StatefulRule` companion). Easier after #8 because the trait is
+   `dyn`-clean.
+7. **#9a** — Wire `linkme` infrastructure alongside the existing `RULES`
+   const; engine still uses the const.
+8. **#9b** — Migrate rules to self-register; delete the hand-maintained
+   const and `pub mod` declarations (with `build.rs` discovering modules
+   from the directory listing).
+9. **#10** — `proxy::TransactionPipeline` collapses the three duplicated
+   `lint → record → capture` call-sites without dragging IO into the rule
+   crate.
+10. **#11a** — Add `description()` / `rfc_reference()` / `examples()` to
+    `Rule`/`ProtocolRule` with empty defaults; introduce `Compliance` and
+    `Example` types in the rule crate.
+11. **#11b** — Add `gendocs` binary that consumes the metadata.
+12. **#11c** — Fill per-rule metadata. Single commit if reviewable;
+    otherwise batched by rule category.
+13. **#11d** — CI gate that fails on `docs/rules/` drift vs. regenerated
+    output.
+14. **#2** — Workspace split into `lint-http-core`, `lint-http-rules`,
+    `lint-http-proxy`. The payoff: rule crate's public API now has no
+    engine-shaped types and the split reduces to a `Cargo.toml` exercise plus
+    visibility tightening.
+
+**Path B — Independent tracks.** Don't touch the rule trait; can run in
+parallel with Path A. One atomic commit each unless noted.
+
+- **#5** — Lossless capture schema. The silent header-collapsing bug is a
+  correctness issue, not just architecture; worth fixing before more
+  captures pile up in the wild. Touches capture and serde only. May want to
+  ship a one-shot migrator as a follow-up commit.
+- **#3** — Streaming proxy body pipeline. XL change touching every error
+  path; if needed, split into "introduce bounded body type + capture-prefix
+  tee" and "swap body collection sites" as two atomic commits.
+- **#4** — Dedicated capture writer task with bounded mpsc.
+
+**Path C — Opportunistic (Tier 3/4), one atomic commit per item:**
+
+- **#12** — Replace verbose poison-handling with `parking_lot` (or helpers).
+- **#13** — Live captures stream / control endpoint.
+- **#14** — Consolidate the outbound HTTP client + cache the root cert store.
+- **#15** — Connection accept controls + graceful shutdown.
+- **#16** — `Arc<HttpTransaction>` in state to remove deep clones.
+- **#17a–#17e** — Hygiene polish (five separate commits, see #17 above).
+- **#18a–#18d** — CLI subcommands (four separate commits, see #18 above).
+  Plan **#18b** *after* #2 and #8c so it exercises the new crate boundary
+  and the engine-free `lint_transaction`, rather than reaching across them.

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,10 +118,9 @@ pub struct Config {
 }
 
 impl Config {
-    /// Load configuration from a TOML file and return the config along with the rule engine.
-    pub async fn load_from_path<P: AsRef<std::path::Path>>(
-        path: P,
-    ) -> anyhow::Result<(Self, crate::rules::RuleConfigEngine)> {
+    /// Load configuration from a TOML file, validating every enabled rule's
+    /// config section so a malformed config fails fast at startup.
+    pub async fn load_from_path<P: AsRef<std::path::Path>>(path: P) -> anyhow::Result<Self> {
         let path_ref = path.as_ref();
         let s = tokio::fs::read_to_string(path_ref).await?;
         let cfg: Self = toml::from_str(&s)?;
@@ -131,10 +130,10 @@ impl Config {
             anyhow::bail!("h3_listen requires [tls] enabled = true");
         }
 
-        // Validate all enabled rules' configurations and get the engine
-        let engine = crate::rules::validate_rules(&cfg)?;
+        // Validate all enabled rules' configurations.
+        crate::rules::validate_rules(&cfg)?;
 
-        Ok((cfg, engine))
+        Ok(cfg)
     }
 
     /// Returns true if the rule is enabled.
@@ -188,7 +187,7 @@ captures_seed = false
 enabled = false
 "#;
         fs::write(&tmp_toml, toml).await?;
-        let (cfg, _engine) = Config::load_from_path(&tmp_toml).await?;
+        let cfg = Config::load_from_path(&tmp_toml).await?;
         assert!(cfg.is_enabled("server_cache_control_present"));
         fs::remove_file(&tmp_toml).await?;
         Ok(())
@@ -212,7 +211,7 @@ captures = "captures.jsonl"
 enabled = false
 "#;
         fs::write(&tmp_toml, toml).await?;
-        let (cfg, _engine) = Config::load_from_path(&tmp_toml).await?;
+        let cfg = Config::load_from_path(&tmp_toml).await?;
         assert!(cfg.is_enabled("some_rule"));
         let config = cfg.get_rule_config("some_rule");
         assert!(config.is_some());
@@ -287,7 +286,7 @@ h3_listen = "127.0.0.1:3443"
 enabled = true
 "#;
         fs::write(&tmp_toml, toml).await?;
-        let (cfg, _engine) = Config::load_from_path(&tmp_toml).await?;
+        let cfg = Config::load_from_path(&tmp_toml).await?;
         assert_eq!(cfg.general.h3_listen, Some("127.0.0.1:3443".to_string()));
         fs::remove_file(&tmp_toml).await?;
         Ok(())
@@ -329,7 +328,7 @@ captures = "captures.jsonl"
 enabled = false
 "#;
         fs::write(&tmp_toml, toml).await?;
-        let (cfg, _engine) = Config::load_from_path(&tmp_toml).await?;
+        let cfg = Config::load_from_path(&tmp_toml).await?;
         assert!(cfg.general.h3_listen.is_none());
         fs::remove_file(&tmp_toml).await?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ mod test_helpers;
 #[cfg(test)]
 pub use test_helpers::{
     disable_rule, enable_rule, enable_rule_with_paths, make_headers_from_pairs, make_test_client,
-    make_test_config_with_enabled_rules, make_test_engine, make_test_rule_config,
-    make_test_transaction, make_test_transaction_with_response,
+    make_test_config_with_enabled_rules, make_test_rule_config, make_test_transaction,
+    make_test_transaction_with_response,
 };
 
 pub fn make_temp_captures_path(prefix: &str) -> std::path::PathBuf {

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -29,7 +29,6 @@ pub fn lint_transaction(
     tx: &crate::http_transaction::HttpTransaction,
     cfg: &Config,
     state: &crate::state::StateStore,
-    engine: &crate::rules::RuleConfigEngine,
 ) -> Vec<Violation> {
     let mut out = Vec::new();
 
@@ -87,7 +86,7 @@ pub fn lint_transaction(
                 }),
         };
 
-        out.extend(rule.check_transaction_erased(tx, history, cfg, engine));
+        out.extend(rule.check_transaction(tx, history, cfg));
     }
 
     out
@@ -97,9 +96,7 @@ pub fn lint_transaction(
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::test_helpers::{
-        disable_rule, make_test_config_with_enabled_rules, make_test_engine,
-    };
+    use crate::test_helpers::{disable_rule, make_test_config_with_enabled_rules};
 
     #[test]
     fn lint_response_rules_emit_when_enabled() {
@@ -108,9 +105,8 @@ mod tests {
             "server_cache_control_present",
             "server_etag_or_last_modified",
         ]);
-        let engine = make_test_engine(&cfg);
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = lint_transaction(&tx, &cfg, &state, &engine);
+        let v = lint_transaction(&tx, &cfg, &state);
 
         assert!(v.iter().any(|x| x.rule == "server_cache_control_present"));
         assert!(v.iter().any(|x| x.rule == "server_etag_or_last_modified"));
@@ -123,7 +119,6 @@ mod tests {
             "client_user_agent_present",
             "client_accept_encoding_present",
         ]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -132,7 +127,7 @@ mod tests {
         );
         tx.timing = TimingInfo { duration_ms: 5 };
 
-        let v = lint_transaction(&tx, &cfg, &state, &engine);
+        let v = lint_transaction(&tx, &cfg, &state);
 
         assert!(v.iter().any(|x| x.rule == "client_user_agent_present"));
         assert!(v.iter().any(|x| x.rule == "client_accept_encoding_present"));
@@ -145,17 +140,15 @@ mod tests {
             "server_cache_control_present",
             "server_etag_or_last_modified",
         ]);
-        let engine_enabled = make_test_engine(&cfg_enabled);
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = lint_transaction(&tx, &cfg_enabled, &state, &engine_enabled);
+        let v = lint_transaction(&tx, &cfg_enabled, &state);
         assert!(v.iter().any(|x| x.rule == "server_cache_control_present"));
         assert!(v.iter().any(|x| x.rule == "server_etag_or_last_modified"));
 
         let mut cfg_disabled = Config::default();
         disable_rule(&mut cfg_disabled, "server_cache_control_present");
         disable_rule(&mut cfg_disabled, "server_etag_or_last_modified");
-        let engine_disabled = make_test_engine(&cfg_disabled);
-        let v2 = lint_transaction(&tx, &cfg_disabled, &state, &engine_disabled);
+        let v2 = lint_transaction(&tx, &cfg_disabled, &state);
         assert!(!v2.iter().any(|x| x.rule == "server_cache_control_present"));
         assert!(!v2.iter().any(|x| x.rule == "server_etag_or_last_modified"));
     }
@@ -167,7 +160,6 @@ mod tests {
             "client_user_agent_present",
             "server_cache_control_present",
         ]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -183,7 +175,7 @@ mod tests {
             trailers: None,
         });
 
-        let violations = lint_transaction(&tx, &cfg, &state, &engine);
+        let violations = lint_transaction(&tx, &cfg, &state);
 
         assert!(!violations.is_empty());
 
@@ -205,7 +197,6 @@ mod tests {
         // that has connection_id set (used by ByConnection queries).
         let state = crate::state::StateStore::new(300, 10);
         let cfg = make_test_config_with_enabled_rules(&["server_cache_control_present"]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -223,7 +214,7 @@ mod tests {
             trailers: None,
         });
 
-        let violations = lint_transaction(&tx, &cfg, &state, &engine);
+        let violations = lint_transaction(&tx, &cfg, &state);
         assert!(violations
             .iter()
             .any(|v| v.rule == "server_cache_control_present"));
@@ -234,7 +225,6 @@ mod tests {
         // Enable a ByOrigin rule to exercise the lazy ByOrigin init path
         let state = crate::state::StateStore::new(300, 10);
         let cfg = make_test_config_with_enabled_rules(&["stateful_authentication_failure_loop"]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -250,7 +240,7 @@ mod tests {
             trailers: None,
         });
         // Should not panic; exercises the ByOrigin lazy init
-        let _violations = lint_transaction(&tx, &cfg, &state, &engine);
+        let _violations = lint_transaction(&tx, &cfg, &state);
     }
 
     #[test]
@@ -258,7 +248,6 @@ mod tests {
         // Enable a ByResourceAll rule to exercise the lazy ByResourceAll init path
         let state = crate::state::StateStore::new(300, 10);
         let cfg = make_test_config_with_enabled_rules(&["stateful_private_cache_visibility"]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -274,7 +263,7 @@ mod tests {
             trailers: None,
         });
         // Should not panic; exercises the ByResourceAll lazy init
-        let _violations = lint_transaction(&tx, &cfg, &state, &engine);
+        let _violations = lint_transaction(&tx, &cfg, &state);
     }
 
     #[test]
@@ -282,7 +271,6 @@ mod tests {
         // Enable a ByOrigin rule with a relative URI to exercise the None path
         let state = crate::state::StateStore::new(300, 10);
         let cfg = make_test_config_with_enabled_rules(&["stateful_authentication_failure_loop"]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -298,7 +286,7 @@ mod tests {
             trailers: None,
         });
         // Should use empty history for the ByOrigin None case
-        let _violations = lint_transaction(&tx, &cfg, &state, &engine);
+        let _violations = lint_transaction(&tx, &cfg, &state);
     }
 
     #[test]
@@ -315,7 +303,6 @@ mod tests {
             "server_cache_control_present",
             "client_user_agent_present",
         ]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -325,7 +312,7 @@ mod tests {
         tx.timing = TimingInfo { duration_ms: 5 };
         // No tx.response set — this is the request-only path.
 
-        let v = lint_transaction(&tx, &cfg, &state, &engine);
+        let v = lint_transaction(&tx, &cfg, &state);
 
         assert!(
             v.iter().any(|x| x.rule == "client_user_agent_present"),
@@ -342,7 +329,6 @@ mod tests {
         // Transaction with a relative/invalid URI to exercise the ByOrigin None path
         let state = crate::state::StateStore::new(300, 10);
         let cfg = make_test_config_with_enabled_rules(&["server_cache_control_present"]);
-        let engine = make_test_engine(&cfg);
         use crate::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
         let mut tx = HttpTransaction::new(
             crate::test_helpers::make_test_client(),
@@ -358,7 +344,7 @@ mod tests {
             trailers: None,
         });
 
-        let violations = lint_transaction(&tx, &cfg, &state, &engine);
+        let violations = lint_transaction(&tx, &cfg, &state);
         // Should still run rules even with relative URI
         assert!(!violations.is_empty());
     }

--- a/src/lint_protocol.rs
+++ b/src/lint_protocol.rs
@@ -12,14 +12,12 @@ use crate::config::Config;
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory};
 use crate::protocol_event_store::ProtocolEventStore;
-use crate::rules::RuleConfigEngine;
 
 /// Lint a single protocol event against all enabled protocol rules.
 pub fn lint_protocol_event(
     event: &ProtocolEvent,
     cfg: &Config,
     event_store: &ProtocolEventStore,
-    engine: &RuleConfigEngine,
 ) -> Vec<Violation> {
     let mut out = Vec::new();
 
@@ -33,7 +31,7 @@ pub fn lint_protocol_event(
                 ProtocolEventHistory::new(entries)
             });
 
-            out.extend(rule.check_event_erased(event, history, cfg, engine));
+            out.extend(rule.check_event(event, history, cfg));
         }
     }
 
@@ -50,14 +48,13 @@ mod tests {
     fn lint_protocol_event_returns_empty_for_no_enabled_rules() {
         let cfg = Config::default();
         let store = ProtocolEventStore::new(300, 100);
-        let engine = RuleConfigEngine::new();
         let event = ProtocolEvent {
             timestamp: Utc::now(),
             connection_id: Uuid::new_v4(),
             kind: crate::protocol_event::ProtocolEventKind::H3GoawayReceived { stream_id: None },
         };
 
-        let violations = lint_protocol_event(&event, &cfg, &store, &engine);
+        let violations = lint_protocol_event(&event, &cfg, &store);
         assert!(violations.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,8 @@ struct Args {
 async fn run_app(args: Args) -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let (cfg, engine) = config::Config::load_from_path(&args.config).await?;
+    let cfg = config::Config::load_from_path(&args.config).await?;
     let cfg = std::sync::Arc::new(cfg);
-    let engine = std::sync::Arc::new(engine);
 
     let addr: SocketAddr = cfg.general.listen.parse()?;
     let capture_writer = capture::CaptureWriter::new(
@@ -31,7 +30,7 @@ async fn run_app(args: Args) -> anyhow::Result<()> {
     .await?;
 
     // Start proxy and return its result (no signal handling here).
-    proxy::run_proxy(addr, capture_writer, cfg, engine).await
+    proxy::run_proxy(addr, capture_writer, cfg).await
 }
 
 // Testable variant of run_app that allows tests to pass in an accept limit so the
@@ -40,9 +39,8 @@ async fn run_app(args: Args) -> anyhow::Result<()> {
 async fn run_app_with_limit(args: Args, accept_limit: Option<usize>) -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let (cfg, engine) = config::Config::load_from_path(&args.config).await?;
+    let cfg = config::Config::load_from_path(&args.config).await?;
     let cfg = std::sync::Arc::new(cfg);
-    let engine = std::sync::Arc::new(engine);
 
     let addr: SocketAddr = cfg.general.listen.parse()?;
     let capture_writer = capture::CaptureWriter::new(
@@ -52,7 +50,7 @@ async fn run_app_with_limit(args: Args, accept_limit: Option<usize>) -> anyhow::
     .await?;
 
     // Start proxy with an accept limit for testing
-    crate::proxy::run_proxy_with_limit(addr, capture_writer, cfg, engine, accept_limit).await
+    crate::proxy::run_proxy_with_limit(addr, capture_writer, cfg, accept_limit).await
 }
 
 #[tokio::main]
@@ -92,7 +90,7 @@ mod tests {
                 .to_string(),
         };
 
-        let (cfg, _engine) = config::Config::load_from_path(&args.config).await?;
+        let cfg = config::Config::load_from_path(&args.config).await?;
 
         assert!(!cfg.is_enabled("server_cache_control_present"));
         assert_eq!(cfg.general.listen, "127.0.0.1:3000");

--- a/src/proxy/connect.rs
+++ b/src/proxy/connect.rs
@@ -162,7 +162,7 @@ mod tests {
             None
         };
 
-        let (shared, tmp_path, _cw) = make_shared_with_cfg(cfg, ca_arc.clone(), None).await?;
+        let (shared, tmp_path, _cw) = make_shared_with_cfg(cfg, ca_arc.clone()).await?;
 
         let req = Request::builder()
             .method("CONNECT")

--- a/src/proxy/http.rs
+++ b/src/proxy/http.rs
@@ -408,7 +408,7 @@ where
             .map(|s| s.to_string());
     }
 
-    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state, &shared.engine);
+    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
     tx.violations = violations.clone();
 
     shared.state.record_transaction(&tx);
@@ -470,9 +470,7 @@ mod tests {
             "server_cache_control_present",
             "server_etag_or_last_modified",
         ]);
-        let engine = crate::test_helpers::make_test_engine(&cfg_inner);
-        let (shared, tmp, _cw) =
-            make_shared_with_cfg(StdArc::new(cfg_inner), None, Some(StdArc::new(engine))).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg_inner), None).await?;
 
         let req = make_request_with_headers("GET", mock.uri(), None)?;
 
@@ -504,7 +502,7 @@ mod tests {
     #[tokio::test]
     async fn handle_request_upstream_error() -> anyhow::Result<()> {
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         // Use a port that is (likely) closed to provoke a client error
         let req = make_request_with_headers("GET", "http://127.0.0.1:9/", None)?;
@@ -540,7 +538,7 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         // Build a relative URI and set Host header so proxy builds absolute URI from Host
         let host = mock.address().to_string();
@@ -585,7 +583,7 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let uri = format!("{}/ok", mock.uri());
         let req = make_request_with_headers(
@@ -631,7 +629,7 @@ mod tests {
         let key_path = ca_dir.join("ca.key");
         let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
 
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg.clone(), Some(ca.clone()), None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg.clone(), Some(ca.clone())).await?;
 
         let req = Request::builder()
             .method("GET")
@@ -668,7 +666,7 @@ mod tests {
     #[tokio::test]
     async fn handle_request_connect_without_tls_returns_405() -> anyhow::Result<()> {
         let (shared, tmp, _cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
 
         // Try to use CONNECT method
         let req = Request::builder()
@@ -712,7 +710,7 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let req = make_request_with_headers("GET", format!("{}/hop", mock.uri()), None)?;
 
@@ -780,7 +778,7 @@ mod tests {
     #[tokio::test]
     async fn handle_request_ca_cert_endpoint_without_tls_returns_404() -> anyhow::Result<()> {
         let cfg = StdArc::new(crate::config::Config::default()); // TLS disabled by default
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let req = Request::builder()
             .method("GET")
@@ -826,7 +824,7 @@ mod tests {
     #[tokio::test]
     async fn handle_http_logic_body_collect_error_returns_500() -> anyhow::Result<()> {
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let req = Request::builder()
             .method("GET")
@@ -862,7 +860,7 @@ mod tests {
         let mut cfg_inner = crate::config::Config::default();
         cfg_inner.tls.suppress_headers = vec!["user-agent".to_string()];
         let cfg = StdArc::new(cfg_inner);
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let uri: Uri = mock.uri().parse()?;
         let req = Request::builder()
@@ -932,9 +930,7 @@ mod tests {
             "server_etag_or_last_modified",
             "server_response_405_allow",
         ]);
-        let engine = crate::test_helpers::make_test_engine(&cfg_inner);
-        let (shared, tmp, _cw) =
-            make_shared_with_cfg(StdArc::new(cfg_inner), None, Some(StdArc::new(engine))).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg_inner), None).await?;
 
         let cases = vec!["/no-content-type", "/no-etag", "/405-no-allow"];
         for path in cases {
@@ -988,7 +984,7 @@ mod tests {
     async fn handle_request_relative_uri_with_invalid_host_falls_back_and_returns_502(
     ) -> anyhow::Result<()> {
         let (shared, tmp, _cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
 
         // Relative URI with invalid Host header should fail to parse and fallback to localhost
         let req = Request::builder()
@@ -1041,7 +1037,7 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/", addr.port()).parse()?;
         let req = Request::builder()
@@ -1092,7 +1088,7 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         // Build a WebSocket upgrade request with full URI
         let uri: Uri = format!("http://127.0.0.1:{}/ws", ws_port).parse()?;
@@ -1163,7 +1159,7 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         // Regular GET — NOT a WebSocket upgrade request
         let uri: Uri = format!("http://127.0.0.1:{}/upgrade", port).parse()?;

--- a/src/proxy/http3.rs
+++ b/src/proxy/http3.rs
@@ -222,12 +222,8 @@ fn emit_h3_protocol_event(
         connection_id,
         kind,
     };
-    let violations = crate::lint_protocol::lint_protocol_event(
-        &pe,
-        &shared.cfg,
-        &shared.protocol_event_store,
-        &shared.engine,
-    );
+    let violations =
+        crate::lint_protocol::lint_protocol_event(&pe, &shared.cfg, &shared.protocol_event_store);
     shared.protocol_event_store.record_event(&pe);
     for v in &violations {
         warn!(
@@ -462,7 +458,7 @@ async fn handle_h3_request(
     tx.connection_id = Some(conn_metadata.id);
     tx.sequence_number = Some(stream_id as u32);
 
-    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state, &shared.engine);
+    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
     tx.violations = violations;
 
     shared.state.record_transaction(&tx);
@@ -515,11 +511,10 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
             .to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
-        let engine = StdArc::new(crate::rules::RuleConfigEngine::new());
 
         // Bind to an ephemeral port
         let listen: SocketAddr = "127.0.0.1:0".parse()?;
-        let result = run_proxy_with_limit(listen, cw, StdArc::new(cfg), engine, Some(0)).await;
+        let result = run_proxy_with_limit(listen, cw, StdArc::new(cfg), Some(0)).await;
 
         // Should fail because h3_listen requires TLS
         assert!(result.is_err());
@@ -541,7 +536,7 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let req = make_request_with_headers("GET", format!("{}/quic-test", mock.uri()), None)?;
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -48,7 +48,6 @@ pub(super) struct Shared {
     pub(super) state: Arc<crate::state::StateStore>,
     pub(super) protocol_event_store: Arc<crate::protocol_event_store::ProtocolEventStore>,
     pub(super) ca: Option<Arc<CertificateAuthority>>,
-    pub(super) engine: Arc<crate::rules::RuleConfigEngine>,
     pub(super) quic_transport_params: Option<crate::protocol_event::QuicTransportParameters>,
 }
 
@@ -56,10 +55,9 @@ pub async fn run_proxy(
     listen: SocketAddr,
     captures: CaptureWriter,
     cfg: Arc<Config>,
-    engine: Arc<crate::rules::RuleConfigEngine>,
 ) -> anyhow::Result<()> {
     // Default behavior: no accept limit (runs forever)
-    run_proxy_with_limit(listen, captures, cfg, engine, None).await
+    run_proxy_with_limit(listen, captures, cfg, None).await
 }
 
 /// Testable variant of `run_proxy` that accepts an optional `accept_limit`.
@@ -71,7 +69,6 @@ pub async fn run_proxy_with_limit(
     listen: SocketAddr,
     captures: CaptureWriter,
     cfg: Arc<Config>,
-    engine: Arc<crate::rules::RuleConfigEngine>,
     accept_limit: Option<usize>,
 ) -> anyhow::Result<()> {
     let https = HttpsConnectorBuilder::new()
@@ -161,7 +158,6 @@ pub async fn run_proxy_with_limit(
         state,
         protocol_event_store,
         ca,
-        engine,
         quic_transport_params,
     });
 
@@ -243,10 +239,10 @@ mod tests {
         let addr = l.local_addr()?;
 
         let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
 
         // run_proxy should return an error since the port is already in use
-        let res = run_proxy(addr, cw, shared.cfg.clone(), shared.engine.clone()).await;
+        let res = run_proxy(addr, cw, shared.cfg.clone()).await;
         assert!(res.is_err());
 
         let _ = fs::remove_file(&tmp).await;
@@ -268,11 +264,11 @@ mod tests {
         cfg_inner.general.captures_seed = true;
         cfg_inner.general.captures = dir.to_string_lossy().to_string();
         let cfg = StdArc::new(cfg_inner);
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None, None).await?;
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None).await?;
 
         // run_proxy should still return an error due to port being taken, but during
         // startup it should attempt to seed captures and hit the Err branch.
-        let res = run_proxy(addr, cw, shared.cfg.clone(), shared.engine.clone()).await;
+        let res = run_proxy(addr, cw, shared.cfg.clone()).await;
         assert!(res.is_err());
 
         // Cleanup
@@ -285,11 +281,11 @@ mod tests {
     #[tokio::test]
     async fn run_proxy_starts_and_can_be_aborted() -> anyhow::Result<()> {
         let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
 
         let task = tokio::spawn(async move {
-            let _ = run_proxy(addr, cw, shared.cfg.clone(), shared.engine.clone()).await;
+            let _ = run_proxy(addr, cw, shared.cfg.clone()).await;
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -310,15 +306,15 @@ mod tests {
         drop(l);
 
         let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
 
         // spawn the proxy with accept_limit = 1
         let cw_clone = cw.clone();
         let cfg_clone = shared.cfg.clone();
-        let engine_clone = shared.engine.clone();
-        let task = tokio::spawn(async move {
-            run_proxy_with_limit(addr, cw_clone, cfg_clone, engine_clone, Some(1)).await
-        });
+        let task =
+            tokio::spawn(
+                async move { run_proxy_with_limit(addr, cw_clone, cfg_clone, Some(1)).await },
+            );
 
         // Wait until we can connect (server startup may be slightly delayed)
         // Keep the stream open until the server task completes to avoid races where
@@ -355,18 +351,12 @@ mod tests {
         drop(l);
 
         let (_shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
 
         // accept_limit = 0 should return quickly
         tokio::time::timeout(
             std::time::Duration::from_secs(1),
-            run_proxy_with_limit(
-                addr,
-                cw,
-                _shared.cfg.clone(),
-                _shared.engine.clone(),
-                Some(0),
-            ),
+            run_proxy_with_limit(addr, cw, _shared.cfg.clone(), Some(0)),
         )
         .await
         .expect("run_proxy_with_limit did not return within timeout")?;
@@ -385,10 +375,10 @@ mod tests {
         drop(l);
 
         let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None, None).await?;
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
 
         let task = tokio::spawn(async move {
-            run_proxy_with_limit(addr, cw, shared.cfg.clone(), shared.engine.clone(), Some(2)).await
+            run_proxy_with_limit(addr, cw, shared.cfg.clone(), Some(2)).await
         });
 
         // make two connections and keep them open until the server finishes
@@ -443,10 +433,10 @@ mod tests {
         cfg_inner.general.captures_seed = true;
         cfg_inner.general.captures = pcap.clone();
         let cfg = StdArc::new(cfg_inner);
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None, None).await?;
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None).await?;
 
         // run_proxy should attempt to load captures and then fail on bind
-        let res = run_proxy(addr, cw, shared.cfg.clone(), shared.engine.clone()).await;
+        let res = run_proxy(addr, cw, shared.cfg.clone()).await;
         assert!(res.is_err());
 
         // Cleanup
@@ -467,11 +457,11 @@ mod tests {
         cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
 
         let cfg = StdArc::new(cfg);
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg.clone(), None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg.clone(), None).await?;
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
 
         let task = tokio::spawn(async move {
-            let _ = run_proxy(addr, _cw, shared.cfg.clone(), shared.engine.clone()).await;
+            let _ = run_proxy(addr, _cw, shared.cfg.clone()).await;
         });
 
         // Wait up to 2s for the CA files to be created by startup

--- a/src/proxy/test_support.rs
+++ b/src/proxy/test_support.rs
@@ -25,7 +25,6 @@ use super::Shared;
 pub(super) async fn make_shared_with_cfg(
     cfg: StdArc<crate::config::Config>,
     ca: Option<std::sync::Arc<CertificateAuthority>>,
-    engine: Option<StdArc<crate::rules::RuleConfigEngine>>,
 ) -> anyhow::Result<(StdArc<Shared>, String, CaptureWriter)> {
     let tmp =
         std::env::temp_dir().join(format!("lint_proxy_connect_test_{}.jsonl", Uuid::new_v4()));
@@ -47,7 +46,6 @@ pub(super) async fn make_shared_with_cfg(
     let protocol_event_store = StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
         300, 100,
     ));
-    let engine = engine.unwrap_or_else(|| StdArc::new(crate::rules::RuleConfigEngine::new()));
     let shared = StdArc::new(Shared {
         client,
         captures: cw.clone(),
@@ -55,7 +53,6 @@ pub(super) async fn make_shared_with_cfg(
         state,
         protocol_event_store,
         ca,
-        engine,
         quic_transport_params: None,
     });
     Ok((shared, p, cw))

--- a/src/proxy/websocket.rs
+++ b/src/proxy/websocket.rs
@@ -125,7 +125,7 @@ pub(super) async fn handle_websocket_upgrade(
             .map(|s| s.to_string());
     }
 
-    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state, &shared.engine);
+    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
     tx.violations = violations.clone();
     shared.state.record_transaction(&tx);
     let _ = captures.write_transaction(&tx).await;
@@ -153,7 +153,6 @@ pub(super) async fn handle_websocket_upgrade(
             connection_id: conn_metadata.id,
             store: shared.protocol_event_store.clone(),
             cfg: shared.cfg.clone(),
-            engine: shared.engine.clone(),
         };
         tokio::spawn(async move {
             // Wait for both sides to complete the upgrade
@@ -266,7 +265,6 @@ struct ProtocolLintCtx {
     connection_id: uuid::Uuid,
     store: Arc<crate::protocol_event_store::ProtocolEventStore>,
     cfg: Arc<Config>,
-    engine: Arc<crate::rules::RuleConfigEngine>,
 }
 
 /// Relay WebSocket messages between client and server, recording each message
@@ -298,7 +296,6 @@ async fn relay_websocket(
 
     let pe_store = pe_ctx.store;
     let pe_cfg = pe_ctx.cfg;
-    let pe_engine = pe_ctx.engine;
     let connection_id = pe_ctx.connection_id;
 
     let msgs_c2s = messages.clone();
@@ -306,7 +303,6 @@ async fn relay_websocket(
     let close_c2s = close_code.clone();
     let pe_store_c2s = pe_store.clone();
     let cfg_c2s = pe_cfg.clone();
-    let engine_c2s = pe_engine.clone();
     let c2s = async move {
         while let Some(result) = client_read.next().await {
             match result {
@@ -331,12 +327,7 @@ async fn relay_websocket(
                             payload_length: info.payload_length,
                         },
                     };
-                    let v = crate::lint_protocol::lint_protocol_event(
-                        &pe,
-                        &cfg_c2s,
-                        &pe_store_c2s,
-                        &engine_c2s,
-                    );
+                    let v = crate::lint_protocol::lint_protocol_event(&pe, &cfg_c2s, &pe_store_c2s);
                     pe_store_c2s.record_event(&pe);
                     if !v.is_empty() {
                         viols_c2s.lock().await.extend(v);
@@ -357,7 +348,6 @@ async fn relay_websocket(
     let close_s2c = close_code.clone();
     let pe_store_s2c = pe_store.clone();
     let cfg_s2c = pe_cfg.clone();
-    let engine_s2c = pe_engine.clone();
     let s2c = async move {
         while let Some(result) = server_read.next().await {
             match result {
@@ -382,12 +372,7 @@ async fn relay_websocket(
                             payload_length: info.payload_length,
                         },
                     };
-                    let v = crate::lint_protocol::lint_protocol_event(
-                        &pe,
-                        &cfg_s2c,
-                        &pe_store_s2c,
-                        &engine_s2c,
-                    );
+                    let v = crate::lint_protocol::lint_protocol_event(&pe, &cfg_s2c, &pe_store_s2c);
                     pe_store_s2c.record_event(&pe);
                     if !v.is_empty() {
                         viols_s2c.lock().await.extend(v);
@@ -621,7 +606,6 @@ mod tests {
                         crate::protocol_event_store::ProtocolEventStore::new(300, 100),
                     ),
                     cfg: std::sync::Arc::new(crate::config::Config::default()),
-                    engine: std::sync::Arc::new(crate::rules::RuleConfigEngine::new()),
                 },
             )
             .await;
@@ -743,7 +727,7 @@ mod tests {
     async fn handle_websocket_upgrade_upstream_connect_error() -> anyhow::Result<()> {
         // Test that handle_websocket_upgrade returns 502 when upstream is unreachable
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         // Build a request targeting a closed port
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
@@ -815,7 +799,7 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let upstream_req = Request::builder()
@@ -893,7 +877,6 @@ mod tests {
                         crate::protocol_event_store::ProtocolEventStore::new(300, 100),
                     ),
                     cfg: std::sync::Arc::new(crate::config::Config::default()),
-                    engine: std::sync::Arc::new(crate::rules::RuleConfigEngine::new()),
                 },
             )
             .await;
@@ -990,7 +973,6 @@ mod tests {
                         crate::protocol_event_store::ProtocolEventStore::new(300, 100),
                     ),
                     cfg: std::sync::Arc::new(crate::config::Config::default()),
-                    engine: std::sync::Arc::new(crate::rules::RuleConfigEngine::new()),
                 },
             )
             .await;
@@ -1086,7 +1068,7 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, None).await?;
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let upstream_req = Request::builder()
@@ -1165,7 +1147,6 @@ mod tests {
                         crate::protocol_event_store::ProtocolEventStore::new(300, 100),
                     ),
                     cfg: std::sync::Arc::new(crate::config::Config::default()),
-                    engine: std::sync::Arc::new(crate::rules::RuleConfigEngine::new()),
                 },
             )
             .await;

--- a/src/rules/client_accept_encoding_present.rs
+++ b/src/rules/client_accept_encoding_present.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientAcceptEncodingPresent;
 
 impl Rule for ClientAcceptEncodingPresent {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_accept_encoding_present"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientAcceptEncodingPresent {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.headers.contains_key("accept-encoding") {
@@ -53,11 +50,10 @@ mod tests {
         } else {
             crate::test_helpers::make_test_transaction()
         };
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if header_present {
             assert!(violation.is_none());

--- a/src/rules/client_accept_ranges_on_partial_content.rs
+++ b/src/rules/client_accept_ranges_on_partial_content.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientAcceptRangesOnPartialContent;
 
 impl Rule for ClientAcceptRangesOnPartialContent {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_accept_ranges_on_partial_content"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientAcceptRangesOnPartialContent {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests that contain a UTF-8 Range header we can parse.
@@ -147,7 +144,7 @@ mod tests {
             None => crate::transaction_history::TransactionHistory::empty(),
         };
 
-        let v = rule.check(&tx, &history, &cfg, &crate::rules::RuleConfigEngine::new());
+        let v = rule.check_transaction(&tx, &history, &cfg);
         if expect_violation {
             assert!(v.is_some());
         } else {
@@ -170,11 +167,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-1")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -188,11 +184,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-1")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -208,7 +203,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "client_accept_ranges_on_partial_content");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -241,11 +236,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-1")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -272,11 +266,10 @@ mod tests {
         hm.insert("range", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Be lenient: if the request Range header is non-utf8, do not raise a violation when Accept-Ranges was present
         assert!(v.is_none());
@@ -302,11 +295,10 @@ mod tests {
         hm.insert("range", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // If Range header itself is not valid UTF-8, the rule should not emit a misleading violation about Accept-Ranges
         assert!(v.is_none());

--- a/src/rules/client_cache_respect.rs
+++ b/src/rules/client_cache_respect.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientCacheRespect;
 
 impl Rule for ClientCacheRespect {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_cache_respect"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientCacheRespect {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Use the previous transaction passed by the linter (if any)
@@ -114,11 +111,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(req_headers_pairs.as_slice());
         let history = crate::queries::by_resource::by_resource(&store, &client, resource);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -153,11 +149,10 @@ mod tests {
         tx.request.uri = resource.to_string();
 
         let history = crate::queries::by_resource::by_resource(&store, &client, resource);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         assert!(violation.is_none());

--- a/src/rules/client_expect_header_valid.rs
+++ b/src/rules/client_expect_header_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientExpectHeaderValid;
 
 impl Rule for ClientExpectHeaderValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_expect_header_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientExpectHeaderValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check request headers
@@ -168,11 +165,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ClientExpectHeaderValid;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&[("expect", value)]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
@@ -198,11 +194,10 @@ mod tests {
         hm.insert("Expect", HeaderValue::from_str("a=b/c")?);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -221,11 +216,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -243,11 +237,10 @@ mod tests {
 
         // Should report a violation due to invalid 'a/b' token
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
         Ok(())
@@ -262,11 +255,10 @@ mod tests {
         hm.insert("Expect", HeaderValue::from_static("100-Continue=param"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/client_host_header.rs
+++ b/src/rules/client_host_header.rs
@@ -9,8 +9,6 @@ use std::net::IpAddr;
 pub struct ClientHostHeader;
 
 impl Rule for ClientHostHeader {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_host_header"
     }
@@ -19,12 +17,11 @@ impl Rule for ClientHostHeader {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let host_values = tx.request.headers.get_all("host");
@@ -208,11 +205,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ClientHostHeader;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&header_pairs);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -233,11 +229,10 @@ mod tests {
             ("host", "example.com"),
             ("host", "other.example.com"),
         ]);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         assert_eq!(
@@ -260,11 +255,10 @@ mod tests {
         hm.insert("host", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         assert!(violation.is_some());
@@ -294,11 +288,10 @@ mod tests {
             "example.com:999999999999999999999",
         )]);
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         let v = violation.unwrap();

--- a/src/rules/client_patch_method_content_type_match.rs
+++ b/src/rules/client_patch_method_content_type_match.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct ClientPatchMethodContentTypeMatch;
 
 impl Rule for ClientPatchMethodContentTypeMatch {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_patch_method_content_type_match"
     }
@@ -20,12 +18,11 @@ impl Rule for ClientPatchMethodContentTypeMatch {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to PATCH requests
@@ -226,7 +223,7 @@ mod tests {
             Some(p) => crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
             None => crate::transaction_history::TransactionHistory::empty(),
         };
-        let v = rule.check(&tx, &history, &cfg, &crate::rules::RuleConfigEngine::new());
+        let v = rule.check_transaction(&tx, &history, &cfg);
         if expect_violation {
             assert!(v.is_some());
         } else {
@@ -263,11 +260,10 @@ mod tests {
         prev.request.uri = tx.request.uri.clone();
         prev.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -291,11 +287,10 @@ mod tests {
             "application/example-patch+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -319,11 +314,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -349,11 +343,10 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -377,11 +370,10 @@ mod tests {
             "application/example+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -405,11 +397,10 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -433,11 +424,10 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -461,11 +451,10 @@ mod tests {
             "application/merge-patch+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // whitespace-only header triggers empty token detection and thus a violation
         assert!(v.is_some());
@@ -491,11 +480,10 @@ mod tests {
         hm.insert("content-type", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -517,11 +505,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "bad")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // malformed Content-Type is delegated to other rules; this rule should not emit a violation
         assert!(v.is_none());
@@ -553,11 +540,10 @@ mod tests {
             "application/example-patch+json",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -567,7 +553,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "client_patch_method_content_type_match");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -582,11 +568,10 @@ mod tests {
         let mut prev = make_prev_with_accept_patch(Some("application/merge-patch+json"));
         prev.request.uri = tx.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -608,11 +593,10 @@ mod tests {
         let mut prev = crate::test_helpers::make_test_transaction();
         prev.request.uri = tx.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/client_prefer_header_and_preference_applied.rs
+++ b/src/rules/client_prefer_header_and_preference_applied.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientPreferHeaderAndPreferenceApplied;
 
 impl Rule for ClientPreferHeaderAndPreferenceApplied {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_prefer_header_and_preference_applied"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientPreferHeaderAndPreferenceApplied {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only meaningful when request includes Prefer and response is present
@@ -105,11 +102,10 @@ mod tests {
             );
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -138,11 +134,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // treat non-utf8 header as present -> no violation from this rule
         assert!(v.is_none());
@@ -169,11 +164,10 @@ mod tests {
         hm.insert("prefer", HeaderValue::from_bytes(&[0xff]).unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -190,11 +184,10 @@ mod tests {
             ("Prefer", "respond-async"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -208,11 +201,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("Prefer", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -222,7 +214,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "client_prefer_header_and_preference_applied");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/client_range_header_syntax_valid.rs
+++ b/src/rules/client_range_header_syntax_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientRangeHeaderSyntaxValid;
 
 impl Rule for ClientRangeHeaderSyntaxValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_range_header_syntax_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientRangeHeaderSyntaxValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use hyper::header::RANGE;
@@ -160,11 +157,10 @@ mod tests {
         tx.request.headers.insert("range", value.parse()?);
 
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -192,11 +188,10 @@ mod tests {
             .append("range", "items=0-1".parse::<HeaderValue>()?);
 
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -206,11 +201,10 @@ mod tests {
     fn header_absent_no_violation() -> anyhow::Result<()> {
         let tx = make_test_transaction();
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -224,11 +218,10 @@ mod tests {
         tx.request.headers.insert("range", bad);
 
         let rule = ClientRangeHeaderSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/client_request_method_token_valid.rs
+++ b/src/rules/client_request_method_token_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientRequestMethodTokenValid;
 
 impl Rule for ClientRequestMethodTokenValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_request_method_token_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientRequestMethodTokenValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let m = tx.request.method.as_str();
@@ -83,11 +80,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.method = method.as_str().to_string();
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -108,11 +104,10 @@ mod tests {
         let mut tx = make_test_transaction();
         tx.request.method = "get".to_string();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -121,11 +116,10 @@ mod tests {
         // Invalid character should be reported with char in message
         let mut tx2 = make_test_transaction();
         tx2.request.method = "G@T".to_string();
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         let msg2 = v2.unwrap().message;

--- a/src/rules/client_request_origin_header_present_for_cors.rs
+++ b/src/rules/client_request_origin_header_present_for_cors.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientRequestOriginHeaderPresentForCors;
 
 impl Rule for ClientRequestOriginHeaderPresentForCors {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_request_origin_header_present_for_cors"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientRequestOriginHeaderPresentForCors {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -98,11 +95,10 @@ mod tests {
         tx.request.method = "OPTIONS".into();
         tx.request.headers = make_headers_from_pairs(&[("access-control-request-method", "POST")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing Origin"));
@@ -118,11 +114,10 @@ mod tests {
             ("origin", "https://example.com"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -137,11 +132,10 @@ mod tests {
             ("origin", "http:///bad"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Origin header invalid"));
@@ -154,11 +148,10 @@ mod tests {
         tx.request.uri = "http://other.example/resource".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -174,11 +167,10 @@ mod tests {
         tx.request.uri = "http://example.com/resource".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -201,7 +193,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/client_request_target_form_checks.rs
+++ b/src/rules/client_request_target_form_checks.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientRequestTargetFormChecks;
 
 impl Rule for ClientRequestTargetFormChecks {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_request_target_form_checks"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientRequestTargetFormChecks {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let method = tx.request.method.as_str();
@@ -101,11 +98,10 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -139,7 +135,7 @@ mod tests {
         // Enable the rule as it would be in a user's config
         crate::test_helpers::enable_rule(&mut cfg, "client_request_target_form_checks");
         // Should validate and produce an engine without error
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/client_request_target_no_fragment.rs
+++ b/src/rules/client_request_target_no_fragment.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientRequestTargetNoFragment;
 
 impl Rule for ClientRequestTargetNoFragment {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_request_target_no_fragment"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientRequestTargetNoFragment {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if tx.request.uri.contains('#') {
@@ -56,11 +53,10 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/client_request_uri_percent_encoding_valid.rs
+++ b/src/rules/client_request_uri_percent_encoding_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientRequestUriPercentEncodingValid;
 
 impl Rule for ClientRequestUriPercentEncodingValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_request_uri_percent_encoding_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientRequestUriPercentEncodingValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let s = tx.request.uri.as_str();
@@ -61,11 +58,10 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/client_request_version_method_validity.rs
+++ b/src/rules/client_request_version_method_validity.rs
@@ -26,8 +26,6 @@ use crate::rules::Rule;
 pub struct ClientRequestVersionMethodValidity;
 
 impl Rule for ClientRequestVersionMethodValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_request_version_method_validity"
     }
@@ -36,12 +34,11 @@ impl Rule for ClientRequestVersionMethodValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let method = tx.request.method.as_str();
@@ -112,11 +109,10 @@ mod tests {
         let rule = ClientRequestVersionMethodValidity;
         let tx = make_tx_with_req(method, headers);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -131,11 +127,10 @@ mod tests {
         let rule = ClientRequestVersionMethodValidity;
         let tx = make_tx_with_req("GET", vec![("content-length", "not-a-number")]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -146,11 +141,10 @@ mod tests {
         let huge = "9".repeat(100);
         let tx = make_tx_with_req("GET", vec![("content-length", huge.as_str())]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -162,19 +156,17 @@ mod tests {
         let tx_space = make_tx_with_req("GET", vec![("content-length", "   ")]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v_empty = rule.check(
+        let v_empty = rule.check_transaction(
             &tx_empty,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_empty.is_none());
 
-        let v_space = rule.check(
+        let v_space = rule.check_transaction(
             &tx_space,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_space.is_none());
     }
@@ -186,22 +178,20 @@ mod tests {
 
         let tx = make_tx_with_req("GET", vec![("content-length", "10")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("GET request"));
 
         let tx2 = make_tx_with_req("TRACE", vec![("transfer-encoding", "chunked")]);
         let v2 = rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v2.message.contains("TRACE request"));
@@ -211,7 +201,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "client_request_version_method_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/client_sec_websocket_headers_consistency.rs
+++ b/src/rules/client_sec_websocket_headers_consistency.rs
@@ -9,8 +9,6 @@ use base64::Engine;
 pub struct ClientSecWebsocketHeadersConsistency;
 
 impl Rule for ClientSecWebsocketHeadersConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_sec_websocket_headers_consistency"
     }
@@ -19,12 +17,11 @@ impl Rule for ClientSecWebsocketHeadersConsistency {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only consider WebSocket handshake requests: GET method and Upgrade includes 'websocket'
@@ -189,11 +186,10 @@ mod tests {
         let rule = ClientSecWebsocketHeadersConsistency;
         let tx = make_ws_request(headers);
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert_eq!(v.is_some(), expect_violation);
     }
@@ -207,11 +203,10 @@ mod tests {
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -223,11 +218,10 @@ mod tests {
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -242,11 +236,10 @@ mod tests {
         ]);
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Connection: Upgrade"));
@@ -261,11 +254,10 @@ mod tests {
         ]);
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Sec-WebSocket-Version"));
@@ -283,11 +275,10 @@ mod tests {
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -318,11 +309,10 @@ mod tests {
 
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Sec-WebSocket-Key"));
@@ -342,11 +332,10 @@ mod tests {
         let rule = ClientSecWebsocketHeadersConsistency;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -355,7 +344,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "client_sec_websocket_headers_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/client_user_agent_present.rs
+++ b/src/rules/client_user_agent_present.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ClientUserAgentPresent;
 
 impl Rule for ClientUserAgentPresent {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "client_user_agent_present"
     }
@@ -18,12 +16,11 @@ impl Rule for ClientUserAgentPresent {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.headers.contains_key("user-agent") {
@@ -54,11 +51,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ClientUserAgentPresent;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&header_pairs);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_accept_and_content_type_negotiation.rs
+++ b/src/rules/message_accept_and_content_type_negotiation.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAcceptAndContentTypeNegotiation;
 
 impl Rule for MessageAcceptAndContentTypeNegotiation {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_accept_and_content_type_negotiation"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAcceptAndContentTypeNegotiation {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check when request has Accept and response has Content-Type
@@ -154,11 +151,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", ct)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -178,7 +174,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_accept_and_content_type_negotiation",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -204,11 +200,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -227,11 +222,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/plain")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -249,11 +243,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/plain")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -272,11 +265,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/plain")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -295,11 +287,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -313,11 +304,10 @@ mod tests {
 
         let tx = crate::test_helpers::make_test_transaction();
         // tx.response is None
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_accept_encoding_parameter_validity.rs
+++ b/src/rules/message_accept_encoding_parameter_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAcceptEncodingParameterValidity;
 
 impl Rule for MessageAcceptEncodingParameterValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_accept_encoding_parameter_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAcceptEncodingParameterValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // This rule validates `Accept-Encoding` header parameters (q-values and param forms) in requests.
@@ -159,11 +156,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -196,11 +192,10 @@ mod tests {
         ]);
 
         // Non-UTF8 header values should be considered a violation by this rule
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -235,11 +230,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -273,11 +267,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -286,7 +279,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_accept_encoding_parameter_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_accept_header_media_type_syntax.rs
+++ b/src/rules/message_accept_header_media_type_syntax.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAcceptHeaderMediaTypeSyntax;
 
 impl Rule for MessageAcceptHeaderMediaTypeSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_accept_header_media_type_syntax"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate a single Accept-like header value (media-range list)
@@ -241,11 +238,10 @@ mod tests {
             }
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -267,7 +263,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_accept_header_media_type_syntax",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -282,11 +278,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept", "text/html; q=1.0000")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_accept_language_weight_validity.rs
+++ b/src/rules/message_accept_language_weight_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAcceptLanguageWeightValidity;
 
 impl Rule for MessageAcceptLanguageWeightValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_accept_language_weight_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAcceptLanguageWeightValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Accept-Language header value (may contain comma-separated members)
@@ -164,11 +161,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -201,11 +197,10 @@ mod tests {
             "message_accept_language_weight_validity",
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -226,11 +221,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -246,11 +240,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;q=1.0000")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -268,11 +261,10 @@ mod tests {
             "message_accept_language_weight_validity",
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -290,11 +282,10 @@ mod tests {
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;foo=\"ok\"")]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -305,11 +296,10 @@ mod tests {
             "en;foo=\"unterminated",
         )]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -324,11 +314,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;b@d=1")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -343,11 +332,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;param")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -362,11 +350,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "*;q=0.5")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -381,11 +368,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-language", "en;Q=0.5")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -405,11 +391,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -427,11 +412,10 @@ mod tests {
             "accept-language",
             "en;foo=\"a\\\"b\"",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -452,7 +436,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_accept_language_weight_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_accept_ranges_and_206_consistency.rs
+++ b/src/rules/message_accept_ranges_and_206_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAcceptRangesAnd206Consistency;
 
 impl Rule for MessageAcceptRangesAnd206Consistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_accept_ranges_and_206_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAcceptRangesAnd206Consistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -140,11 +137,10 @@ mod tests {
             None => crate::test_helpers::make_test_transaction(),
         };
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for input={:?}", input);
@@ -172,11 +168,10 @@ mod tests {
             &[("content-range", "bytes 0-0/1"), ("accept-ranges", "BYTES")],
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -189,11 +184,10 @@ mod tests {
             ],
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -211,11 +205,10 @@ mod tests {
             206,
             [("accept-ranges", "x@bad")].as_slice(),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -244,11 +237,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -275,11 +267,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -305,11 +296,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -335,11 +325,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -364,11 +353,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -380,7 +368,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_accept_ranges_and_206_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_access_control_allow_credentials_when_origin.rs
+++ b/src/rules/message_access_control_allow_credentials_when_origin.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAccessControlAllowCredentialsWhenOrigin;
 
 impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_access_control_allow_credentials_when_origin"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -129,11 +126,10 @@ mod tests {
             tx = crate::test_helpers::make_test_transaction_with_response(200, &pairs);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?} & {:?}", acao, acc);
@@ -168,11 +164,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -198,11 +193,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -212,11 +206,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageAccessControlAllowCredentialsWhenOrigin;
         let tx = make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -228,11 +221,10 @@ mod tests {
             200,
             &[("access-control-allow-credentials", "true")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -247,11 +239,10 @@ mod tests {
                 ("access-control-allow-credentials", "true"),
             ],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -266,11 +257,10 @@ mod tests {
                 ("access-control-allow-credentials", "TRUE"),
             ],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -285,11 +275,10 @@ mod tests {
                 ("access-control-allow-credentials", "  true  "),
             ],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -317,11 +306,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -336,11 +324,10 @@ mod tests {
                 ("access-control-allow-credentials", "1"),
             ],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -363,8 +350,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_access_control_allow_origin_valid.rs
+++ b/src/rules/message_access_control_allow_origin_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAccessControlAllowOriginValid;
 
 impl Rule for MessageAccessControlAllowOriginValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_access_control_allow_origin_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAccessControlAllowOriginValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -110,11 +107,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageAccessControlAllowOriginValid;
         let tx = make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -126,11 +122,10 @@ mod tests {
             200,
             &[("content-type", "text/plain")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -146,11 +141,10 @@ mod tests {
             200,
             &[("access-control-allow-origin", val)],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -167,11 +161,10 @@ mod tests {
             200,
             &[("access-control-allow-origin", "https://a, https://b")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("single value"));
@@ -198,11 +191,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple"));
@@ -215,11 +207,10 @@ mod tests {
             200,
             &[("access-control-allow-origin", "example.com")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid origin"));
@@ -246,11 +237,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -274,8 +264,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_age_header_numeric.rs
+++ b/src/rules/message_age_header_numeric.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAgeHeaderNumeric;
 
 impl Rule for MessageAgeHeaderNumeric {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_age_header_numeric"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAgeHeaderNumeric {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
@@ -80,11 +77,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageAgeHeaderNumeric;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -104,11 +100,10 @@ mod tests {
         let rule = MessageAgeHeaderNumeric;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("age", "120, 240")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -133,11 +128,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -149,11 +143,10 @@ mod tests {
     fn no_response_no_violation() -> anyhow::Result<()> {
         let rule = MessageAgeHeaderNumeric;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -169,11 +162,10 @@ mod tests {
     fn violation_message_meaningful() -> anyhow::Result<()> {
         let rule = MessageAgeHeaderNumeric;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[("age", "bad")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_allow_header_method_tokens.rs
+++ b/src/rules/message_allow_header_method_tokens.rs
@@ -9,8 +9,6 @@ use hyper::HeaderMap;
 pub struct MessageAllowHeaderMethodTokens;
 
 impl Rule for MessageAllowHeaderMethodTokens {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_allow_header_method_tokens"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageAllowHeaderMethodTokens {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &HeaderMap| -> Option<Violation> {
@@ -115,11 +112,10 @@ mod tests {
             HeaderValue::from_str(allow_value).unwrap(),
         );
 
-        rule.check(
+        rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -205,11 +201,10 @@ mod tests {
         let tx = make_test_transaction();
 
         // Transaction has no Allow header
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }
@@ -226,8 +221,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_auth_scheme_iana_registered.rs
+++ b/src/rules/message_auth_scheme_iana_registered.rs
@@ -62,8 +62,6 @@ fn parse_allowed_config(
 pub struct MessageAuthSchemeIanaRegistered;
 
 impl Rule for MessageAuthSchemeIanaRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_auth_scheme_iana_registered"
     }
@@ -72,20 +70,16 @@ impl Rule for MessageAuthSchemeIanaRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         // Helper to check a single scheme token against allowed list
@@ -218,11 +212,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("www-authenticate", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -247,11 +240,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("authorization", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -280,7 +272,7 @@ mod tests {
                 t
             }),
         );
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -293,11 +285,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("www-authenticate", " realm=\"x\"")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -323,11 +314,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -350,11 +340,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -369,11 +358,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Basic")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Authorization header"));
@@ -480,11 +468,10 @@ mod tests {
             "Basic realm=\"x\", NewScheme abc=",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -510,11 +497,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -530,11 +516,10 @@ mod tests {
             "bAsIc realm=\"x\"",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -560,11 +545,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -580,11 +564,10 @@ mod tests {
             "bAsIc QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -612,11 +595,10 @@ mod tests {
             "Basic realm=\"x\"",
         )]);
 
-        let v = MessageAuthSchemeIanaRegistered.check(
+        let v = MessageAuthSchemeIanaRegistered.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfgt,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_authorization_credentials_present.rs
+++ b/src/rules/message_authorization_credentials_present.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageAuthorizationCredentialsPresent;
 
 impl Rule for MessageAuthorizationCredentialsPresent {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_authorization_credentials_present"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageAuthorizationCredentialsPresent {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
@@ -80,11 +77,10 @@ mod tests {
                 .append("authorization", HeaderValue::from_str(h)?);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -106,11 +102,10 @@ mod tests {
             HeaderValue::from_bytes(b"Bearer \xff").unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -133,11 +128,10 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Basic"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -147,7 +141,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_authorization_credentials_present");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_basic_auth_base64_validity.rs
+++ b/src/rules/message_basic_auth_base64_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageBasicAuthBase64Validity;
 
 impl Rule for MessageBasicAuthBase64Validity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_basic_auth_base64_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageBasicAuthBase64Validity {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
@@ -87,11 +84,10 @@ mod tests {
                 .append("authorization", HeaderValue::from_str(h)?);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header '{:?}'", header);
@@ -116,11 +112,10 @@ mod tests {
             HeaderValue::from_str(&format!("Basic {}", enc)).unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("control"));
@@ -138,11 +133,10 @@ mod tests {
             HeaderValue::from_static("Basic not-base64"),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -154,11 +148,10 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Basic"));
         let rule = MessageBasicAuthBase64Validity;
-        let v1 = rule.check(
+        let v1 = rule.check_transaction(
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
         assert!(v1.unwrap().message.contains("missing credentials"));
@@ -167,11 +160,10 @@ mod tests {
         tx2.request
             .headers
             .append("authorization", HeaderValue::from_static("Basic "));
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2.unwrap().message.contains("missing credentials"));
@@ -185,11 +177,10 @@ mod tests {
             HeaderValue::from_bytes(b"Basic \xff").unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -206,11 +197,10 @@ mod tests {
             HeaderValue::from_str(&format!("basic {}", enc)).unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -226,11 +216,10 @@ mod tests {
             HeaderValue::from_str(&format!("Basic {}", enc)).unwrap(),
         );
         let rule = MessageBasicAuthBase64Validity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -239,7 +228,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_basic_auth_base64_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_bearer_token_format_validity.rs
+++ b/src/rules/message_bearer_token_format_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageBearerTokenFormatValidity;
 
 impl Rule for MessageBearerTokenFormatValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_bearer_token_format_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageBearerTokenFormatValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
@@ -93,11 +90,10 @@ mod tests {
                 .append("authorization", HeaderValue::from_str(h)?);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -124,11 +120,10 @@ mod tests {
             HeaderValue::from_bytes(b"Bearer \xff").unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -144,7 +139,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_bearer_token_format_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -159,11 +154,10 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("bearer abc123"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -183,11 +177,10 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Bearer a b"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -203,11 +196,10 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Bearer ab=c"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -225,11 +217,10 @@ mod tests {
             .headers
             .append("authorization", HeaderValue::from_static("Bearer =abc"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_cache_control_and_pragma_consistency.rs
+++ b/src/rules/message_cache_control_and_pragma_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCacheControlAndPragmaConsistency;
 
 impl Rule for MessageCacheControlAndPragmaConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cache_control_and_pragma_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCacheControlAndPragmaConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check requests: Pragma: no-cache vs Cache-Control: only-if-cached contradiction
@@ -111,11 +108,10 @@ mod tests {
         }
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -138,11 +134,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("pragma", "no-cache")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Pragma"));
@@ -163,11 +158,10 @@ mod tests {
         tx.request.headers = hm;
 
         // Non-UTF8 values are ignored by this consistency rule; syntax/token rules should report encoding problems.
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -196,11 +190,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -222,11 +215,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -242,11 +234,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("pragma", "foo")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -271,11 +262,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -293,11 +283,10 @@ mod tests {
         hm.append("pragma", hyper::header::HeaderValue::from_static("bar"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_cache_control_directive_validity.rs
+++ b/src/rules/message_cache_control_directive_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCacheControlDirectiveValidity;
 
 impl Rule for MessageCacheControlDirectiveValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cache_control_directive_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCacheControlDirectiveValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Apply to both request and response messages
@@ -239,11 +236,10 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", value);
@@ -269,11 +265,10 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_resp(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", value);
@@ -290,11 +285,10 @@ mod tests {
             ("cache-control", "no-cache"),
             ("cache-control", "max-age=60"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -309,11 +303,10 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("cache-control", bad);
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -323,11 +316,10 @@ mod tests {
     fn whitespace_only_request_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("   ");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -340,11 +332,10 @@ mod tests {
     fn whitespace_only_response_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_resp("   ");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -357,11 +348,10 @@ mod tests {
     fn private_unterminated_quoted_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("private=\"unterminated");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -376,11 +366,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("cache-control", ",max-age=1")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -404,8 +393,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -413,11 +402,10 @@ mod tests {
     fn foo_empty_value_allowed() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -427,11 +415,10 @@ mod tests {
     fn foo_quoted_value_allowed() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=\"bar\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -441,11 +428,10 @@ mod tests {
     fn directive_value_invalid_token() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=bad@val");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -455,11 +441,10 @@ mod tests {
     fn max_age_too_large_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("max-age=18446744073709551616");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -469,11 +454,10 @@ mod tests {
     fn empty_directive_name_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("=bar");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -483,11 +467,10 @@ mod tests {
     fn private_quoted_empty_field_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("private=\"field1,,field3\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -497,11 +480,10 @@ mod tests {
     fn private_quoted_invalid_field_char_is_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("private=\"field1,bad@field\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -523,11 +505,10 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -537,11 +518,10 @@ mod tests {
     fn whitespace_around_name_value_accepted() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req(" max-age = 3600 ");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -551,11 +531,10 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -565,11 +544,10 @@ mod tests {
     fn multiple_directives_unquoted_comma_accepted() -> anyhow::Result<()> {
         let rule = MessageCacheControlDirectiveValidity;
         let tx = make_req("foo=bar,baz");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_cache_control_token_valid.rs
+++ b/src/rules/message_cache_control_token_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCacheControlTokenValid;
 
 impl Rule for MessageCacheControlTokenValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cache_control_token_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCacheControlTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Apply to both request and response messages
@@ -169,11 +166,10 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -193,11 +189,10 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_resp(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -216,11 +211,10 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("cache-control", bad);
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -234,11 +228,10 @@ mod tests {
             ("cache-control", "no-cache"),
             ("cache-control", "max-age=60"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -252,11 +245,10 @@ mod tests {
             ("cache-control", "no-cache"),
             ("cache-control", "max-age=60"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -266,11 +258,10 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -280,11 +271,10 @@ mod tests {
     fn quoted_value_unterminated_reports_violation() -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req("foo=\"unterminated");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -294,11 +284,10 @@ mod tests {
     fn empty_directive_value_is_accepted() -> anyhow::Result<()> {
         let rule = MessageCacheControlTokenValid;
         let tx = make_req("foo=");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -313,11 +302,10 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("cache-control", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -329,11 +317,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("cache-control", ",max-age=1")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -357,8 +344,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_caching_directive_interaction.rs
+++ b/src/rules/message_caching_directive_interaction.rs
@@ -14,8 +14,6 @@ use crate::rules::Rule;
 pub struct MessageCachingDirectiveInteraction;
 
 impl Rule for MessageCachingDirectiveInteraction {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_caching_directive_interaction"
     }
@@ -24,12 +22,11 @@ impl Rule for MessageCachingDirectiveInteraction {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to check a single HeaderMap for contradictions
@@ -183,11 +180,10 @@ mod tests {
             "message_caching_directive_interaction",
         ]);
         let tx = make_req(val);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", val);
@@ -209,11 +205,10 @@ mod tests {
             "message_caching_directive_interaction",
         ]);
         let tx = make_resp(val);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", val);
@@ -234,11 +229,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_caching_directive_interaction",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -250,11 +244,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_caching_directive_interaction",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -266,11 +259,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_caching_directive_interaction",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -287,11 +279,10 @@ mod tests {
         hm.append("cache-control", HeaderValue::from_static("no-store"));
         hm.append("cache-control", HeaderValue::from_static("public"));
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -303,11 +294,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_caching_directive_interaction",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -319,11 +309,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_caching_directive_interaction",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -332,7 +321,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_caching_directive_interaction");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_charset_iana_registered.rs
+++ b/src/rules/message_charset_iana_registered.rs
@@ -63,8 +63,6 @@ fn parse_allowed_config(
 pub struct MessageCharsetIanaRegistered;
 
 impl Rule for MessageCharsetIanaRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_charset_iana_registered"
     }
@@ -73,20 +71,16 @@ impl Rule for MessageCharsetIanaRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         use crate::helpers::headers::parse_media_type;
@@ -253,11 +247,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -286,11 +279,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -392,11 +384,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -410,11 +401,10 @@ mod tests {
             "content-type",
             "text/plain; CHARSET = UTF-8",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -429,11 +419,10 @@ mod tests {
             "content-type",
             "text/plain; charset",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -448,11 +437,10 @@ mod tests {
             "content-type",
             "text/plain; charset",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -467,11 +455,10 @@ mod tests {
             "content-type",
             "text/plain; charset=utf-8;",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -485,11 +472,10 @@ mod tests {
             "content-type",
             "text/plain; charset=utf-8; charset=unknown-charset",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -504,7 +490,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageCharsetIanaRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_charset_iana_registered",
@@ -523,10 +509,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<CharsetConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_allowed_config(&full_cfg, rule.id())?;
         assert!(arc.allowed.contains(&"utf-8".to_string()));
         Ok(())
     }
@@ -544,11 +527,10 @@ mod tests {
             .headers
             .insert("content-type", bad);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_compression_and_transfer_encoding_consistency.rs
+++ b/src/rules/message_compression_and_transfer_encoding_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCompressionAndTransferEncodingConsistency;
 
 impl Rule for MessageCompressionAndTransferEncodingConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_compression_and_transfer_encoding_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses
@@ -133,11 +130,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_compression_and_transfer_encoding_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -171,11 +167,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_compression_and_transfer_encoding_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -206,11 +201,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_compression_and_transfer_encoding_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Non-UTF8 content-encoding should be ignored and not cause a panic or violation
         assert!(v.is_none());
@@ -223,11 +217,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_compression_and_transfer_encoding_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -246,7 +239,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_compression_and_transfer_encoding_consistency",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_conditional_headers_consistency.rs
+++ b/src/rules/message_conditional_headers_consistency.rs
@@ -16,8 +16,6 @@ use crate::rules::Rule;
 pub struct MessageConditionalHeadersConsistency;
 
 impl Rule for MessageConditionalHeadersConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_conditional_headers_consistency"
     }
@@ -26,12 +24,11 @@ impl Rule for MessageConditionalHeadersConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
@@ -119,11 +116,10 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -141,11 +137,10 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -160,11 +155,10 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-range", "\"a\"")]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("without Range"));
@@ -179,11 +173,10 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("MUST not contain a weak"));
@@ -203,11 +196,10 @@ mod tests {
         tx.request.headers = hm;
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -222,11 +214,10 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -241,11 +232,10 @@ mod tests {
         )]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("only defined for GET/HEAD"));
@@ -261,11 +251,10 @@ mod tests {
         )]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -280,11 +269,10 @@ mod tests {
         )]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -299,11 +287,10 @@ mod tests {
         ]);
 
         let rule = MessageConditionalHeadersConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -318,7 +305,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_conditional_headers_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_connection_header_tokens_valid.rs
+++ b/src/rules/message_connection_header_tokens_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageConnectionHeaderTokensValid;
 
 impl Rule for MessageConnectionHeaderTokensValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_connection_header_tokens_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageConnectionHeaderTokensValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &hyper::HeaderMap| -> Option<Violation> {
@@ -102,11 +99,10 @@ mod tests {
         }
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
@@ -145,11 +141,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "case '{}' expected violation", value);
@@ -173,11 +168,10 @@ mod tests {
         tx.request.headers = hm;
 
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
         Ok(())
@@ -198,11 +192,10 @@ mod tests {
 
         // Should report a violation due to invalid 'a/b' token
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
         Ok(())
@@ -216,11 +209,10 @@ mod tests {
         tx.request.headers = hyper::HeaderMap::new();
 
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
         Ok(())
@@ -240,11 +232,10 @@ mod tests {
         tx.request.headers = hm;
 
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
         Ok(())

--- a/src/rules/message_connection_upgrade.rs
+++ b/src/rules/message_connection_upgrade.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageConnectionUpgrade;
 
 impl Rule for MessageConnectionUpgrade {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_connection_upgrade"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageConnectionUpgrade {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request headers
@@ -90,11 +87,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -117,11 +113,10 @@ mod tests {
         let status = 101; // Switching Protocols
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_content_disposition_parameter_validity.rs
+++ b/src/rules/message_content_disposition_parameter_validity.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct MessageContentDispositionParameterValidity;
 
 impl Rule for MessageContentDispositionParameterValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_disposition_parameter_validity"
     }
@@ -20,12 +18,11 @@ impl Rule for MessageContentDispositionParameterValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check_value = |hdr_name: &str, val: &str| -> Option<Violation> {
@@ -324,11 +321,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", value);
@@ -349,11 +345,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -371,11 +366,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -399,11 +393,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -420,11 +413,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -442,11 +434,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -472,11 +463,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -493,11 +483,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -514,11 +503,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -535,11 +523,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -557,11 +544,10 @@ mod tests {
             "warn",
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("filename* extended value invalid"));
@@ -580,11 +566,10 @@ mod tests {
             "warn",
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("extended parameter 'title*' invalid"));
@@ -602,11 +587,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -623,11 +607,10 @@ mod tests {
             "message_content_disposition_parameter_validity",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_content_disposition_token_valid.rs
+++ b/src/rules/message_content_disposition_token_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentDispositionTokenValid;
 
 impl Rule for MessageContentDispositionTokenValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_disposition_token_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentDispositionTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Content-Disposition header value
@@ -124,11 +121,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", value);
@@ -149,11 +145,10 @@ mod tests {
             "message_content_disposition_token_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -171,11 +166,10 @@ mod tests {
             "message_content_disposition_token_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -194,11 +188,10 @@ mod tests {
             "message_content_disposition_token_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -226,11 +219,10 @@ mod tests {
             "message_content_disposition_token_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -246,11 +238,10 @@ mod tests {
             "message_content_disposition_token_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_content_encoding_and_type_consistency.rs
+++ b/src/rules/message_content_encoding_and_type_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentEncodingAndTypeConsistency;
 
 impl Rule for MessageContentEncodingAndTypeConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_encoding_and_type_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentEncodingAndTypeConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a Content-Encoding-like header value (comma-separated members).
@@ -153,11 +150,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -184,11 +180,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -215,11 +210,10 @@ mod tests {
             HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         let v = violation.unwrap();
@@ -234,11 +228,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip, ")]);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }
@@ -250,11 +243,10 @@ mod tests {
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "*")]);
-        let v1 = rule.check(
+        let v1 = rule.check_transaction(
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
 
@@ -262,11 +254,10 @@ mod tests {
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx2.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "*")]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
@@ -282,11 +273,10 @@ mod tests {
         hm.append("content-encoding", HeaderValue::from_static("gzip"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -300,11 +290,10 @@ mod tests {
         hm.append("content-encoding", HeaderValue::from_static("gzip"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -315,7 +304,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_content_encoding_and_type_consistency",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -333,11 +322,10 @@ mod tests {
         // part but its token before the ';' is empty -> triggers the rule
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip,;,br")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -352,11 +340,10 @@ mod tests {
             .headers
             .append("content-encoding", HeaderValue::from_bytes(&[0xff])?);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -374,11 +361,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_content_encoding_iana_registered.rs
+++ b/src/rules/message_content_encoding_iana_registered.rs
@@ -64,8 +64,6 @@ fn parse_allowed_config(
 pub struct MessageContentEncodingIanaRegistered;
 
 impl Rule for MessageContentEncodingIanaRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_encoding_iana_registered"
     }
@@ -74,20 +72,16 @@ impl Rule for MessageContentEncodingIanaRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         // Helper to check a single header value against allowed list
@@ -195,11 +189,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -229,11 +222,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -336,12 +328,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_fails_when_allowed_missing() {
+    fn validate_fails_when_allowed_missing() {
         let rule = MessageContentEncodingIanaRegistered;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_content_encoding_iana_registered",
         ]);
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         assert!(res.is_err());
     }
 
@@ -381,7 +373,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageContentEncodingIanaRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_content_encoding_iana_registered",
@@ -400,10 +392,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<ContentEncodingConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_allowed_config(&full_cfg, rule.id())?;
         assert!(arc.allowed.contains(&"gzip".to_string()));
         Ok(())
     }
@@ -423,11 +412,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x!bad")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -453,11 +441,10 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -466,11 +453,10 @@ mod tests {
         let mut hm2 = hyper::HeaderMap::new();
         hm2.insert("accept-encoding", HeaderValue::from_bytes(b"\xff").unwrap());
         tx2.request.headers = hm2;
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -498,11 +484,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", "x-custom;q=0.5")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -532,11 +517,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x-custom")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -551,22 +535,20 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip, ")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept-encoding", "gzip, ")]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
         Ok(())
@@ -581,11 +563,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "gzip; param=1")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -638,11 +619,10 @@ mod tests {
             tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(
                 &[("content-encoding", coding.as_str())],
             );
-            let v = rule.check(
+            let v = rule.check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(
                 v.is_none(),
@@ -656,11 +636,10 @@ mod tests {
                 "accept-encoding",
                 coding.as_str(),
             )]);
-            let v2 = rule.check(
+            let v2 = rule.check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(
                 v2.is_none(),
@@ -717,11 +696,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x-foo")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -743,11 +721,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-encoding", "x@bad")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_content_length.rs
+++ b/src/rules/message_content_length.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentLength;
 
 impl Rule for MessageContentLength {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_length"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentLength {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &hyper::HeaderMap| -> Option<Violation> {
@@ -98,11 +95,10 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_headers(&[("content-length", value)]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "value '{}' expected violation", value);
@@ -132,11 +128,10 @@ mod tests {
             &[("content-length", value)],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "response value '{}' expected violation", value);
@@ -164,11 +159,10 @@ mod tests {
         let pairs: Vec<(&str, &str)> = values.iter().map(|v| ("content-length", *v)).collect();
         let tx = crate::test_helpers::make_test_transaction_with_headers(&pairs);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -198,11 +192,10 @@ mod tests {
             trailers: None,
         });
 
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -231,11 +224,10 @@ mod tests {
         hm.insert(hyper::header::CONTENT_LENGTH, bad_value);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));

--- a/src/rules/message_content_length_vs_transfer_encoding.rs
+++ b/src/rules/message_content_length_vs_transfer_encoding.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentLengthVsTransferEncoding;
 
 impl Rule for MessageContentLengthVsTransferEncoding {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_length_vs_transfer_encoding"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentLengthVsTransferEncoding {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request headers
@@ -74,11 +71,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -103,11 +99,10 @@ mod tests {
         let status = 200;
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_content_location_and_uri_consistency.rs
+++ b/src/rules/message_content_location_and_uri_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentLocationAndUriConsistency;
 
 impl Rule for MessageContentLocationAndUriConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_location_and_uri_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentLocationAndUriConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -173,11 +170,10 @@ mod tests {
             "message_content_location_and_uri_consistency",
         ]);
         let tx = make_tx_with_req_uri(req_uri, status, headers);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -197,11 +193,10 @@ mod tests {
             200,
             &[("content-location", "/bad%2G")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));
@@ -217,11 +212,10 @@ mod tests {
             200,
             &[("content-location", "/a b")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not contain whitespace"));
@@ -240,11 +234,10 @@ mod tests {
             HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -259,11 +252,10 @@ mod tests {
             200,
             &[("content-location", "")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -275,11 +267,10 @@ mod tests {
             "message_content_location_and_uri_consistency",
         ]);
         let tx = make_tx_with_req_uri("/foo", 200, &[("content-location", "/foo#frag")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -291,11 +282,10 @@ mod tests {
             "message_content_location_and_uri_consistency",
         ]);
         let tx = make_tx_with_req_uri("/foo", 200, &[("content-location", "/foo/")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -311,11 +301,10 @@ mod tests {
             200,
             &[("content-location", "http://example.com/foo")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -324,7 +313,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_content_location_and_uri_consistency");
-        let _ = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_content_md5_vs_digest_preference.rs
+++ b/src/rules/message_content_md5_vs_digest_preference.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentMd5VsDigestPreference;
 
 impl Rule for MessageContentMd5VsDigestPreference {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_md5_vs_digest_preference"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentMd5VsDigestPreference {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to check a header map for both Content-Digest and Content-MD5
@@ -75,11 +72,10 @@ mod tests {
             ("content-md5", "dGVzdA=="),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -100,11 +96,10 @@ mod tests {
             ("content-md5", "dGVzdA=="),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -122,11 +117,10 @@ mod tests {
             "sha-256=:\tdGVzdA==:",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -143,11 +137,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-md5", "dGVzdA==")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -173,11 +166,10 @@ mod tests {
             HeaderValue::from_static("sha-256=:\tdGVzdA==:"),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -206,11 +198,10 @@ mod tests {
             ("content-md5", "dGVzdA=="),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -219,15 +210,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_cache_parses_rule_config() -> anyhow::Result<()> {
+    fn validate_parses_rule_config() -> anyhow::Result<()> {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_content_md5_vs_digest_preference",
         ]);
-        let mut engine = crate::rules::RuleConfigEngine::new();
-        engine.validate_and_cache_all(&cfg)?;
-        let cfg_obj: std::sync::Arc<crate::rules::RuleConfig> =
-            engine.get_cached("message_content_md5_vs_digest_preference");
-        assert!(cfg_obj.enabled);
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_content_security_policy_and_frame_options_consistency.rs
+++ b/src/rules/message_content_security_policy_and_frame_options_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentSecurityPolicyAndFrameOptionsConsistency;
 
 impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_security_policy_and_frame_options_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
@@ -274,11 +271,10 @@ mod tests {
             ("x-frame-options", xfo),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -313,11 +309,10 @@ mod tests {
         headers.insert("x-frame-options", bad);
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -335,11 +330,10 @@ mod tests {
         ]);
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not match"));
@@ -362,7 +356,7 @@ mod tests {
             &mut cfg,
             "message_content_security_policy_and_frame_options_consistency",
         );
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -379,11 +373,10 @@ mod tests {
             ("x-frame-options", "ALLOW-FROM https://a"),
         ]);
         tx.response.as_mut().unwrap().headers = headers;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -399,11 +392,10 @@ mod tests {
             ("x-frame-options", "DENY"),
         ]);
         // since the directive is malformed (no members) we treat as absent and no violation
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -422,11 +414,10 @@ mod tests {
         headers.append("x-frame-options", "DENY".parse().unwrap());
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -441,11 +432,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "ALLOW-FROM https://example/"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -460,11 +450,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "UNKNOWN https://example"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -482,11 +471,10 @@ mod tests {
             ("x-frame-options", "ALLOW-FROM http://example"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -501,11 +489,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://a"),
             ("x-frame-options", "ALLOW-FROM"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -520,11 +507,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors 'none'"),
             ("x-frame-options", "ALLOW-FROM https://example"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -541,11 +527,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://EXample"),
             ("x-frame-options", "ALLOW-FROM https://example"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -563,11 +548,10 @@ mod tests {
             ),
             ("x-frame-options", "ALLOW-FROM https://example"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -582,11 +566,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "SAMEORIGIN"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -604,11 +587,10 @@ mod tests {
         ]);
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -626,11 +608,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors https://example"),
             ("x-frame-options", "allow-from https://example"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -663,11 +644,10 @@ mod tests {
             ("x-frame-options", "SAMEORIGIN"),
         ]);
         // report-only policies should not affect framing enforcement -> ignore
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -682,11 +662,10 @@ mod tests {
             ("content-security-policy", "frame-ancestors 'self'"),
             ("x-frame-options", "SAMEORIGIN"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -704,11 +683,10 @@ mod tests {
         headers.insert("content-security-policy", bad);
         tx.response.as_mut().unwrap().headers = headers;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -723,11 +701,10 @@ mod tests {
             "content-security-policy",
             "frame-ancestors https://example",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_content_transfer_encoding_valid.rs
+++ b/src/rules/message_content_transfer_encoding_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentTransferEncodingValid;
 
 impl Rule for MessageContentTransferEncodingValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_transfer_encoding_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentTransferEncodingValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Allowed encodings per RFC 2045 §6
@@ -130,11 +127,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -159,11 +155,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -180,11 +175,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", "8bit")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -194,11 +188,10 @@ mod tests {
             "content-transfer-encoding",
             "xcodec",
         )]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         Ok(())
@@ -216,11 +209,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-transfer-encoding", " ")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
@@ -229,11 +221,10 @@ mod tests {
             ("content-transfer-encoding", "base64"),
             ("content-transfer-encoding", "x-bad"),
         ]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         Ok(())

--- a/src/rules/message_content_type_iana_registered.rs
+++ b/src/rules/message_content_type_iana_registered.rs
@@ -64,8 +64,6 @@ fn parse_allowed_config(
 pub struct MessageContentTypeIanaRegistered;
 
 impl Rule for MessageContentTypeIanaRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_type_iana_registered"
     }
@@ -74,20 +72,16 @@ impl Rule for MessageContentTypeIanaRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         let check_media_type =
@@ -202,11 +196,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -234,11 +227,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -255,11 +247,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -286,11 +277,10 @@ mod tests {
             "content-type",
             "application/vnd.unknown",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -327,11 +317,10 @@ mod tests {
         tx1.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -341,11 +330,10 @@ mod tests {
             "application/ld+json",
         )]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -359,11 +347,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/x-custom")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -440,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageContentTypeIanaRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_content_type_iana_registered",
@@ -459,10 +446,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<ContentTypeConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_allowed_config(&full_cfg, rule.id())?;
         assert!(arc.allowed.contains(&"text/plain".to_string()));
         Ok(())
     }
@@ -480,11 +464,10 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -496,11 +479,10 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx2.request.headers = hm2;
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }

--- a/src/rules/message_content_type_well_formed.rs
+++ b/src/rules/message_content_type_well_formed.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageContentTypeWellFormed;
 
 impl Rule for MessageContentTypeWellFormed {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_content_type_well_formed"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageContentTypeWellFormed {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request Content-Type
@@ -237,11 +234,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
@@ -250,11 +246,10 @@ mod tests {
             200,
             &[("content-type", "text")],
         );
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
@@ -268,17 +263,15 @@ mod tests {
             200,
             &[("content-type", "application/json")],
         );
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
-        let v4 = rule.check(
+        let v4 = rule.check_transaction(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_none());
         assert!(v4.is_none());

--- a/src/rules/message_cookie_attribute_consistency.rs
+++ b/src/rules/message_cookie_attribute_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCookieAttributeConsistency;
 
 impl Rule for MessageCookieAttributeConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cookie_attribute_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCookieAttributeConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -273,11 +270,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = MessageCookieAttributeConsistency;
-        rule.check(
+        rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -323,8 +319,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -352,11 +348,10 @@ mod tests {
             .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
 
         let rule = MessageCookieAttributeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -434,11 +429,10 @@ mod tests {
             .append("set-cookie", HeaderValue::from_static("=bad; Secure"));
 
         let rule = MessageCookieAttributeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_cookie_domain_validity.rs
+++ b/src/rules/message_cookie_domain_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCookieDomainValidity;
 
 impl Rule for MessageCookieDomainValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cookie_domain_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCookieDomainValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -99,11 +96,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = MessageCookieDomainValidity;
-        rule.check(
+        rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -152,11 +148,10 @@ mod tests {
         });
 
         let rule = MessageCookieDomainValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -200,11 +195,10 @@ mod tests {
             .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
 
         let rule = MessageCookieDomainValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -216,7 +210,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_cookie_domain_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_cookie_path_validity.rs
+++ b/src/rules/message_cookie_path_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCookiePathValidity;
 
 impl Rule for MessageCookiePathValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cookie_path_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCookiePathValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -93,11 +90,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = MessageCookiePathValidity;
-        rule.check(
+        rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         )
     }
 
@@ -180,11 +176,10 @@ mod tests {
         });
 
         let rule = MessageCookiePathValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -210,11 +205,10 @@ mod tests {
         });
 
         let rule = MessageCookiePathValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -259,11 +253,10 @@ mod tests {
     fn check_missing_response() {
         let tx = crate::test_helpers::make_test_transaction();
         let rule = MessageCookiePathValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -272,7 +265,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_cookie_path_validity");
-        let _ = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_cross_origin_embedder_policy_valid.rs
+++ b/src/rules/message_cross_origin_embedder_policy_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCrossOriginEmbedderPolicyValid;
 
 impl Rule for MessageCrossOriginEmbedderPolicyValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cross_origin_embedder_policy_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCrossOriginEmbedderPolicyValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // COEP is a response-only header per spec; ignore requests
@@ -115,11 +112,10 @@ mod tests {
             );
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -137,11 +133,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageCrossOriginEmbedderPolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -167,11 +162,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -201,11 +195,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -229,7 +222,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -240,11 +233,10 @@ mod tests {
             200,
             &[("cross-origin-embedder-policy", "require-corp ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -257,11 +249,10 @@ mod tests {
             &[("cross-origin-embedder-policy", "unsafe-none")],
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not enable cross-origin isolation"));
@@ -279,11 +270,10 @@ mod tests {
             )],
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));
@@ -303,18 +293,17 @@ mod tests {
         );
 
         // validate configuration parsing still succeeds
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
 
         // Mixed-case header value must be accepted (case-insensitive)
         let tx = crate::test_helpers::make_test_transaction_with_response(
             200,
             &[("cross-origin-embedder-policy", "CrEdEntIalLess")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "expected no violation for mixed-case value");
 

--- a/src/rules/message_cross_origin_opener_policy_valid.rs
+++ b/src/rules/message_cross_origin_opener_policy_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCrossOriginOpenerPolicyValid;
 
 impl Rule for MessageCrossOriginOpenerPolicyValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cross_origin_opener_policy_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCrossOriginOpenerPolicyValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // COOP is a response-only header per spec; ignore requests
@@ -113,11 +110,10 @@ mod tests {
             );
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -135,11 +131,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageCrossOriginOpenerPolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -164,11 +159,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -198,11 +192,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -226,7 +219,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -237,11 +230,10 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", "same-origin ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -254,11 +246,10 @@ mod tests {
             &[("cross-origin-opener-policy", "other")],
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("unsupported value"));
@@ -273,11 +264,10 @@ mod tests {
             &[("cross-origin-opener-policy", "same-origin, unsafe-none")],
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));
@@ -290,11 +280,10 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", " same-origin-allow-popups ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_cross_origin_resource_policy_valid.rs
+++ b/src/rules/message_cross_origin_resource_policy_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageCrossOriginResourcePolicyValid;
 
 impl Rule for MessageCrossOriginResourcePolicyValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_cross_origin_resource_policy_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageCrossOriginResourcePolicyValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // CORP is a response-only header per spec; ignore requests
@@ -118,11 +115,10 @@ mod tests {
             );
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -140,11 +136,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageCrossOriginResourcePolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -169,11 +164,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -203,11 +197,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -231,7 +224,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -242,11 +235,10 @@ mod tests {
             200,
             &[("cross-origin-resource-policy", "same-origin ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -259,11 +251,10 @@ mod tests {
             &[("cross-origin-resource-policy", "other")],
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("unsupported value"));
@@ -278,11 +269,10 @@ mod tests {
             &[("cross-origin-resource-policy", "same-origin, cross-origin")],
         );
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));

--- a/src/rules/message_date_and_time_headers_consistency.rs
+++ b/src/rules/message_date_and_time_headers_consistency.rs
@@ -9,8 +9,6 @@ use crate::rules::Rule;
 pub struct MessageDateAndTimeHeadersConsistency;
 
 impl Rule for MessageDateAndTimeHeadersConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_date_and_time_headers_consistency"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageDateAndTimeHeadersConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use chrono::Duration;
@@ -216,11 +213,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&h);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -241,11 +237,10 @@ mod tests {
             ("last-modified", "Wed, 21 Oct 2015 07:30:00 GMT"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -262,11 +257,10 @@ mod tests {
             ("sunset", "Wed, 21 Oct 2015 07:27:00 GMT"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -283,11 +277,10 @@ mod tests {
             ("if-modified-since", "Wed, 21 Oct 2015 07:30:00 GMT"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -306,11 +299,10 @@ mod tests {
         hm.insert("date", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -325,11 +317,10 @@ mod tests {
             ("sunset", "not-a-date"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -351,11 +342,10 @@ mod tests {
         hm.insert("last-modified", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -374,11 +364,10 @@ mod tests {
         hm.insert("if-modified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -393,11 +382,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("date", "not-a-date")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -414,11 +402,10 @@ mod tests {
             "Tue, 01 Jan 2030 00:00:00 GMT",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -435,11 +422,10 @@ mod tests {
         hm.insert("date", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -456,11 +442,10 @@ mod tests {
             ("last-modified", "not-a-date"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Parse error for Last-Modified should be ignored by this rule (other rule will report)
         assert!(v.is_none());
@@ -476,11 +461,10 @@ mod tests {
             ("if-modified-since", "not-a-date"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Parse error for If-Modified-Since should be ignored by this rule (other rule will report)
         assert!(v.is_none());
@@ -496,11 +480,10 @@ mod tests {
             "Wed, 21 Oct 2015 07:30:00 GMT",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Without a Date header to compare against, the rule should not produce a violation
         assert!(v.is_none());
@@ -521,11 +504,10 @@ mod tests {
         hm.insert("sunset", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -544,7 +526,7 @@ mod tests {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_date_and_time_headers_consistency");
         // Should validate and produce an engine without error
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_digest_auth_validity.rs
+++ b/src/rules/message_digest_auth_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageDigestAuthValidity;
 
 impl Rule for MessageDigestAuthValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_digest_auth_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageDigestAuthValidity {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
@@ -220,11 +217,10 @@ mod tests {
                 .append("authorization", h.parse().unwrap());
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -249,11 +245,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -276,11 +271,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -301,11 +295,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -321,11 +314,10 @@ mod tests {
             "authorization",
             hyper::header::HeaderValue::from_bytes(b"Digest \xff").unwrap(),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -346,11 +338,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -375,11 +366,10 @@ mod tests {
             "Digest username=\"Mu\\\"fasa\", realm=\"test\", nonce=\"abc\", uri=\"/\", response=\"d\"".parse().unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -401,11 +391,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -442,11 +431,10 @@ mod tests {
             .headers
             .append("authorization", "Digest    ".parse().unwrap());
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -467,11 +455,10 @@ mod tests {
             .headers
             .append("authorization", "Digest".parse().unwrap());
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -494,11 +481,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -524,11 +510,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -554,11 +539,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -588,11 +572,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -625,11 +608,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -656,11 +638,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -678,11 +659,10 @@ mod tests {
         tx.request
             .headers
             .append("authorization", "".parse().unwrap());
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -702,11 +682,10 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -725,11 +704,10 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -754,11 +732,10 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -773,7 +750,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_digest_auth_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_digest_header_syntax.rs
+++ b/src/rules/message_digest_header_syntax.rs
@@ -9,8 +9,6 @@ use base64::Engine;
 pub struct MessageDigestHeaderSyntax;
 
 impl Rule for MessageDigestHeaderSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_digest_header_syntax"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageDigestHeaderSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Shared parser for comma-separated key=value members
@@ -537,11 +534,10 @@ mod tests {
             "message_digest_header_syntax",
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -562,11 +558,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -579,11 +574,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -597,11 +591,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -620,11 +613,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -633,7 +625,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_digest_header_syntax");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -654,11 +646,10 @@ mod tests {
             "message_digest_header_syntax",
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -677,11 +668,10 @@ mod tests {
             "message_digest_header_syntax",
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", value);
@@ -697,11 +687,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -718,11 +707,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -746,11 +734,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -765,11 +752,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -783,11 +769,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -804,11 +789,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -823,11 +807,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -842,11 +825,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -864,11 +846,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -886,11 +867,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -905,11 +885,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -924,11 +903,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -943,11 +921,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -963,11 +940,10 @@ mod tests {
             "message_digest_header_syntax",
         ]);
         // Add a simple check that presence of header yields a violation via our rule: we will add handling next
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -982,11 +958,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1001,11 +976,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1021,11 +995,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1040,11 +1013,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1059,11 +1031,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1080,11 +1051,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1115,11 +1085,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1134,11 +1103,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1155,11 +1123,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1184,11 +1151,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1213,11 +1179,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1233,11 +1198,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1255,11 +1219,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1284,11 +1247,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -1320,11 +1282,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1349,11 +1310,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1378,11 +1338,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1398,11 +1357,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1424,11 +1382,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1449,11 +1406,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -1482,11 +1438,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1503,11 +1458,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1526,11 +1480,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1552,11 +1505,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Since legacy Digest is checked first, we expect a violation about Digest being obsoleted
         assert!(v.is_some());
@@ -1576,11 +1528,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1599,11 +1550,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -1630,11 +1580,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1648,11 +1597,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1669,11 +1617,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1697,11 +1644,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let vreq = rule.check(
+        let vreq = rule.check_transaction(
             &req,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(vreq.is_none());
 
@@ -1724,11 +1670,10 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let vresp = rule.check(
+        let vresp = rule.check_transaction(
             &resp_tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(vresp.is_none());
     }
@@ -1743,11 +1688,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1764,11 +1708,10 @@ mod tests {
             200,
             &[("want-content-digest", "sha-512 = 2")],
         );
-        let v_ok = rule.check(
+        let v_ok = rule.check_transaction(
             &tx_ok,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_ok.is_none());
 
@@ -1777,11 +1720,10 @@ mod tests {
             200,
             &[("want-content-digest", "sha-512=3, sha-256")],
         );
-        let v_bad = rule.check(
+        let v_bad = rule.check_transaction(
             &tx_bad,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v_bad.is_some());
         let msg = v_bad.unwrap().message;
@@ -1798,11 +1740,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1819,11 +1760,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1835,11 +1775,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1856,11 +1795,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1878,11 +1816,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -1899,11 +1836,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1917,11 +1853,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_digest_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_early_data_header_safe_method.rs
+++ b/src/rules/message_early_data_header_safe_method.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageEarlyDataHeaderSafeMethod;
 
 impl Rule for MessageEarlyDataHeaderSafeMethod {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_early_data_header_safe_method"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageEarlyDataHeaderSafeMethod {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Early-Data is defined as a request header (RFC 8470). If present and equal to '1',
@@ -88,11 +85,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("early-data", h)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -124,10 +120,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_early_data_header_safe_method",
         ]);
-        let boxed = rule.validate_and_box(&cfg)?;
-        let _arc = boxed
-            .downcast::<crate::rules::RuleConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -146,11 +139,10 @@ mod tests {
         hm.append("early-data", "1".parse::<HeaderValue>().unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -170,11 +162,10 @@ mod tests {
         hm.append("early-data", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_etag_syntax.rs
+++ b/src/rules/message_etag_syntax.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct MessageEtagSyntax;
 
 impl Rule for MessageEtagSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_etag_syntax"
     }
@@ -20,12 +18,11 @@ impl Rule for MessageEtagSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -109,11 +106,10 @@ mod tests {
 
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "warn");
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for value={:?}", value);
@@ -146,11 +142,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -175,11 +170,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -188,7 +182,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_etag_syntax");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_expires_and_cache_control_consistency.rs
+++ b/src/rules/message_expires_and_cache_control_consistency.rs
@@ -13,8 +13,6 @@ use chrono::{DateTime, Utc};
 pub struct MessageExpiresAndCacheControlConsistency;
 
 impl Rule for MessageExpiresAndCacheControlConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_expires_and_cache_control_consistency"
     }
@@ -23,12 +21,11 @@ impl Rule for MessageExpiresAndCacheControlConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -193,11 +190,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for headers={:?}", headers);
@@ -216,7 +212,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_expires_and_cache_control_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -235,11 +231,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -255,11 +250,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // invalid Expires is left to other rules; this rule returns None
         assert!(v.is_none());
@@ -280,11 +274,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -307,11 +300,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // non-UTF8 cache-control means cc_present stays false -> no violation
         assert!(v.is_none());
@@ -332,11 +324,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -361,11 +352,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "got {:?}", v);
         Ok(())
@@ -406,11 +396,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -433,11 +422,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -510,11 +498,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -534,11 +521,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_expires_and_cache_control_consistency",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // non-UTF8 expires means has_expires stays false -> no violation
         assert!(v.is_none());

--- a/src/rules/message_extension_headers_registered.rs
+++ b/src/rules/message_extension_headers_registered.rs
@@ -62,8 +62,6 @@ fn parse_allowed_config(
 pub struct MessageExtensionHeadersRegistered;
 
 impl Rule for MessageExtensionHeadersRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_extension_headers_registered"
     }
@@ -72,20 +70,16 @@ impl Rule for MessageExtensionHeadersRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         // Helper to check headers map against allowed set
@@ -177,11 +171,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&header_pairs);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -205,11 +198,10 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -312,11 +304,10 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("x-unknown", "v")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -326,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageExtensionHeadersRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_extension_headers_registered",
@@ -345,10 +336,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<ExtensionHeadersConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_allowed_config(&full_cfg, rule.id())?;
         assert!(arc.allowed.contains(&"host".to_string()));
         Ok(())
     }
@@ -359,11 +347,10 @@ mod tests {
         let cfg = make_cfg_with_allowed(vec!["x-custom"]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("X-CUSTOM", "1")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -376,11 +363,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-a", "1"), ("x-b", "2")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -436,7 +422,7 @@ mod tests {
                 t
             }),
         );
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_form_data_content_disposition_valid.rs
+++ b/src/rules/message_form_data_content_disposition_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageFormDataContentDispositionValid;
 
 impl Rule for MessageFormDataContentDispositionValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_form_data_content_disposition_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageFormDataContentDispositionValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper that checks a single header value
@@ -190,11 +187,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", cd);
@@ -224,11 +220,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}'", cd);
@@ -251,11 +246,10 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -273,11 +267,10 @@ mod tests {
             "content-disposition",
             "form-data; name=\"\"",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -294,11 +287,10 @@ mod tests {
             "content-disposition",
             "form-data; name=\"   \"",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -315,11 +307,10 @@ mod tests {
             "content-disposition",
             "form-data; name=\"unterminated",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -337,11 +328,10 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -357,11 +347,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "form-data")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -378,11 +367,10 @@ mod tests {
             "content-disposition",
             "Form-Data; NAME=User",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -397,11 +385,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "; name=user")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -416,11 +403,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "form-data;")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -443,11 +429,10 @@ mod tests {
             HeaderValue::from_static("form-data; name=\"b\""),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -462,11 +447,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -483,11 +467,10 @@ mod tests {
             "content-disposition",
             "form-data; badparam",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Although a parameter is present, the absence of a 'name' parameter should still be
         // treated as a violation for 'form-data' dispositions.
@@ -513,11 +496,10 @@ mod tests {
             HeaderValue::from_static("form-data; filename=example.txt"),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -526,7 +508,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_form_data_content_disposition_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_forwarded_header_validity.rs
+++ b/src/rules/message_forwarded_header_validity.rs
@@ -9,8 +9,6 @@ use std::net::IpAddr;
 pub struct MessageForwardedHeaderValidity;
 
 impl Rule for MessageForwardedHeaderValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_forwarded_header_validity"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageForwardedHeaderValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Forwarded element (one comma-separated member)
@@ -432,11 +429,10 @@ mod tests {
     fn valid_forwarded_simple_for_ipv4() {
         let tx = make_tx_with_forwarded("for=192.0.2.43");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -445,11 +441,10 @@ mod tests {
     fn valid_forwarded_for_ipv6_bracketed() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1]\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -458,11 +453,10 @@ mod tests {
     fn valid_forwarded_with_port() {
         let tx = make_tx_with_forwarded("for=198.51.100.17:1234;proto=https;by=203.0.113.5");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -471,11 +465,10 @@ mod tests {
     fn invalid_forwarded_empty_element() {
         let tx = make_tx_with_forwarded(", ;for=192.0.2.43");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Leading empty list members and stray semicolons are ignored by header parsing; consider this valid
         assert!(v.is_none());
@@ -485,11 +478,10 @@ mod tests {
     fn invalid_forwarded_missing_eq() {
         let tx = make_tx_with_forwarded("for");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -498,11 +490,10 @@ mod tests {
     fn invalid_forwarded_bad_ipv4() {
         let tx = make_tx_with_forwarded("for=999.999.999.999");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -511,11 +502,10 @@ mod tests {
     fn invalid_forwarded_bad_ipv6_brackets() {
         let tx = make_tx_with_forwarded("for=[2001:db8::zzz]");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -524,11 +514,10 @@ mod tests {
     fn invalid_forwarded_bad_port() {
         let tx = make_tx_with_forwarded("for=192.0.2.1:99999");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -542,11 +531,10 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff])?;
         hm.append("forwarded", bad);
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -559,11 +547,10 @@ mod tests {
             &[("forwarded", "for=192.0.2.4, proto=https")],
         );
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -572,11 +559,10 @@ mod tests {
     fn invalid_forwarded_obfuscated_token_invalid_char() {
         let tx = make_tx_with_forwarded("for=obf@bad");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -585,11 +571,10 @@ mod tests {
     fn invalid_forwarded_proto_token_char() {
         let tx = make_tx_with_forwarded("proto=ht@tp");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -598,11 +583,10 @@ mod tests {
     fn invalid_forwarded_host_with_large_port() {
         let tx = make_tx_with_forwarded("host=example.com:99999");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -611,11 +595,10 @@ mod tests {
     fn invalid_forwarded_host_missing_bracket() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -624,11 +607,10 @@ mod tests {
     fn invalid_forwarded_for_unterminated_quoted_ipv6() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -637,11 +619,10 @@ mod tests {
     fn forwarded_by_unknown_is_ok() {
         let tx = make_tx_with_forwarded("by=unknown");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -650,11 +631,10 @@ mod tests {
     fn forwarded_for_obfuscated_token_ok() {
         let tx = make_tx_with_forwarded("for=x-foo");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -663,11 +643,10 @@ mod tests {
     fn unknown_param_value_invalid_token_char() {
         let tx = make_tx_with_forwarded("foo=bad@value");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -679,11 +658,10 @@ mod tests {
             &[("forwarded", "for=999.999.999.999")],
         );
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -695,11 +673,10 @@ mod tests {
             &[("forwarded", "foo=bad@value")],
         );
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -708,11 +685,10 @@ mod tests {
     fn valid_forwarded_quoted_ipv6_with_port() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1]:1234\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -721,11 +697,10 @@ mod tests {
     fn invalid_forwarded_quoted_ipv6_empty_inside() {
         let tx = make_tx_with_forwarded("for=\"[]\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -734,11 +709,10 @@ mod tests {
     fn invalid_forwarded_quoted_ipv6_bad_port_syntax() {
         let tx = make_tx_with_forwarded("for=\"[2001:db8::1]x\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -747,11 +721,10 @@ mod tests {
     fn valid_forwarded_host_with_port_regname() {
         let tx = make_tx_with_forwarded("host=example.com:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -760,11 +733,10 @@ mod tests {
     fn invalid_forwarded_host_invalid_char() {
         let tx = make_tx_with_forwarded("host=exa mple");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -773,11 +745,10 @@ mod tests {
     fn unknown_param_quoted_string_ok() {
         let tx = make_tx_with_forwarded("foo=\"bar baz\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -790,11 +761,10 @@ mod tests {
             ("forwarded", "for=999.999.999.999"),
         ]);
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -803,11 +773,10 @@ mod tests {
     fn unknown_param_token_ok() {
         let tx = make_tx_with_forwarded("foo=bar");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -816,11 +785,10 @@ mod tests {
     fn invalid_forwarded_ipv6_port_non_numeric() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1]:x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -829,11 +797,10 @@ mod tests {
     fn invalid_forwarded_ipv6_port_empty() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1]:");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -842,11 +809,10 @@ mod tests {
     fn invalid_forwarded_host_bracketed_port_non_numeric() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]:notnum");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -855,11 +821,10 @@ mod tests {
     fn valid_forwarded_host_bracketed_with_port() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -868,11 +833,10 @@ mod tests {
     fn valid_forwarded_obfuscated_with_port() {
         let tx = make_tx_with_forwarded("for=x-foo:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -881,11 +845,10 @@ mod tests {
     fn invalid_forwarded_obfuscated_token_with_port_invalid_char() {
         let tx = make_tx_with_forwarded("for=obf@bad:8080");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -894,11 +857,10 @@ mod tests {
     fn quoted_unknown_ok() {
         let tx = make_tx_with_forwarded("for=\"unknown\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -907,11 +869,10 @@ mod tests {
     fn invalid_forwarded_bare_ipv6_no_brackets() {
         let tx = make_tx_with_forwarded("for=2001:db8::1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -920,11 +881,10 @@ mod tests {
     fn invalid_param_name_invalid_token_char() {
         let tx = make_tx_with_forwarded("@=1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -933,11 +893,10 @@ mod tests {
     fn invalid_forwarded_empty_value() {
         let tx = make_tx_with_forwarded("foo=");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -946,11 +905,10 @@ mod tests {
     fn invalid_forwarded_proto_quoted_with_space_is_violation() {
         let tx = make_tx_with_forwarded("proto=\"ht tp\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -959,11 +917,10 @@ mod tests {
     fn unknown_param_quoted_with_escaped_quote_ok() {
         let tx = make_tx_with_forwarded("foo=\"a\\\"b\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -972,11 +929,10 @@ mod tests {
     fn invalid_forwarded_host_with_port_and_space() {
         let tx = make_tx_with_forwarded("host=exa mple:80");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -985,11 +941,10 @@ mod tests {
     fn invalid_forwarded_empty_param_name() {
         let tx = make_tx_with_forwarded("=value");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1003,11 +958,10 @@ mod tests {
         let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
         hm.append("forwarded", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -1017,11 +971,10 @@ mod tests {
     fn unknown_param_quoted_with_semicolon_ok() {
         let tx = make_tx_with_forwarded("foo=\"a;b\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1030,11 +983,10 @@ mod tests {
     fn invalid_forwarded_for_missing_closing_bracket() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1043,11 +995,10 @@ mod tests {
     fn invalid_forwarded_for_non_colon_after_bracket() {
         let tx = make_tx_with_forwarded("for=[2001:db8::1]x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1056,11 +1007,10 @@ mod tests {
     fn invalid_forwarded_host_non_colon_after_bracket() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1069,11 +1019,10 @@ mod tests {
     fn invalid_forwarded_empty_header_value() {
         let tx = make_tx_with_forwarded("");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Empty header value is ignored by header parsing; considered valid
         assert!(v.is_none());
@@ -1083,11 +1032,10 @@ mod tests {
     fn invalid_forwarded_quoted_string_extra_chars() {
         let tx = make_tx_with_forwarded("foo=\"bar\"x");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1096,11 +1044,10 @@ mod tests {
     fn invalid_forwarded_empty_quoted_for() {
         let tx = make_tx_with_forwarded("for=\"\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -1111,11 +1058,10 @@ mod tests {
     fn valid_forwarded_quoted_ipv4_with_port() {
         let tx = make_tx_with_forwarded("for=\"192.0.2.1:8080\"");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1124,11 +1070,10 @@ mod tests {
     fn forwarded_extra_semicolon_ignored() {
         let tx = make_tx_with_forwarded("for=192.0.2.1; ;proto=https");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1137,11 +1082,10 @@ mod tests {
     fn valid_forwarded_host_ipv4_with_port() {
         let tx = make_tx_with_forwarded("host=192.0.2.1:80");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1150,11 +1094,10 @@ mod tests {
     fn valid_forwarded_host_bracketed_no_port() {
         let tx = make_tx_with_forwarded("host=[2001:db8::1]");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -1163,11 +1106,10 @@ mod tests {
     fn forwarded_host_empty_port_is_accepted() {
         let tx = make_tx_with_forwarded("host=example.com:");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Empty port after ':' is accepted (treated as absent) by the implementation
         assert!(v.is_none());
@@ -1177,11 +1119,10 @@ mod tests {
     fn invalid_forwarded_host_with_at() {
         let tx = make_tx_with_forwarded("host=user@host");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1198,11 +1139,10 @@ mod tests {
                 let mut hm = crate::test_helpers::make_headers_from_pairs(&[]);
                 hm.append("forwarded", bad);
                 tx.request.headers = hm;
-                let v = rule.check(
+                let v = rule.check_transaction(
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
                     &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                    &crate::rules::RuleConfigEngine::new(),
                 );
                 assert!(v.is_some());
             }
@@ -1218,11 +1158,10 @@ mod tests {
     fn invalid_forwarded_host_empty_brackets() {
         let tx = make_tx_with_forwarded("host=[]");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1231,11 +1170,10 @@ mod tests {
     fn invalid_forwarded_ipv4_port_non_numeric() {
         let tx = make_tx_with_forwarded("for=192.0.2.1:xyz");
         let rule = MessageForwardedHeaderValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -1244,7 +1182,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_forwarded_header_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_from_header_email_syntax.rs
+++ b/src/rules/message_from_header_email_syntax.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageFromHeaderEmailSyntax;
 
 impl Rule for MessageFromHeaderEmailSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_from_header_email_syntax"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageFromHeaderEmailSyntax {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -92,11 +89,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", from);
@@ -122,11 +118,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));

--- a/src/rules/message_header_field_names_token.rs
+++ b/src/rules/message_header_field_names_token.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageHeaderFieldNamesToken;
 
 impl Rule for MessageHeaderFieldNamesToken {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_header_field_names_token"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageHeaderFieldNamesToken {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // token characters per RFC token (tchar) - use shared helper
@@ -97,11 +94,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -135,11 +131,10 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/message_http2_pseudo_headers_validity.rs
+++ b/src/rules/message_http2_pseudo_headers_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageHttp2PseudoHeadersValidity;
 
 impl Rule for MessageHttp2PseudoHeadersValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_http2_pseudo_headers_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageHttp2PseudoHeadersValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate request-related pseudo-header semantics using canonical transaction fields.
@@ -256,11 +253,10 @@ mod tests {
         tx.request.method = method.to_string();
         tx.request.uri = uri.to_string();
         let rule = MessageHttp2PseudoHeadersValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -283,11 +279,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         let rule = MessageHttp2PseudoHeadersValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -311,7 +306,7 @@ mod tests {
             "message_http2_pseudo_headers_validity".into(),
             toml::Value::Table(table),
         );
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 
@@ -320,13 +315,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "1http://example.com/".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid scheme"));
@@ -337,13 +331,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/bad%2G".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));
@@ -354,13 +347,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/foo bar".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("contains whitespace"));
@@ -371,13 +363,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -391,13 +382,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("malformed bracketed IPv6"));
@@ -408,13 +398,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:abc".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("port invalid"));
@@ -425,13 +414,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:70000".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("port out of range"));
@@ -442,13 +430,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("port invalid"));
@@ -459,13 +446,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "user:pass@example.com".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not include userinfo"));
@@ -476,13 +462,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1]:443".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -492,13 +477,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "::1".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must be bracketed"));
@@ -509,13 +493,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "CONNECT".into();
         tx.request.uri = "fe80::1:80".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must be bracketed"));
@@ -526,13 +509,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com/path".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -542,13 +524,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "/ok%20here".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -558,13 +539,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GE€T".into();
         tx.request.uri = "/".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid token"));
@@ -573,13 +553,12 @@ mod tests {
     #[test]
     fn response_status_low_out_of_range_is_violation() {
         let tx = crate::test_helpers::make_test_transaction_with_response(99, &[]);
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("3-digit"));
@@ -590,13 +569,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "https:///path".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -610,13 +588,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "http://user:pass@example.com/path".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not include userinfo"));
@@ -627,13 +604,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "OPTIONS".into();
         tx.request.uri = "*".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -643,13 +619,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = "GET".into();
         tx.request.uri = "*".into();
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Asterisk ('*')"));
@@ -658,13 +633,12 @@ mod tests {
     #[test]
     fn response_status_out_of_range_is_violation() {
         let tx = crate::test_helpers::make_test_transaction_with_response(700, &[]);
-        let v = MessageHttp2PseudoHeadersValidity.check(
+        let v = MessageHttp2PseudoHeadersValidity.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "message_http2_pseudo_headers_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("3-digit"));

--- a/src/rules/message_http3_host_authority_consistency.rs
+++ b/src/rules/message_http3_host_authority_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageHttp3HostAuthorityConsistency;
 
 impl Rule for MessageHttp3HostAuthorityConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_http3_host_authority_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageHttp3HostAuthorityConsistency {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions.
@@ -112,11 +109,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host(uri, Some(host));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -152,11 +148,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host(uri, Some(host));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -175,11 +170,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://example.com/path", None);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -190,11 +184,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("/path", Some("example.com"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -206,11 +199,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://example.com/path", Some(""));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not be empty"));
@@ -221,11 +213,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://example.com/path", Some("  "));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not be empty"));
@@ -240,11 +231,10 @@ mod tests {
             make_h3_transaction_with_uri_and_host("https://example.com/path", Some("other.com"));
         tx.request.version = "HTTP/1.1".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -256,11 +246,10 @@ mod tests {
             make_h3_transaction_with_uri_and_host("https://example.com/path", Some("other.com"));
         tx.request.version = "HTTP/2.0".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -278,11 +267,10 @@ mod tests {
         tx.request.headers = hyper::HeaderMap::new();
         tx.request.headers.insert("host", bad);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF-8"));
@@ -299,11 +287,10 @@ mod tests {
             Some("  example.com  "),
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -315,11 +302,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("example.com:443", Some("example.com:443"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -330,11 +316,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("example.com:443", Some("other.com:443"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("inconsistent"));
@@ -345,11 +330,10 @@ mod tests {
         let rule = MessageHttp3HostAuthorityConsistency;
         let tx = make_h3_transaction_with_uri_and_host("https://[::1]/path", Some("[::1]"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -361,11 +345,10 @@ mod tests {
         let tx =
             make_h3_transaction_with_uri_and_host("https://example.com./path", Some("example.com"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("inconsistent"));
@@ -378,11 +361,10 @@ mod tests {
         let tx =
             make_h3_transaction_with_uri_and_host("https://example.com?q=1", Some("example.com"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -393,11 +375,10 @@ mod tests {
         let tx =
             make_h3_transaction_with_uri_and_host("https://example.com#frag", Some("example.com"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -414,7 +395,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_http3_host_authority_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_http3_no_connection_header.rs
+++ b/src/rules/message_http3_no_connection_header.rs
@@ -17,8 +17,6 @@ const FORBIDDEN_HEADERS: &[&str] = &[
 pub struct MessageHttp3NoConnectionHeader;
 
 impl Rule for MessageHttp3NoConnectionHeader {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_http3_no_connection_header"
     }
@@ -27,12 +25,11 @@ impl Rule for MessageHttp3NoConnectionHeader {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions.
@@ -160,11 +157,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[(header_name, header_value)]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(header_name));
@@ -177,11 +173,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("accept", "text/html")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -201,11 +196,10 @@ mod tests {
         let rule = MessageHttp3NoConnectionHeader;
         let tx = make_h3_transaction_with_response(200, &[(header_name, header_value)]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(header_name));
@@ -216,11 +210,10 @@ mod tests {
         let rule = MessageHttp3NoConnectionHeader;
         let tx = make_h3_transaction_with_response(200, &[("content-type", "text/html")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -233,11 +226,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "trailers")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -248,11 +240,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "gzip")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("TE header"));
@@ -264,11 +255,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "Trailers")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -280,11 +270,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers, gzip")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("TE header"));
@@ -300,11 +289,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("connection", "keep-alive")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -317,11 +305,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("connection", "keep-alive")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -334,11 +321,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("accept", "*/*")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -351,11 +337,10 @@ mod tests {
         let rule = MessageHttp3NoConnectionHeader;
         let tx = make_h3_transaction_with_response(200, &[("te", "trailers")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("request-only"));
@@ -378,11 +363,10 @@ mod tests {
         tx.request.version = "HTTP/3".into();
         // Response version stays HTTP/1.1 (upstream)
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -397,11 +381,10 @@ mod tests {
             .expect("should construct non-utf8 header");
         tx.request.headers.insert("te", bad);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF-8"));
@@ -415,11 +398,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Empty TE is not a violation (parse_list_header filters empty tokens)
         assert!(v.is_none());
@@ -434,11 +416,10 @@ mod tests {
             ("te", "gzip"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         // Forbidden header check runs first
@@ -457,7 +438,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_http3_no_connection_header");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_http3_pseudo_headers_validity.rs
+++ b/src/rules/message_http3_pseudo_headers_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageHttp3PseudoHeadersValidity;
 
 impl Rule for MessageHttp3PseudoHeadersValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_http3_pseudo_headers_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions.
@@ -175,11 +172,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = "".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":method"));
@@ -191,11 +187,10 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = "   ".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":method"));
@@ -210,11 +205,10 @@ mod tests {
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com/path".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -228,11 +222,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -246,11 +239,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":path"));
@@ -265,11 +257,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -284,11 +275,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Asterisk"));
@@ -308,11 +298,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Asterisk"));
@@ -328,11 +317,10 @@ mod tests {
         tx.request.uri = "/resource".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -346,11 +334,10 @@ mod tests {
         tx.request.uri = "https://example.com/path".into();
         tx.request.headers = hyper::HeaderMap::new(); // no Host needed
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -363,11 +350,10 @@ mod tests {
         tx.request.uri = "*".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -382,11 +368,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -398,11 +383,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -415,11 +399,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "   ".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -435,11 +418,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -453,11 +435,10 @@ mod tests {
         tx.request.uri = "/ws".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("extended CONNECT"));
@@ -472,11 +453,10 @@ mod tests {
         tx.request.uri = "*".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));
@@ -492,11 +472,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com:443")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -510,11 +489,10 @@ mod tests {
         tx.request.uri = "example.com:443".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -526,11 +504,10 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(200, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -540,11 +517,10 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(0, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -555,11 +531,10 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(600, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -576,11 +551,10 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(status, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -598,11 +572,10 @@ mod tests {
         tx.request.version = version.into();
         tx.request.method = "".into(); // would be a violation for HTTP/3
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -617,11 +590,10 @@ mod tests {
         tx.request.version = "HTTP/3".into();
         // Response version stays HTTP/1.1 — status 0 should not be flagged.
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -636,11 +608,10 @@ mod tests {
         tx.request.uri = "https://example.com/".into();
         tx.response = None;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -657,7 +628,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_http3_pseudo_headers_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -671,11 +642,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1]:443".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -690,11 +660,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "https://example.com/ws".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -710,11 +679,10 @@ mod tests {
             ("content-type", "application/json"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -726,11 +694,10 @@ mod tests {
         tx.request.method = "HEAD".into();
         tx.request.uri = "https://example.com/resource".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -740,11 +707,10 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(99, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -760,11 +726,10 @@ mod tests {
         tx.request.uri = "/resource".into();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("host", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -776,11 +741,10 @@ mod tests {
         tx.request.method = "DELETE".into();
         tx.request.uri = "https://example.com/resource/42".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -796,11 +760,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":path"));
@@ -815,11 +778,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -832,11 +794,10 @@ mod tests {
         tx.request.method = "connect".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -848,11 +809,10 @@ mod tests {
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com:8443/path".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -863,11 +823,10 @@ mod tests {
         let rule = MessageHttp3PseudoHeadersValidity;
         let tx = make_h3_transaction_with_response(100, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -886,11 +845,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -903,11 +861,10 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":status"));
@@ -922,11 +879,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":path"));
@@ -943,11 +899,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -963,11 +918,10 @@ mod tests {
             ("content-type", "application/json"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -980,11 +934,10 @@ mod tests {
         tx.request.uri = "/resource/1".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains(":authority"));

--- a/src/rules/message_http_version_syntax_valid.rs
+++ b/src/rules/message_http_version_syntax_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageHttpVersionSyntaxValid;
 
 impl Rule for MessageHttpVersionSyntaxValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_http_version_syntax_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageHttpVersionSyntaxValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request version token (now required)
@@ -100,11 +97,10 @@ mod tests {
         });
 
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -114,11 +110,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "http/1.1".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Request HTTP-version invalid"));
@@ -129,21 +124,19 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/11.0".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.version = "HTTP/1.10".into();
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
     }
@@ -160,11 +153,10 @@ mod tests {
             trailers: None,
         });
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -174,11 +166,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -188,11 +179,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1.x".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -202,11 +192,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1.1.1".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -224,11 +213,10 @@ mod tests {
             trailers: None,
         });
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Response HTTP-version invalid"));
@@ -239,11 +227,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/1.".into();
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -253,11 +240,10 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction();
         let rule = MessageHttpVersionSyntaxValid;
         // make_test_transaction defaults version to "HTTP/1.1"
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -274,11 +260,10 @@ mod tests {
             trailers: None,
         });
         let rule = MessageHttpVersionSyntaxValid;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_if_match_etag_syntax.rs
+++ b/src/rules/message_if_match_etag_syntax.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct MessageIfMatchEtagSyntax;
 
 impl Rule for MessageIfMatchEtagSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_if_match_etag_syntax"
     }
@@ -20,12 +18,11 @@ impl Rule for MessageIfMatchEtagSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
@@ -95,11 +92,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -125,11 +121,10 @@ mod tests {
         hm.insert("if-match", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -139,7 +134,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_if_match_etag_syntax");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -149,11 +144,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -166,11 +160,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", ",")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -187,11 +180,10 @@ mod tests {
         hm.append("if-match", HeaderValue::from_static("\"b\""));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -209,11 +201,10 @@ mod tests {
         hm.append("if-match", HeaderValue::from_static("b"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_if_modified_since_date_format.rs
+++ b/src/rules/message_if_modified_since_date_format.rs
@@ -9,8 +9,6 @@ use crate::rules::Rule;
 pub struct MessageIfModifiedSinceDateFormat;
 
 impl Rule for MessageIfModifiedSinceDateFormat {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_if_modified_since_date_format"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageIfModifiedSinceDateFormat {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
@@ -83,11 +80,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", h)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -109,11 +105,10 @@ mod tests {
         hm.insert("if-modified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -126,11 +121,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -152,11 +146,10 @@ mod tests {
         hm.append("if-modified-since", HeaderValue::from_static("not-a-date"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -180,11 +173,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Using multiple valid headers is acceptable (validate each); no violation expected if all valid
         assert!(v.is_none());
@@ -195,7 +187,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_if_modified_since_date_format");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_if_none_match_etag_syntax.rs
+++ b/src/rules/message_if_none_match_etag_syntax.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct MessageIfNoneMatchEtagSyntax;
 
 impl Rule for MessageIfNoneMatchEtagSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_if_none_match_etag_syntax"
     }
@@ -20,12 +18,11 @@ impl Rule for MessageIfNoneMatchEtagSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
@@ -96,11 +93,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -126,11 +122,10 @@ mod tests {
         hm.insert("if-none-match", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -140,7 +135,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_if_none_match_etag_syntax");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -150,11 +145,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -168,11 +162,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", ",")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -189,11 +182,10 @@ mod tests {
         hm.append("if-none-match", HeaderValue::from_static("\"b\""));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -211,11 +203,10 @@ mod tests {
         hm.append("if-none-match", HeaderValue::from_static("b"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_if_unmodified_since_date_format.rs
+++ b/src/rules/message_if_unmodified_since_date_format.rs
@@ -9,8 +9,6 @@ use crate::rules::Rule;
 pub struct MessageIfUnmodifiedSinceDateFormat;
 
 impl Rule for MessageIfUnmodifiedSinceDateFormat {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_if_unmodified_since_date_format"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageIfUnmodifiedSinceDateFormat {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to requests only
@@ -84,11 +81,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-unmodified-since", h)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -110,11 +106,10 @@ mod tests {
         hm.insert("if-unmodified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -127,11 +122,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-unmodified-since", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -156,11 +150,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -184,11 +177,10 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Using multiple valid headers is acceptable (validate each); no violation expected if all valid
         assert!(v.is_none());
@@ -199,7 +191,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_if_unmodified_since_date_format");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_language_tag_format_valid.rs
+++ b/src/rules/message_language_tag_format_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageLanguageTagFormatValid;
 
 impl Rule for MessageLanguageTagFormatValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_language_tag_format_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageLanguageTagFormatValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate language-tag tokens according to helpers::language
@@ -125,11 +122,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -157,11 +153,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-language", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -183,7 +178,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_language_tag_format_valid",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -205,11 +200,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -230,11 +224,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-language", "en, fr")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/message_link_header_validity.rs
+++ b/src/rules/message_link_header_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageLinkHeaderValidity;
 
 impl Rule for MessageLinkHeaderValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_link_header_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageLinkHeaderValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers (Link is meaningful on responses / 103 Early Hints)
@@ -248,11 +245,10 @@ mod tests {
             crate::test_helpers::make_test_transaction()
         };
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -275,21 +271,19 @@ mod tests {
 
         // 103 with preload but missing as
         let tx = make_resp_with_header(103, ("Link", "<https://example.com/>; rel=preload"));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
         // 103 with no rel -> violation
         let tx2 = make_resp_with_header(103, ("Link", "<https://example.com/>; title=\"x\""));
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
     }
@@ -308,77 +302,70 @@ mod tests {
         hm.append("link", bad);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
 
         // Trailing comma -> empty member
         let tx2 = make_resp_with_header(200, ("Link", "<https://example/>; rel=next,"));
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2.unwrap().message.contains("empty member"));
 
         // Missing closing '>'
         let tx3 = make_resp_with_header(200, ("Link", "<https://example.com/; rel=next"));
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         assert!(v3.unwrap().message.contains("missing closing"));
 
         // Missing value for param
         let tx4 = make_resp_with_header(200, ("Link", "<https://example/>; rel"));
-        let v4 = rule.check(
+        let v4 = rule.check_transaction(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
         assert!(v4.unwrap().message.contains("missing '=' or value"));
 
         // Invalid quoted-string
         let tx5 = make_resp_with_header(200, ("Link", "<https://example/>; title=\"unterminated"));
-        let v5 = rule.check(
+        let v5 = rule.check_transaction(
             &tx5,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v5.is_some());
         assert!(v5.unwrap().message.contains("quoted-string"));
 
         // Invalid token char in param value
         let tx6 = make_resp_with_header(200, ("Link", "<https://example/>; as=bad@val"));
-        let v6 = rule.check(
+        let v6 = rule.check_transaction(
             &tx6,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v6.is_some());
         assert!(v6.unwrap().message.contains("invalid character"));
 
         // rel contains invalid char
         let tx7 = make_resp_with_header(200, ("Link", "<https://example/>; rel=bad@rel"));
-        let v7 = rule.check(
+        let v7 = rule.check_transaction(
             &tx7,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v7.is_some());
         let msg7 = v7.unwrap().message;
@@ -398,7 +385,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_link_header_validity");
-        let _ = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -411,21 +398,19 @@ mod tests {
 
         // rel with multiple types (space-separated) should be OK
         let tx = make_resp_with_header(200, ("Link", "<https://example/>; rel=next prev"));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
         // quoted-string title with escaped quote is accepted
         let tx2 = make_resp_with_header(200, ("Link", "<https://example/>; title=\"a\\\"b\""));
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
 
@@ -434,21 +419,19 @@ mod tests {
             200,
             ("Link", "<https://example/>; rel=preload; as=\"script\""),
         );
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_none());
 
         // trailing semicolon ignored
         let tx4 = make_resp_with_header(200, ("Link", "<https://example/>; rel=next;"));
-        let v4 = rule.check(
+        let v4 = rule.check_transaction(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_none());
 
@@ -464,11 +447,10 @@ mod tests {
                 .parse::<HeaderValue>()
                 .unwrap(),
         );
-        let vm = rule.check(
+        let vm = rule.check_transaction(
             &txm,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(vm.is_some());
     }

--- a/src/rules/message_max_forwards_numeric.rs
+++ b/src/rules/message_max_forwards_numeric.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageMaxForwardsNumeric;
 
 impl Rule for MessageMaxForwardsNumeric {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_max_forwards_numeric"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageMaxForwardsNumeric {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
@@ -79,11 +76,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction;
         let mut tx = make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(hdrs);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -114,11 +110,10 @@ mod tests {
         hm.insert("max-forwards", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_media_type_suffix_validity.rs
+++ b/src/rules/message_media_type_suffix_validity.rs
@@ -59,8 +59,6 @@ fn parse_allowed_config(
 }
 
 impl Rule for MessageMediaTypeSuffixValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_media_type_suffix_validity"
     }
@@ -69,20 +67,16 @@ impl Rule for MessageMediaTypeSuffixValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         let check_media = |hdr_name: &str, val: &str| -> Option<Violation> {
@@ -193,11 +187,10 @@ mod tests {
             &[("content-type", "application/ld+json")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -209,11 +202,10 @@ mod tests {
             &[("content-type", "application/vnd.example+unknown")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("+unknown"));
@@ -227,11 +219,10 @@ mod tests {
             "application/vnd.foo+xml; q=0.8, application/bar+nope",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("+nope"));
@@ -244,11 +235,10 @@ mod tests {
             &[("content-type", "application/foo+")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty structured suffix"));
@@ -261,11 +251,10 @@ mod tests {
             &[("content-type", "application/ld+JSON")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -277,11 +266,10 @@ mod tests {
             &[("content-type", "text")],
         );
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -294,11 +282,10 @@ mod tests {
             "application/vnd.foo+unknown",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("+unknown"));
@@ -312,11 +299,10 @@ mod tests {
             "application/example+JSON",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -329,11 +315,10 @@ mod tests {
             "application/vnd.foo+JSON; q=0.8, text/html",
         )]);
         let rule = MessageMediaTypeSuffixValidity;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -421,7 +406,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageMediaTypeSuffixValidity;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_media_type_suffix_validity",
@@ -440,10 +425,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<MessageMediaTypeSuffixConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_allowed_config(&full_cfg, rule.id())?;
         assert!(arc.allowed.contains(&"json".to_string()));
         Ok(())
     }
@@ -460,7 +442,7 @@ mod tests {
                 toml::Value::Array(vec![toml::Value::String("json".into())]),
             );
         }
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_multipart_boundary_syntax.rs
+++ b/src/rules/message_multipart_boundary_syntax.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageMultipartBoundarySyntax;
 
 impl Rule for MessageMultipartBoundarySyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_multipart_boundary_syntax"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageMultipartBoundarySyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request Content-Type
@@ -254,11 +251,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", h)]);
         }
 
-        let v = MessageMultipartBoundarySyntax.check(
+        let v = MessageMultipartBoundarySyntax.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}", header);
@@ -280,11 +276,10 @@ mod tests {
             tx2.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", h)]);
         }
-        let v2 = MessageMultipartBoundarySyntax.check(
+        let v2 = MessageMultipartBoundarySyntax.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg2,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v2.is_some(), "expected violation for response {:?}", header);
@@ -307,11 +302,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "not-a-media-type")]);
-        let v = MessageMultipartBoundarySyntax.check(
+        let v = MessageMultipartBoundarySyntax.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -327,11 +321,10 @@ mod tests {
             "content-type",
             "multipart/mixed; boundary=\"unfinished",
         )]);
-        let v = MessageMultipartBoundarySyntax.check(
+        let v = MessageMultipartBoundarySyntax.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -348,11 +341,10 @@ mod tests {
             "content-type",
             "text/plain; boundary=abc",
         )]);
-        let v = MessageMultipartBoundarySyntax.check(
+        let v = MessageMultipartBoundarySyntax.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -368,11 +360,10 @@ mod tests {
             "content-type",
             "multipart/mixed; boundary=\"bad$\"",
         )]);
-        let v = MessageMultipartBoundarySyntax.check(
+        let v = MessageMultipartBoundarySyntax.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_multipart_content_type_and_body_consistency.rs
+++ b/src/rules/message_multipart_content_type_and_body_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageMultipartContentTypeAndBodyConsistency;
 
 impl Rule for MessageMultipartContentTypeAndBodyConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_multipart_content_type_and_body_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageMultipartContentTypeAndBodyConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request body when Content-Type is multipart
@@ -123,11 +120,10 @@ mod tests {
             b"--abc\r\nContent-Type: text/plain\r\n\r\nhi\r\n--abc--\r\n",
         ));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -140,11 +136,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("--abc"));
@@ -158,11 +153,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--abc\r\nPart\r\n--abc\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing terminating boundary"));
@@ -176,11 +170,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -192,11 +185,10 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=abc")],
         );
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -210,11 +202,10 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"--xyz\r\nfoo\r\n--xyz--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -227,11 +218,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--a b\r\nx\r\n--a b--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -244,11 +234,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -262,11 +251,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -276,11 +264,10 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=\"unterminated")],
         );
         tx2.response_body = Some(Bytes::from_static(b"no boundaries"));
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -294,11 +281,10 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -315,11 +301,10 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"--xyz\r\nPart\r\n--xyz\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("terminating boundary"));
@@ -334,11 +319,10 @@ mod tests {
         // body contains only the final boundary marker
         tx.response_body = Some(Bytes::from_static(b"--abc--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -352,11 +336,10 @@ mod tests {
         // unescaped boundary is: a"b
         tx.response_body = Some(Bytes::from_static(b"--a\"b\r\nx\r\n--a\"b--\r\n"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -374,11 +357,10 @@ mod tests {
             b"--gc0pJq0M:08jU534c0p\r\npart\r\n--gc0pJq0M:08jU534c0p--\r\n",
         ));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -391,11 +373,10 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"\x00\x01--bin\x02--bin--\x03"));
         let rule = MessageMultipartContentTypeAndBodyConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -415,7 +396,7 @@ mod tests {
             &mut cfg,
             "message_multipart_content_type_and_body_consistency",
         );
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_origin_isolated_header_validity.rs
+++ b/src/rules/message_origin_isolated_header_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageOriginIsolatedHeaderValidity;
 
 impl Rule for MessageOriginIsolatedHeaderValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_origin_isolated_header_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageOriginIsolatedHeaderValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = if let Some(r) = &tx.response {
@@ -104,11 +101,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_origin_isolated_header_validity",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -137,11 +133,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Origin-Isolation"));
@@ -162,11 +157,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -187,11 +181,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         let msg = v.unwrap().message;
         assert!(msg.contains("non-ASCII") || msg.contains("control"));
@@ -205,11 +198,10 @@ mod tests {
             200,
             &[("origin-isolation", "?0")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("?0"));
@@ -222,11 +214,10 @@ mod tests {
             200,
             &[("origin-isolation", "?1, ?1")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("single value"));
@@ -236,11 +227,10 @@ mod tests {
     fn no_response_returns_none() {
         let rule = MessageOriginIsolatedHeaderValidity;
         let tx = crate::test_helpers::make_test_transaction(); // no response set
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -256,7 +246,7 @@ mod tests {
         let rule = MessageOriginIsolatedHeaderValidity;
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_origin_isolated_header_validity");
-        let _engine = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_permissions_policy_directives_valid.rs
+++ b/src/rules/message_permissions_policy_directives_valid.rs
@@ -9,8 +9,6 @@ use crate::rules::Rule;
 pub struct MessagePermissionsPolicyDirectivesValid;
 
 impl Rule for MessagePermissionsPolicyDirectivesValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_permissions_policy_directives_valid"
     }
@@ -19,12 +17,11 @@ impl Rule for MessagePermissionsPolicyDirectivesValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only inspect responses (server header)
@@ -264,11 +261,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}: got none", hdr);
@@ -298,11 +294,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -319,7 +314,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_permissions_policy_directives_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -344,11 +339,10 @@ mod tests {
             ",geolocation=(self)",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty directive"));
@@ -365,11 +359,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "geolocation=")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("has empty value"));
@@ -388,11 +381,10 @@ mod tests {
             "geolocation=1",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("numeric value"));
@@ -411,11 +403,10 @@ mod tests {
             "geolocation=(self",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("unterminated inner-list"));
@@ -434,11 +425,10 @@ mod tests {
             "geolocation=(self  )",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty inner-list"));
@@ -457,11 +447,10 @@ mod tests {
             "geolocation=\"abc",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid quoted-string"));
@@ -480,11 +469,10 @@ mod tests {
             "geolocation=1abc",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid token value"));
@@ -503,11 +491,10 @@ mod tests {
             "geolocation=(self);",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty parameter"));
@@ -526,11 +513,10 @@ mod tests {
             "geolocation=(self);123",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid bare parameter"));
@@ -549,11 +535,10 @@ mod tests {
             "geolocation=(self);foo=!",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid parameter 'foo'"));
@@ -572,11 +557,10 @@ mod tests {
             "geolocation=(self);report-to=\"endpoint\"",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -595,11 +579,10 @@ mod tests {
             "geolocation;meta=1=(self)",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -617,11 +600,10 @@ mod tests {
             "geolocation=1.2",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("numeric value"));
@@ -640,11 +622,10 @@ mod tests {
             "geolocation=:YWJj:",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("byte-sequence"));
@@ -663,11 +644,10 @@ mod tests {
             "geolocation=(self);foo=1",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -685,11 +665,10 @@ mod tests {
             "geolocation=(self);foo",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -707,11 +686,10 @@ mod tests {
             "geolocation=(self);foo=\"bar\"",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -729,11 +707,10 @@ mod tests {
             "geolocation=feat:sub/1.2-_",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -751,11 +728,10 @@ mod tests {
             "geolocation=(self);*=1",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -773,11 +749,10 @@ mod tests {
             "geolocation=(self);Foo=1",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid parameter 'Foo'"));
@@ -795,11 +770,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "1geo=(self)")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -815,11 +789,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -841,11 +814,10 @@ mod tests {
             "geolocation=(self);a.b_c*=1",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_pragma_token_valid.rs
+++ b/src/rules/message_pragma_token_valid.rs
@@ -11,8 +11,6 @@ use crate::rules::Rule;
 pub struct MessagePragmaTokenValid;
 
 impl Rule for MessagePragmaTokenValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_pragma_token_valid"
     }
@@ -21,12 +19,11 @@ impl Rule for MessagePragmaTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate request headers
@@ -164,11 +161,10 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessagePragmaTokenValid;
         let tx = make_req(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -195,11 +191,10 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessagePragmaTokenValid;
         let tx = make_resp(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -223,11 +218,10 @@ mod tests {
     fn trailing_comma_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("no-cache,");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -236,11 +230,10 @@ mod tests {
     fn directive_name_invalid_char_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("n@me=1");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -249,11 +242,10 @@ mod tests {
     fn token_value_invalid_char_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=ba@d");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -262,11 +254,10 @@ mod tests {
     fn quoted_value_unterminated_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=\"unterminated");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -275,11 +266,10 @@ mod tests {
     fn empty_directive_value_is_accepted() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -288,11 +278,10 @@ mod tests {
     fn list_with_invalid_middle_member_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("no-cache, bad@name=1, max-age=0");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -306,11 +295,10 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("pragma", bad);
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -320,11 +308,10 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() {
         let rule = MessagePragmaTokenValid;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -344,11 +331,10 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -358,11 +344,10 @@ mod tests {
     fn empty_directive_value_in_response_is_accepted() {
         let rule = MessagePragmaTokenValid;
         let tx = make_resp("foo=");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -374,11 +359,10 @@ mod tests {
             ("pragma", "no-cache"),
             ("pragma", "foo=bar"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -394,7 +378,7 @@ mod tests {
             "message_pragma_token_valid".into(),
             toml::Value::Table(table),
         );
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_prefer_header_valid.rs
+++ b/src/rules/message_prefer_header_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessagePreferHeaderValid;
 
 impl Rule for MessagePreferHeaderValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_prefer_header_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessagePreferHeaderValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to requests only
@@ -214,11 +211,10 @@ mod tests {
     fn check_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessagePreferHeaderValid;
         let tx = make_req(value);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -242,11 +238,10 @@ mod tests {
             ("prefer", "respond-async, wait=100"),
             ("prefer", "handling=lenient"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -263,11 +258,10 @@ mod tests {
         hm.insert("prefer", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -278,11 +272,10 @@ mod tests {
         // A member that starts with a semicolon or is empty should trigger an empty preference token violation
         let rule = MessagePreferHeaderValid;
         let tx = make_req(";foo");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -294,22 +287,20 @@ mod tests {
     fn invalid_token_char_messages_include_char() -> anyhow::Result<()> {
         let rule = MessagePreferHeaderValid;
         let tx = make_req("f@o=1");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
         assert!(msg.contains("'@'"));
 
         let tx2 = make_req("return=minimal; foo=bad@");
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         let msg2 = v2.unwrap().message;
@@ -329,8 +320,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_preference_applied_header_valid.rs
+++ b/src/rules/message_preference_applied_header_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessagePreferenceAppliedHeaderValid;
 
 impl Rule for MessagePreferenceAppliedHeaderValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_preference_applied_header_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only meaningful when a response is present
@@ -224,11 +221,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[(parts2[0].trim(), parts2[1].trim())]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -258,11 +254,10 @@ mod tests {
         let bad = HeaderValue::from_bytes(&[0xff]).expect("should construct non-utf8 header");
         hm.insert("preference-applied", bad);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -273,11 +268,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -290,11 +284,10 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo=\"bar\"")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=\"bar\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -307,11 +300,10 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "f@o")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("'@'"));
@@ -324,11 +316,10 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=bad@")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -343,11 +334,10 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo=\"bar\"")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=\"bar")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("quoted-string error"));
@@ -361,11 +351,10 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("prefer", "foo")]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("preference-applied", "foo=bar")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/message_priority_header_syntax.rs
+++ b/src/rules/message_priority_header_syntax.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessagePriorityHeaderSyntax;
 
 impl Rule for MessagePriorityHeaderSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_priority_header_syntax"
     }
@@ -18,12 +16,11 @@ impl Rule for MessagePriorityHeaderSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request
@@ -248,11 +245,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_priority_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}', got none", value);
@@ -281,11 +277,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_priority_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -302,11 +297,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_priority_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -323,54 +317,49 @@ mod tests {
         // valid parameter on urgency
         let tx1 = make_tx_with_req("u=3;foo=bar");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // empty parameter name is ignored (tolerant) per structured-field-like handling
         let tx2 = make_tx_with_req("u=3;;i");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // empty member between commas
         let tx3 = make_tx_with_req("u=1, ,i");
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         assert!(v3.unwrap().message.contains("empty member"));
 
         // param key uppercase -> violation
         let tx4 = make_tx_with_req("u=1;X=1");
-        let v4 = rule.check(
+        let v4 = rule.check_transaction(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
         assert!(v4.unwrap().message.contains("invalid parameter key"));
 
         // param with empty value
         let tx5 = make_tx_with_req("u=1;foo=");
-        let v5 = rule.check(
+        let v5 = rule.check_transaction(
             &tx5,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v5.is_some());
         if let Some(v) = v5 {
@@ -385,33 +374,30 @@ mod tests {
         // unknown key with token-like value is accepted
         let tx6 = make_tx_with_req("x=token/value");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx6,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // i=?0 accepted
         let tx7 = make_tx_with_req("i=?0");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx7,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
 
         // explicit boolean on unknown key accepted
         let tx8 = make_tx_with_req("y=?1");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx8,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -425,33 +411,30 @@ mod tests {
 
         // unknown key with invalid boolean -> violation
         let tx2 = make_tx_with_req("x=?2");
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2.unwrap().message.contains("invalid boolean value"));
 
         // invalid member key (starts with digit)
         let tx3 = make_tx_with_req("1=3");
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         assert!(v3.unwrap().message.contains("invalid member key"));
 
         // invalid numeric with leading plus -> violation, reported as "invalid value"
         let tx4 = make_tx_with_req("x=+1");
-        let v4 = rule.check(
+        let v4 = rule.check_transaction(
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
         let msg = v4.unwrap().message;
@@ -460,11 +443,10 @@ mod tests {
         // star key accepted
         let tx5 = make_tx_with_req("*=5");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx5,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -481,11 +463,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_priority_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -525,11 +506,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_priority_header_syntax",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -549,7 +529,7 @@ mod tests {
         );
 
         // should succeed
-        let _boxed = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_problem_details_structure.rs
+++ b/src/rules/message_problem_details_structure.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageProblemDetailsStructure;
 
 impl Rule for MessageProblemDetailsStructure {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_problem_details_structure"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageProblemDetailsStructure {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -151,11 +148,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for hdr={:?}", hdr);
@@ -185,11 +181,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Problem Details response"));
@@ -210,11 +205,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -234,11 +228,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -259,11 +252,10 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b""));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -284,11 +276,10 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b"{}"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -309,11 +300,10 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b"{\"type\":\"x\"}"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -334,11 +324,10 @@ mod tests {
         });
         tx.response_body = Some(bytes::Bytes::from_static(b"not json"));
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }

--- a/src/rules/message_range_and_content_range_consistency.rs
+++ b/src/rules/message_range_and_content_range_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageRangeAndContentRangeConsistency;
 
 impl Rule for MessageRangeAndContentRangeConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_range_and_content_range_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageRangeAndContentRangeConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -158,11 +155,10 @@ mod tests {
             .insert("range", "bytes=0-499".parse().unwrap());
 
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -174,11 +170,10 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing Content-Range"));
@@ -194,11 +189,10 @@ mod tests {
             .headers
             .insert("range", "bytes=5-3".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -210,11 +204,10 @@ mod tests {
             &[("content-range", "bytes 0-1/10")],
         );
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -236,11 +229,10 @@ mod tests {
             .headers
             .insert("range", "bytes=0-499".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -253,11 +245,10 @@ mod tests {
             &[("content-range", "bytes */1234")],
         );
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx_ok,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -265,20 +256,18 @@ mod tests {
             416,
             &[("content-range", "bytes 0-0/1234")],
         );
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx_bad,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
         let tx_missing = crate::test_helpers::make_test_transaction_with_response(416, &[]);
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx_missing,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
     }
@@ -293,11 +282,10 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must not use '*'"));
@@ -313,11 +301,10 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = MessageRangeAndContentRangeConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -333,7 +320,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_range_and_content_range_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_referer_uri_valid.rs
+++ b/src/rules/message_referer_uri_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageRefererUriValid;
 
 impl Rule for MessageRefererUriValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_referer_uri_valid"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageRefererUriValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -105,11 +102,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", referer);
@@ -135,11 +131,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -157,11 +152,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid scheme"));
@@ -179,11 +173,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid character"));
@@ -201,11 +194,10 @@ mod tests {
             "message_referer_uri_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));

--- a/src/rules/message_refresh_header_syntax_valid.rs
+++ b/src/rules/message_refresh_header_syntax_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageRefreshHeaderSyntaxValid;
 
 impl Rule for MessageRefreshHeaderSyntaxValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_refresh_header_syntax_valid"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -155,11 +152,10 @@ mod tests {
     fn cases(#[case] hdrs: &[(&str, &str)], #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = MessageRefreshHeaderSyntaxValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, hdrs);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}", hdrs);
@@ -188,11 +184,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -208,11 +203,10 @@ mod tests {
             &[("refresh", "5"), ("refresh", "10; url=/x")],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -226,11 +220,10 @@ mod tests {
             &[("refresh", "5"), ("refresh", "bad")],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -241,11 +234,10 @@ mod tests {
         let rule = MessageRefreshHeaderSyntaxValid;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("refresh", "   ")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -259,11 +251,10 @@ mod tests {
         let rule = MessageRefreshHeaderSyntaxValid;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("refresh", "5;")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -277,11 +268,10 @@ mod tests {
             200,
             &[("refresh", "5; url=/a,b")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -295,11 +285,10 @@ mod tests {
             200,
             &[("refresh", "5; url=/in valid")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -310,11 +299,10 @@ mod tests {
             200,
             &[("refresh", "5; url=/x%G1")],
         );
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         let msg2 = v2.unwrap().message;
@@ -325,11 +313,10 @@ mod tests {
             200,
             &[("refresh", "5; url=1http://example/")],
         );
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
         let msg3 = v3.unwrap().message;
@@ -356,7 +343,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_request_body_length_accuracy.rs
+++ b/src/rules/message_request_body_length_accuracy.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageRequestBodyLengthAccuracy;
 
 impl Rule for MessageRequestBodyLengthAccuracy {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_request_body_length_accuracy"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageRequestBodyLengthAccuracy {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -128,11 +125,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -150,11 +146,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -173,11 +168,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -196,11 +190,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -218,11 +211,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -245,11 +237,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -275,11 +266,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -300,11 +290,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -325,11 +314,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("too large"));
@@ -352,11 +340,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -374,11 +361,10 @@ mod tests {
         };
 
         let rule = MessageRequestBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -387,7 +373,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_request_body_length_accuracy");
-        let _ = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_response_body_length_accuracy.rs
+++ b/src/rules/message_response_body_length_accuracy.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageResponseBodyLengthAccuracy;
 
 impl Rule for MessageResponseBodyLengthAccuracy {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_response_body_length_accuracy"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageResponseBodyLengthAccuracy {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -130,11 +127,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -151,11 +147,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -173,11 +168,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -195,11 +189,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -216,11 +209,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid Content-Length"));
@@ -242,11 +234,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -271,11 +262,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -295,11 +285,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -316,11 +305,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -337,11 +325,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -364,11 +351,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "overflowing Content-Length should be reported");
         let msg = v.unwrap().message;
@@ -391,11 +377,10 @@ mod tests {
         });
 
         let rule = MessageResponseBodyLengthAccuracy;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -407,7 +392,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_response_body_length_accuracy");
-        let _ = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_retry_after_date_or_delay.rs
+++ b/src/rules/message_retry_after_date_or_delay.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageRetryAfterDateOrDelay;
 
 impl Rule for MessageRetryAfterDateOrDelay {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_retry_after_date_or_delay"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageRetryAfterDateOrDelay {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
@@ -88,11 +85,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = MessageRetryAfterDateOrDelay;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -128,11 +124,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -142,11 +137,10 @@ mod tests {
     fn no_response_no_violation() -> anyhow::Result<()> {
         let rule = MessageRetryAfterDateOrDelay;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -165,11 +159,10 @@ mod tests {
             503,
             &[("retry-after", "bad")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -196,11 +189,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -215,11 +207,10 @@ mod tests {
             503,
             &[("retry-after", "120, 240")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_sec_fetch_dest_value_valid.rs
+++ b/src/rules/message_sec_fetch_dest_value_valid.rs
@@ -14,8 +14,6 @@ use crate::rules::Rule;
 pub struct MessageSecFetchDestValueValid;
 
 impl Rule for MessageSecFetchDestValueValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_sec_fetch_dest_value_valid"
     }
@@ -24,12 +22,11 @@ impl Rule for MessageSecFetchDestValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
@@ -140,11 +137,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -173,11 +169,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_sec_fetch_dest_value_valid",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -194,11 +189,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "b@d")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -216,11 +210,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", " image ")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -240,11 +233,10 @@ mod tests {
             ("sec-fetch-dest", "invalid"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for multiple header fields");
         let msg = v.unwrap().message;
@@ -263,11 +255,10 @@ mod tests {
             ("sec-fetch-dest", "bad2"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -286,11 +277,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "bogus")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for unrecognized token");
         let msg = v.unwrap().message;
@@ -309,11 +299,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "image,script")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for comma-separated value");
         let msg = v.unwrap().message;
@@ -332,7 +321,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_sec_fetch_dest_value_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_sec_fetch_mode_value_valid.rs
+++ b/src/rules/message_sec_fetch_mode_value_valid.rs
@@ -11,8 +11,6 @@ use crate::rules::Rule;
 pub struct MessageSecFetchModeValueValid;
 
 impl Rule for MessageSecFetchModeValueValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_sec_fetch_mode_value_valid"
     }
@@ -21,12 +19,11 @@ impl Rule for MessageSecFetchModeValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
@@ -116,11 +113,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -149,11 +145,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_sec_fetch_mode_value_valid",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -170,11 +165,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", "b@d")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -197,11 +191,10 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("invalid"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-Mode"));
@@ -223,11 +216,10 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-Mode"));
@@ -249,11 +241,10 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("bad2"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-Mode"));
@@ -270,11 +261,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", " same-origin ")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -293,7 +283,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_sec_fetch_mode_value_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_sec_fetch_site_value_valid.rs
+++ b/src/rules/message_sec_fetch_site_value_valid.rs
@@ -11,8 +11,6 @@ use crate::rules::Rule;
 pub struct MessageSecFetchSiteValueValid;
 
 impl Rule for MessageSecFetchSiteValueValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_sec_fetch_site_value_valid"
     }
@@ -21,12 +19,11 @@ impl Rule for MessageSecFetchSiteValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
@@ -115,11 +112,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -149,11 +145,10 @@ mod tests {
             "message_sec_fetch_site_value_valid",
         ]);
         // get_header_str will return None for non-utf8 and this rule treats non-UTF8 as violation
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -170,11 +165,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", "b@d")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -192,11 +186,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", " same-origin ")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -221,11 +214,10 @@ mod tests {
         tx.request.headers = hm;
 
         // Multiple header fields are always a violation (potential header injection)
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation for multiple header fields");
         let msg = v.unwrap().message;
@@ -252,11 +244,10 @@ mod tests {
         hm.append("sec-fetch-site", HeaderValue::from_static("bad2"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -280,11 +271,10 @@ mod tests {
         hm.append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -303,7 +293,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_sec_fetch_site_value_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_sec_fetch_user_value_valid.rs
+++ b/src/rules/message_sec_fetch_user_value_valid.rs
@@ -11,8 +11,6 @@ use crate::rules::Rule;
 pub struct MessageSecFetchUserValueValid;
 
 impl Rule for MessageSecFetchUserValueValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_sec_fetch_user_value_valid"
     }
@@ -21,12 +19,11 @@ impl Rule for MessageSecFetchUserValueValid {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let headers = &tx.request.headers;
@@ -103,11 +100,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -132,11 +128,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unrecognized Sec-Fetch-User"));
@@ -153,11 +148,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?1;param")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unrecognized Sec-Fetch-User"));
@@ -174,11 +168,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?1,?1")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unrecognized Sec-Fetch-User"));
@@ -195,11 +188,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "   ")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("is empty"));
@@ -221,11 +213,10 @@ mod tests {
         hm.append("sec-fetch-user", HeaderValue::from_static("?1"));
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple Sec-Fetch-User"));
@@ -246,11 +237,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_sec_fetch_user_value_valid",
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -267,7 +257,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_sec_fetch_user_value_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_server_header_product_valid.rs
+++ b/src/rules/message_server_header_product_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageServerHeaderProductValid;
 
 impl Rule for MessageServerHeaderProductValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_server_header_product_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageServerHeaderProductValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check_value = |hdr: &str, val: &str| -> Option<Violation> {
@@ -154,11 +151,10 @@ mod tests {
         }
         tx.response = resp.response;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -180,11 +176,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -202,11 +197,10 @@ mod tests {
         hm.insert("server", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -223,11 +217,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "Bad (unbalanced")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -244,11 +237,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "(Apache)")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -265,11 +257,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "(test) nginx/1.18.0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -279,7 +270,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_server_header_product_valid");
-        let _ = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_strict_transport_security_validity.rs
+++ b/src/rules/message_strict_transport_security_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageStrictTransportSecurityValidity;
 
 impl Rule for MessageStrictTransportSecurityValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_strict_transport_security_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageStrictTransportSecurityValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applicable to responses
@@ -241,11 +238,10 @@ mod tests {
             "warn",
         );
         let got = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some();
         assert_eq!(got, expect_violation, "value: {}", val);
@@ -275,11 +271,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -293,11 +288,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -311,11 +305,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -329,11 +322,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -347,11 +339,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -365,11 +356,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -383,11 +373,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -401,11 +390,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -419,11 +407,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -437,11 +424,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -455,11 +441,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -473,11 +458,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -503,11 +487,10 @@ mod tests {
             "warn",
         );
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
     }
@@ -516,7 +499,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_strict_transport_security_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_structured_headers_validity.rs
+++ b/src/rules/message_structured_headers_validity.rs
@@ -62,8 +62,6 @@ fn parse_headers_config(
 }
 
 impl Rule for MessageStructuredHeadersValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_structured_headers_validity"
     }
@@ -72,20 +70,16 @@ impl Rule for MessageStructuredHeadersValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_headers_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_headers_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_headers_config(cfg, self.id()).ok()?;
         for hdr in &config.headers {
@@ -436,18 +430,17 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // header.to_str() will error and we expect a violation reporting invalid utf-8
         assert!(v.is_some());
     }
 
     #[rstest]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageStructuredHeadersValidity;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_structured_headers_validity",
@@ -466,10 +459,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<MessageStructuredHeadersConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_headers_config(&full_cfg, rule.id())?;
         assert!(arc.headers.contains(&"x-struct".to_string()));
         Ok(())
     }
@@ -506,11 +496,10 @@ mod tests {
             200,
             &[("x-struct", "\"unterminated")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -648,7 +637,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate_and_box(&full_cfg).is_err());
+        assert!(rule.validate(&full_cfg).is_err());
         Ok(())
     }
 
@@ -669,7 +658,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate_and_box(&full_cfg).is_err());
+        assert!(rule.validate(&full_cfg).is_err());
         Ok(())
     }
 
@@ -690,7 +679,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate_and_box(&full_cfg).is_err());
+        assert!(rule.validate(&full_cfg).is_err());
         Ok(())
     }
 
@@ -714,7 +703,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate_and_box(&full_cfg).is_err());
+        assert!(rule.validate(&full_cfg).is_err());
         Ok(())
     }
 
@@ -882,11 +871,10 @@ mod tests {
             hyper::header::HeaderValue::from_static("\"unterminated"),
         );
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vi) = v {
@@ -909,11 +897,10 @@ mod tests {
         if let Some(resp) = &mut tx.response {
             resp.headers = rh;
         }
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vi) = v {

--- a/src/rules/message_sunset_and_deprecation_consistency.rs
+++ b/src/rules/message_sunset_and_deprecation_consistency.rs
@@ -9,8 +9,6 @@ use chrono::TimeZone;
 pub struct MessageSunsetAndDeprecationConsistency;
 
 impl Rule for MessageSunsetAndDeprecationConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_sunset_and_deprecation_consistency"
     }
@@ -20,12 +18,11 @@ impl Rule for MessageSunsetAndDeprecationConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only applies to responses
@@ -124,11 +121,10 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(v) = &v {
             eprintln!(
@@ -150,11 +146,10 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -172,11 +167,10 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -191,19 +185,17 @@ mod tests {
             crate::test_helpers::make_test_transaction_with_response(200, &[("deprecation", "@0")]);
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -228,11 +220,10 @@ mod tests {
         });
 
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -251,11 +242,10 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -267,11 +257,10 @@ mod tests {
             &[("sunset", "not-a-date"), ("deprecation", "@0")],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -290,11 +279,10 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -311,11 +299,10 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -331,11 +318,10 @@ mod tests {
             ],
         );
         let rule = MessageSunsetAndDeprecationConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -352,11 +338,10 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -373,11 +358,10 @@ mod tests {
         );
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -400,11 +384,10 @@ mod tests {
 
         let rule = MessageSunsetAndDeprecationConsistency;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -412,7 +395,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_sunset_and_deprecation_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_te_header_constraints.rs
+++ b/src/rules/message_te_header_constraints.rs
@@ -9,8 +9,6 @@ use crate::rules::Rule;
 pub struct MessageTeHeaderConstraints;
 
 impl Rule for MessageTeHeaderConstraints {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_te_header_constraints"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageTeHeaderConstraints {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // TE should not appear in responses
@@ -211,11 +208,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation but got none");
@@ -237,11 +233,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -280,11 +275,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation but got none");
@@ -330,11 +324,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation but got none");
@@ -362,7 +355,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_te_header_constraints");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_timing_allow_origin_validity.rs
+++ b/src/rules/message_timing_allow_origin_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageTimingAllowOriginValidity;
 
 impl Rule for MessageTimingAllowOriginValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_timing_allow_origin_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageTimingAllowOriginValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -109,11 +106,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = MessageTimingAllowOriginValidity;
         let tx = make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -125,11 +121,10 @@ mod tests {
             200,
             &[("content-type", "text/plain")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -146,11 +141,10 @@ mod tests {
             200,
             &[("timing-allow-origin", val)],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -181,11 +175,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -199,11 +192,10 @@ mod tests {
             200,
             &[("timing-allow-origin", "https://a,  ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -220,11 +212,10 @@ mod tests {
             200,
             &[("timing-allow-origin", " ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty"));
@@ -237,11 +228,10 @@ mod tests {
             200,
             &[("timing-allow-origin", "https://[::1]:8080")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -253,11 +243,10 @@ mod tests {
             200,
             &[("timing-allow-origin", "*, https://example.com")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -269,11 +258,10 @@ mod tests {
             200,
             &[("timing-allow-origin", "NULL")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -285,11 +273,10 @@ mod tests {
             200,
             &[("timing-allow-origin", "https:///foo")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("invalid origin"));
@@ -313,11 +300,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -344,8 +330,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_trailer_fields_validity.rs
+++ b/src/rules/message_trailer_fields_validity.rs
@@ -58,8 +58,6 @@ const PROHIBITED_TRAILER_FIELDS: &[&str] = &[
 pub struct MessageTrailerFieldsValidity;
 
 impl Rule for MessageTrailerFieldsValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_trailer_fields_validity"
     }
@@ -68,12 +66,11 @@ impl Rule for MessageTrailerFieldsValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check request trailers.
@@ -267,12 +264,7 @@ mod tests {
         );
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(
             v.is_some(),
             "expected violation for prohibited trailer '{field}'"
@@ -299,12 +291,7 @@ mod tests {
         );
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(
             v.is_some(),
             "expected violation for prohibited request trailer '{field}'"
@@ -322,12 +309,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -339,12 +321,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -354,12 +331,7 @@ mod tests {
     fn no_trailers_no_violation() {
         let rule = MessageTrailerFieldsValidity;
         let tx = make_test_transaction_with_response(200, &[]);
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -367,12 +339,7 @@ mod tests {
     fn request_only_no_trailers_no_violation() {
         let rule = MessageTrailerFieldsValidity;
         let tx = make_test_transaction();
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -386,12 +353,7 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -405,12 +367,7 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -423,12 +380,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -440,12 +392,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -459,12 +406,7 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -479,12 +421,7 @@ mod tests {
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
         // No Trailer header → declared is empty → undeclared check skipped
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -498,12 +435,7 @@ mod tests {
         trailers.insert("content-length", "42".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("prohibited"));
     }
@@ -518,12 +450,7 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("hop-by-hop"));
     }
@@ -537,12 +464,7 @@ mod tests {
         trailers.insert("x-req-hop", "value".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("hop-by-hop"));
     }
@@ -555,12 +477,7 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("hop-by-hop"));
     }
@@ -573,12 +490,7 @@ mod tests {
         trailers.insert("x-other", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -592,12 +504,7 @@ mod tests {
         trailers.insert("transfer-encoding", "chunked".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         // Should say "prohibited", not "hop-by-hop", since static check runs first.
         assert!(v.unwrap().message.contains("prohibited"));
@@ -620,12 +527,7 @@ mod tests {
         resp_trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("host"));
     }
@@ -652,12 +554,7 @@ mod tests {
         trailers.insert("x-signature", "sig".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -669,12 +566,7 @@ mod tests {
         let mut tx = make_test_transaction_with_response(200, &[("trailer", "x-checksum")]);
         tx.response.as_mut().unwrap().trailers = Some(hyper::HeaderMap::new());
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -690,12 +582,7 @@ mod tests {
         trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -711,12 +598,7 @@ mod tests {
         trailers.insert("etag", "\"abc\"".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -728,12 +610,7 @@ mod tests {
         trailers.insert("server-timing", "db;dur=53".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -746,12 +623,7 @@ mod tests {
         trailers.insert("transfer-encoding", "chunked".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("prohibited"));
     }
@@ -766,12 +638,7 @@ mod tests {
         trailers.insert("x-extra", "extra".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -793,12 +660,7 @@ mod tests {
         trailers.insert("content-type", "text/plain".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("prohibited"));
     }
@@ -816,12 +678,7 @@ mod tests {
         resp_trailers.insert("content-length", "99".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("authorization"));
     }
@@ -839,12 +696,7 @@ mod tests {
         resp_trailers.insert("date", "Sat, 01 Jan 2026 00:00:00 GMT".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("date"));
     }
@@ -862,12 +714,7 @@ mod tests {
         trailers.insert("server-timing", "total;dur=100".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check(
-            &tx,
-            &empty_history(),
-            &cfg(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -884,7 +731,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_trailer_fields_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_trailer_headers_valid.rs
+++ b/src/rules/message_trailer_headers_valid.rs
@@ -9,8 +9,6 @@ use crate::rules::Rule;
 pub struct MessageTrailerHeadersValid;
 
 impl Rule for MessageTrailerHeadersValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_trailer_headers_valid"
     }
@@ -19,12 +17,11 @@ impl Rule for MessageTrailerHeadersValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Cache Connection header nomination once for both request and response checks
@@ -134,11 +131,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", trailer_val)]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -165,11 +161,10 @@ mod tests {
                     ("connection", "Keep-Alive"),
                     ("trailer", "Keep-Alive"),
                 ]);
-            let v2 = rule.check(
+            let v2 = rule.check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(
                 v2.is_some(),
@@ -192,11 +187,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -212,11 +206,10 @@ mod tests {
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("trailer", "ETag")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -233,11 +226,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "bad token")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -255,11 +247,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "bad token")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("invalid character"));
@@ -279,11 +270,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "Transfer-Encoding")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("nominate") || v.message.contains("hop-by-hop"));
@@ -304,11 +294,10 @@ mod tests {
             ("connection", "Keep-Alive"),
             ("trailer", "Keep-Alive"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -328,11 +317,10 @@ mod tests {
         hm.append("trailer", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -352,11 +340,10 @@ mod tests {
         hm.append("trailer", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -376,11 +363,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "Keep-Alive")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -399,11 +385,10 @@ mod tests {
             ("connection", "Keep-Alive"),
             ("trailer", "keep-alive"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -419,11 +404,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "   ")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -438,11 +422,10 @@ mod tests {
         );
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("trailer", "   ")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -461,11 +444,10 @@ mod tests {
         hm.append("trailer", HeaderValue::from_static("ETag"));
         hm.append("trailer", HeaderValue::from_static("bad token"));
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -481,11 +463,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("trailer", "trailer")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -503,8 +484,8 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        // validate_and_box should succeed without error
-        let _config = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_transfer_coding_iana_registered.rs
+++ b/src/rules/message_transfer_coding_iana_registered.rs
@@ -61,8 +61,6 @@ fn parse_allowed_config(
 pub struct MessageTransferCodingIanaRegistered;
 
 impl Rule for MessageTransferCodingIanaRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_transfer_coding_iana_registered"
     }
@@ -71,20 +69,16 @@ impl Rule for MessageTransferCodingIanaRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         // check a list-style header value (Transfer-Encoding or TE) against allowed list
@@ -193,11 +187,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -225,11 +218,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -248,11 +240,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x@bad")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -276,11 +267,10 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -288,11 +278,10 @@ mod tests {
         let mut hm2 = hyper::HeaderMap::new();
         hm2.insert("te", HeaderValue::from_bytes(b"\xff").unwrap());
         tx2.request.headers = hm2;
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -380,7 +369,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = MessageTransferCodingIanaRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_transfer_coding_iana_registered",
@@ -399,10 +388,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<TransferCodingConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_allowed_config(&full_cfg, rule.id())?;
         assert!(arc.allowed.contains(&"chunked".to_string()));
         Ok(())
     }
@@ -431,11 +417,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "x-custom;q=0.5")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -465,11 +450,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x-custom")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -497,11 +481,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x-foo")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -565,11 +548,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", v)]);
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -601,11 +583,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers, x-custom")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -623,11 +604,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x@bad")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();

--- a/src/rules/message_transfer_encoding_chunked_final.rs
+++ b/src/rules/message_transfer_encoding_chunked_final.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageTransferEncodingChunkedFinal;
 
 impl Rule for MessageTransferEncodingChunkedFinal {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_transfer_encoding_chunked_final"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageTransferEncodingChunkedFinal {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check = |headers: &hyper::HeaderMap| -> Option<Violation> {
@@ -102,11 +99,10 @@ mod tests {
             value,
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "request '{}' expected violation", value);
@@ -123,11 +119,10 @@ mod tests {
 
         let tx = crate::test_helpers::make_test_transaction();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -149,11 +144,10 @@ mod tests {
             &[("transfer-encoding", value)],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "response '{}' expected violation", value);
@@ -174,11 +168,10 @@ mod tests {
             ("transfer-encoding", "gzip"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -194,11 +187,10 @@ mod tests {
         hm.insert(hyper::header::TRANSFER_ENCODING, bad_value);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none()); // Rule skips invalid UTF-8 headers
         Ok(())

--- a/src/rules/message_user_agent_token_valid.rs
+++ b/src/rules/message_user_agent_token_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageUserAgentTokenValid;
 
 impl Rule for MessageUserAgentTokenValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_user_agent_token_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageUserAgentTokenValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let check_value = |hdr: &str, val: &str| -> Option<Violation> {
@@ -165,11 +162,10 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("user-agent", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -191,11 +187,10 @@ mod tests {
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "A@gen/1.0")]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
 
@@ -204,11 +199,10 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent/1@0")]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
 
@@ -228,11 +222,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = hm;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_some());
 
@@ -251,11 +244,10 @@ mod tests {
         hm.insert("user-agent", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -272,11 +264,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Bad/UA!")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -294,11 +285,10 @@ mod tests {
         hm.append("user-agent", HeaderValue::from_static("Bad@UA/1.0"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -316,11 +306,10 @@ mod tests {
         hm.insert("user-agent", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -340,11 +329,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent  /1.0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -363,11 +351,10 @@ mod tests {
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "A@gen/1.0")]);
-        let v1 = rule.check(
+        let v1 = rule.check_transaction(
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
         if let Some(violation) = v1 {
@@ -377,11 +364,10 @@ mod tests {
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent/1@0")]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         if let Some(violation) = v2 {
@@ -403,11 +389,10 @@ mod tests {
             "(compatible; something)",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -432,11 +417,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent (unclosed")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(violation) = v {
@@ -457,11 +441,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent (incomplete")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -480,11 +463,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent\\(1.0\\)")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Parentheses are not allowed in token syntax, so we expect a violation, but the parser should
         // not treat them as comment delimiters (i.e., no parse error about unmatched comment).
@@ -510,7 +492,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_user_agent_token_valid",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_via_header_syntax_valid.rs
+++ b/src/rules/message_via_header_syntax_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageViaHeaderSyntaxValid;
 
 impl Rule for MessageViaHeaderSyntaxValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_via_header_syntax_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageViaHeaderSyntaxValid {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use hyper::HeaderMap;
@@ -243,11 +240,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("via", "1.1 example.com")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -257,11 +253,10 @@ mod tests {
     fn check_response_header_invalid() -> anyhow::Result<()> {
         let rule = MessageViaHeaderSyntaxValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[("via", "1.1")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -302,11 +297,10 @@ mod tests {
         hm.insert("via", bad);
         tx.request.headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/message_warning_header_syntax.rs
+++ b/src/rules/message_warning_header_syntax.rs
@@ -171,8 +171,6 @@ fn check_warning_value_str(val: &str) -> Option<String> {
 pub struct MessageWarningHeaderSyntax;
 
 impl Rule for MessageWarningHeaderSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_warning_header_syntax"
     }
@@ -181,12 +179,11 @@ impl Rule for MessageWarningHeaderSyntax {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check response headers
@@ -263,11 +260,10 @@ mod tests {
             make_test_transaction()
         };
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header {:?}", header);
@@ -292,11 +288,10 @@ mod tests {
             .unwrap()
             .headers
             .append("Warning", HeaderValue::from_bytes(&[0xff]).unwrap());
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-UTF8"));
@@ -315,11 +310,10 @@ mod tests {
                 .parse::<hyper::header::HeaderValue>()
                 .unwrap(),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -329,11 +323,10 @@ mod tests {
             "Warning",
             "110-\"bad\"".parse::<hyper::header::HeaderValue>().unwrap(),
         );
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
         assert!(v2
@@ -371,11 +364,10 @@ mod tests {
         let rule = MessageWarningHeaderSyntax;
 
         let tx = make_test_transaction_with_response(200, &[("Warning", header)]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(expect_msg) = expect {
@@ -392,11 +384,10 @@ mod tests {
             .headers
             .insert("Warning", HeaderValue::from_static(""));
         let rule = MessageWarningHeaderSyntax;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -409,11 +400,10 @@ mod tests {
             &[("Warning", "214 host \"ok\", ,214 host \"bad\"")],
         );
         let rule = MessageWarningHeaderSyntax;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty member"));
@@ -430,11 +420,10 @@ mod tests {
             )],
         );
         let rule = MessageWarningHeaderSyntax;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -447,7 +436,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_warning_header_syntax",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -470,11 +459,10 @@ mod tests {
             .unwrap()
             .headers
             .append("Warning", HeaderValue::from_static("110 - \"Stale\""));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -485,11 +473,10 @@ mod tests {
         let rule = MessageWarningHeaderSyntax;
 
         let tx = make_test_transaction_with_response(200, &[("Warning", "110-\"bad\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Missing space after warn-code"));
@@ -509,11 +496,10 @@ mod tests {
             "Warning",
             HeaderValue::from_bytes(b"214 host \"abc\\\"").unwrap(),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;

--- a/src/rules/message_well_known_uri_format.rs
+++ b/src/rules/message_well_known_uri_format.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageWellKnownUriFormat;
 
 impl Rule for MessageWellKnownUriFormat {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_well_known_uri_format"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageWellKnownUriFormat {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let path = crate::helpers::uri::extract_path_from_request_target(&tx.request.uri)?;
@@ -72,20 +69,18 @@ mod tests {
             "message_well_known_uri_format",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
         tx = make_tx_with_uri("https://example.com/.well-known/security.txt");
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -100,11 +95,10 @@ mod tests {
             "message_well_known_uri_format",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -119,11 +113,10 @@ mod tests {
             "message_well_known_uri_format",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -138,11 +131,10 @@ mod tests {
             "message_well_known_uri_format",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -155,11 +147,10 @@ mod tests {
             "message_well_known_uri_format",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -176,7 +167,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_well_known_uri_format",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/message_www_authenticate_challenge_syntax.rs
+++ b/src/rules/message_www_authenticate_challenge_syntax.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageWwwAuthenticateChallengeSyntax;
 
 impl Rule for MessageWwwAuthenticateChallengeSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_www_authenticate_challenge_syntax"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageWwwAuthenticateChallengeSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers; ignore non-UTF8 header values
@@ -87,11 +84,10 @@ mod tests {
             "message_www_authenticate_challenge_syntax",
         ]);
         let tx = make_resp(val);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "val='{}' expected violation", val);
@@ -115,11 +111,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -134,11 +129,10 @@ mod tests {
             401,
             &[("www-authenticate", "error=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -157,11 +151,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"x\", ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(vv) = v {
             assert!(
@@ -182,11 +175,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"a\", NewScheme abcdef=")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -208,11 +200,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic re@alm=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name"));
@@ -228,11 +219,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=abc@")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(vv) = v {
             assert!(
@@ -263,11 +253,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic =\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name is empty"));
@@ -283,11 +272,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"unfinished")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let vv = v.unwrap();
@@ -306,11 +294,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic a=\"good\"extra")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let vv = v.unwrap();
@@ -329,11 +316,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"x\", , error=\"y\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if let Some(vv) = v {
             assert!(
@@ -355,11 +341,10 @@ mod tests {
             401,
             &[("www-authenticate", " realm=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing auth-scheme"));
@@ -375,11 +360,10 @@ mod tests {
             401,
             &[("www-authenticate", ",")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("empty"));
@@ -402,11 +386,10 @@ mod tests {
             hyper::header::HeaderValue::from_static("NewScheme abc="),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -428,11 +411,10 @@ mod tests {
             hyper::header::HeaderValue::from_static("Basic realm=\"x\""),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -447,11 +429,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vv) = v {
@@ -470,11 +451,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"a\\\"b\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -489,11 +469,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=token123")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -508,11 +487,10 @@ mod tests {
             401,
             &[("www-authenticate", "NewScheme abc+/.=-_123")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -528,11 +506,10 @@ mod tests {
             401,
             &[("www-authenticate", "New abc/def=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name"));
@@ -549,11 +526,10 @@ mod tests {
             401,
             &[("www-authenticate", "New abc/def=xyz")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -568,11 +544,10 @@ mod tests {
             401,
             &[("www-authenticate", "NonCommon abc=")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -587,11 +562,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic abc=")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         if let Some(vv) = v {
@@ -609,11 +583,10 @@ mod tests {
             401,
             &[("www-authenticate", "NewScheme realm")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("suspicious single token"));
@@ -629,11 +602,10 @@ mod tests {
             401,
             &[("www-authenticate", "New abc/def=\"x\", realm=\"y\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("auth-param name"));
@@ -644,7 +616,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "message_www_authenticate_challenge_syntax",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/message_x_forwarded_consistency.rs
+++ b/src/rules/message_x_forwarded_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct MessageXForwardedConsistency;
 
 impl Rule for MessageXForwardedConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "message_x_forwarded_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for MessageXForwardedConsistency {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use crate::helpers::headers::parse_list_header;
@@ -228,11 +225,10 @@ mod tests {
             tx.request.headers =
                 crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-for", v)]);
         }
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -248,11 +244,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-for", "not-an-ip")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
@@ -260,11 +255,10 @@ mod tests {
             200,
             &[("x-forwarded-proto", "https")],
         );
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -285,11 +279,10 @@ mod tests {
             tx.request.headers =
                 crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-proto", v)]);
         }
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -316,11 +309,10 @@ mod tests {
             tx.request.headers =
                 crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", v)]);
         }
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -340,11 +332,10 @@ mod tests {
         let mut hm = tx.request.headers.clone();
         hm.append("x-forwarded-for", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.request.headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -356,11 +347,10 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx2.response.as_mut().unwrap().headers = hm2;
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -371,11 +361,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-proto", "https, ftp")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid X-Forwarded-Proto"));
@@ -387,11 +376,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-for", "*")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -406,7 +394,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "message_x_forwarded_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -416,11 +404,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", ":80")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -435,11 +422,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "example.com:")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -450,11 +436,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "[::1]:notnum")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -470,11 +455,10 @@ mod tests {
             "x-forwarded-host",
             "example.com/extra",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -486,11 +470,10 @@ mod tests {
             200,
             &[("x-forwarded-host", "user@host")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -503,11 +486,10 @@ mod tests {
             "x-forwarded-for",
             "203.0.113.195,bogus,198.51.100.17",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid X-Forwarded-For"));
@@ -519,11 +501,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "[::zz]:8080")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid IPv6 literal"));
@@ -535,11 +516,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "exa mple.com")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -550,11 +530,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "[::1]:70000")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid port"));
@@ -566,11 +545,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-proto", "https,:")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -583,11 +561,10 @@ mod tests {
             "x-forwarded-host",
             "example\t.com:80",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -598,11 +575,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-forwarded-host", "user@host:80")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid host"));

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: ISC
 
 use crate::lint::Violation;
-use std::any::Any;
-use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 /// Standard configuration for rules
 /// Used as the Config type for non-configurable rules.
@@ -35,27 +33,20 @@ pub enum RuleScope {
 }
 
 pub trait Rule: Send + Sync {
-    /// The type of parsed configuration this rule requires.
-    /// Use `RuleConfig` for rules that only need severity.
-    type Config: Send + Sync + 'static;
-
     fn id(&self) -> &'static str;
 
-    /// Validate and parse the rule's configuration. Called once at startup.
-    /// Returns the parsed configuration object or an error if invalid.
-    /// For rules using `RuleConfig`, this method has a default implementation.
-    /// Rules with custom configurations must override this method.
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<Arc<dyn Any + Send + Sync>> {
-        // Default implementation for rules using RuleConfig (only severity)
-        let config = parse_rule_config(config, self.id())?;
-        Ok(Arc::new(config))
+    /// Validate the rule's configuration section. Called once per enabled
+    /// rule at startup so a malformed config fails fast rather than silently
+    /// disabling the rule at lint time.
+    ///
+    /// The default checks the base `enabled` / `severity` fields. Rules with
+    /// a custom config section override this to validate their own fields.
+    fn validate(&self, cfg: &crate::config::Config) -> anyhow::Result<()> {
+        parse_rule_config(cfg, self.id()).map(|_| ())
     }
 
-    /// The scope where the rule should be executed. Default is `Both` for
-    /// backward compatibility; rules may override for better precision.
+    /// The scope where the rule should be executed. Default is `Both`;
+    /// rules may override for better precision.
     ///
     /// The engine partitions rules by scope and dispatches accordingly:
     /// - `Client` and `Both` rules run on every transaction.
@@ -68,151 +59,14 @@ pub trait Rule: Send + Sync {
         RuleScope::Both
     }
 
-    /// **Legacy entry point.** Evaluate an `HttpTransaction` using the rule's
-    /// parsed associated `Self::Config`. Existing rules override this; the
-    /// default `check` impl unboxes the config from the engine cache and
-    /// delegates here.
-    ///
-    /// New rules should override [`check`](Self::check) directly and ignore
-    /// this method — its default `unreachable!()` body is never reached for
-    /// rules that override `check`. This method, the associated `Config`
-    /// type, and the engine cache will be removed once all rules have
-    /// migrated; see REPORT.md item #8 for the staged plan.
+    /// Evaluate an `HttpTransaction` against this rule. Rules parse whatever
+    /// configuration they need directly from the global `cfg: &Config`.
     fn check_transaction(
-        &self,
-        _tx: &crate::http_transaction::HttpTransaction,
-        _history: &crate::transaction_history::TransactionHistory,
-        _config: &Self::Config,
-    ) -> Option<Violation> {
-        unreachable!(
-            "rule '{}' overrides neither `check_transaction` (legacy) nor `check` (preferred)",
-            self.id()
-        )
-    }
-
-    /// Evaluate an `HttpTransaction` against this rule. The default impl
-    /// looks up the parsed associated config from the engine cache and
-    /// delegates to [`check_transaction`](Self::check_transaction), so
-    /// existing rules continue to work unchanged.
-    ///
-    /// New rules should override **this** method instead — it takes the
-    /// global `cfg: &Config` directly, avoiding the engine round-trip and
-    /// the type-erasure ceremony. Once all rules are migrated, the legacy
-    /// path goes away (REPORT.md #8c) and `check` is renamed to
-    /// `check_transaction`.
-    fn check(
-        &self,
-        tx: &crate::http_transaction::HttpTransaction,
-        history: &crate::transaction_history::TransactionHistory,
-        _cfg: &crate::config::Config,
-        engine: &RuleConfigEngine,
-    ) -> Option<Violation> {
-        let parsed = engine.get_cached::<Self::Config>(self.id());
-        self.check_transaction(tx, history, &parsed)
-    }
-}
-
-/// Helper trait to enable type-erased configuration caching.
-/// Automatically implemented for all Rule implementations.
-/// This trait exists to work around the fact that Rule has an associated type
-/// which prevents using dyn Rule directly in RULES array.
-pub trait RuleConfigValidator: Send + Sync {
-    fn id(&self) -> &'static str;
-    fn scope(&self) -> RuleScope;
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<Arc<dyn Any + Send + Sync>>;
-
-    fn check_transaction_erased(
-        &self,
-        tx: &crate::http_transaction::HttpTransaction,
-        history: &crate::transaction_history::TransactionHistory,
-        config: &crate::config::Config,
-        engine: &RuleConfigEngine,
-    ) -> Option<Violation>;
-}
-
-impl<T: Rule> RuleConfigValidator for T {
-    fn id(&self) -> &'static str {
-        <Self as Rule>::id(self)
-    }
-
-    fn scope(&self) -> RuleScope {
-        <Self as Rule>::scope(self)
-    }
-
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<Arc<dyn Any + Send + Sync>> {
-        <Self as Rule>::validate_and_box(self, config)
-    }
-
-    fn check_transaction_erased(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        engine: &RuleConfigEngine,
-    ) -> Option<Violation> {
-        // Route through the new `Rule::check` entry point. For rules that
-        // still override only the legacy `check_transaction`, the default
-        // `check` impl unboxes the config from the engine cache and
-        // delegates back to it — preserving today's behaviour exactly.
-        <Self as Rule>::check(self, tx, history, cfg, engine)
-    }
-}
-
-/// Engine that caches parsed rule configurations.
-/// Stores type-erased parsed configs in a HashMap keyed by rule ID.
-#[derive(Debug, Default)]
-pub struct RuleConfigEngine {
-    cache: HashMap<&'static str, Arc<dyn Any + Send + Sync>>,
-}
-
-impl RuleConfigEngine {
-    /// Create a new empty config engine.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Validate and cache configurations for all enabled rules (both
-    /// transaction-level and protocol-level).
-    /// Should be called once at startup after loading config.
-    pub fn validate_and_cache_all(&mut self, config: &crate::config::Config) -> anyhow::Result<()> {
-        for rule in RULES {
-            if config.is_enabled(rule.id()) {
-                let boxed = rule.validate_and_box(config).map_err(|e| {
-                    anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
-                })?;
-                self.cache.insert(rule.id(), boxed);
-            }
-        }
-        for rule in PROTOCOL_RULES {
-            if config.is_enabled(rule.id()) {
-                let boxed = rule.validate_and_box(config).map_err(|e| {
-                    anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
-                })?;
-                self.cache.insert(rule.id(), boxed);
-            }
-        }
-        Ok(())
-    }
-
-    /// Retrieve the cached parsed config for a rule.
-    /// Panics if the rule hasn't been validated/cached - this is a programming error.
-    pub fn get_cached<T: Send + Sync + 'static>(&self, rule_id: &'static str) -> Arc<T> {
-        self.cache
-            .get(rule_id)
-            .and_then(|arc| arc.clone().downcast::<T>().ok())
-            .unwrap_or_else(|| {
-                panic!(
-                    "Rule '{}' config not found in cache. This is a bug - validate_and_cache_all must be called for all enabled rules before linting.",
-                    rule_id
-                )
-            })
-    }
+    ) -> Option<Violation>;
 }
 
 /// Get rule enabled flag, failing if not explicitly configured.
@@ -276,7 +130,7 @@ pub fn get_rule_severity_required(
     }
 }
 
-pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<RuleConfigEngine> {
+pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
     // Ensure every rule table specifies valid `enabled` and `severity` entries.
     for (rule_name, val) in &config.rules {
         if let toml::Value::Table(table) = val {
@@ -325,9 +179,23 @@ pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<RuleConf
         }
     }
 
-    let mut engine = RuleConfigEngine::new();
-    engine.validate_and_cache_all(config)?;
-    Ok(engine)
+    // Per-rule validation: every enabled rule parses its own config section so
+    // a malformed section (including custom fields) fails fast at startup.
+    for rule in RULES {
+        if config.is_enabled(rule.id()) {
+            rule.validate(config).map_err(|e| {
+                anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
+            })?;
+        }
+    }
+    for rule in PROTOCOL_RULES {
+        if config.is_enabled(rule.id()) {
+            rule.validate(config).map_err(|e| {
+                anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
+            })?;
+        }
+    }
+    Ok(())
 }
 
 pub mod client_accept_encoding_present;
@@ -519,105 +387,30 @@ pub mod stateful_websocket_handshake_validity;
 //
 // `ProtocolRule` mirrors `Rule` but operates on `ProtocolEvent` instead of
 // `HttpTransaction`.  It lives in the same module to share `RuleConfig`,
-// `RuleConfigEngine`, severity helpers, and the config TOML infrastructure.
+// severity helpers, and the config TOML infrastructure.
 
 /// A rule that evaluates protocol-level events (WebSocket frames, HTTP/3
 /// control frames, QUIC transport events) rather than HTTP transactions.
 pub trait ProtocolRule: Send + Sync {
-    /// The type of parsed configuration this rule requires.
-    type Config: Send + Sync + 'static;
-
     fn id(&self) -> &'static str;
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<Arc<dyn Any + Send + Sync>> {
-        let config = parse_rule_config(config, self.id())?;
-        Ok(Arc::new(config))
+    /// Validate the rule's configuration section at startup. See
+    /// [`Rule::validate`] for the contract.
+    fn validate(&self, cfg: &crate::config::Config) -> anyhow::Result<()> {
+        parse_rule_config(cfg, self.id()).map(|_| ())
     }
 
-    /// **Legacy entry point.** Evaluate a single protocol event using the
-    /// rule's parsed associated `Self::Config`. Existing rules override this;
-    /// the default `check` impl unboxes the config from the engine cache and
-    /// delegates here.
-    ///
-    /// New rules should override [`check`](Self::check) directly. See the
-    /// matching `Rule::check_transaction` doc-comment and REPORT.md item #8.
+    /// Evaluate a single protocol event against this rule. Rules parse
+    /// whatever configuration they need directly from `cfg: &Config`.
     fn check_event(
-        &self,
-        _event: &crate::protocol_event::ProtocolEvent,
-        _history: &crate::protocol_event::ProtocolEventHistory,
-        _config: &Self::Config,
-    ) -> Option<Violation> {
-        unreachable!(
-            "protocol rule '{}' overrides neither `check_event` (legacy) nor `check` (preferred)",
-            self.id()
-        )
-    }
-
-    /// Evaluate a protocol event against this rule. The default impl looks
-    /// up the parsed associated config from the engine cache and delegates
-    /// to [`check_event`](Self::check_event); existing rules continue to
-    /// work unchanged. New rules should override **this** method instead.
-    /// Renamed to `check_event` once the legacy path is removed (REPORT.md
-    /// #8c).
-    fn check(
-        &self,
-        event: &crate::protocol_event::ProtocolEvent,
-        history: &crate::protocol_event::ProtocolEventHistory,
-        _cfg: &crate::config::Config,
-        engine: &RuleConfigEngine,
-    ) -> Option<Violation> {
-        let parsed = engine.get_cached::<Self::Config>(self.id());
-        self.check_event(event, history, &parsed)
-    }
-}
-
-/// Type-erased wrapper for `ProtocolRule`, mirroring `RuleConfigValidator`.
-pub trait ProtocolRuleConfigValidator: Send + Sync {
-    fn id(&self) -> &'static str;
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<Arc<dyn Any + Send + Sync>>;
-
-    fn check_event_erased(
-        &self,
-        event: &crate::protocol_event::ProtocolEvent,
-        history: &crate::protocol_event::ProtocolEventHistory,
-        config: &crate::config::Config,
-        engine: &RuleConfigEngine,
-    ) -> Option<Violation>;
-}
-
-impl<T: ProtocolRule> ProtocolRuleConfigValidator for T {
-    fn id(&self) -> &'static str {
-        <Self as ProtocolRule>::id(self)
-    }
-
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<Arc<dyn Any + Send + Sync>> {
-        <Self as ProtocolRule>::validate_and_box(self, config)
-    }
-
-    fn check_event_erased(
         &self,
         event: &crate::protocol_event::ProtocolEvent,
         history: &crate::protocol_event::ProtocolEventHistory,
         cfg: &crate::config::Config,
-        engine: &RuleConfigEngine,
-    ) -> Option<Violation> {
-        // Route through the new `ProtocolRule::check` entry point. Default
-        // impl preserves the legacy delegation to `check_event` for rules
-        // that haven't migrated yet.
-        <Self as ProtocolRule>::check(self, event, history, cfg, engine)
-    }
+    ) -> Option<Violation>;
 }
 
-pub const PROTOCOL_RULES: &[&dyn ProtocolRuleConfigValidator] = &[
+pub const PROTOCOL_RULES: &[&dyn ProtocolRule] = &[
     &server_quic_transport_parameters::ServerQuicTransportParameters,
     &stateful_http3_goaway_semantics::StatefulHttp3GoawaySemantics,
     &stateful_http3_max_push_id::StatefulHttp3MaxPushId,
@@ -625,7 +418,7 @@ pub const PROTOCOL_RULES: &[&dyn ProtocolRuleConfigValidator] = &[
     &stateful_websocket_frame_opcode_sequence::StatefulWebsocketFrameOpcodeSequence,
 ];
 
-pub const RULES: &[&dyn RuleConfigValidator] = &[
+pub const RULES: &[&dyn Rule] = &[
     &client_accept_encoding_present::ClientAcceptEncodingPresent,
     &client_accept_ranges_on_partial_content::ClientAcceptRangesOnPartialContent,
     &client_cache_respect::ClientCacheRespect,
@@ -813,20 +606,19 @@ pub const RULES: &[&dyn RuleConfigValidator] = &[
 /// has-response / no-response cases.
 ///
 /// Implementation detail of [`rules_for_scope`]; not part of the public API.
-pub(crate) static REQUEST_ONLY_RULES: LazyLock<Vec<&'static dyn RuleConfigValidator>> =
-    LazyLock::new(|| {
-        RULES
-            .iter()
-            .copied()
-            .filter(|r| !matches!(r.scope(), RuleScope::Server))
-            .collect()
-    });
+pub(crate) static REQUEST_ONLY_RULES: LazyLock<Vec<&'static dyn Rule>> = LazyLock::new(|| {
+    RULES
+        .iter()
+        .copied()
+        .filter(|r| !matches!(r.scope(), RuleScope::Server))
+        .collect()
+});
 
 /// Returns the rule slice the engine should iterate for a transaction with
 /// the given response presence. `Server` rules are excluded when there is no
 /// response; `Client` and `Both` rules run on every transaction. The returned
 /// slice preserves the source order of `RULES`.
-pub fn rules_for_scope(has_response: bool) -> &'static [&'static dyn RuleConfigValidator] {
+pub fn rules_for_scope(has_response: bool) -> &'static [&'static dyn Rule] {
     if has_response {
         RULES
     } else {
@@ -838,98 +630,6 @@ pub fn rules_for_scope(has_response: bool) -> &'static [&'static dyn RuleConfigV
 mod tests {
     use super::*;
     use crate::test_helpers::{enable_rule, enable_rule_with_paths};
-
-    #[test]
-    fn protocol_check_override_short_circuits_engine_cache() {
-        // Mirror of `check_override_short_circuits_engine_cache` for the
-        // protocol-rule side. Same load-bearing role for the #8a bridge on
-        // `ProtocolRule`.
-        struct ProtocolProbe;
-        impl ProtocolRule for ProtocolProbe {
-            type Config = ();
-
-            fn id(&self) -> &'static str {
-                "_test_protocol_check_override_probe"
-            }
-
-            fn check(
-                &self,
-                _event: &crate::protocol_event::ProtocolEvent,
-                _history: &crate::protocol_event::ProtocolEventHistory,
-                _cfg: &crate::config::Config,
-                _engine: &RuleConfigEngine,
-            ) -> Option<Violation> {
-                Some(Violation {
-                    rule: "_test_protocol_check_override_probe".into(),
-                    severity: crate::lint::Severity::Info,
-                    message: "from protocol check override".into(),
-                })
-            }
-        }
-
-        let probe = ProtocolProbe;
-        let engine = RuleConfigEngine::new();
-        let cfg = crate::config::Config::default();
-        let event = crate::protocol_event::ProtocolEvent {
-            timestamp: chrono::Utc::now(),
-            connection_id: uuid::Uuid::new_v4(),
-            kind: crate::protocol_event::ProtocolEventKind::H3MaxPushId { push_id: 0 },
-        };
-        let history = crate::protocol_event::ProtocolEventHistory::empty();
-
-        let result = <ProtocolProbe as ProtocolRuleConfigValidator>::check_event_erased(
-            &probe, &event, &history, &cfg, &engine,
-        );
-
-        let v = result.expect("override should produce a violation");
-        assert_eq!(v.message, "from protocol check override");
-    }
-
-    #[test]
-    fn check_override_short_circuits_engine_cache() {
-        // Load-bearing test for the #8a bridge: a rule that overrides
-        // `Rule::check` directly must be routed through the new entry point
-        // *without* the dispatch trying to unbox a config from the engine
-        // cache. If the bridge regressed (e.g. `check_transaction_erased`
-        // started calling `check_transaction` again), the engine lookup
-        // would panic on this empty engine.
-        struct Probe;
-        impl Rule for Probe {
-            type Config = ();
-
-            fn id(&self) -> &'static str {
-                "_test_check_override_probe"
-            }
-
-            fn check(
-                &self,
-                _tx: &crate::http_transaction::HttpTransaction,
-                _history: &crate::transaction_history::TransactionHistory,
-                _cfg: &crate::config::Config,
-                _engine: &RuleConfigEngine,
-            ) -> Option<Violation> {
-                Some(Violation {
-                    rule: "_test_check_override_probe".into(),
-                    severity: crate::lint::Severity::Info,
-                    message: "from check override".into(),
-                })
-            }
-        }
-
-        let probe = Probe;
-        let engine = RuleConfigEngine::new();
-        let cfg = crate::config::Config::default();
-        let tx = crate::test_helpers::make_test_transaction();
-        let history = crate::transaction_history::TransactionHistory::empty();
-
-        let result = <Probe as RuleConfigValidator>::check_transaction_erased(
-            &probe, &tx, &history, &cfg, &engine,
-        );
-
-        let v = result.expect("override should produce a violation");
-        assert_eq!(v.message, "from check override");
-        assert_eq!(v.rule, "_test_check_override_probe");
-    }
 
     #[test]
     fn rule_ids_unique_and_non_empty() {
@@ -1018,7 +718,7 @@ mod tests {
         enable_rule(&mut cfg, "server_cache_control_present");
         // server_clear_site_data requires paths; enable with valid paths too
         enable_rule_with_paths(&mut cfg, "server_clear_site_data", &["/logout"]);
-        let _engine = validate_rules(&cfg)?;
+        validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -1064,24 +764,6 @@ mod tests {
         assert!(res.is_err());
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("server_clear_site_data"));
-        Ok(())
-    }
-
-    #[test]
-    #[should_panic(expected = "config not found in cache")]
-    fn test_get_cached_missing_panics() {
-        let engine = RuleConfigEngine::new();
-        let _: std::sync::Arc<RuleConfig> = engine.get_cached("nonexistent_rule");
-    }
-
-    #[test]
-    fn rule_config_engine_validate_and_cache_for_new_rule() -> anyhow::Result<()> {
-        let mut cfg = crate::config::Config::default();
-        crate::test_helpers::enable_rule(&mut cfg, "message_forwarded_header_validity");
-        let mut engine = RuleConfigEngine::new();
-        engine.validate_and_cache_all(&cfg)?;
-        let cfg_obj: Arc<RuleConfig> = engine.get_cached("message_forwarded_header_validity");
-        assert!(cfg_obj.enabled);
         Ok(())
     }
 
@@ -1211,8 +893,6 @@ mod tests {
     fn default_rule_scope_is_both() {
         struct DummyRule;
         impl Rule for DummyRule {
-            type Config = RuleConfig;
-
             fn id(&self) -> &'static str {
                 "dummy_rule"
             }
@@ -1221,18 +901,17 @@ mod tests {
                 &self,
                 _tx: &crate::http_transaction::HttpTransaction,
                 _history: &crate::transaction_history::TransactionHistory,
-                _config: &Self::Config,
+                _cfg: &crate::config::Config,
             ) -> Option<Violation> {
                 None
             }
         }
 
         let r = DummyRule;
-        // Direct call to default implementation (disambiguate trait method)
         assert_eq!(crate::rules::Rule::scope(&r), RuleScope::Both);
 
-        // Also verify through the type-erased validator trait
-        let v: &dyn RuleConfigValidator = &r;
+        // Also verify through a trait object (now object-safe).
+        let v: &dyn Rule = &r;
         assert_eq!(v.scope(), RuleScope::Both);
     }
 
@@ -1250,24 +929,6 @@ mod tests {
         let rc = parse_rule_config(&cfg, "server_cache_control_present")?;
         assert!(rc.enabled);
         assert_eq!(rc.severity, crate::lint::Severity::Warn);
-        Ok(())
-    }
-
-    #[test]
-    fn validate_and_cache_all_get_cached_success() -> anyhow::Result<()> {
-        let mut cfg = crate::config::Config::default();
-        let mut table = toml::map::Map::new();
-        table.insert("enabled".to_string(), toml::Value::Boolean(true));
-        table.insert("severity".to_string(), toml::Value::String("error".into()));
-        cfg.rules.insert(
-            "server_cache_control_present".into(),
-            toml::Value::Table(table),
-        );
-
-        let mut engine = RuleConfigEngine::new();
-        engine.validate_and_cache_all(&cfg)?;
-        let rc: std::sync::Arc<RuleConfig> = engine.get_cached("server_cache_control_present");
-        assert_eq!(rc.severity, crate::lint::Severity::Error);
         Ok(())
     }
 

--- a/src/rules/semantic_cache_coherence.rs
+++ b/src/rules/semantic_cache_coherence.rs
@@ -18,8 +18,6 @@ use crate::rules::Rule;
 pub struct SemanticCacheCoherence;
 
 impl Rule for SemanticCacheCoherence {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_cache_coherence"
     }
@@ -30,12 +28,11 @@ impl Rule for SemanticCacheCoherence {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -129,9 +126,7 @@ mod tests {
             &[("date", "Wed, 21 Oct 2015 07:28:00 GMT")],
         );
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check(&tx, &history, &cfg, &crate::rules::RuleConfigEngine::new())
-            .is_none());
+        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
     }
 
     #[test]
@@ -150,14 +145,7 @@ mod tests {
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule
-            .check(
-                &curr,
-                &history,
-                &cfg,
-                &crate::rules::RuleConfigEngine::new()
-            )
-            .is_none());
+        assert!(rule.check_transaction(&curr, &history, &cfg,).is_none());
     }
 
     #[test]
@@ -176,12 +164,7 @@ mod tests {
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
-            &curr,
-            &history,
-            &cfg,
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&curr, &history, &cfg);
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("appears stale"));
     }
@@ -202,12 +185,7 @@ mod tests {
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
-            &curr,
-            &history,
-            &cfg,
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let v = rule.check_transaction(&curr, &history, &cfg);
         assert!(v.is_some());
     }
 
@@ -219,21 +197,14 @@ mod tests {
         let mut curr = make_resp_tx("https://example.com/foo", 200, &[]);
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        assert!(rule
-            .check(
-                &curr,
-                &history,
-                &cfg,
-                &crate::rules::RuleConfigEngine::new()
-            )
-            .is_none());
+        assert!(rule.check_transaction(&curr, &history, &cfg,).is_none());
     }
 
     #[test]
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "semantic_cache_coherence");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/semantic_head_response_headers_match_get.rs
+++ b/src/rules/semantic_head_response_headers_match_get.rs
@@ -63,8 +63,6 @@ fn parse_headers_config(
 pub struct SemanticHeadResponseHeadersMatchGet;
 
 impl Rule for SemanticHeadResponseHeadersMatchGet {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_head_response_headers_match_get"
     }
@@ -73,20 +71,16 @@ impl Rule for SemanticHeadResponseHeadersMatchGet {
         crate::rules::RuleScope::Server
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_headers_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_headers_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         // Only applies to HEAD responses with a previous GET on the same URI
         if !tx.request.method.eq_ignore_ascii_case("HEAD") {
@@ -307,11 +301,10 @@ mod tests {
         // ensure URIs match
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type", "content-length"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -323,11 +316,10 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing header"));
@@ -340,11 +332,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("x-foo", "bar")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["x-foo"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -360,11 +351,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("content-length", "5")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -377,11 +367,10 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -393,11 +382,10 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -406,11 +394,10 @@ mod tests {
     fn no_previous_does_nothing() {
         let rule = SemanticHeadResponseHeadersMatchGet;
         let head = make_head_with_headers(&[("etag", "\"v1\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -423,11 +410,10 @@ mod tests {
         // different URIs
         head.request.uri = "/other".parse().unwrap();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -440,11 +426,10 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -468,11 +453,10 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // prev had non-utf8 'etag' -> treated as present -> HEAD missing it should be a violation
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -508,11 +492,10 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // Both present but non-UTF8 -> rule should be lenient and not report a violation
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -524,11 +507,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -537,7 +519,7 @@ mod tests {
     fn parse_config_requires_headers_array() {
         let cfg = crate::config::Config::default();
         let rule = SemanticHeadResponseHeadersMatchGet;
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         assert!(res.is_err());
     }
 
@@ -558,7 +540,7 @@ mod tests {
         );
 
         let rule = SemanticHeadResponseHeadersMatchGet;
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         assert!(res.is_err());
     }
 
@@ -582,7 +564,7 @@ mod tests {
         );
 
         let rule = SemanticHeadResponseHeadersMatchGet;
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         assert!(res.is_err());
     }
 
@@ -617,11 +599,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v2\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Header 'etag' value differs"));
@@ -635,11 +616,10 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // 'x-foo' is not in the configured headers list -> should be ignored
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -651,11 +631,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("transfer-encoding", "chunked")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -667,11 +646,10 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -683,11 +661,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("content-length", "5")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -699,11 +676,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "accept, accept-encoding")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -715,11 +691,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "a, c")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Vary"));
@@ -735,11 +710,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -763,11 +737,10 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // presence detected, but values are not compared when one side is non-UTF8
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -779,11 +752,10 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\""), ("content-type", "text/html")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("content-type"));
@@ -796,17 +768,16 @@ mod tests {
         let mut head = make_head_with_headers(&[("accept-encoding", "deflate, gzip")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["accept-encoding"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
 
     #[test]
-    fn validate_and_box_parses_config() -> anyhow::Result<()> {
+    fn validate_parses_config() -> anyhow::Result<()> {
         let rule = SemanticHeadResponseHeadersMatchGet;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "semantic_head_response_headers_match_get",
@@ -825,10 +796,7 @@ mod tests {
             }),
         );
 
-        let boxed = rule.validate_and_box(&full_cfg)?;
-        let arc = boxed
-            .downcast::<SemanticHeadResponseHeadersMatchGetConfig>()
-            .map_err(|_| anyhow::anyhow!("downcast failed"))?;
+        let arc = parse_headers_config(&full_cfg, rule.id())?;
         assert!(arc.headers.contains(&"etag".to_string()));
         Ok(())
     }
@@ -877,11 +845,10 @@ mod tests {
         head.response = None;
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -894,11 +861,10 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // validate_content_length on prev will error -> rule must be lenient
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -910,11 +876,10 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &head,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -939,7 +904,7 @@ mod tests {
             }),
         );
 
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/semantic_options_method_capabilities.rs
+++ b/src/rules/semantic_options_method_capabilities.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct SemanticOptionsMethodCapabilities;
 
 impl Rule for SemanticOptionsMethodCapabilities {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_options_method_capabilities"
     }
@@ -18,12 +16,11 @@ impl Rule for SemanticOptionsMethodCapabilities {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only care about OPTIONS requests with a final response
@@ -93,11 +90,10 @@ mod tests {
         let rule = SemanticOptionsMethodCapabilities;
         let tx = make_opts_tx(status, header);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for status {}", status);
@@ -117,11 +113,10 @@ mod tests {
         let tx = make_opts_tx(200, None);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Allow"));
@@ -134,11 +129,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "semantic_options_method_capabilities",
         ]);
-        let v = SemanticOptionsMethodCapabilities.check(
+        let v = SemanticOptionsMethodCapabilities.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -157,11 +151,10 @@ mod tests {
         tx.request.method = "OPTIONS".into();
         tx.response = None;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -173,7 +166,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "semantic_options_method_capabilities");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/semantic_origin_matching_for_cors.rs
+++ b/src/rules/semantic_origin_matching_for_cors.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct SemanticOriginMatchingForCors;
 
 impl Rule for SemanticOriginMatchingForCors {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_origin_matching_for_cors"
     }
@@ -18,12 +16,11 @@ impl Rule for SemanticOriginMatchingForCors {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -152,11 +149,10 @@ mod tests {
     fn no_origin_header_ignored() {
         let rule = SemanticOriginMatchingForCors;
         let tx = make_test_transaction_with_response(200, &[]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -167,11 +163,10 @@ mod tests {
         let mut tx = make_test_transaction();
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         // response has no ACAO
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -184,11 +179,10 @@ mod tests {
             &[("access-control-allow-origin", "https://example.com")],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -199,11 +193,10 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "*")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -220,11 +213,10 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("'*' is not allowed"));
@@ -239,11 +231,10 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not match request Origin"));
@@ -255,11 +246,10 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -276,11 +266,10 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("'*' is not allowed"));
@@ -295,11 +284,10 @@ mod tests {
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://a")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single value"));
@@ -323,11 +311,10 @@ mod tests {
             trailers: None,
         });
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Multiple Access-Control-Allow-Origin"));
@@ -339,11 +326,10 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "NULL")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -353,11 +339,10 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "NULL")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -368,11 +353,10 @@ mod tests {
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "*")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "bad://")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         // The helper now returns a generic message for missing authority,
@@ -397,7 +381,7 @@ mod tests {
             "semantic_origin_matching_for_cors".into(),
             toml::Value::Table(table),
         );
-        let _engine = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/semantic_patch_partial_update.rs
+++ b/src/rules/semantic_patch_partial_update.rs
@@ -13,8 +13,6 @@ use crate::rules::Rule;
 pub struct SemanticPatchPartialUpdate;
 
 impl Rule for SemanticPatchPartialUpdate {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_patch_partial_update"
     }
@@ -23,12 +21,11 @@ impl Rule for SemanticPatchPartialUpdate {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.method.eq_ignore_ascii_case("PATCH") {
@@ -154,11 +151,10 @@ mod tests {
         let rule = SemanticPatchPartialUpdate;
         let tx = make_tx_with_req(headers);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -184,11 +180,10 @@ mod tests {
         );
         tx.request.body_length = Some(1);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // rule should not produce a violation; malformed header handled elsewhere
         assert!(v.is_none());
@@ -201,11 +196,10 @@ mod tests {
         tx.request.method = "PATCH".into();
         tx.request.body_length = Some(5);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -220,11 +214,10 @@ mod tests {
         tx.request.method = "PATCH".into();
         tx.request_body = Some(Bytes::from("hello"));
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -236,7 +229,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "semantic_patch_partial_update");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/semantic_post_creates_resource.rs
+++ b/src/rules/semantic_post_creates_resource.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct SemanticPostCreatesResource;
 
 impl Rule for SemanticPostCreatesResource {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_post_creates_resource"
     }
@@ -18,12 +16,11 @@ impl Rule for SemanticPostCreatesResource {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only consider POST requests with a response
@@ -103,11 +100,10 @@ mod tests {
         let rule = SemanticPostCreatesResource;
         let tx = make_tx(status, headers);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for status {}", status);
@@ -126,11 +122,10 @@ mod tests {
         let rule = SemanticPostCreatesResource;
         let tx = make_tx(200, vec![("Location", "/new")]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -147,11 +142,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -166,11 +160,10 @@ mod tests {
         // presence is what matters
         let tx = make_tx(200, vec![("location", "/a"), ("location", "/b")]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -185,11 +178,10 @@ mod tests {
         let rule = SemanticPostCreatesResource;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -198,7 +190,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "semantic_post_creates_resource");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/semantic_status_code_semantics.rs
+++ b/src/rules/semantic_status_code_semantics.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct SemanticStatusCodeSemantics;
 
 impl Rule for SemanticStatusCodeSemantics {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_status_code_semantics"
     }
@@ -18,12 +16,11 @@ impl Rule for SemanticStatusCodeSemantics {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -93,11 +90,10 @@ mod tests {
     fn missing_www_on_401_reports_violation() {
         let rule = SemanticStatusCodeSemantics;
         let tx = crate::test_helpers::make_test_transaction_with_response(401, &[]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("WWW-Authenticate"));
@@ -107,11 +103,10 @@ mod tests {
     fn missing_proxy_on_407_reports_violation() {
         let rule = SemanticStatusCodeSemantics;
         let tx = crate::test_helpers::make_test_transaction_with_response(407, &[]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Proxy-Authenticate"));
@@ -124,11 +119,10 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -140,11 +134,10 @@ mod tests {
             200,
             &[("www-authenticate", "Basic realm=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-401"));
@@ -158,11 +151,10 @@ mod tests {
             401,
             &[("WWW-AUTHENTICATE", "Basic realm=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -178,11 +170,10 @@ mod tests {
             HeaderValue::from_bytes(&[0xff]).unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -200,11 +191,10 @@ mod tests {
             401,
             &[("proxy-authenticate", "Basic realm=\"proxy\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -221,11 +211,10 @@ mod tests {
                 ("www-authenticate", "Basic realm=\"x\""),
             ],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("WWW-Authenticate"));
@@ -238,11 +227,10 @@ mod tests {
             200,
             &[("proxy-authenticate", "Basic realm=\"x\"")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Proxy-Authenticate"));
@@ -253,7 +241,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "semantic_status_code_semantics",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/semantic_trace_method_echo.rs
+++ b/src/rules/semantic_trace_method_echo.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct SemanticTraceMethodEcho;
 
 impl Rule for SemanticTraceMethodEcho {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "semantic_trace_method_echo"
     }
@@ -18,12 +16,11 @@ impl Rule for SemanticTraceMethodEcho {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if !tx.request.method.eq_ignore_ascii_case("TRACE") {
@@ -159,11 +156,10 @@ mod tests {
     fn non_trace_request_is_ignored() {
         let rule = SemanticTraceMethodEcho;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -176,11 +172,10 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "chunked")]);
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("MUST NOT include content"));
@@ -194,11 +189,10 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("content-length", "1")]);
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Content-Length 1"));
@@ -211,11 +205,10 @@ mod tests {
         tx.request.body_length = Some(4);
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("captured request body"));
@@ -228,11 +221,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-length", "0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -244,11 +236,10 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-length", "abc")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -268,11 +259,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -290,11 +280,10 @@ mod tests {
         });
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("message/http"));
@@ -318,11 +307,10 @@ mod tests {
         });
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("message/http"));
@@ -344,11 +332,10 @@ mod tests {
         });
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("should be message/http"));
@@ -367,11 +354,10 @@ mod tests {
         });
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("is invalid"));
@@ -389,11 +375,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -414,11 +399,10 @@ mod tests {
         });
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("message/http"));
@@ -439,11 +423,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -463,11 +446,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -484,11 +466,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -498,7 +479,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "semantic_trace_method_echo",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_200_vs_204_body_consistency.rs
+++ b/src/rules/server_200_vs_204_body_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct Server200Vs204BodyConsistency;
 
 impl Rule for Server200Vs204BodyConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_200_vs_204_body_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for Server200Vs204BodyConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -134,11 +131,10 @@ mod tests {
 
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -159,7 +155,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_200_vs_204_body_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -168,11 +164,10 @@ mod tests {
         let rule = Server200Vs204BodyConsistency;
         let tx = crate::test_helpers::make_test_transaction();
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -184,11 +179,10 @@ mod tests {
         let tx = make_tx_with_response(200, "GET", &[("content-length", "0")]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .expect("expected violation");
         assert!(v.message.contains("Content-Length: 0"));
@@ -205,11 +199,10 @@ mod tests {
         }
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .expect("expected violation");
         assert!(v.message.contains("captured length 0"));
@@ -246,11 +239,10 @@ mod tests {
         });
 
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())

--- a/src/rules/server_3xx_vs_request_method.rs
+++ b/src/rules/server_3xx_vs_request_method.rs
@@ -13,8 +13,6 @@ use crate::rules::Rule;
 pub struct Server3xxVsRequestMethod;
 
 impl Rule for Server3xxVsRequestMethod {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_3xx_vs_request_method"
     }
@@ -23,12 +21,11 @@ impl Rule for Server3xxVsRequestMethod {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses
@@ -98,11 +95,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -116,11 +112,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -130,11 +125,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(303, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -145,11 +139,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(200, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "non-3xx status should be ignored");
     }
@@ -159,11 +152,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(307, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -173,11 +165,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "GET", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -187,11 +178,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "POST", false);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -201,11 +191,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "post", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -220,11 +209,10 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("location", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -235,11 +223,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         for m in &["OPTIONS", "TRACE"] {
             let tx = make_tx(301, m, true);
-            let v = rule.check(
+            let v = rule.check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             );
             assert!(v.is_none(), "method {} should be treated as safe", m);
         }
@@ -249,7 +236,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_3xx_vs_request_method");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -258,11 +245,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(300, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -272,11 +258,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(308, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -286,11 +271,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "HEAD", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -300,11 +284,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "PUT", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -314,11 +297,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "PATCH", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -328,11 +310,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "DELETE", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -343,11 +324,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let mut tx = make_tx(301, "POST", true);
         tx.request.method = "".to_string();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -362,11 +342,10 @@ mod tests {
         hm.append("location", HeaderValue::from_static("/first"));
         hm.append("location", HeaderValue::from_static("/second"));
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -380,11 +359,10 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("location", HeaderValue::from_static(""));
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -395,11 +373,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = crate::test_helpers::make_test_transaction(); // no response
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -409,11 +386,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
         let tx = make_tx(302, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -427,11 +403,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "CONNECT", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -446,11 +421,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "oPtIoNs", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "mixed-case OPTIONS should be treated as safe");
     }
@@ -460,11 +434,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "TrAcE", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "mixed-case TRACE should be treated as safe");
     }
@@ -474,11 +447,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "CONNECT", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -491,11 +463,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(302, "PUT", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let v = v.unwrap();
@@ -508,11 +479,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(304, "POST", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -525,11 +495,10 @@ mod tests {
         let rule = Server3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_tx(301, "connect", true);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),

--- a/src/rules/server_accept_ranges_values_valid.rs
+++ b/src/rules/server_accept_ranges_values_valid.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct ServerAcceptRangesValuesValid;
 
 impl Rule for ServerAcceptRangesValuesValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_accept_ranges_values_valid"
     }
@@ -20,12 +18,11 @@ impl Rule for ServerAcceptRangesValuesValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -107,11 +104,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -135,11 +131,10 @@ mod tests {
     fn missing_response_returns_none() {
         let rule = ServerAcceptRangesValuesValid;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -148,7 +143,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_accept_ranges_values_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_alt_svc_h3_advertisement_valid.rs
+++ b/src/rules/server_alt_svc_h3_advertisement_valid.rs
@@ -13,8 +13,6 @@ pub struct ServerAltSvcH3AdvertisementValid;
 const MAX_REASONABLE_MA: u64 = 365 * 24 * 3600;
 
 impl Rule for ServerAltSvcH3AdvertisementValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_alt_svc_h3_advertisement_valid"
     }
@@ -23,12 +21,11 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
@@ -228,11 +225,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -255,11 +251,10 @@ mod tests {
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("h3-29"));
@@ -275,11 +270,10 @@ mod tests {
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("ma=0"));
@@ -294,11 +288,10 @@ mod tests {
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("unreasonably large"));
@@ -313,11 +306,10 @@ mod tests {
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("non-numeric"));
@@ -328,11 +320,10 @@ mod tests {
     fn missing_response_returns_none() {
         let rule = ServerAltSvcH3AdvertisementValid;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -345,11 +336,10 @@ mod tests {
             &[("alt-svc", "h2=\":443\""), ("alt-svc", "h3-29=\":443\"")],
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -362,11 +352,10 @@ mod tests {
             &[("alt-svc", "h2=\":443\"; ma=0")],
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -380,11 +369,10 @@ mod tests {
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &config,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("no value"));
@@ -408,11 +396,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -430,11 +417,10 @@ mod tests {
             &[("alt-svc", "h3example.com:443")],
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -447,11 +433,10 @@ mod tests {
             &[("alt-svc", "=\":443\"")],
         );
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -460,7 +445,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_alt_svc_h3_advertisement_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/server_alt_svc_header_syntax.rs
+++ b/src/rules/server_alt_svc_header_syntax.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct ServerAltSvcHeaderSyntax;
 
 impl Rule for ServerAltSvcHeaderSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_alt_svc_header_syntax"
     }
@@ -20,12 +18,11 @@ impl Rule for ServerAltSvcHeaderSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -212,11 +209,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -235,11 +231,10 @@ mod tests {
         let rule = ServerAltSvcHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -262,11 +257,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -276,7 +270,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_alt_svc_header_syntax");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/server_alt_svc_protocol_iana_registered.rs
+++ b/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -62,8 +62,6 @@ fn parse_allowed_config(
 pub struct ServerAltSvcProtocolIanaRegistered;
 
 impl Rule for ServerAltSvcProtocolIanaRegistered {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_alt_svc_protocol_iana_registered"
     }
@@ -72,20 +70,16 @@ impl Rule for ServerAltSvcProtocolIanaRegistered {
         crate::rules::RuleScope::Server
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_allowed_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_allowed_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -199,11 +193,10 @@ mod tests {
             None => crate::test_helpers::make_test_transaction_with_response(200, &[]),
         };
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -228,11 +221,10 @@ mod tests {
                 ("alt-svc", "xproto=example.com:443"),
             ],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -249,11 +241,10 @@ mod tests {
             200,
             &[("alt-svc", "h2example.com:443")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         // syntax rule will report missing '='; this rule should be conservative and not panic or report
         assert!(v.is_none());
@@ -278,11 +269,10 @@ mod tests {
         });
 
         let cfg = make_cfg();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -309,7 +299,7 @@ mod tests {
             }),
         );
 
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/server_authentication_challenge_validity.rs
+++ b/src/rules/server_authentication_challenge_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerAuthenticationChallengeValidity;
 
 impl Rule for ServerAuthenticationChallengeValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_authentication_challenge_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerAuthenticationChallengeValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers; ignore non-UTF8 header values
@@ -115,11 +112,10 @@ mod tests {
         let rule = ServerAuthenticationChallengeValidity;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp("Basic realm=\"example\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -129,11 +125,10 @@ mod tests {
         let rule = ServerAuthenticationChallengeValidity;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp("Basic realm=\"a\", NewAuth realm=\"a\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let vv = v.unwrap();
@@ -145,11 +140,10 @@ mod tests {
         let rule = ServerAuthenticationChallengeValidity;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = make_resp("Basic realm=\"a\", NewAuth realm=\"b\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -169,11 +163,10 @@ mod tests {
             hyper::header::HeaderValue::from_static("NewAuth realm=\"a\""),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -184,11 +177,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // Basic realm="a" and NewAuth realm=a -> should be treated equal
         let tx = make_resp("Basic realm=\"a\", NewAuth realm=a");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -206,11 +198,10 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -221,11 +212,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // realm with escaped quote inside quoted-string
         let tx = make_resp("Basic realm=\"a\\\"b\", NewAuth realm=\"a\\\"b\"");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -236,11 +226,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // NewAuth has no realm, Basic has realm a
         let tx = make_resp("Basic realm=\"a\", NewAuth");
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -250,7 +239,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "server_authentication_challenge_validity",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/server_cache_control_present.rs
+++ b/src/rules/server_cache_control_present.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerCacheControlPresent;
 
 impl Rule for ServerCacheControlPresent {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_cache_control_present"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerCacheControlPresent {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if let Some(resp) = &tx.response {
@@ -62,11 +59,10 @@ mod tests {
             Some((k, v)) => make_test_transaction_with_response(status, &[(k, v)]),
             None => make_test_transaction_with_response(status, &[]),
         };
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/server_charset_specification.rs
+++ b/src/rules/server_charset_specification.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerCharsetSpecification;
 
 impl Rule for ServerCharsetSpecification {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_charset_specification"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerCharsetSpecification {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -96,11 +93,10 @@ mod tests {
             });
         }
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/server_clear_site_data.rs
+++ b/src/rules/server_clear_site_data.rs
@@ -80,8 +80,6 @@ paths = ["/logout"]"#
 }
 
 impl Rule for ServerClearSiteData {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_clear_site_data"
     }
@@ -90,20 +88,16 @@ impl Rule for ServerClearSiteData {
         crate::rules::RuleScope::Server
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_paths_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_paths_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         // Only check successful responses
         let Some(resp) = &tx.response else {
@@ -217,11 +211,10 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -340,10 +333,10 @@ mod tests {
             _ => panic!("unknown scenario"),
         }
 
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         if valid {
-            let boxed = res?;
-            let parsed = boxed.downcast::<super::ClearSiteDataConfig>().unwrap();
+            res?;
+            let parsed = super::parse_paths_config(&cfg, rule.id())?;
             assert_eq!(
                 parsed.paths,
                 vec!["/logout".to_string(), "/signout".to_string()]
@@ -380,11 +373,10 @@ mod tests {
             "server_clear_site_data",
             &["/logout"],
         );
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_content_security_policy_validity.rs
+++ b/src/rules/server_content_security_policy_validity.rs
@@ -14,8 +14,6 @@ use crate::rules::Rule;
 pub struct ServerContentSecurityPolicyValidity;
 
 impl Rule for ServerContentSecurityPolicyValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_content_security_policy_validity"
     }
@@ -24,12 +22,11 @@ impl Rule for ServerContentSecurityPolicyValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
@@ -266,11 +263,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-security-policy", h)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header '{:?}'", header);
@@ -295,11 +291,10 @@ mod tests {
             "def@ult-src 'self'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid character"));
@@ -316,11 +311,10 @@ mod tests {
             "default-src 'self'; ",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("empty directive"));
@@ -337,11 +331,10 @@ mod tests {
             "default-src 'self",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Unterminated"));
@@ -358,11 +351,10 @@ mod tests {
             "default-src ''",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty single-quoted"));
@@ -372,7 +364,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_content_security_policy_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -388,11 +380,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers = headers;
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("not valid UTF-8"));
@@ -409,11 +400,10 @@ mod tests {
             "script-src nonce-",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty nonce value"));
@@ -430,11 +420,10 @@ mod tests {
             "script-src sha256-",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -457,11 +446,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers = headers;
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid character"));
@@ -483,11 +471,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-security-policy", "   ")]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("MUST not be empty"));
@@ -504,11 +491,10 @@ mod tests {
             "default-src 'self';;;script-src 'self'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("empty directive"));
@@ -525,11 +511,10 @@ mod tests {
             "script-src nonce-abc def",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -546,11 +531,10 @@ mod tests {
             "script-src 'nonce-abc def'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid nonce value") || v.message.contains("Unterminated"));
@@ -567,11 +551,10 @@ mod tests {
             "script-src 'nonce-'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty nonce value"));
@@ -588,11 +571,10 @@ mod tests {
             "script-src sha256-abc",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -609,11 +591,10 @@ mod tests {
             "script-src 'sha256-'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -630,11 +611,10 @@ mod tests {
             "script-src sha384-abc",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -651,11 +631,10 @@ mod tests {
             "script-src 'sha512-'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -672,11 +651,10 @@ mod tests {
             "script-src sha512-abc",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("single-quoted"));
@@ -693,11 +671,10 @@ mod tests {
             "script-src 'sha256-abc' https://example.com",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -713,11 +690,10 @@ mod tests {
             "script-src 'sha384-abc' https://example.com",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -733,11 +709,10 @@ mod tests {
             "script-src 'sha512-abc' https://example.com",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -753,11 +728,10 @@ mod tests {
             "script-src 'nonce-abc' 'sha256-abc' 'sha384-abc' 'sha512-abc' default-src 'self'",
         )]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unexpected violation: {:?}", v);
     }
@@ -773,11 +747,10 @@ mod tests {
             "script-src 'sha384-'",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -793,11 +766,10 @@ mod tests {
             "script-src sha384-",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -813,11 +785,10 @@ mod tests {
             "script-src sha512-",
         )]);
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Empty hash value"));
@@ -828,11 +799,10 @@ mod tests {
         let rule = ServerContentSecurityPolicyValidity;
         let cfg = make_cfg();
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_content_type_present.rs
+++ b/src/rules/server_content_type_present.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerContentTypePresent;
 
 impl Rule for ServerContentTypePresent {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_content_type_present"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerContentTypePresent {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -106,11 +103,10 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -129,11 +125,10 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerContentTypePresent;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_deprecation_header_syntax.rs
+++ b/src/rules/server_deprecation_header_syntax.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerDeprecationHeaderSyntax;
 
 impl Rule for ServerDeprecationHeaderSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_deprecation_header_syntax"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerDeprecationHeaderSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
@@ -111,11 +108,10 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = ServerDeprecationHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -146,11 +142,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -172,11 +167,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -191,11 +185,10 @@ mod tests {
             200,
             &[("deprecation", "   @1688169599   ")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -208,11 +201,10 @@ mod tests {
             200,
             &[("deprecation", "@abc")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -226,11 +218,10 @@ mod tests {
         let rule = ServerDeprecationHeaderSyntax;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("deprecation", "@")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -243,11 +234,10 @@ mod tests {
             200,
             &[("deprecation", "@-1")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -260,11 +250,10 @@ mod tests {
             200,
             &[("deprecation", "TRUE")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -276,11 +265,10 @@ mod tests {
     fn no_response_no_violation() {
         let rule = ServerDeprecationHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_etag_or_last_modified.rs
+++ b/src/rules/server_etag_or_last_modified.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerEtagOrLastModified;
 
 impl Rule for ServerEtagOrLastModified {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_etag_or_last_modified"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerEtagOrLastModified {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -72,11 +69,10 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(violation.is_some());
@@ -94,11 +90,10 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerEtagOrLastModified;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_http3_status_code_validity.rs
+++ b/src/rules/server_http3_status_code_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerHttp3StatusCodeValidity;
 
 impl Rule for ServerHttp3StatusCodeValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_http3_status_code_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerHttp3StatusCodeValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 connections.
@@ -122,11 +119,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(101, &[("upgrade", "websocket")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         let v = v.expect("should be a violation");
         assert_eq!(v.rule, "server_http3_status_code_validity");
@@ -140,11 +136,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(101, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("101"));
@@ -160,11 +155,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(status, headers);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -176,11 +170,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(100, &[("content-length", "0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         let v = v.expect("should be a violation");
         assert_eq!(v.rule, "server_http3_status_code_validity");
@@ -193,11 +186,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(103, &[("content-length", "42")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -215,11 +207,10 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("message body"));
@@ -233,11 +224,10 @@ mod tests {
             resp.body_length = Some(0);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -255,11 +245,10 @@ mod tests {
             )]));
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("trailer"));
@@ -278,11 +267,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(status, &[]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -297,11 +285,10 @@ mod tests {
             &[("upgrade", "websocket")],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -317,11 +304,10 @@ mod tests {
         tx.request.version = "HTTP/3".into();
         // response.version stays HTTP/1.1
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -334,11 +320,10 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/3".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -351,11 +336,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(199, &[("content-length", "0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("199"));
@@ -367,11 +351,10 @@ mod tests {
         let rule = ServerHttp3StatusCodeValidity;
         let tx = make_h3_transaction_with_response(200, &[("content-length", "42")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -386,11 +369,10 @@ mod tests {
             resp.body_length = Some(100);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -406,11 +388,10 @@ mod tests {
             )]));
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -426,11 +407,10 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Content-Length"));
@@ -445,11 +425,10 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("101"));
@@ -465,11 +444,10 @@ mod tests {
             resp.body_length = None;
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -483,11 +461,10 @@ mod tests {
             crate::test_helpers::make_test_transaction_with_response(101, &[("upgrade", "h2c")]);
         tx.request.version = "HTTP/2.0".into();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -502,11 +479,10 @@ mod tests {
             resp.body_length = Some(5);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("102"));
@@ -523,11 +499,10 @@ mod tests {
             resp.trailers = Some(hyper::HeaderMap::new());
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("trailer"));
@@ -548,11 +523,10 @@ mod tests {
             )]));
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("trailer"));
@@ -570,7 +544,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_http3_status_code_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_keep_alive_timeout_reasonable.rs
+++ b/src/rules/server_keep_alive_timeout_reasonable.rs
@@ -57,8 +57,6 @@ fn parse_keep_alive_config(
 pub struct ServerKeepAliveTimeoutReasonable;
 
 impl Rule for ServerKeepAliveTimeoutReasonable {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_keep_alive_timeout_reasonable"
     }
@@ -67,20 +65,16 @@ impl Rule for ServerKeepAliveTimeoutReasonable {
         crate::rules::RuleScope::Server
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_keep_alive_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_keep_alive_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_keep_alive_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -199,11 +193,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("keep-alive", v)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for {:?}: got {:?}", hv, v);
@@ -239,11 +232,10 @@ mod tests {
                 t
             }),
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -257,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_requires_max_timeout_field() {
+    fn validate_requires_max_timeout_field() {
         let rule = ServerKeepAliveTimeoutReasonable;
         let mut cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         // Insert a table that lacks max_timeout_seconds -> should error on parse
@@ -271,7 +263,7 @@ mod tests {
             }),
         );
 
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         assert!(res.is_err());
     }
 
@@ -295,10 +287,10 @@ mod tests {
     }
 
     #[test]
-    fn validate_and_box_rejects_non_positive_max_timeout() {
+    fn validate_rejects_non_positive_max_timeout() {
         let rule = ServerKeepAliveTimeoutReasonable;
 
-        // Zero value should be rejected by validate_and_box
+        // Zero value should be rejected by validate
         let mut cfg_zero = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         cfg_zero.rules.insert(
             rule.id().into(),
@@ -310,7 +302,7 @@ mod tests {
                 t
             }),
         );
-        let res_zero = rule.validate_and_box(&cfg_zero);
+        let res_zero = rule.validate(&cfg_zero);
         assert!(res_zero.is_err());
         let msg = format!("{}", res_zero.unwrap_err());
         assert!(msg.contains("must be a positive integer"));
@@ -327,7 +319,7 @@ mod tests {
                 t
             }),
         );
-        let res_neg = rule.validate_and_box(&cfg_neg);
+        let res_neg = rule.validate(&cfg_neg);
         assert!(res_neg.is_err());
         let msg2 = format!("{}", res_neg.unwrap_err());
         assert!(msg2.contains("must be a positive integer"));
@@ -367,9 +359,9 @@ mod tests {
             }),
         );
 
-        let _boxed = rule.validate_and_box(&full_cfg)?;
+        rule.validate(&full_cfg)?;
         // Also ensure validate_rules (overall) will succeed when full config provided
-        let _engine = crate::rules::validate_rules(&full_cfg)?;
+        crate::rules::validate_rules(&full_cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_last_modified_rfc1123_format.rs
+++ b/src/rules/server_last_modified_rfc1123_format.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerLastModifiedRfc1123Format;
 
 impl Rule for ServerLastModifiedRfc1123Format {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_last_modified_rfc1123_format"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerLastModifiedRfc1123Format {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -78,11 +75,10 @@ mod tests {
             });
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());
@@ -113,11 +109,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())

--- a/src/rules/server_location_header_uri_valid.rs
+++ b/src/rules/server_location_header_uri_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerLocationHeaderUriValid;
 
 impl Rule for ServerLocationHeaderUriValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_location_header_uri_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerLocationHeaderUriValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -110,11 +107,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{}'", loc);
@@ -147,11 +143,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -175,11 +170,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid scheme"));
@@ -203,11 +197,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid character"));
@@ -232,11 +225,10 @@ mod tests {
             "server_location_header_uri_valid",
             "warn",
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid percent-encoding"));

--- a/src/rules/server_must_revalidate_and_immutable_mismatch.rs
+++ b/src/rules/server_must_revalidate_and_immutable_mismatch.rs
@@ -12,8 +12,6 @@ use crate::rules::Rule;
 pub struct ServerMustRevalidateAndImmutableMismatch;
 
 impl Rule for ServerMustRevalidateAndImmutableMismatch {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_must_revalidate_and_immutable_mismatch"
     }
@@ -22,12 +20,11 @@ impl Rule for ServerMustRevalidateAndImmutableMismatch {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -113,11 +110,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for cc={:?}", cc);
@@ -158,11 +154,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -190,11 +185,10 @@ mod tests {
             .insert("cache-control", bad);
 
         let rule = ServerMustRevalidateAndImmutableMismatch;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -217,7 +211,7 @@ mod tests {
         table.insert("severity".to_string(), toml::Value::String("warn".into()));
         cfg.rules
             .insert(rule.id().to_string(), toml::Value::Table(table));
-        let _ = rule.validate_and_box(&cfg)?;
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_no_body_for_1xx_204_304.rs
+++ b/src/rules/server_no_body_for_1xx_204_304.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerNoBodyFor1xx204304;
 
 impl Rule for ServerNoBodyFor1xx204304 {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_no_body_for_1xx_204_304"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerNoBodyFor1xx204304 {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -121,11 +118,10 @@ mod tests {
             "server_no_body_for_1xx_204_304",
             "error",
         );
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &test_rule_config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -146,14 +142,13 @@ mod tests {
     fn check_missing_response() {
         let rule = ServerNoBodyFor1xx204304;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_severity(
                 "server_no_body_for_1xx_204_304",
                 "error",
             ),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_patch_accept_patch_header.rs
+++ b/src/rules/server_patch_accept_patch_header.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct ServerPatchAcceptPatchHeader;
 
 impl Rule for ServerPatchAcceptPatchHeader {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_patch_accept_patch_header"
     }
@@ -20,12 +18,11 @@ impl Rule for ServerPatchAcceptPatchHeader {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies when the request method is PATCH and a response exists
@@ -155,11 +152,10 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -206,11 +202,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -237,11 +232,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -251,7 +245,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_patch_accept_patch_header");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_priority_and_cacheability_consistency.rs
+++ b/src/rules/server_priority_and_cacheability_consistency.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerPriorityAndCacheabilityConsistency;
 
 impl Rule for ServerPriorityAndCacheabilityConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_priority_and_cacheability_consistency"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerPriorityAndCacheabilityConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -81,11 +78,10 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("priority", "u=3")]);
 
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Priority header"));
@@ -98,11 +94,10 @@ mod tests {
             &[("priority", "u=1"), ("cache-control", "public, max-age=60")],
         );
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -114,11 +109,10 @@ mod tests {
             &[("priority", "u=1"), ("vary", "Accept-Encoding")],
         );
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -127,11 +121,10 @@ mod tests {
     fn no_priority_is_ignored() {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -144,11 +137,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
         Ok(())
@@ -164,11 +156,10 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -179,11 +170,10 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(503, &[("priority", "u=1")]);
         let rule = ServerPriorityAndCacheabilityConsistency;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -192,7 +182,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_priority_and_cacheability_consistency");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/server_problem_details_content_type.rs
+++ b/src/rules/server_problem_details_content_type.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerProblemDetailsContentType;
 
 impl Rule for ServerProblemDetailsContentType {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_problem_details_content_type"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerProblemDetailsContentType {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -109,11 +106,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some());

--- a/src/rules/server_quic_transport_parameters.rs
+++ b/src/rules/server_quic_transport_parameters.rs
@@ -25,18 +25,15 @@ pub struct ServerQuicTransportParameters;
 const MAX_REASONABLE_IDLE_TIMEOUT_MS: u64 = 600_000;
 
 impl ProtocolRule for ServerQuicTransportParameters {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_quic_transport_parameters"
     }
 
-    fn check(
+    fn check_event(
         &self,
         event: &ProtocolEvent,
         _history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let params = match &event.kind {
@@ -176,12 +173,7 @@ mod tests {
     fn reasonable_params_pass() {
         let rule = ServerQuicTransportParameters;
         let evt = make_event(reasonable_params());
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -193,12 +185,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = Some(0);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("initial_max_streams_bidi"));
     }
@@ -209,12 +196,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = Some(1);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -224,12 +206,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = None;
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -241,12 +218,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_data = Some(0);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("initial_max_data"));
     }
@@ -257,12 +229,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_data = None;
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -274,12 +241,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_bidi_local = Some(0);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -295,12 +257,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_bidi_remote = Some(0);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -316,12 +273,7 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_uni = Some(0);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -337,12 +289,7 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(0);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
     }
@@ -353,12 +300,7 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = None;
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
     }
@@ -369,12 +311,7 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(MAX_REASONABLE_IDLE_TIMEOUT_MS + 1);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("excessively large"));
@@ -386,12 +323,7 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(MAX_REASONABLE_IDLE_TIMEOUT_MS);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -401,12 +333,7 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(1);
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -420,12 +347,7 @@ mod tests {
             connection_id: Uuid::new_v4(),
             kind: ProtocolEventKind::H3StreamOpened { stream_id: 0 },
         };
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -444,12 +366,7 @@ mod tests {
                 payload_length: 10,
             },
         };
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -459,7 +376,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_quic_transport_parameters");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -477,12 +394,7 @@ mod tests {
             initial_max_stream_data_uni: None,
         };
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         // Only max_idle_timeout triggers because None means no timeout
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
@@ -502,12 +414,7 @@ mod tests {
             initial_max_stream_data_uni: Some(0),
         };
         let evt = make_event(p);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         // First check is initial_max_streams_bidi
         assert!(result.unwrap().message.contains("initial_max_streams_bidi"));

--- a/src/rules/server_redirect_status_and_location_validity.rs
+++ b/src/rules/server_redirect_status_and_location_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerRedirectStatusAndLocationValidity;
 
 impl Rule for ServerRedirectStatusAndLocationValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_redirect_status_and_location_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerRedirectStatusAndLocationValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // If response has a Location header but the status code is not one
@@ -79,11 +76,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("location", l)]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -109,11 +105,10 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -129,7 +124,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_redirect_status_and_location_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_response_405_allow.rs
+++ b/src/rules/server_response_405_allow.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerResponse405Allow;
 
 impl Rule for ServerResponse405Allow {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_response_405_allow"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerResponse405Allow {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if let Some(resp) = &tx.response {
@@ -63,11 +60,10 @@ mod tests {
             None => vec![],
         };
         let tx = make_test_transaction_with_response(status, &header_pairs);
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {

--- a/src/rules/server_response_location_on_redirect.rs
+++ b/src/rules/server_response_location_on_redirect.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerResponseLocationOnRedirect;
 
 impl Rule for ServerResponseLocationOnRedirect {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_response_location_on_redirect"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerResponseLocationOnRedirect {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -95,11 +92,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for status {}", status);
@@ -127,11 +123,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_retry_after_status_validity.rs
+++ b/src/rules/server_retry_after_status_validity.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerRetryAfterStatusValidity;
 
 impl Rule for ServerRetryAfterStatusValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_retry_after_status_validity"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerRetryAfterStatusValidity {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
@@ -77,11 +74,10 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("retry-after", "120")]);
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert_eq!(v.is_some(), expect_violation);
     }
@@ -91,11 +87,10 @@ mod tests {
         let rule = ServerRetryAfterStatusValidity;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -112,7 +107,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "server_retry_after_status_validity",
         ]);
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -125,11 +120,10 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("retry-after", "60")]);
 
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
-                &crate::rules::RuleConfigEngine::new(),
             )
             .expect("expected violation");
         assert!(v.message.contains("status 500"));

--- a/src/rules/server_server_timing_header_syntax.rs
+++ b/src/rules/server_server_timing_header_syntax.rs
@@ -13,8 +13,6 @@ use crate::rules::Rule;
 pub struct ServerServerTimingHeaderSyntax;
 
 impl Rule for ServerServerTimingHeaderSyntax {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_server_timing_header_syntax"
     }
@@ -23,12 +21,11 @@ impl Rule for ServerServerTimingHeaderSyntax {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -275,11 +272,10 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -305,11 +301,10 @@ mod tests {
             ],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -333,11 +328,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -349,7 +343,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_server_timing_header_syntax");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -360,11 +354,10 @@ mod tests {
             200,
             &[("Server-Timing", "db;dur=50;dur=abc")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "duplicate params should be ignored");
     }
@@ -376,11 +369,10 @@ mod tests {
             200,
             &[("Server-Timing", "db;=5")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "empty parameter name should be ignored");
     }
@@ -392,11 +384,10 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc=\"abc\"x")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -414,11 +405,10 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -432,11 +422,10 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc=")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -450,11 +439,10 @@ mod tests {
             200,
             &[("Server-Timing", "db;desc=bad@value")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -466,11 +454,10 @@ mod tests {
         let rule = ServerServerTimingHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
         // tx.response is None
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_status_and_caching_semantics.rs
+++ b/src/rules/server_status_and_caching_semantics.rs
@@ -11,8 +11,6 @@ use crate::rules::Rule;
 pub struct ServerStatusAndCachingSemantics;
 
 impl Rule for ServerStatusAndCachingSemantics {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_status_and_caching_semantics"
     }
@@ -21,12 +19,11 @@ impl Rule for ServerStatusAndCachingSemantics {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -112,11 +109,10 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &hdrs);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -144,11 +140,10 @@ mod tests {
         hm.insert("cache-control", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         Ok(())
@@ -158,7 +153,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_status_and_caching_semantics");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/server_status_code_valid_range.rs
+++ b/src/rules/server_status_code_valid_range.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerStatusCodeValidRange;
 
 impl Rule for ServerStatusCodeValidRange {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_status_code_valid_range"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerStatusCodeValidRange {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -76,11 +73,10 @@ mod tests {
             "error",
         );
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -103,11 +99,10 @@ mod tests {
             "error",
         );
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_vary_and_cache_consistency.rs
+++ b/src/rules/server_vary_and_cache_consistency.rs
@@ -14,8 +14,6 @@ use crate::rules::Rule;
 pub struct ServerVaryAndCacheConsistency;
 
 impl Rule for ServerVaryAndCacheConsistency {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_vary_and_cache_consistency"
     }
@@ -24,12 +22,11 @@ impl Rule for ServerVaryAndCacheConsistency {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -137,11 +134,10 @@ mod tests {
     ) {
         let rule = ServerVaryAndCacheConsistency;
         let tx = make_tx(vary, cc);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -174,11 +170,10 @@ mod tests {
             .unwrap()
             .headers
             .insert("cache-control", bad);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -211,11 +206,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -226,21 +220,19 @@ mod tests {
 
         // Public (mixed case) should be detected
         let tx = make_tx(Some("*"), Some("Public"));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
 
         // MAX-AGE uppercase
         let tx2 = make_tx(Some("*"), Some("MAX-AGE=60"));
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
     }
@@ -265,11 +257,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -279,11 +270,10 @@ mod tests {
         // Vary: * with a non-cacheability extension should not be flagged
         let rule = ServerVaryAndCacheConsistency;
         let tx = make_tx(Some("*"), Some("foo=bar"));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -294,8 +284,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "server_vary_and_cache_consistency",
         ]);
-        // validate_and_box should succeed without error
-        let _boxed = rule.validate_and_box(&cfg)?;
+        // validate should succeed without error
+        rule.validate(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/server_vary_header_valid.rs
+++ b/src/rules/server_vary_header_valid.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct ServerVaryHeaderValid;
 
 impl Rule for ServerVaryHeaderValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_vary_header_valid"
     }
@@ -20,12 +18,11 @@ impl Rule for ServerVaryHeaderValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -134,11 +131,10 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "warn");
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for header={:?}", header);
@@ -161,11 +157,10 @@ mod tests {
             &[("vary", "Accept-Encoding"), ("vary", "User-Agent")],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -179,11 +174,10 @@ mod tests {
             &[("vary", "*"), ("vary", "Accept-Encoding")],
         );
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -207,11 +201,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -223,7 +216,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "server_vary_header_valid");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -237,11 +230,10 @@ mod tests {
     fn no_response_returns_none() {
         let rule = ServerVaryHeaderValid;
         let tx = crate::test_helpers::make_test_transaction(); // request-only, no response
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/server_x_content_type_options.rs
+++ b/src/rules/server_x_content_type_options.rs
@@ -60,8 +60,6 @@ fn parse_x_content_type_options_config(
 }
 
 impl Rule for ServerXContentTypeOptions {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_x_content_type_options"
     }
@@ -70,20 +68,16 @@ impl Rule for ServerXContentTypeOptions {
         crate::rules::RuleScope::Server
     }
 
-    fn validate_and_box(
-        &self,
-        config: &crate::config::Config,
-    ) -> anyhow::Result<std::sync::Arc<dyn std::any::Any + Send + Sync>> {
-        let parsed = parse_x_content_type_options_config(config, self.id())?;
-        Ok(std::sync::Arc::new(parsed))
+    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
+        parse_x_content_type_options_config(config, self.id())?;
+        Ok(())
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = parse_x_content_type_options_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
@@ -166,11 +160,10 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
 
         if expect_violation {
@@ -266,17 +259,15 @@ mod tests {
             _ => panic!("unknown scenario"),
         }
 
-        let res = rule.validate_and_box(&cfg);
+        let res = rule.validate(&cfg);
         if expect_error {
             assert!(res.is_err());
             if let Some(sub) = expected_substring {
                 assert!(res.unwrap_err().to_string().contains(sub));
             }
         } else {
-            let boxed = res?;
-            let parsed = boxed
-                .downcast::<super::XContentTypeOptionsConfig>()
-                .unwrap();
+            res?;
+            let parsed = super::parse_x_content_type_options_config(&cfg, rule.id())?;
             assert_eq!(parsed.content_types, vec!["text/html".to_string()]);
         }
         Ok(())
@@ -316,11 +307,10 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_some());
         Ok(())
@@ -345,11 +335,10 @@ mod tests {
             "server_x_content_type_options".to_string(),
             toml::Value::Table(table),
         );
-        let violation = rule.check(
+        let violation = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(violation.is_none());
     }

--- a/src/rules/server_x_frame_options_value_valid.rs
+++ b/src/rules/server_x_frame_options_value_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerXFrameOptionsValueValid;
 
 impl Rule for ServerXFrameOptionsValueValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_x_frame_options_value_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerXFrameOptionsValueValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check response headers
@@ -136,11 +133,10 @@ mod tests {
                 &[("x-frame-options", h)],
             );
         }
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(
@@ -177,11 +173,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple X-Frame-Options"));
@@ -208,11 +203,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));

--- a/src/rules/server_x_xss_protection_value_valid.rs
+++ b/src/rules/server_x_xss_protection_value_valid.rs
@@ -8,8 +8,6 @@ use crate::rules::Rule;
 pub struct ServerXXssProtectionValueValid;
 
 impl Rule for ServerXXssProtectionValueValid {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "server_x_xss_protection_value_valid"
     }
@@ -18,12 +16,11 @@ impl Rule for ServerXXssProtectionValueValid {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -109,11 +106,10 @@ mod tests {
             );
         }
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         if expect_violation {
             assert!(v.is_some(), "expected violation for '{:?}', got none", val);
@@ -145,11 +141,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Multiple X-XSS-Protection"));
@@ -176,11 +171,10 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("non-ASCII"));
@@ -196,11 +190,10 @@ mod tests {
     fn no_response_returns_none() {
         let rule = ServerXXssProtectionValueValid;
         let tx = make_test_transaction(); // no response set
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -209,11 +202,10 @@ mod tests {
     fn response_without_header_returns_none() {
         let rule = ServerXXssProtectionValueValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -225,11 +217,10 @@ mod tests {
             200,
             &[("x-xss-protection", "1")],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -244,11 +235,10 @@ mod tests {
             200,
             &[("x-xss-protection", val)],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -263,11 +253,10 @@ mod tests {
             200,
             &[("x-xss-protection", val)],
         );
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;

--- a/src/rules/stateful_101_switching_protocols.rs
+++ b/src/rules/stateful_101_switching_protocols.rs
@@ -21,8 +21,6 @@ use crate::rules::Rule;
 pub struct Stateful101SwitchingProtocols;
 
 impl Rule for Stateful101SwitchingProtocols {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_101_switching_protocols"
     }
@@ -31,12 +29,11 @@ impl Rule for Stateful101SwitchingProtocols {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
@@ -210,13 +207,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -231,13 +227,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -252,13 +247,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -273,13 +267,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -294,13 +287,12 @@ mod tests {
         tx.response = None;
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -312,13 +304,12 @@ mod tests {
         let tx = make_upgrade_tx("HTTP/1.1", &[], 101, &[("upgrade", "websocket")]);
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("did not include an Upgrade header"));
@@ -336,13 +327,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing required Upgrade header"));
@@ -360,13 +350,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("was not offered by the client"));
@@ -384,13 +373,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/1.0"));
@@ -408,13 +396,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/2"));
@@ -430,13 +417,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/2"));
@@ -454,13 +440,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP/3"));
@@ -490,13 +475,12 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &current,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("HTTP traffic after 101"));
@@ -516,13 +500,12 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &current,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -539,13 +522,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -560,13 +542,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("was not offered"));
@@ -584,13 +565,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -614,13 +594,12 @@ mod tests {
         ]);
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -635,13 +614,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("no protocol tokens"));
@@ -657,13 +635,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("no protocol tokens"));
@@ -679,13 +656,12 @@ mod tests {
         );
         let rule = Stateful101SwitchingProtocols;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("was not offered"));
@@ -705,13 +681,12 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
-            .check(
+            .check_transaction(
                 &current,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_101_switching_protocols"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -720,7 +695,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_101_switching_protocols");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_103_early_hints_before_final.rs
+++ b/src/rules/stateful_103_early_hints_before_final.rs
@@ -11,8 +11,6 @@ use crate::rules::Rule;
 pub struct Stateful103EarlyHintsBeforeFinal;
 
 impl Rule for Stateful103EarlyHintsBeforeFinal {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_103_early_hints_before_final"
     }
@@ -21,12 +19,11 @@ impl Rule for Stateful103EarlyHintsBeforeFinal {
         crate::rules::RuleScope::Server
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses with status 103
@@ -90,13 +87,12 @@ mod tests {
         tx.request.uri = "/x".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let m = v.unwrap().message;
@@ -115,13 +111,12 @@ mod tests {
         tx.request.uri = "/b".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -138,13 +133,12 @@ mod tests {
         tx.request.uri = "/r".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -153,7 +147,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_103_early_hints_before_final");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -187,13 +181,12 @@ mod tests {
         tx.request.uri = "/z".to_string();
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }

--- a/src/rules/stateful_authentication_failure_loop.rs
+++ b/src/rules/stateful_authentication_failure_loop.rs
@@ -10,8 +10,6 @@ use crate::rules::Rule;
 pub struct StatefulAuthenticationFailureLoop;
 
 impl Rule for StatefulAuthenticationFailureLoop {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_authentication_failure_loop"
     }
@@ -20,12 +18,11 @@ impl Rule for StatefulAuthenticationFailureLoop {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
@@ -85,13 +82,12 @@ mod tests {
         // supply history newest-first; tx3 is most recent
         let history = crate::transaction_history::TransactionHistory::new(vec![tx3, tx2, tx1]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_authentication_failure_loop",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("4 consecutive"));
@@ -111,13 +107,12 @@ mod tests {
         // put newest transaction first (tx4) to satisfy TransactionHistory
         let history = crate::transaction_history::TransactionHistory::new(vec![tx4, tx3, tx2, tx1]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_authentication_failure_loop",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // Only 2 consecutive 401s before the 200, so no loop
         assert!(v.is_none());
@@ -135,13 +130,12 @@ mod tests {
         // newest-first history
         let history = crate::transaction_history::TransactionHistory::new(vec![tx3, tx2, tx1]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_authentication_failure_loop",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -150,6 +144,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_authentication_failure_loop");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_cache_validation_chain.rs
+++ b/src/rules/stateful_cache_validation_chain.rs
@@ -31,8 +31,6 @@ use crate::rules::Rule;
 pub struct StatefulCacheValidationChain;
 
 impl Rule for StatefulCacheValidationChain {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_cache_validation_chain"
     }
@@ -41,12 +39,11 @@ impl Rule for StatefulCacheValidationChain {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -195,13 +192,12 @@ mod tests {
     fn non_conditional_request_is_ok() {
         let rule = StatefulCacheValidationChain;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -212,13 +208,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -230,13 +225,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "*")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -248,13 +242,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -266,13 +259,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -284,13 +276,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "W/\"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -302,13 +293,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "W/\"b\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -320,13 +310,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "*")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -338,13 +327,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -357,13 +345,12 @@ mod tests {
         // first token wrong, second token correct
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -375,13 +362,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -395,13 +381,12 @@ mod tests {
             ("if-none-match", "\"a\""),
             ("if-modified-since", "Thu, 02 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -417,13 +402,12 @@ mod tests {
             "if-modified-since",
             "wed, 01 Jan 2020 00:00:00 GMT",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -437,13 +421,12 @@ mod tests {
             ("if-none-match", "\"a\""),
             ("if-modified-since", "Wed, 01 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -457,13 +440,12 @@ mod tests {
             "if-modified-since",
             "Thu, 02 Jan 2020 00:00:00 GMT",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -475,13 +457,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", "not-a-date")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -496,13 +477,12 @@ mod tests {
             "if-modified-since",
             "Thu, 02 Jan 2020 00:00:00 GMT",
         )]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -516,13 +496,12 @@ mod tests {
             ("if-none-match", "\"b\""),
             ("if-modified-since", "Thu, 02 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -536,13 +515,12 @@ mod tests {
             ("if-none-match", "\"a\""),
             ("if-modified-since", "Thu, 02 Jan 2020 00:00:00 GMT"),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -556,13 +534,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev2, prev1]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -571,7 +548,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_cache_validation_chain");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/stateful_conditional_request_handling.rs
+++ b/src/rules/stateful_conditional_request_handling.rs
@@ -15,8 +15,6 @@ use crate::rules::Rule;
 pub struct StatefulConditionalRequestHandling;
 
 impl Rule for StatefulConditionalRequestHandling {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_conditional_request_handling"
     }
@@ -25,12 +23,11 @@ impl Rule for StatefulConditionalRequestHandling {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies when request contains one or more conditional headers
@@ -174,13 +171,12 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("no previous response recorded"));
@@ -195,13 +191,12 @@ mod tests {
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let prev_empty = make_prev_with_headers(&[]);
-        let v1 = rule.check(
+        let v1 = rule.check_transaction(
             &tx1,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v1.is_some());
 
@@ -211,13 +206,12 @@ mod tests {
             "if-modified-since",
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_some());
 
@@ -225,13 +219,12 @@ mod tests {
         let mut tx3 = crate::test_helpers::make_test_transaction();
         tx3.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-match", "\"a\"")]);
-        let v3 = rule.check(
+        let v3 = rule.check_transaction(
             &tx3,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v3.is_some());
 
@@ -241,13 +234,12 @@ mod tests {
             "if-unmodified-since",
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
-        let v4 = rule.check(
+        let v4 = rule.check_transaction(
             &tx4,
             &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v4.is_some());
     }
@@ -262,13 +254,12 @@ mod tests {
         let prev = make_prev_with_headers(&[("etag", "\"a\"")]);
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
 
@@ -279,13 +270,12 @@ mod tests {
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
         let prev2 = make_prev_with_headers(&[("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")]);
-        let v2 = rule.check(
+        let v2 = rule.check_transaction(
             &tx2,
             &crate::transaction_history::TransactionHistory::new(vec![prev2.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v2.is_none());
     }
@@ -302,13 +292,12 @@ mod tests {
 
         let rule = StatefulConditionalRequestHandling;
         // previous satisfies validator check
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("consider returning 304"));
@@ -329,13 +318,12 @@ mod tests {
         let prev = make_prev_with_headers(&[("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")]);
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("consider returning 304"));
@@ -353,13 +341,12 @@ mod tests {
 
         let rule = StatefulConditionalRequestHandling;
         // response ETag doesn't match request conditional -> allowed
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -374,13 +361,12 @@ mod tests {
         let prev = crate::test_helpers::make_test_transaction();
 
         let rule = StatefulConditionalRequestHandling;
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -393,7 +379,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_conditional_request_handling");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_cookie_domain_matching.rs
+++ b/src/rules/stateful_cookie_domain_matching.rs
@@ -21,8 +21,6 @@ use crate::rules::Rule;
 pub struct StatefulCookieDomainMatching;
 
 impl Rule for StatefulCookieDomainMatching {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_cookie_domain_matching"
     }
@@ -31,12 +29,11 @@ impl Rule for StatefulCookieDomainMatching {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
@@ -172,13 +169,12 @@ mod tests {
         let tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -192,13 +188,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -215,13 +210,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_domain_matching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("different domain"));
@@ -246,13 +240,12 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -265,13 +258,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_domain_matching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid for path"));
@@ -283,13 +275,12 @@ mod tests {
         let tx = make_tx_with_req("https://example.com/", None);
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -309,13 +300,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -330,13 +320,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -355,13 +344,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_domain_matching"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -370,6 +358,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_cookie_domain_matching");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_cookie_lifecycle.rs
+++ b/src/rules/stateful_cookie_lifecycle.rs
@@ -15,8 +15,6 @@ use crate::rules::Rule;
 pub struct StatefulCookieLifecycle;
 
 impl Rule for StatefulCookieLifecycle {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_cookie_lifecycle"
     }
@@ -27,12 +25,11 @@ impl Rule for StatefulCookieLifecycle {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
@@ -253,13 +250,12 @@ mod tests {
         let tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_lifecycle"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -274,13 +270,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_lifecycle"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -293,13 +288,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -313,13 +307,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(30);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_lifecycle"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -332,13 +325,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("expired or removed"));
@@ -358,13 +350,12 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(20);
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("value"));
@@ -378,13 +369,12 @@ mod tests {
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Secure cookie"));
@@ -415,13 +405,12 @@ mod tests {
             prev_nonsecure.clone(),
             prev_secure.clone(),
         ]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -437,13 +426,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid for path"));
@@ -458,13 +446,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/foobar", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid for path"));
@@ -482,13 +469,12 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cookie_lifecycle",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // request to other.com should not be influenced by cookie from example.com
         assert!(
@@ -501,6 +487,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_cookie_lifecycle");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_cookie_same_site_enforcement.rs
+++ b/src/rules/stateful_cookie_same_site_enforcement.rs
@@ -17,8 +17,6 @@ use crate::rules::Rule;
 pub struct StatefulCookieSameSiteEnforcement;
 
 impl Rule for StatefulCookieSameSiteEnforcement {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_cookie_same_site_enforcement"
     }
@@ -27,12 +25,11 @@ impl Rule for StatefulCookieSameSiteEnforcement {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
@@ -210,13 +207,12 @@ mod tests {
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -235,13 +231,12 @@ mod tests {
             Some(Utc::now()),
         )]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -260,13 +255,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("none"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -285,13 +279,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("invalid"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -311,13 +304,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -337,13 +329,12 @@ mod tests {
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         // even though cross-site, the secure cookie should not match because of scheme
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -364,13 +355,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -393,13 +383,12 @@ mod tests {
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("cors"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -422,13 +411,12 @@ mod tests {
             .append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.method = "GET".parse().unwrap();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -451,13 +439,12 @@ mod tests {
             .append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.method = "HEAD".parse().unwrap();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -476,13 +463,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -504,13 +490,12 @@ mod tests {
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("cors"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -521,13 +506,12 @@ mod tests {
         let tx = make_tx_with_req("https://example.com/", Some("a=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -536,7 +520,7 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_cookie_same_site_enforcement");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 
     #[test]
@@ -553,13 +537,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("same-site"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -578,13 +561,12 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_cookie_same_site_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }

--- a/src/rules/stateful_digest_auth_nonce_handling.rs
+++ b/src/rules/stateful_digest_auth_nonce_handling.rs
@@ -31,8 +31,6 @@ use crate::rules::Rule;
 pub struct StatefulDigestAuthNonceHandling;
 
 impl Rule for StatefulDigestAuthNonceHandling {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_digest_auth_nonce_handling"
     }
@@ -41,12 +39,11 @@ impl Rule for StatefulDigestAuthNonceHandling {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about client-side requests with Digest Authorization
@@ -303,13 +300,12 @@ mod tests {
     fn no_challenge_before_auth_is_reported() {
         let nonce1 = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -326,13 +322,12 @@ mod tests {
                 &make_challenge(&nonce1, Some("o1"), None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o2")));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("opaque does not match"));
@@ -346,13 +341,12 @@ mod tests {
                 &make_challenge(&nonce1, Some("o1"), None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing opaque"));
@@ -363,13 +357,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Basic abc")]);
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -381,13 +374,12 @@ mod tests {
             "authorization",
             "Digest realm=\"r\"",
         )]);
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -400,13 +392,12 @@ mod tests {
             "authorization",
             "Digest bogus=\"x\", =bad",
         )]);
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -426,13 +417,12 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev_request, prev_challenge]);
         let tx = tx_req_with_auth(&auth2);
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("nonce-count did not increase"));
@@ -449,13 +439,12 @@ mod tests {
             )]);
         // client correctly uses same nonce but wrong nc
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000005"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("must reset nc"));
@@ -471,13 +460,12 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev_request, prev_challenge]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000002"), Some("o1")));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -491,13 +479,12 @@ mod tests {
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("nonce differs"));
@@ -512,13 +499,12 @@ mod tests {
             )]);
         // request omits opaque entirely
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing opaque"));
@@ -534,13 +520,12 @@ mod tests {
             )]);
         // client uses different nonce entirely
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -557,13 +542,12 @@ mod tests {
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, None, None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -576,13 +560,12 @@ mod tests {
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("GARBAGE"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Invalid nc"));
@@ -597,13 +580,12 @@ mod tests {
                 &make_challenge(&nonce1, None, Some("true")),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         let msg = v.unwrap().message;
@@ -619,13 +601,12 @@ mod tests {
             )]);
         // correct reset
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -641,13 +622,12 @@ mod tests {
         );
         let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -660,13 +640,12 @@ mod tests {
                 &make_challenge(&nonce, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce, None, None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -683,13 +662,12 @@ mod tests {
         );
         let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -708,13 +686,12 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
         let nonce = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // no digest challenge seen -> violation for missing challenge
         assert!(v.is_some());
@@ -729,13 +706,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Digest")]);
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -750,13 +726,12 @@ mod tests {
             HeaderValue::from_bytes(&[0xff, 0xff]).unwrap(),
         );
         tx.request.headers = headers;
-        let v = StatefulDigestAuthNonceHandling.check(
+        let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_digest_auth_nonce_handling",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -765,6 +740,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_digest_auth_nonce_handling");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_http3_goaway_semantics.rs
+++ b/src/rules/stateful_http3_goaway_semantics.rs
@@ -17,18 +17,15 @@ use crate::rules::ProtocolRule;
 pub struct StatefulHttp3GoawaySemantics;
 
 impl ProtocolRule for StatefulHttp3GoawaySemantics {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_http3_goaway_semantics"
     }
 
-    fn check(
+    fn check_event(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         match &event.kind {
@@ -137,12 +134,7 @@ mod tests {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -153,12 +145,7 @@ mod tests {
         let prev = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -169,12 +156,7 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -185,12 +167,7 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(10));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("increased from previous"));
@@ -207,12 +184,7 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, None);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -223,12 +195,7 @@ mod tests {
         let prev = make_goaway(conn, None);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -239,12 +206,7 @@ mod tests {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -255,12 +217,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 8);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -271,12 +228,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 10);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -287,12 +239,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 5);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("stream 5"));
@@ -309,12 +256,7 @@ mod tests {
         let goaway = make_goaway(conn, None);
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -327,12 +269,7 @@ mod tests {
             Uuid::new_v4(),
             ProtocolEventKind::H3StreamClosed { stream_id: 0 },
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -350,12 +287,7 @@ mod tests {
                 payload_length: 10,
             },
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -365,7 +297,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_http3_goaway_semantics");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 
@@ -388,12 +320,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![goaway, stream]);
         // New GOAWAY with id=12 > 10 should fail
         let evt = make_goaway(conn, Some(12));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -417,12 +344,7 @@ mod tests {
         // Stream 3 > goaway id 2 — first event is H3StreamClosed which
         // should be skipped; the goaway at index 1 triggers violation.
         let evt = make_stream_opened(conn, 3);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -447,12 +369,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![g1, g2]);
         // New GOAWAY with id=8: compared to most recent (6), 8 > 6 → fail
         let evt = make_goaway(conn, Some(8));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -464,12 +381,7 @@ mod tests {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_goaway(conn, Some(0));
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -481,12 +393,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -498,12 +405,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 1);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -515,12 +417,7 @@ mod tests {
         let prev = make_goaway(conn, Some(100));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(0));
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 }

--- a/src/rules/stateful_http3_max_push_id.rs
+++ b/src/rules/stateful_http3_max_push_id.rs
@@ -17,18 +17,15 @@ use crate::rules::ProtocolRule;
 pub struct StatefulHttp3MaxPushId;
 
 impl ProtocolRule for StatefulHttp3MaxPushId {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_http3_max_push_id"
     }
 
-    fn check(
+    fn check_event(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let current = match &event.kind {
@@ -104,12 +101,7 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -118,12 +110,7 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 100);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -133,12 +120,7 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, (1u64 << 62) - 1);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -151,12 +133,7 @@ mod tests {
         let prev = make_max_push_id(conn, 5);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 10);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -168,12 +145,7 @@ mod tests {
         let prev = make_max_push_id(conn, 7);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 7);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -186,12 +158,7 @@ mod tests {
         let prev = make_max_push_id(conn, 10);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 4);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert_eq!(v.rule, "stateful_http3_max_push_id");
         assert!(v.message.contains("MAX_PUSH_ID 4"));
@@ -206,12 +173,7 @@ mod tests {
         let prev = make_max_push_id(conn, 1);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 0"));
         assert!(v.message.contains("previous 1"));
@@ -224,12 +186,7 @@ mod tests {
         let prev = make_max_push_id(conn, 100);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 99);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -255,12 +212,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![g1, g2, g3]);
         // 20 (most recent) == 20 -> OK
         let evt = make_max_push_id(conn, 20);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -282,12 +234,7 @@ mod tests {
         let older = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 50 }, t);
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 8);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -305,12 +252,7 @@ mod tests {
         let older = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 5 }, t);
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 10);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 10"));
         assert!(v.message.contains("previous 20"));
@@ -341,12 +283,7 @@ mod tests {
 
         // New MAX_PUSH_ID = 5 < 10 → violation; settings should be skipped.
         let evt = make_max_push_id(conn, 5);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -366,12 +303,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![settings, stream]);
         // No prior MAX_PUSH_ID → first one is accepted at any value.
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -387,12 +319,7 @@ mod tests {
                 settings: vec![(0x06, 4096)],
             },
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -404,12 +331,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) },
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -418,12 +340,7 @@ mod tests {
         let rule = StatefulHttp3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 });
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -442,12 +359,7 @@ mod tests {
                 payload_length: 10,
             },
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -471,7 +383,7 @@ mod tests {
                 sev_str,
             );
             let v = rule
-                .check(&evt, &history, &cfg, &crate::rules::RuleConfigEngine::new())
+                .check_event(&evt, &history, &cfg)
                 .expect("expected violation");
             assert_eq!(v.severity, sev);
             assert_eq!(v.rule, "stateful_http3_max_push_id");
@@ -496,12 +408,7 @@ mod tests {
         }
         let history = ProtocolEventHistory::new(history_vec);
         let evt = make_max_push_id(conn, 6);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 6"));
         assert!(v.message.contains("previous 7"));
@@ -542,12 +449,7 @@ mod tests {
         let history = ProtocolEventHistory::new(history_vec);
         let evt = make_max_push_id(conn, 14);
         let v = rule
-            .check(
-                &evt,
-                &history,
-                &make_config(),
-                &crate::rules::RuleConfigEngine::new(),
-            )
+            .check_event(&evt, &history, &make_config())
             .expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 14"));
         assert!(v.message.contains("previous 15"));
@@ -563,12 +465,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 0);
         let v = rule
-            .check(
-                &evt,
-                &history,
-                &make_config(),
-                &crate::rules::RuleConfigEngine::new(),
-            )
+            .check_event(&evt, &history, &make_config())
             .expect("expected violation");
         // The message should reference RFC 9114 §7.2.7 and the H3_ID_ERROR
         // connection error code so operators can map it to the spec.
@@ -583,7 +480,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_http3_max_push_id");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_http3_settings_frame.rs
+++ b/src/rules/stateful_http3_settings_frame.rs
@@ -27,18 +27,15 @@ const RESERVED_SETTING_IDS: &[u64] = &[
 ];
 
 impl ProtocolRule for StatefulHttp3SettingsFrame {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_http3_settings_frame"
     }
 
-    fn check(
+    fn check_event(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let settings = match &event.kind {
@@ -128,12 +125,7 @@ mod tests {
                 (0x07, 100),  // SETTINGS_QPACK_BLOCKED_STREAMS
             ],
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -142,12 +134,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -157,12 +144,7 @@ mod tests {
         let conn = Uuid::new_v4();
         // Extension/unknown setting identifiers are allowed.
         let evt = make_settings(conn, vec![(0x33, 1), (0xFF00, 42)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -175,12 +157,7 @@ mod tests {
         let prev = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -192,12 +169,7 @@ mod tests {
         let prev = make_settings(conn, vec![]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![]);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -216,12 +188,7 @@ mod tests {
         let closed = make_event_at(conn, ProtocolEventKind::H3StreamClosed { stream_id: 0 }, t);
         let history = ProtocolEventHistory::new(vec![opened, closed]);
         let evt = make_settings(conn, vec![(0x06, 4096)]);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -259,12 +226,7 @@ mod tests {
         );
         let history = ProtocolEventHistory::new(vec![opened, prev_settings, transport]);
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -275,12 +237,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x00, 0)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x00"));
     }
@@ -290,12 +247,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x02, 1)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x02"));
     }
@@ -305,12 +257,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x03, 100)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
     }
@@ -320,12 +267,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x04, 65535)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x04"));
     }
@@ -335,12 +277,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x05, 16384)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x05"));
     }
@@ -351,12 +288,7 @@ mod tests {
         let conn = Uuid::new_v4();
         // Mix valid settings with one reserved.
         let evt = make_settings(conn, vec![(0x06, 8192), (0x03, 100), (0x07, 50)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
     }
@@ -369,12 +301,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x01, 4096)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -383,12 +310,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -397,12 +319,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x07, 200)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -412,12 +329,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x08, 1)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -427,12 +339,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x33, 1)]);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -443,12 +350,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 });
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -460,12 +362,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) },
         );
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -474,12 +371,7 @@ mod tests {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3MaxPushId { push_id: 10 });
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -493,12 +385,7 @@ mod tests {
         let prev = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![(0x02, 1)]); // reserved + duplicate
-        let result = rule.check(
-            &evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -509,7 +396,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_http3_settings_frame");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_immutable_cache_never_stale.rs
+++ b/src/rules/stateful_immutable_cache_never_stale.rs
@@ -30,8 +30,6 @@ use crate::rules::Rule;
 pub struct StatefulImmutableCacheNeverStale;
 
 impl Rule for StatefulImmutableCacheNeverStale {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_immutable_cache_never_stale"
     }
@@ -40,12 +38,11 @@ impl Rule for StatefulImmutableCacheNeverStale {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent prior response with an immutable
@@ -192,13 +189,12 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulImmutableCacheNeverStale;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_immutable_cache_never_stale",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -209,13 +205,12 @@ mod tests {
         let prev = make_prev_with_headers(&[("cache-control", "max-age=60")], Utc::now());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_immutable_cache_never_stale",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -233,13 +228,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_immutable_cache_never_stale",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Unnecessary revalidation"));
@@ -264,13 +258,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_immutable_cache_never_stale"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -288,13 +281,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_immutable_cache_never_stale"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -308,13 +300,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_immutable_cache_never_stale"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -323,7 +314,7 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_immutable_cache_never_stale");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 
     #[test]
@@ -335,13 +326,12 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_immutable_cache_never_stale",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none(), "unconditional fresh use should not warn");
     }
@@ -366,13 +356,12 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // age_val=5, elapsed clamped to 0 -> current_age=5 < freshness(50) => violation
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_immutable_cache_never_stale",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -391,13 +380,12 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // freshness lifetime zero, so no violation should be reported
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_immutable_cache_never_stale"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }

--- a/src/rules/stateful_max_age_directive_validity.rs
+++ b/src/rules/stateful_max_age_directive_validity.rs
@@ -31,8 +31,6 @@ use crate::rules::Rule;
 pub struct StatefulMaxAgeDirectiveValidity;
 
 impl Rule for StatefulMaxAgeDirectiveValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_max_age_directive_validity"
     }
@@ -42,12 +40,11 @@ impl Rule for StatefulMaxAgeDirectiveValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate most recent prior response with a usable max-age
@@ -153,13 +150,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(30);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -178,13 +174,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -200,13 +195,12 @@ mod tests {
         tx2.timestamp = base + chrono::Duration::seconds(10);
         let history2 = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(
-            rule.check(
+            rule.check_transaction(
                 &tx2,
                 &history2,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_max_age_directive_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none(),
             "conditional at boundary should not warn"
@@ -228,13 +222,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("still fresh"));
@@ -255,13 +248,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -279,13 +271,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Stale cached entry"));
@@ -303,13 +294,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -326,13 +316,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -350,13 +339,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_none(),
@@ -379,13 +367,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(30);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "expected violation because still fresh");
     }
@@ -410,13 +397,12 @@ mod tests {
         tx.timestamp = base;
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(
             v.is_some(),
@@ -439,13 +425,12 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
         // age == max-age should be treated as stale; unconditional request
         // should therefore be flagged since validator exists.
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "unconditional fetch at boundary should warn");
 
@@ -458,13 +443,12 @@ mod tests {
         tx2.timestamp = base;
         let history2 = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(
-            rule.check(
+            rule.check_transaction(
                 &tx2,
                 &history2,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_max_age_directive_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none(),
             "conditional at boundary should not warn"
@@ -485,13 +469,12 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // age computed from elapsed clamped to 0 yields fresh state; no violation expected
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_max_age_directive_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -543,7 +526,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_max_age_directive_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_must_revalidate_enforcement.rs
+++ b/src/rules/stateful_must_revalidate_enforcement.rs
@@ -34,8 +34,6 @@ use crate::rules::Rule;
 pub struct StatefulMustRevalidateEnforcement;
 
 impl Rule for StatefulMustRevalidateEnforcement {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_must_revalidate_enforcement"
     }
@@ -45,12 +43,11 @@ impl Rule for StatefulMustRevalidateEnforcement {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // find the most recent past response that contained must-revalidate
@@ -156,13 +153,12 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulMustRevalidateEnforcement;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -173,13 +169,12 @@ mod tests {
         let prev = make_prev(200, &[("cache-control", "max-age=60")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -233,13 +228,12 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         // current_age should equal age header (5) not negative elapsed
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // freshness zero and no validator -> no violation
         assert!(v.is_none());
@@ -268,13 +262,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -304,13 +297,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "equal age should now be treated as stale");
     }
@@ -328,13 +320,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -350,13 +341,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -377,13 +367,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -404,13 +393,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -432,13 +420,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -460,13 +447,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "equal age should be considered stale");
     }
@@ -487,13 +473,12 @@ mod tests {
         tx.timestamp = base; // no elapsed time
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "max-age=0 should be stale immediately");
     }
@@ -514,13 +499,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_must_revalidate_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -529,7 +513,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_must_revalidate_enforcement");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/stateful_no_cache_revalidation.rs
+++ b/src/rules/stateful_no_cache_revalidation.rs
@@ -32,8 +32,6 @@ use crate::rules::Rule;
 pub struct StatefulNoCacheRevalidation;
 
 impl Rule for StatefulNoCacheRevalidation {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_no_cache_revalidation"
     }
@@ -44,12 +42,11 @@ impl Rule for StatefulNoCacheRevalidation {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent past response with a no-cache directive.
@@ -125,13 +122,12 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulNoCacheRevalidation;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_no_cache_revalidation",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -182,13 +178,12 @@ mod tests {
         tx.request.uri = "/resource".to_string();
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_no_cache_revalidation",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("no-cache"));
@@ -208,13 +203,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_cache_revalidation"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -231,13 +225,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_cache_revalidation"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -246,14 +239,11 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_no_cache_revalidation");
-        let engine = crate::rules::validate_rules(&cfg).unwrap();
+        // Enabling the rule with a valid config must pass validation.
+        crate::rules::validate_rules(&cfg).unwrap();
         // Ensure the rule is registered in the global RULES registry.
         assert!(crate::rules::RULES
             .iter()
             .any(|rule| rule.id() == "stateful_no_cache_revalidation"));
-        // Ensure enabling the rule results in a cached configuration so
-        // RuleConfigEngine::get_cached will not panic at runtime.
-        let _cfg_obj: std::sync::Arc<crate::rules::RuleConfig> =
-            engine.get_cached("stateful_no_cache_revalidation");
     }
 }

--- a/src/rules/stateful_no_store_enforcement.rs
+++ b/src/rules/stateful_no_store_enforcement.rs
@@ -32,8 +32,6 @@ use crate::rules::Rule;
 pub struct StatefulNoStoreEnforcement;
 
 impl Rule for StatefulNoStoreEnforcement {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_no_store_enforcement"
     }
@@ -43,12 +41,11 @@ impl Rule for StatefulNoStoreEnforcement {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Build maps of validators to a boolean indicating whether the most
@@ -240,13 +237,12 @@ mod tests {
         let rule = StatefulNoStoreEnforcement;
         let tx = crate::test_helpers::make_test_transaction();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -261,13 +257,12 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -283,13 +278,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_no_store_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("ETag"));
@@ -309,13 +303,12 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -337,13 +330,12 @@ mod tests {
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_no_store_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Last-Modified"));
@@ -361,13 +353,12 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -393,13 +384,12 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -428,13 +418,12 @@ mod tests {
         let history =
             crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -465,13 +454,12 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -490,13 +478,12 @@ mod tests {
         tx.request.headers = hm;
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -521,13 +508,12 @@ mod tests {
         )]);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_no_store_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -536,6 +522,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_no_store_enforcement");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_oauth2_code_flow.rs
+++ b/src/rules/stateful_oauth2_code_flow.rs
@@ -28,8 +28,6 @@ use crate::rules::Rule;
 pub struct StatefulOauth2CodeFlow;
 
 impl Rule for StatefulOauth2CodeFlow {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_oauth2_code_flow"
     }
@@ -39,12 +37,11 @@ impl Rule for StatefulOauth2CodeFlow {
         crate::rules::RuleScope::Client
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req_uri = &tx.request.uri;
@@ -146,13 +143,12 @@ mod tests {
         let tx = make_tx("https://idp.example.com/authorize?response_type=code&client_id=1");
         let history = crate::transaction_history::TransactionHistory::empty();
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing or empty state"));
@@ -164,13 +160,12 @@ mod tests {
         let tx = make_tx("https://idp.example.com/authorize?response_type=code&state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -181,13 +176,12 @@ mod tests {
         let tx = make_tx("https://app.example.com/callback?code=abc");
         let history = crate::transaction_history::TransactionHistory::empty();
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing or empty state"));
@@ -199,13 +193,12 @@ mod tests {
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("not seen"));
@@ -220,13 +213,12 @@ mod tests {
         )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -238,13 +230,12 @@ mod tests {
         let tx = make_tx("https://example.com/foo?state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -258,13 +249,12 @@ mod tests {
         )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=foo#bar");
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -275,13 +265,12 @@ mod tests {
         let tx = make_tx("https://idp.example.com/authorize?response_type=code#frag");
         let history = crate::transaction_history::TransactionHistory::empty();
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing or empty state"));
@@ -296,24 +285,22 @@ mod tests {
         // callback with empty state should flag missing or empty
         let tx2 = make_tx("https://app.example.com/callback?code=123&state=");
         let v = rule
-            .check(
+            .check_transaction(
                 &tx1,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing or empty state"));
         let v2 = rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_oauth2_code_flow",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v2.message.contains("missing or empty state"));
@@ -323,6 +310,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_oauth2_code_flow");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_private_cache_visibility.rs
+++ b/src/rules/stateful_private_cache_visibility.rs
@@ -18,8 +18,6 @@ use crate::rules::Rule;
 pub struct StatefulPrivateCacheVisibility;
 
 impl Rule for StatefulPrivateCacheVisibility {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_private_cache_visibility"
     }
@@ -29,12 +27,11 @@ impl Rule for StatefulPrivateCacheVisibility {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only interested in conditional requests; nothing to do otherwise
@@ -183,13 +180,12 @@ mod tests {
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_private_cache_visibility"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -208,13 +204,12 @@ mod tests {
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_private_cache_visibility"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -234,13 +229,12 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_private_cache_visibility",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Validator '"));
@@ -262,13 +256,12 @@ mod tests {
             .headers
             .append("if-modified-since", lm.parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_private_cache_visibility",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -289,13 +282,12 @@ mod tests {
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_private_cache_visibility"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }

--- a/src/rules/stateful_range_request_and_caching.rs
+++ b/src/rules/stateful_range_request_and_caching.rs
@@ -29,8 +29,6 @@ use crate::rules::Rule;
 pub struct StatefulRangeRequestAndCaching;
 
 impl Rule for StatefulRangeRequestAndCaching {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_range_request_and_caching"
     }
@@ -39,12 +37,11 @@ impl Rule for StatefulRangeRequestAndCaching {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -154,13 +151,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -179,13 +175,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("missing If-Range"));
@@ -207,13 +202,12 @@ mod tests {
             ("if-range", "\"a\""),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -237,13 +231,12 @@ mod tests {
             ("if-range", "Wed, 21 Oct 2015 07:28:00 GMT"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -267,13 +260,12 @@ mod tests {
             ("if-range", "Wed, 20 Oct 2015 07:28:00 GMT"),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not match"));
@@ -295,13 +287,12 @@ mod tests {
             ("if-range", "\"b\""),
         ]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not match"));
@@ -321,13 +312,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -346,13 +336,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -371,13 +360,12 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("range", "bytes=0-0")]);
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -386,7 +374,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_range_request_and_caching");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 

--- a/src/rules/stateful_redirect_chain_validity.rs
+++ b/src/rules/stateful_redirect_chain_validity.rs
@@ -19,8 +19,6 @@ use crate::rules::Rule;
 pub struct StatefulRedirectChainValidity;
 
 impl Rule for StatefulRedirectChainValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_redirect_chain_validity"
     }
@@ -29,12 +27,11 @@ impl Rule for StatefulRedirectChainValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = match &tx.response {
@@ -158,13 +155,12 @@ mod tests {
     fn detects_circular_redirect_for_equal_path(#[case] req: &str, #[case] loc: &str) {
         let rule = StatefulRedirectChainValidity;
         let tx = make_resp_tx(req, 301, Some(loc));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("circular redirect"));
@@ -175,13 +171,12 @@ mod tests {
         let rule = StatefulRedirectChainValidity;
         // different host should NOT be considered circular
         let tx = make_resp_tx("http://example.com/a", 301, Some("http://other/a"));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -196,13 +191,12 @@ mod tests {
         let mut tx = make_resp_tx("/r", 302, Some("/x"));
         tx.client = crate::test_helpers::make_test_client();
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Repeated redirect"));
@@ -229,13 +223,12 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not valid UTF-8"));
@@ -245,13 +238,12 @@ mod tests {
     fn non_redirect_status_with_location_is_ignored() {
         let rule = StatefulRedirectChainValidity;
         let tx = make_resp_tx("/r", 200, Some("/x"));
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         // This rule only inspects redirect/creation status codes — ignore otherwise
         assert!(v.is_none());
@@ -268,13 +260,12 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
 
         // previous had non-redirect status -> should NOT trigger repeated-redirect violation
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -283,13 +274,12 @@ mod tests {
     fn no_location_is_ignored() {
         let rule = StatefulRedirectChainValidity;
         let tx = make_resp_tx("/r", 302, None);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -298,7 +288,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_redirect_chain_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_s_max_age_enforcement.rs
+++ b/src/rules/stateful_s_max_age_enforcement.rs
@@ -25,8 +25,6 @@ use crate::rules::Rule;
 pub struct StatefulSMaxAgeEnforcement;
 
 impl Rule for StatefulSMaxAgeEnforcement {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_s_max_age_enforcement"
     }
@@ -36,12 +34,11 @@ impl Rule for StatefulSMaxAgeEnforcement {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent prior response with both s-maxage and a
@@ -130,13 +127,12 @@ mod tests {
     fn no_history_no_violation() {
         let rule = StatefulSMaxAgeEnforcement;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_s_max_age_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_none());
     }
@@ -155,13 +151,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -181,13 +176,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(6);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
 
@@ -201,13 +195,12 @@ mod tests {
         tx2.timestamp = base + chrono::Duration::seconds(4);
         let history2 = crate::transaction_history::TransactionHistory::new(vec![prev2]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx2,
                 &history2,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -232,13 +225,12 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(20);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_s_max_age_enforcement",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("s-maxage=10"));
@@ -264,13 +256,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -295,13 +286,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(40);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -324,13 +314,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(20);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -357,13 +346,12 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_some());
     }
@@ -391,13 +379,12 @@ mod tests {
         // age clamped to 0, so current_age=0 < s_max_age -> no violation even though
         // the conditional header is present
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_s_max_age_enforcement"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -406,7 +393,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_s_max_age_enforcement");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/rules/stateful_vary_header_cache_validity.rs
+++ b/src/rules/stateful_vary_header_cache_validity.rs
@@ -35,8 +35,6 @@ use crate::rules::Rule;
 pub struct StatefulVaryHeaderCacheValidity;
 
 impl Rule for StatefulVaryHeaderCacheValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_vary_header_cache_validity"
     }
@@ -46,12 +44,11 @@ impl Rule for StatefulVaryHeaderCacheValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -233,13 +230,12 @@ mod tests {
         let tx = make_tx_with_req("https://example.com/foo");
         let history = crate::transaction_history::TransactionHistory::empty();
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_vary_header_cache_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -264,13 +260,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_vary_header_cache_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -297,13 +292,12 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -333,13 +327,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_vary_header_cache_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -360,13 +353,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_vary_header_cache_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -386,13 +378,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_vary_header_cache_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -416,13 +407,12 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("accept-encoding"));
@@ -447,13 +437,12 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -485,13 +474,12 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("x-foo"));
@@ -515,13 +503,12 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
     }
@@ -546,13 +533,12 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_vary_header_cache_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new()
             )
             .is_none());
     }
@@ -576,13 +562,12 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::new(vec![past]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some());
         assert!(v
@@ -622,13 +607,12 @@ mod tests {
 
         // newest-first: later matching entry (good) must come first
         let history = crate::transaction_history::TransactionHistory::new(vec![good, old]);
-        let v = rule.check(
+        let v = rule.check_transaction(
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_vary_header_cache_validity",
             ]),
-            &crate::rules::RuleConfigEngine::new(),
         );
         assert!(v.is_some(), "should inspect later matching entry");
     }
@@ -637,6 +621,6 @@ mod tests {
     fn validate_rules_with_valid_config() {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_vary_header_cache_validity");
-        let _engine = crate::rules::validate_rules(&cfg).unwrap();
+        crate::rules::validate_rules(&cfg).unwrap();
     }
 }

--- a/src/rules/stateful_websocket_frame_opcode_sequence.rs
+++ b/src/rules/stateful_websocket_frame_opcode_sequence.rs
@@ -19,18 +19,15 @@ use crate::rules::ProtocolRule;
 pub struct StatefulWebsocketFrameOpcodeSequence;
 
 impl ProtocolRule for StatefulWebsocketFrameOpcodeSequence {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_websocket_frame_opcode_sequence"
     }
 
-    fn check(
+    fn check_event(
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let (session_id, direction, opcode, payload_length) = match &event.kind {
@@ -149,12 +146,7 @@ mod tests {
         let conn = Uuid::new_v4();
         let session = Uuid::new_v4();
         let evt = make_ws_event(conn, session, MessageDirection::Client, 1, 42);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -164,12 +156,7 @@ mod tests {
         let conn = Uuid::new_v4();
         let session = Uuid::new_v4();
         let evt = make_ws_event(conn, session, MessageDirection::Server, 2, 1024);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 
@@ -181,12 +168,7 @@ mod tests {
 
         for opcode in [8, 9, 10] {
             let evt = make_ws_event(conn, session, MessageDirection::Client, opcode, 10);
-            let result = rule.check(
-                &evt,
-                &ProtocolEventHistory::empty(),
-                &make_config(),
-                &crate::rules::RuleConfigEngine::new(),
-            );
+            let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
             assert!(result.is_none(), "opcode {} should pass", opcode);
         }
     }
@@ -199,12 +181,7 @@ mod tests {
 
         for opcode in [3, 4, 5, 6, 7, 11, 12, 13, 14, 15] {
             let evt = make_ws_event(conn, session, MessageDirection::Client, opcode, 0);
-            let result = rule.check(
-                &evt,
-                &ProtocolEventHistory::empty(),
-                &make_config(),
-                &crate::rules::RuleConfigEngine::new(),
-            );
+            let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
             assert!(result.is_some(), "opcode {} should fail", opcode);
             assert!(result.unwrap().message.contains("reserved opcode"));
         }
@@ -218,12 +195,7 @@ mod tests {
 
         // Ping with 126 bytes payload
         let evt = make_ws_event(conn, session, MessageDirection::Client, 9, 126);
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("125-byte limit"));
     }
@@ -240,12 +212,7 @@ mod tests {
 
         // Now client sends a Text frame
         let text_evt = make_ws_event(conn, session, MessageDirection::Client, 1, 50);
-        let result = rule.check(
-            &text_evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&text_evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("after Close"));
     }
@@ -262,12 +229,7 @@ mod tests {
 
         // Server sends a Text frame (different direction — allowed during close handshake)
         let text_evt = make_ws_event(conn, session, MessageDirection::Server, 1, 50);
-        let result = rule.check(
-            &text_evt,
-            &history,
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&text_evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -279,12 +241,7 @@ mod tests {
             connection_id: Uuid::new_v4(),
             kind: ProtocolEventKind::H3GoawayReceived { stream_id: None },
         };
-        let result = rule.check(
-            &evt,
-            &ProtocolEventHistory::empty(),
-            &make_config(),
-            &crate::rules::RuleConfigEngine::new(),
-        );
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }
 }

--- a/src/rules/stateful_websocket_handshake_validity.rs
+++ b/src/rules/stateful_websocket_handshake_validity.rs
@@ -22,8 +22,6 @@ use crate::rules::Rule;
 pub struct StatefulWebsocketHandshakeValidity;
 
 impl Rule for StatefulWebsocketHandshakeValidity {
-    type Config = ();
-
     fn id(&self) -> &'static str {
         "stateful_websocket_handshake_validity"
     }
@@ -32,12 +30,11 @@ impl Rule for StatefulWebsocketHandshakeValidity {
         crate::rules::RuleScope::Both
     }
 
-    fn check(
+    fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
-        _engine: &crate::rules::RuleConfigEngine,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
@@ -221,13 +218,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -246,13 +242,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing 'Sec-WebSocket-Accept'"));
@@ -276,13 +271,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("does not match expected"));
@@ -302,13 +296,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing Sec-WebSocket-Key"));
@@ -332,13 +325,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Invalid Sec-WebSocket-Key"));
@@ -363,13 +355,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -392,13 +383,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("Expected 101"));
@@ -421,13 +411,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing 'Connection' header"));
@@ -451,13 +440,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v
@@ -473,13 +461,12 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("upgrade", "websocket")]);
         let rule = StatefulWebsocketHandshakeValidity;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -495,13 +482,12 @@ mod tests {
         // response absence doesn't matter since rule should bail early
         let rule = StatefulWebsocketHandshakeValidity;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -517,13 +503,12 @@ mod tests {
         // no response recorded
         let rule = StatefulWebsocketHandshakeValidity;
         assert!(rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity"
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .is_none());
     }
@@ -546,13 +531,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("required 'Connection: Upgrade' token"));
@@ -575,13 +559,12 @@ mod tests {
         );
         let rule = StatefulWebsocketHandshakeValidity;
         let v = rule
-            .check(
+            .check_transaction(
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
                     "stateful_websocket_handshake_validity",
                 ]),
-                &crate::rules::RuleConfigEngine::new(),
             )
             .unwrap();
         assert!(v.message.contains("missing 'Upgrade' header"));
@@ -591,7 +574,7 @@ mod tests {
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "stateful_websocket_handshake_validity");
-        let _engine = crate::rules::validate_rules(&cfg)?;
+        crate::rules::validate_rules(&cfg)?;
         Ok(())
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -103,13 +103,6 @@ pub fn make_test_config_with_severity(rule_id: &str, severity: &str) -> crate::c
     cfg
 }
 
-/// Validate and build a `RuleConfigEngine` from a configuration.
-/// Panics if the configuration is invalid.
-#[cfg(test)]
-pub fn make_test_engine(cfg: &crate::config::Config) -> crate::rules::RuleConfigEngine {
-    crate::rules::validate_rules(cfg).expect("test config should be valid")
-}
-
 /// Create a minimal HTTP transaction for testing.
 /// Contains a GET request to `http://example/` with a standard test user agent.
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,12 +12,10 @@ use tokio::time::sleep;
 use lint_http::capture::CaptureWriter;
 use lint_http::config::Config;
 use lint_http::proxy::run_proxy;
-use lint_http::rules::RuleConfigEngine;
 
 // Minimal helper: start run_proxy and wait until it is accepting and CA files exist
 pub async fn start_run_proxy_and_wait(
     cfg: Config,
-    engine: Arc<RuleConfigEngine>,
 ) -> anyhow::Result<(tokio::task::JoinHandle<()>, SocketAddr, String)> {
     // prepare capture file
     let tmp = std::env::temp_dir().join(format!("lint_integ_{}.jsonl", uuid::Uuid::new_v4()));
@@ -34,9 +32,8 @@ pub async fn start_run_proxy_and_wait(
 
     let cfg = Arc::new(cfg);
     let cfg_for_spawn = cfg.clone();
-    let engine2 = engine.clone();
     let handle = tokio::spawn(async move {
-        let _ = run_proxy(addr, cw, cfg_for_spawn, engine2).await;
+        let _ = run_proxy(addr, cw, cfg_for_spawn).await;
     });
 
     // Wait for server to accept connections

--- a/tests/integration_captures_seed.rs
+++ b/tests/integration_captures_seed.rs
@@ -62,7 +62,7 @@ enabled = false
     );
     fs::write(&config_file, config_toml).await?;
 
-    let (cfg, _engine) = lint_http::config::Config::load_from_path(&config_file).await?;
+    let cfg = lint_http::config::Config::load_from_path(&config_file).await?;
     let state = lint_http::state::StateStore::new(cfg.general.ttl_seconds, cfg.general.max_history);
 
     if cfg.general.captures_seed {
@@ -109,7 +109,7 @@ enabled = false
     );
     fs::write(&config_file, config_toml).await?;
 
-    let (cfg, _engine) = lint_http::config::Config::load_from_path(&config_file).await?;
+    let cfg = lint_http::config::Config::load_from_path(&config_file).await?;
 
     // load_captures should return empty vector, not error
     let records = lint_http::capture::load_captures(&cfg.general.captures).await?;

--- a/tests/integration_tls_config.rs
+++ b/tests/integration_tls_config.rs
@@ -38,9 +38,8 @@ async fn test_suppress_headers() -> anyhow::Result<()> {
 
     let cw_clone = cw.clone();
     let cfg_clone = cfg.clone();
-    let engine = Arc::new(lint_http::rules::RuleConfigEngine::default());
     tokio::spawn(async move {
-        if let Err(e) = lint_http::proxy::run_proxy(proxy_addr, cw_clone, cfg_clone, engine).await {
+        if let Err(e) = lint_http::proxy::run_proxy(proxy_addr, cw_clone, cfg_clone).await {
             eprintln!("run_proxy failed: {}", e);
         }
     });
@@ -132,9 +131,8 @@ async fn test_passthrough_domains() -> anyhow::Result<()> {
 
     let cw_clone = cw.clone();
     let cfg_clone = cfg.clone();
-    let engine = Arc::new(lint_http::rules::RuleConfigEngine::default());
     tokio::spawn(async move {
-        if let Err(e) = lint_http::proxy::run_proxy(proxy_addr, cw_clone, cfg_clone, engine).await {
+        if let Err(e) = lint_http::proxy::run_proxy(proxy_addr, cw_clone, cfg_clone).await {
             eprintln!("run_proxy failed: {}", e);
         }
     });

--- a/tests/proxy_connect_integration.rs
+++ b/tests/proxy_connect_integration.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: ISC
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::time::{sleep, timeout};
@@ -14,7 +13,6 @@ mod common;
 use common::start_run_proxy_and_wait;
 
 use lint_http::config::Config;
-use lint_http::rules::RuleConfigEngine;
 
 // Unified helper: perform CONNECT, do TLS handshake trusting `ca_cert_path`, optionally advertise ALPNs, optionally send an inner request.
 // Returns (negotiated_alpn, optional_response_bytes).
@@ -176,8 +174,7 @@ async fn connect_tls_full_forwarding() -> anyhow::Result<()> {
     cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
 
     // 3) Start proxy and wait
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone(), engine.clone()).await?;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
 
     // 4) Perform CONNECT + TLS + inner request
     let host = "example.com";
@@ -245,8 +242,7 @@ async fn connect_tls_alpn_client_selects_http1() -> anyhow::Result<()> {
     cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
 
     // 3) Start proxy and wait
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone(), engine.clone()).await?;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
 
     // 4) Perform CONNECT + TLS + inner request, advertising http/1.1
     let host = "example.com";
@@ -313,8 +309,7 @@ async fn connect_tls_alpn_mismatch_fails_handshake() -> anyhow::Result<()> {
     cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
 
     // 3) Start proxy and wait
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone(), engine.clone()).await?;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
 
     // 4) Perform CONNECT + TLS + inner request, advertising only 'h3' which does not match server
     let host = "example.com";

--- a/tests/proxy_connect_passthrough.rs
+++ b/tests/proxy_connect_passthrough.rs
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: ISC
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 
 use lint_http::config::Config;
-use lint_http::rules::RuleConfigEngine;
 
 mod common;
 use common::start_run_proxy_and_wait;
@@ -83,8 +81,7 @@ async fn connect_passthrough_tunnels_raw_tcp() -> anyhow::Result<()> {
     // Use a literal IP in passthrough domain so the proxy connects to the toy server
     cfg.tls.passthrough_domains = vec!["127.0.0.1".into()];
 
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone(), engine.clone()).await?;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
 
     // CONNECT and then send raw ping/pong to the toy server IP
     let mut stream = tokio::net::TcpStream::connect(addr).await?;
@@ -142,8 +139,7 @@ async fn connect_passthrough_upstream_unavailable() -> anyhow::Result<()> {
     // Use a literal IP in passthrough domain so the proxy connects to the toy server
     cfg.tls.passthrough_domains = vec!["127.0.0.1".into()];
 
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone(), engine.clone()).await?;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
 
     // CONNECT and expect it to succeed but subsequent I/O to close
     let mut stream = tokio::net::TcpStream::connect(addr).await?;
@@ -197,8 +193,7 @@ async fn connect_without_tls_returns_405() -> anyhow::Result<()> {
     // Start proxy with TLS disabled
     let mut cfg = Config::default();
     cfg.tls.enabled = false;
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone(), engine.clone()).await?;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
 
     // CONNECT and read response
     let res = do_connect_and_get_response(addr, "example.com", 12345).await?;

--- a/tests/proxy_h3_integration.rs
+++ b/tests/proxy_h3_integration.rs
@@ -15,7 +15,6 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use lint_http::capture::CaptureWriter;
 use lint_http::config::Config;
-use lint_http::rules::RuleConfigEngine;
 
 /// Build a quinn client endpoint that trusts the CA at `ca_cert_path` and
 /// advertises ALPN `h3`.
@@ -88,11 +87,10 @@ async fn start_proxy_with_h3(
     let captures_path = tmp.to_str().unwrap().to_string();
     let cw = CaptureWriter::new(captures_path.clone(), false).await?;
 
-    let engine = Arc::new(RuleConfigEngine::new());
     let cfg = Arc::new(cfg);
     let cfg2 = cfg.clone();
     let handle = tokio::spawn(async move {
-        let _ = lint_http::proxy::run_proxy(tcp_addr, cw, cfg2, engine).await;
+        let _ = lint_http::proxy::run_proxy(tcp_addr, cw, cfg2).await;
     });
 
     // Wait for TCP listener

--- a/tests/proxy_websocket_relay.rs
+++ b/tests/proxy_websocket_relay.rs
@@ -4,13 +4,10 @@
 
 //! Integration test: WebSocket upgrade through the proxy with frame relay and capture.
 
-use std::sync::Arc;
-
 use futures_util::{SinkExt, StreamExt};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use lint_http::config::Config;
-use lint_http::rules::RuleConfigEngine;
 
 mod common;
 use common::start_run_proxy_and_wait;
@@ -53,8 +50,7 @@ async fn websocket_upgrade_through_proxy_captures_session() -> anyhow::Result<()
 
     // Start the proxy
     let cfg = Config::default();
-    let engine = Arc::new(RuleConfigEngine::new());
-    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg, engine).await?;
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
 
     // Connect to the proxy and perform WebSocket handshake via HTTP upgrade
     // Connect TCP to proxy5


### PR DESCRIPTION
With every rule already overriding the bridge
`check` method (#8b), the legacy config-engine scaffolding was dead weight:

- Remove the associated `Rule::Config` / `ProtocolRule::Config` type, `validate_and_box` (which leaked `Arc<dyn Any>` through the trait), the legacy `check_transaction` / `check_event` `unreachable!()` defaults, the `RuleConfigValidator` / `ProtocolRuleConfigValidator` type-erasure traits, and `RuleConfigEngine` (a config cache populated at startup but never read at lint time).
- Add an object-safe `Rule::validate(&Config) -> Result<()>` for startup validation; the 13 custom-config rules override it to parse their section. `validate_rules` now returns `()`.
- `RULES` / `PROTOCOL_RULES` / `REQUEST_ONLY_RULES` store `&dyn Rule` / `&dyn ProtocolRule` directly now that the trait is object-safe.
- Rename the bridge `check` back to `check_transaction` / `check_event` and drop the `engine` parameter cascading through `lint_transaction` / `lint_protocol_event` / `Config::load_from_path` / `main.rs` / proxy `Shared` / the proxy submodules and integration test harness.

The `Rule` public surface no longer leaks any engine-shaped type, the last prep step before the workspace split (#2). No behavior change; startup fail-fast on malformed config is preserved.
