### PR TITLE
refactor(proxy): collapse lint → record → capture into TransactionPipeli

### DIFF
--- a/src/proxy/http.rs
+++ b/src/proxy/http.rs
@@ -10,10 +10,9 @@ use hyper::{Method, Request, Response, Uri};
 use std::convert::Infallible;
 use std::sync::Arc;
 use tokio::time::Instant;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::capture::CaptureWriter;
-use crate::lint;
 
 use super::connect::handle_connect;
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
@@ -123,7 +122,7 @@ async fn build_and_write_transaction(
     response_headers: Option<hyper::HeaderMap<hyper::header::HeaderValue>>,
     duration_ms: u64,
     req_body: Option<bytes::Bytes>,
-) -> anyhow::Result<()> {
+) {
     let mut tx = crate::http_transaction::HttpTransaction::new(
         client_id.clone(),
         method.to_string(),
@@ -143,8 +142,9 @@ async fn build_and_write_transaction(
         trailers: None,
     });
     tx.timing = crate::http_transaction::TimingInfo { duration_ms };
-    captures.write_transaction(&tx).await?;
-    Ok(())
+    if let Err(e) = captures.write_transaction(&tx).await {
+        warn!(error = %e, "failed to write transaction capture");
+    }
 }
 
 async fn handle_http_logic<B>(
@@ -234,7 +234,7 @@ where
                     Response::new(Full::new(Bytes::from("request body collect error")).boxed())
                 });
             let duration = started.elapsed().as_millis() as u64;
-            let _ = build_and_write_transaction(
+            build_and_write_transaction(
                 captures,
                 &client_id,
                 method.as_str(),
@@ -264,7 +264,7 @@ where
                 });
             // record a failed capture with 500
             let duration = started.elapsed().as_millis() as u64;
-            let _ = build_and_write_transaction(
+            build_and_write_transaction(
                 captures,
                 &client_id,
                 method.as_str(),
@@ -316,7 +316,7 @@ where
                     Response::new(Full::new(Bytes::from("upstream error")).boxed())
                 });
             let duration = started.elapsed().as_millis() as u64;
-            let _ = build_and_write_transaction(
+            build_and_write_transaction(
                 captures,
                 &client_id,
                 method.as_str(),
@@ -356,7 +356,7 @@ where
                     Response::new(Full::new(Bytes::from("upstream error")).boxed())
                 });
             let duration = started.elapsed().as_millis() as u64;
