### PR TITLE
refactor(rules): wire linkme distributed_slice infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "lint-http"
 version = "0.1.0"
 dependencies = [
@@ -1041,6 +1061,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "linkme",
  "pem",
  "quinn",
  "rcgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ sha1 = "0.11"
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
 rustls-native-certs = "0.8"
+linkme = "0.3"
 
 
 [dev-dependencies]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -4,6 +4,7 @@
 
 use crate::lint::Violation;
 use crate::queries::QueryType;
+use linkme::distributed_slice;
 use std::sync::LazyLock;
 
 /// Standard configuration for rules
@@ -411,6 +412,28 @@ pub trait ProtocolRule: Send + Sync {
     ) -> Option<Violation>;
 }
 
+/// Auto-registered HTTP rules collected via `linkme::distributed_slice`.
+///
+/// Migration target for self-registering rules (#9b). The engine does **not**
+/// consult this slice yet — dispatch still iterates the hand-maintained
+/// [`RULES`] const. It exists to wire the `linkme` infrastructure and prove
+/// cross-platform linking; see the `linkme_registers_and_links` test below.
+#[distributed_slice]
+pub static REGISTERED_RULES: [&'static dyn Rule] = [..];
+
+/// Auto-registered protocol rules. Migration target for [`PROTOCOL_RULES`];
+/// declared but not consulted by the engine in this commit.
+#[distributed_slice]
+pub static REGISTERED_PROTOCOL_RULES: [&'static dyn ProtocolRule] = [..];
+
+// Single registration that proves `linkme` distributed_slice collection links
+// on every CI OS (Linux/macOS/Windows-MSVC). Not consulted by dispatch — the
+// engine reads `RULES`, not `REGISTERED_RULES`. #9b registers the full
+// catalogue here and removes the hand-maintained const.
+//   (Toggle to a strictly-empty production slice: prefix this with `#[cfg(test)]`.)
+#[distributed_slice(REGISTERED_RULES)]
+static LINKME_SMOKE_RULE: &dyn Rule = &client_host_header::ClientHostHeader;
+
 pub const PROTOCOL_RULES: &[&dyn ProtocolRule] = &[
     &server_quic_transport_parameters::ServerQuicTransportParameters,
     &stateful_http3_goaway_semantics::StatefulHttp3GoawaySemantics,
@@ -763,6 +786,20 @@ pub fn rules_for_scope(has_response: bool) -> &'static [&'static dyn Rule] {
 mod tests {
     use super::*;
     use crate::test_helpers::{enable_rule, enable_rule_with_paths};
+
+    #[test]
+    fn linkme_registers_and_links() {
+        // Proves the distributed_slice symbol is emitted and collected on this
+        // platform; a linkme/linker failure turns into a hard test failure here.
+        assert!(
+            REGISTERED_RULES
+                .iter()
+                .any(|r| r.id() == "client_host_header"),
+            "linkme distributed_slice did not collect the smoke registration",
+        );
+        // Second slice must link and be readable (empty for now).
+        assert_eq!(REGISTERED_PROTOCOL_RULES.iter().count(), 0);
+    }
 
     #[test]
     fn rule_ids_unique_and_non_empty() {


### PR DESCRIPTION
Add the linkme dependency and declare REGISTERED_RULES / REGISTERED_PROTOCOL_RULES distributed slices in src/rules/mod.rs, the migration target for self-registering rules. Dispatch is unchanged: the engine still iterates the hand-maintained RULES / PROTOCOL_RULES consts.

One existing rule is registered into REGISTERED_RULES via raw CI build matrix (Linux/macOS/Windows-MSVC) and guarded by a linkme_registers_and_links test. No #[lint_http::rule] proc-macro yet.
