### PR TITLE
Add gendocs generator for per-rule docs

### DIFF
--- a/src/bin/gendocs.rs
+++ b/src/bin/gendocs.rs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `gendocs` regenerates the per-rule documentation under `docs/rules/` and the
+//! `docs/rules.md` index from rule metadata. See [`lint_http::gendocs`].
+
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "gendocs",
+    about = "Generate rule documentation from rule metadata"
+)]
+struct Args {
+    /// Output directory; `rules.md` and `rules/<id>.md` are written under it.
+    #[arg(long, default_value = "docs")]
+    out: PathBuf,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    lint_http::gendocs::write_all(&args.out)?;
+    eprintln!("Wrote rule docs to {}", args.out.display());
+    Ok(())
+}

--- a/src/gendocs.rs
+++ b/src/gendocs.rs
@@ -1,0 +1,321 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Documentation generator: renders `docs/rules/<id>.md` and the
+//! `docs/rules.md` index from rule metadata
+//! ([`Rule::description`](crate::rules::Rule::description),
+//! [`rfc_reference`](crate::rules::Rule::rfc_reference),
+//! [`examples`](crate::rules::Rule::examples)).
+//!
+//! The render functions are pure and deterministic so a future CI gate (#11d)
+//! can diff regenerated output against the checked-in docs. While rules still
+//! use the empty metadata defaults the output is intentionally sparse; #11c
+//! fills the metadata in.
+
+use crate::rules::{Compliance, Example, ProtocolRule, Rule};
+use std::path::Path;
+
+/// Fixed license header prepended to every generated markdown file. Held
+/// constant (rather than stamped with the current date) so regenerated output
+/// is byte-for-byte stable.
+const SPDX_HEADER: &str = "<!--\nSPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas \
+<alganet@gmail.com>\n\nSPDX-License-Identifier: ISC\n-->\n";
+
+/// Index sections, in render order, paired with the id prefix that selects a
+/// transaction rule into them. Protocol rules get their own trailing section;
+/// anything matching no prefix falls into "Other Rules".
+const TX_SECTIONS: &[(&str, &str)] = &[
+    ("connection_", "Connection Rules"),
+    ("client_", "Client Rules"),
+    ("server_", "Server Rules"),
+    ("message_", "Message Rules"),
+    ("semantic_", "Semantic Rules"),
+    ("stateful_", "Stateful Rules"),
+];
+
+/// Derive a human-readable title from a snake_case rule id, e.g.
+/// `client_user_agent_present` → `"Client User Agent Present"`. A deterministic
+/// approximation: it does not reproduce hand-written hyphenation/acronyms
+/// (`User-Agent`), which is acceptable for generated scaffolding.
+pub fn title_from_id(id: &str) -> String {
+    id.split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().chain(chars).collect::<String>(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render a single per-rule markdown document from its metadata. Sections that
+/// have no content (Specifications when `rfc_reference` is `None`, Examples
+/// when `examples` is empty) are omitted entirely.
+pub fn render_doc(
+    id: &str,
+    description: &str,
+    rfc_reference: Option<&str>,
+    examples: &[Example],
+) -> String {
+    let mut out = String::new();
+    out.push_str(SPDX_HEADER);
+    out.push_str(&format!("\n# {}\n\n", title_from_id(id)));
+
+    out.push_str("## Description\n\n");
+    if description.trim().is_empty() {
+        out.push_str("_No description provided yet._\n");
+    } else {
+        out.push_str(description.trim_end());
+        out.push('\n');
+    }
+
+    if let Some(reference) = rfc_reference {
+        out.push_str(&format!("\n## Specifications\n\n- {}\n", reference));
+    }
+
+    if !examples.is_empty() {
+        out.push_str("\n## Examples\n");
+        render_examples(&mut out, examples, Compliance::Compliant, "### ✅ Good");
+        render_examples(&mut out, examples, Compliance::NonCompliant, "### ❌ Bad");
+    }
+
+    out
+}
+
+/// Append the subsection for one compliance class, if any matching examples
+/// exist. Each snippet becomes its own fenced `http` block.
+fn render_examples(out: &mut String, examples: &[Example], want: Compliance, heading: &str) {
+    let matching = examples.iter().filter(|e| e.compliance == want);
+    let mut any = false;
+    for example in matching {
+        if !any {
+            out.push_str(&format!("\n{}\n", heading));
+            any = true;
+        }
+        out.push_str(&format!(
+            "\n```http\n{}\n```\n",
+            example.snippet.trim_end_matches('\n')
+        ));
+    }
+}
+
+/// Render the `docs/rules.md` index: transaction rules grouped into
+/// fixed-order sections by id prefix, then a Protocol Rules section. Rules keep
+/// the catalogue's (id-sorted) order within each section.
+pub fn render_index(rules: &[&dyn Rule], protocol_rules: &[&dyn ProtocolRule]) -> String {
+    let mut out = String::new();
+    out.push_str(SPDX_HEADER);
+    out.push_str(
+        "\n# Lint Rules\n\nGenerated index of every rule in the catalogue. Each entry links to \
+the per-rule documentation under `rules/`. Rules are disabled by default and \
+enabled via configuration.\n",
+    );
+
+    let mut covered = vec![false; rules.len()];
+
+    for (prefix, title) in TX_SECTIONS {
+        let mut section = String::new();
+        for (idx, rule) in rules.iter().enumerate() {
+            if !covered[idx] && rule.id().starts_with(prefix) {
+                covered[idx] = true;
+                section.push_str(&index_entry(rule.id(), rule.description()));
+            }
+        }
+        if !section.is_empty() {
+            out.push_str(&format!("\n## {}\n\n", title));
+            out.push_str(&section);
+        }
+    }
+
+    // Transaction rules whose id matched no known prefix.
+    let mut other = String::new();
+    for (idx, rule) in rules.iter().enumerate() {
+        if !covered[idx] {
+            other.push_str(&index_entry(rule.id(), rule.description()));
+        }
+    }
+    if !other.is_empty() {
+        out.push_str("\n## Other Rules\n\n");
+        out.push_str(&other);
+    }
+
+    if !protocol_rules.is_empty() {
+        out.push_str("\n## Protocol Rules\n\n");
+        for rule in protocol_rules {
+            out.push_str(&index_entry(rule.id(), rule.description()));
+        }
+    }
+
+    out
+}
+
+/// One index bullet: `- [id](rules/id.md) — <summary>`. The summary is the
+/// first non-empty line of the description, falling back to the derived title.
+fn index_entry(id: &str, description: &str) -> String {
+    let summary = description
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| title_from_id(id));
+    format!("- [{0}](rules/{0}.md) — {1}\n", id, summary)
+}
+
+/// Render every rule to disk under `out_dir`: `<out_dir>/rules/<id>.md` per
+/// rule plus `<out_dir>/rules.md`. Creates directories as needed.
+pub fn write_all(out_dir: &Path) -> anyhow::Result<()> {
+    let rules_dir = out_dir.join("rules");
+    std::fs::create_dir_all(&rules_dir)?;
+
+    for rule in crate::rules::RULES.iter() {
+        let doc = render_doc(
+            rule.id(),
+            rule.description(),
+            rule.rfc_reference(),
+            rule.examples(),
+        );
+        std::fs::write(rules_dir.join(format!("{}.md", rule.id())), doc)?;
+    }
+    for rule in crate::rules::PROTOCOL_RULES.iter() {
+        let doc = render_doc(
+            rule.id(),
+            rule.description(),
+            rule.rfc_reference(),
+            rule.examples(),
+        );
+        std::fs::write(rules_dir.join(format!("{}.md", rule.id())), doc)?;
+    }
+
+    let index = render_index(&crate::rules::RULES, &crate::rules::PROTOCOL_RULES);
+    std::fs::write(out_dir.join("rules.md"), index)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn title_from_id_capitalizes_each_word() {
+        assert_eq!(
+            title_from_id("client_user_agent_present"),
+            "Client User Agent Present"
+        );
+        assert_eq!(title_from_id("connection_id"), "Connection Id");
+        assert_eq!(title_from_id("single"), "Single");
+    }
+
+    #[test]
+    fn render_doc_includes_all_sections_when_metadata_present() {
+        let examples = [
+            Example {
+                compliance: Compliance::Compliant,
+                snippet: "GET / HTTP/1.1\nHost: example.com\nUser-Agent: x/1.0",
+            },
+            Example {
+                compliance: Compliance::NonCompliant,
+                snippet: "GET / HTTP/1.1\nHost: example.com",
+            },
+        ];
+        let doc = render_doc(
+            "client_user_agent_present",
+            "Requests should carry a User-Agent header.",
+            Some("RFC 9110 §10.1.5"),
+            &examples,
+        );
+
+        assert!(doc.starts_with("<!--\nSPDX-FileCopyrightText"));
+        assert!(doc.contains("# Client User Agent Present"));
+        assert!(doc.contains("## Description\n\nRequests should carry a User-Agent header."));
+        assert!(doc.contains("## Specifications\n\n- RFC 9110 §10.1.5"));
+        assert!(doc.contains("### ✅ Good"));
+        assert!(doc.contains("### ❌ Bad"));
+        assert!(doc.contains("```http\nGET / HTTP/1.1\nHost: example.com\nUser-Agent: x/1.0\n```"));
+    }
+
+    #[test]
+    fn render_doc_omits_empty_sections_for_default_metadata() {
+        // Mirrors the current near-empty state: empty description, no rfc, no
+        // examples (the #11a defaults).
+        let doc = render_doc("server_some_rule", "", None, &[]);
+
+        assert!(doc.contains("# Server Some Rule"));
+        assert!(doc.contains("## Description\n\n_No description provided yet._"));
+        assert!(!doc.contains("## Specifications"));
+        assert!(!doc.contains("## Examples"));
+    }
+
+    #[test]
+    fn render_doc_for_whole_catalogue_is_nonempty_and_well_formed() {
+        // Render every rule in-memory; must not touch the real docs/ tree.
+        for rule in crate::rules::RULES.iter() {
+            let doc = render_doc(
+                rule.id(),
+                rule.description(),
+                rule.rfc_reference(),
+                rule.examples(),
+            );
+            assert!(
+                doc.starts_with(SPDX_HEADER),
+                "{} missing SPDX header",
+                rule.id()
+            );
+            assert!(
+                doc.contains("## Description"),
+                "{} missing Description",
+                rule.id()
+            );
+        }
+        for rule in crate::rules::PROTOCOL_RULES.iter() {
+            let doc = render_doc(
+                rule.id(),
+                rule.description(),
+                rule.rfc_reference(),
+                rule.examples(),
+            );
+            assert!(
+                doc.starts_with(SPDX_HEADER),
+                "{} missing SPDX header",
+                rule.id()
+            );
+        }
+    }
+
+    #[test]
+    fn render_index_mentions_every_rule() {
+        let index = render_index(&crate::rules::RULES, &crate::rules::PROTOCOL_RULES);
+        assert!(index.contains("# Lint Rules"));
+        for rule in crate::rules::RULES.iter() {
+            assert!(
+                index.contains(&format!("[{0}](rules/{0}.md)", rule.id())),
+                "index missing {}",
+                rule.id()
+            );
+        }
+        for rule in crate::rules::PROTOCOL_RULES.iter() {
+            assert!(
+                index.contains(&format!("[{0}](rules/{0}.md)", rule.id())),
+                "index missing protocol rule {}",
+                rule.id()
+            );
+        }
+    }
+
+    #[test]
+    fn write_all_creates_files_in_temp_dir() {
+        let dir = std::env::temp_dir().join(format!("gendocs_test_{}", uuid::Uuid::new_v4()));
+        write_all(&dir).expect("write_all should succeed");
+
+        assert!(dir.join("rules.md").is_file());
+        let first = crate::rules::RULES.first().expect("catalogue is non-empty");
+        assert!(dir
+            .join("rules")
+            .join(format!("{}.md", first.id()))
+            .is_file());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod ca;
 pub mod capture;
 pub mod config;
 pub mod connection;
+pub mod gendocs;
 pub mod h3_instrument;
 pub mod helpers;
 pub mod http_date;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -34,6 +34,26 @@ pub enum RuleScope {
     Both,
 }
 
+/// Whether an [`Example`] illustrates traffic the rule accepts or rejects.
+/// Maps to the ✅ Good / ❌ Bad sections of `docs/rules/TEMPLATE.md`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Compliance {
+    /// Traffic the rule accepts (a "✅ Good" docs example).
+    Compliant,
+    /// Traffic the rule flags (a "❌ Bad" docs example).
+    NonCompliant,
+}
+
+/// A documentation example for a rule: a snippet of HTTP traffic tagged with
+/// whether the rule accepts or rejects it. Consumed by the docs generator
+/// (#11b) and `rules list` (#18c). Intrinsic to the rule, so it lives in the
+/// rule crate alongside the trait rather than in downstream tooling.
+#[derive(Copy, Clone, Debug)]
+pub struct Example {
+    pub compliance: Compliance,
+    pub snippet: &'static str,
+}
+
 pub trait Rule: Send + Sync {
     fn id(&self) -> &'static str;
 
@@ -69,6 +89,25 @@ pub trait Rule: Send + Sync {
         history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation>;
+
+    /// Human-readable summary of what this rule checks and why it matters.
+    /// Renders as the "Description" section of the generated per-rule doc.
+    /// Empty by default; #11c fills these in from the existing docs/rules/ files.
+    fn description(&self) -> &'static str {
+        ""
+    }
+
+    /// Canonical specification reference (e.g. "RFC 9110 §5.2"), if any.
+    /// Renders into the "Specifications" section of the generated doc.
+    fn rfc_reference(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Compliant / non-compliant traffic examples for the generated doc's
+    /// "Examples" section. Empty by default.
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
 }
 
 /// Get rule enabled flag, failing if not explicitly configured.
@@ -231,6 +270,25 @@ pub trait ProtocolRule: Send + Sync {
         history: &crate::protocol_event::ProtocolEventHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation>;
+
+    /// Human-readable summary of what this rule checks and why it matters.
+    /// Renders as the "Description" section of the generated per-rule doc.
+    /// Empty by default; #11c fills these in from the existing docs/rules/ files.
+    fn description(&self) -> &'static str {
+        ""
+    }
+
+    /// Canonical specification reference (e.g. "RFC 9000 §18.2"), if any.
+    /// Renders into the "Specifications" section of the generated doc.
+    fn rfc_reference(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Compliant / non-compliant traffic examples for the generated doc's
+    /// "Examples" section. Empty by default.
+    fn examples(&self) -> &'static [Example] {
+        &[]
+    }
 }
 
 /// Every transaction rule, self-registered at link time via
@@ -461,6 +519,24 @@ mod tests {
         let mut psorted = pids.clone();
         psorted.sort_unstable();
         assert_eq!(pids, psorted, "PROTOCOL_RULES must be sorted by id");
+    }
+
+    #[test]
+    fn metadata_accessors_dispatch_with_empty_defaults() {
+        // #11a only adds the metadata surface; no rule overrides it yet, so
+        // every collected rule must report the empty defaults. This proves the
+        // three accessors exist and dispatch through `&dyn Rule` /
+        // `&dyn ProtocolRule`. #11c will fill in real content per rule.
+        for r in RULES.iter() {
+            assert_eq!(r.description(), "", "{} description default", r.id());
+            assert_eq!(r.rfc_reference(), None, "{} rfc default", r.id());
+            assert!(r.examples().is_empty(), "{} examples default", r.id());
+        }
+        for r in PROTOCOL_RULES.iter() {
+            assert_eq!(r.description(), "", "{} description default", r.id());
+            assert_eq!(r.rfc_reference(), None, "{} rfc default", r.id());
+            assert!(r.examples().is_empty(), "{} examples default", r.id());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Add a gendocs binary and a pure, deterministic lint_http::gendocs module that render docs/rules/<id>.md and the docs/rules.md index from the #11a rule metadata, iterating the linkme-collected RULES / PROTOCOL_RULES views. Render logic lives in the library so the future drift gate and CLI subcommand can call it without spawning a subprocess.

Sections with no content (Specifications, Examples) are omitted, so with the empty metadata defaults the output is intentionally sparse; #11c fills the metadata in. The generator is not run against the real docs/ tree at this step — that would overwrite the hand-written docs. Tests render in-memory and to a temp dir.