-            let _ = build_and_write_transaction(
+            build_and_write_transaction(
                 captures,
                 &client_id,
                 method.as_str(),
@@ -408,11 +408,7 @@ where
             .map(|s| s.to_string());
     }
 
-    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
-    tx.violations = violations.clone();
-
-    shared.state.record_transaction(&tx);
-    let _ = captures.write_transaction(&tx).await;
+    shared.pipeline().commit(tx).await;
 
     let mut resp_builder = Response::builder().status(status);
 

--- a/src/proxy/http3.rs
+++ b/src/proxy/http3.rs
@@ -14,7 +14,6 @@ use tracing::{error, info, trace, warn};
 
 use crate::ca::CertificateAuthority;
 use crate::capture::CaptureWriter;
-use crate::lint;
 
 use super::connect::AlwaysResolves;
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
@@ -222,9 +221,7 @@ fn emit_h3_protocol_event(
         connection_id,
         kind,
     };
-    let violations =
-        crate::lint_protocol::lint_protocol_event(&pe, &shared.cfg, &shared.protocol_event_store);
-    shared.protocol_event_store.record_event(&pe);
+    let violations = shared.protocol_event_pipeline().commit(&pe);
     for v in &violations {
         warn!(
             rule = %v.rule,
@@ -363,7 +360,9 @@ async fn handle_h3_request(
         tx.timing = crate::http_transaction::TimingInfo { duration_ms };
         tx.connection_id = Some(conn_metadata.id);
         tx.sequence_number = Some(sequence_number);
-        let _ = captures.write_transaction(&tx).await;
+        if let Err(e) = captures.write_transaction(&tx).await {
+            warn!(error = %e, "failed to write transaction capture");
+        }
     }
 
     let resp = match shared.client.request(upstream_req).await {
@@ -458,11 +457,7 @@ async fn handle_h3_request(
     tx.connection_id = Some(conn_metadata.id);
     tx.sequence_number = Some(stream_id as u32);
 
-    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
-    tx.violations = violations;
-
-    shared.state.record_transaction(&tx);
-    let _ = shared.captures.write_transaction(&tx).await;
+    shared.pipeline().commit(tx).await;
 
     // Send the response back over HTTP/3.
     // HTTP/3 has no hop-by-hop headers (RFC 9114 §4.2), but the upstream

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -8,6 +8,7 @@ mod connect;
 mod hop_by_hop;
 mod http;
 mod http3;
+mod pipeline;
 #[cfg(test)]
 mod test_support;
 mod websocket;

--- a/src/proxy/pipeline.rs
+++ b/src/proxy/pipeline.rs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Canonical lint → record → capture orchestration for the proxy.
+//!
+//! The ordering is load-bearing: state must be recorded *after* lint,
+//! otherwise the current transaction shows up in its own history. Both
+//! pipelines run lint themselves and `TransactionPipeline::commit` consumes
+//! the transaction, so callers that go through `commit` cannot reorder the
+//! steps, re-commit, or mutate the transaction after capture. The raw
+//! stores and capture writer remain reachable (the error-path helpers
+//! intentionally skip lint and state recording), so the pipeline
+//! centralizes the invariant rather than making bypass impossible.
+
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::capture::CaptureWriter;
+use crate::config::Config;
+use crate::http_transaction::HttpTransaction;
+use crate::lint::Violation;
+use crate::protocol_event::ProtocolEvent;
+use crate::protocol_event_store::ProtocolEventStore;
+use crate::state::StateStore;
+
+use super::Shared;
+
+/// Orchestrates the per-transaction cycle: lint, record to state, write the
+/// capture line.
+pub(super) struct TransactionPipeline {
+    cfg: Arc<Config>,
+    state: Arc<StateStore>,
+    captures: CaptureWriter,
+}
+
+impl TransactionPipeline {
+    /// Lint `tx` (populating `tx.violations`), record it to state, then write
+    /// it to the capture file — in that order. Consumes the transaction so it
+    /// cannot be re-committed or mutated after capture; returns the
+    /// violations for callers that need them.
+    pub(super) async fn commit(&self, mut tx: HttpTransaction) -> Vec<Violation> {
+        tx.violations = crate::lint::lint_transaction(&tx, &self.cfg, &self.state);
+        self.state.record_transaction(&tx);
+        if let Err(e) = self.captures.write_transaction(&tx).await {
+            warn!(error = %e, "failed to write transaction capture");
+        }
+        tx.violations
+    }
+}
+
+/// Orchestrates the per-protocol-event cycle: lint, then record to the event
+/// store. Cloneable so concurrent relay tasks can each own one.
+#[derive(Clone)]
+pub(super) struct ProtocolEventPipeline {
+    cfg: Arc<Config>,
+    store: Arc<ProtocolEventStore>,
+}
+
+impl ProtocolEventPipeline {
+    pub(super) fn new(cfg: Arc<Config>, store: Arc<ProtocolEventStore>) -> Self {
+        Self { cfg, store }
+    }
+
+    /// Lint `event`, then record it — in that order. Returns the violations
+    /// so callers can log or collect them.
+    pub(super) fn commit(&self, event: &ProtocolEvent) -> Vec<Violation> {
+        let violations = crate::lint_protocol::lint_protocol_event(event, &self.cfg, &self.store);
+        self.store.record_event(event);
+        violations
+    }
+}
+
+impl Shared {
+    pub(super) fn pipeline(&self) -> TransactionPipeline {
+        TransactionPipeline {
+            cfg: self.cfg.clone(),
+            state: self.state.clone(),
+            captures: self.captures.clone(),
+        }
+    }
+
+    pub(super) fn protocol_event_pipeline(&self) -> ProtocolEventPipeline {
+        ProtocolEventPipeline::new(self.cfg.clone(), self.protocol_event_store.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{make_shared_with_cfg, read_capture};
+    use super::*;
+    use crate::test_helpers::{
+        make_test_config_with_enabled_rules, make_test_transaction_with_response,
+    };
+    use tokio::fs;
+
+    #[tokio::test]
+    async fn commit_populates_violations_and_writes_capture() -> anyhow::Result<()> {
+        let cfg_inner = make_test_config_with_enabled_rules(&[
+            "server_cache_control_present",
+            "server_etag_or_last_modified",
+        ]);
+        let (shared, tmp, _cw) = make_shared_with_cfg(Arc::new(cfg_inner), None).await?;
+
+        let tx = make_test_transaction_with_response(200, &[]);
+        let violations = shared.pipeline().commit(tx).await;
+
+        assert!(!violations.is_empty());
+
+        let entries = read_capture(&tmp).await?;
+        assert_eq!(entries.len(), 1);
+        let captured = entries[0]["violations"]
+            .as_array()
+            .expect("violations array in capture");
+        assert_eq!(captured.len(), violations.len());
+
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn commit_records_to_state_after_lint() -> anyhow::Result<()> {
+        let cfg_inner = make_test_config_with_enabled_rules(&[
+            "server_cache_control_present",
+            "server_etag_or_last_modified",
+        ]);
+        let (shared, tmp, _cw) = make_shared_with_cfg(Arc::new(cfg_inner), None).await?;
+
+        let tx = make_test_transaction_with_response(200, &[]);
+        let client = tx.client.clone();
+        let uri = tx.request.uri.clone();
+        let violations = shared.pipeline().commit(tx).await;
+
+        // The recorded copy carries the lint result, proving record ran
+        // after lint populated `tx.violations`.
+        let history = shared.state.get_history(&client, &uri);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].violations.len(), violations.len());
+
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn protocol_event_pipeline_commit_records_and_returns() -> anyhow::Result<()> {
+        let (shared, tmp, _cw) =
+            make_shared_with_cfg(Arc::new(crate::config::Config::default()), None).await?;
+
+        let connection_id = uuid::Uuid::new_v4();
+        let pe = ProtocolEvent {
+            timestamp: chrono::Utc::now(),
+            connection_id,
+            kind: crate::protocol_event::ProtocolEventKind::WebSocketFrame {
+                session_id: uuid::Uuid::new_v4(),
+                direction: crate::websocket_session::MessageDirection::Client,
+                fin: true,
+                opcode: 1,
+                rsv: 0,
+                payload_length: 2,
+            },
+        };
+        let violations = shared.protocol_event_pipeline().commit(&pe);
+
+        let recorded = shared
+            .protocol_event_store
+            .get_history_for_connection(connection_id);
+        assert_eq!(recorded.len(), 1);
+
+        // No protocol rules are enabled in the default config.
+        assert!(violations.is_empty());
+
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+}

--- a/src/proxy/websocket.rs
+++ b/src/proxy/websocket.rs
@@ -14,10 +14,9 @@ use tokio::time::Instant;
 use tracing::error;
 
 use crate::capture::CaptureWriter;
-use crate::config::Config;
-use crate::lint;
 
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
+use super::pipeline::ProtocolEventPipeline;
 use super::Shared;
 
 /// Check if a request is a WebSocket upgrade request.
@@ -55,8 +54,6 @@ pub(super) async fn handle_websocket_upgrade(
     shared: Arc<Shared>,
     conn_metadata: Arc<crate::connection::ConnectionMetadata>,
 ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
-    let captures = &shared.captures;
-
     // Connect directly to upstream with upgrade support
     let (mut sender, _conn_handle) = match connect_upstream_for_upgrade(uri, scheme).await {
         Ok(s) => s,
@@ -125,12 +122,8 @@ pub(super) async fn handle_websocket_upgrade(
             .map(|s| s.to_string());
     }
 
-    let violations = lint::lint_transaction(&tx, &shared.cfg, &shared.state);
-    tx.violations = violations.clone();
-    shared.state.record_transaction(&tx);
-    let _ = captures.write_transaction(&tx).await;
-
     let tx_id = tx.id;
+    shared.pipeline().commit(tx).await;
 
     if status == 101 {
         // Extract the server-side upgraded IO
@@ -149,11 +142,8 @@ pub(super) async fn handle_websocket_upgrade(
 
         // Spawn background relay task
         let captures_clone = shared.captures.clone();
-        let pe_ctx = ProtocolLintCtx {
-            connection_id: conn_metadata.id,
-            store: shared.protocol_event_store.clone(),
-            cfg: shared.cfg.clone(),
-        };
+        let connection_id = conn_metadata.id;
+        let pe_pipeline = shared.protocol_event_pipeline();
         tokio::spawn(async move {
             // Wait for both sides to complete the upgrade
             let (client_io, server_io) = match tokio::try_join!(client_on_upgrade, server_upgraded)
@@ -170,7 +160,8 @@ pub(super) async fn handle_websocket_upgrade(
                 TokioIo::new(server_io),
                 tx_id,
                 captures_clone,
-                pe_ctx,
+                connection_id,
+                pe_pipeline,
             )
             .await;
         });
@@ -260,11 +251,24 @@ async fn connect_upstream_for_upgrade(
     }
 }
 
-/// Context for protocol-event linting during WebSocket relay.
-struct ProtocolLintCtx {
+/// Build the protocol event for a single relayed WebSocket frame.
+fn ws_frame_event(
     connection_id: uuid::Uuid,
-    store: Arc<crate::protocol_event_store::ProtocolEventStore>,
-    cfg: Arc<Config>,
+    session_id: uuid::Uuid,
+    info: &crate::websocket_session::WebSocketMessageInfo,
+) -> crate::protocol_event::ProtocolEvent {
+    crate::protocol_event::ProtocolEvent {
+        timestamp: chrono::Utc::now(),
+        connection_id,
+        kind: crate::protocol_event::ProtocolEventKind::WebSocketFrame {
+            session_id,
+            direction: info.direction,
+            fin: info.fin,
+            opcode: info.opcode,
+            rsv: info.rsv,
+            payload_length: info.payload_length,
+        },
+    }
 }
 
 /// Relay WebSocket messages between client and server, recording each message
@@ -274,7 +278,8 @@ async fn relay_websocket(
     server_io: impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
     tx_id: uuid::Uuid,
     captures: CaptureWriter,
-    pe_ctx: ProtocolLintCtx,
+    connection_id: uuid::Uuid,
+    pipeline: ProtocolEventPipeline,
 ) {
     use crate::websocket_session::{MessageDirection, WebSocketMessageInfo, WebSocketSession};
     use futures_util::{SinkExt, StreamExt};
@@ -294,15 +299,10 @@ async fn relay_websocket(
     let close_code = Arc::new(tokio::sync::Mutex::new(None::<u16>));
     let start = Instant::now();
 
-    let pe_store = pe_ctx.store;
-    let pe_cfg = pe_ctx.cfg;
-    let connection_id = pe_ctx.connection_id;
-
     let msgs_c2s = messages.clone();
     let viols_c2s = violations.clone();
     let close_c2s = close_code.clone();
-    let pe_store_c2s = pe_store.clone();
-    let cfg_c2s = pe_cfg.clone();
+    let pipe_c2s = pipeline.clone();
     let c2s = async move {
         while let Some(result) = client_read.next().await {
             match result {
@@ -315,20 +315,8 @@ async fn relay_websocket(
                         }
                     }
                     // Emit protocol event and lint it
-                    let pe = crate::protocol_event::ProtocolEvent {
-                        timestamp: chrono::Utc::now(),
-                        connection_id,
-                        kind: crate::protocol_event::ProtocolEventKind::WebSocketFrame {
-                            session_id,
-                            direction: info.direction,
-                            fin: info.fin,
-                            opcode: info.opcode,
-                            rsv: info.rsv,
-                            payload_length: info.payload_length,
-                        },
-                    };
-                    let v = crate::lint_protocol::lint_protocol_event(&pe, &cfg_c2s, &pe_store_c2s);
-                    pe_store_c2s.record_event(&pe);
+                    let pe = ws_frame_event(connection_id, session_id, &info);
+                    let v = pipe_c2s.commit(&pe);
                     if !v.is_empty() {
                         viols_c2s.lock().await.extend(v);
                     }
@@ -346,8 +334,7 @@ async fn relay_websocket(
     let msgs_s2c = messages.clone();
     let viols_s2c = violations.clone();
     let close_s2c = close_code.clone();
-    let pe_store_s2c = pe_store.clone();
-    let cfg_s2c = pe_cfg.clone();
+    let pipe_s2c = pipeline;
     let s2c = async move {
         while let Some(result) = server_read.next().await {
             match result {
@@ -360,20 +347,8 @@ async fn relay_websocket(
                         }
                     }
                     // Emit protocol event and lint it
-                    let pe = crate::protocol_event::ProtocolEvent {
-                        timestamp: chrono::Utc::now(),
-                        connection_id,
-                        kind: crate::protocol_event::ProtocolEventKind::WebSocketFrame {
-                            session_id,
-                            direction: info.direction,
-                            fin: info.fin,
-                            opcode: info.opcode,
-                            rsv: info.rsv,
-                            payload_length: info.payload_length,
-                        },
-                    };
-                    let v = crate::lint_protocol::lint_protocol_event(&pe, &cfg_s2c, &pe_store_s2c);
-                    pe_store_s2c.record_event(&pe);
+                    let pe = ws_frame_event(connection_id, session_id, &info);
+                    let v = pipe_s2c.commit(&pe);
                     if !v.is_empty() {
                         viols_s2c.lock().await.extend(v);
                     }
@@ -468,6 +443,15 @@ mod tests {
     use std::sync::Arc as StdArc;
     use tokio::time::Instant;
     use uuid::Uuid;
+
+    fn test_pe_pipeline() -> ProtocolEventPipeline {
+        ProtocolEventPipeline::new(
+            StdArc::new(crate::config::Config::default()),
+            StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
+                300, 100,
+            )),
+        )
+    }
 
     #[test]
     fn is_websocket_upgrade_detects_valid_upgrade() {
@@ -600,13 +584,8 @@ mod tests {
                 proxy_server_side,
                 tx_id,
                 cw_clone,
-                ProtocolLintCtx {
-                    connection_id: uuid::Uuid::new_v4(),
-                    store: std::sync::Arc::new(
-                        crate::protocol_event_store::ProtocolEventStore::new(300, 100),
-                    ),
-                    cfg: std::sync::Arc::new(crate::config::Config::default()),
-                },
+                uuid::Uuid::new_v4(),
+                test_pe_pipeline(),
             )
             .await;
         });
@@ -871,13 +850,8 @@ mod tests {
                 proxy_server_side,
                 tx_id,
                 cw_clone,
-                ProtocolLintCtx {
-                    connection_id: uuid::Uuid::new_v4(),
-                    store: std::sync::Arc::new(
-                        crate::protocol_event_store::ProtocolEventStore::new(300, 100),
-                    ),
-                    cfg: std::sync::Arc::new(crate::config::Config::default()),
-                },
+                uuid::Uuid::new_v4(),
+                test_pe_pipeline(),
             )
             .await;
         });
@@ -967,13 +941,8 @@ mod tests {
                 proxy_server_side,
                 tx_id,
                 cw_clone,
-                ProtocolLintCtx {
-                    connection_id: uuid::Uuid::new_v4(),
-                    store: std::sync::Arc::new(
-                        crate::protocol_event_store::ProtocolEventStore::new(300, 100),
-                    ),
-                    cfg: std::sync::Arc::new(crate::config::Config::default()),
-                },
+                uuid::Uuid::new_v4(),
+                test_pe_pipeline(),
             )
             .await;
         });
@@ -1141,13 +1110,8 @@ mod tests {
                 proxy_server_side,
                 tx_id,
                 cw_clone,
-                ProtocolLintCtx {
-                    connection_id: uuid::Uuid::new_v4(),
-                    store: std::sync::Arc::new(
-                        crate::protocol_event_store::ProtocolEventStore::new(300, 100),
-                    ),
-                    cfg: std::sync::Arc::new(crate::config::Config::default()),
-                },
+                uuid::Uuid::new_v4(),
+                test_pe_pipeline(),
             )
             .await;
         });


### PR DESCRIPTION
The lint → record-to-state → write-capture sequence was duplicated at three call sites (http.rs, websocket.rs, http3.rs), with the load-bearing ordering (record AFTER lint, or the transaction sees itself in its own history) maintained only by convention. A new proxy::TransactionPipeline runs the cycle behind one commit() call so the invariant is enforced by construction; ProtocolEventPipeline does the same for the protocol-event side (h3 events and both websocket relay directions).

lint::lint_transaction is untouched — the pipeline lives on the proxy side, so the rule library stays free of IO concerns.

Behavior change: capture-write failures are now logged at warn level instead of silently dropped.

Out of scope: build_and_write_transaction / record_h3_error error-path helpers intentionally skip lint and state-record (error transactions must not enter TransactionHistory); routing them through the pipeline would change behavior and dedup nothing. Revisit if #4 needs all capture writes behind one seam.
