### PR TITLE
Bound proxy body buffering with max_body_bytes

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -11,6 +11,11 @@ captures_seed = false
 # file as base64 strings. Bodies are still captured in memory for rules; this
 # option only affects serialization to the captures file.
 captures_include_body = false
+# Maximum body bytes the proxy will buffer per request or response.
+# Over-limit request bodies are rejected with 413; over-limit response bodies
+# abort the exchange with 502. The captured transaction is marked with
+# request_body_over_limit / response_body_over_limit. Default: 64 MiB.
+# max_body_bytes = 67108864
 # Maximum protocol events per connection/session key for protocol-level rules
 # (e.g. WebSocket frame sequencing). Larger values let rules detect violations
 # across more frames but use more memory. Default: 200.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,7 @@ captures = "captures.jsonl"       # Path to capture file
 ttl_seconds = 300                 # How long to keep state records
 captures_seed = false             # Seed state from captures file on startup
 captures_include_body = false     # When true, captured bodies are included in the captures JSONL (base64). Default: false
+max_body_bytes = 67108864         # Max body bytes buffered per request/response. Default: 64 MiB
 ```
 
 - **listen**: The IP address and port the proxy should bind to.
@@ -44,6 +45,7 @@ captures_include_body = false     # When true, captured bodies are included in t
   - Continuing analysis from previous proxy sessions (stateful rules will have access to "previous" transactions)
   - Setting up elaborate testing scenarios with mocked previous states
   - Default is `false` (disabled).
+- **max_body_bytes**: Maximum number of body bytes the proxy will buffer per request or response (default: 64 MiB). Over-limit request bodies are rejected with `413`; over-limit response bodies abort the exchange with `502`. Either way the captured transaction is marked with `request_body_over_limit` / `response_body_over_limit` and the body itself is not captured.
 
 ### TLS Configuration (Mandatory)
 

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -40,6 +40,15 @@ pub struct GeneralConfig {
     #[serde(default = "default_captures_include_body")]
     pub captures_include_body: bool,
 
+    /// Maximum number of body bytes the proxy will buffer per request or
+    /// response (default: 64 MiB). Over-limit request bodies are rejected
+    /// with 413; over-limit response bodies abort the exchange with 502.
+    /// Either way the captured transaction is marked with
+    /// `request_body_over_limit` / `response_body_over_limit` and the body
+    /// itself is not captured.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
     /// Optional HTTP/3 (QUIC) listen address, e.g. "127.0.0.1:3443".
     /// When set, a QUIC/HTTP3 endpoint is started alongside the TCP listener.
     /// Requires TLS to be enabled.
@@ -68,6 +77,10 @@ const fn default_captures_include_body() -> bool {
     false
 }
 
+const fn default_max_body_bytes() -> usize {
+    64 * 1024 * 1024
+}
+
 fn default_listen() -> String {
     "127.0.0.1:3000".to_string()
 }
@@ -90,6 +103,7 @@ impl Default for GeneralConfig {
             max_protocol_event_history: default_max_protocol_event_history(),
             captures_seed: default_captures_seed(),
             captures_include_body: default_captures_include_body(),
+            max_body_bytes: default_max_body_bytes(),
             h3_listen: None,
             h3_server_name: None,
         }
@@ -273,6 +287,31 @@ enabled = false
     fn h3_listen_defaults_to_none() {
         let cfg = Config::default();
         assert!(cfg.general.h3_listen.is_none());
+    }
+
+    #[test]
+    fn max_body_bytes_defaults_to_64_mib() {
+        let cfg = Config::default();
+        assert_eq!(cfg.general.max_body_bytes, 64 * 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn max_body_bytes_parsed_when_present() -> anyhow::Result<()> {
+        let tmp_toml =
+            std::env::temp_dir().join(format!("lint-http_cfg_test_{}.toml", Uuid::new_v4()));
+        let toml = r#"[general]
+listen = "127.0.0.1:3000"
+captures = "captures.jsonl"
+max_body_bytes = 1024
+
+[tls]
+enabled = false
+"#;
+        fs::write(&tmp_toml, toml).await?;
+        let cfg = Config::load_from_path(&tmp_toml).await?;
+        assert_eq!(cfg.general.max_body_bytes, 1024);
+        fs::remove_file(&tmp_toml).await?;
+        Ok(())
     }
 
     #[tokio::test]

--- a/lint-http-core/src/http_transaction.rs
+++ b/lint-http-core/src/http_transaction.rs
@@ -102,6 +102,16 @@ pub struct HttpTransaction {
     #[serde(default)]
     pub was_upgraded: bool,
 
+    /// True when the request body exceeded `max_body_bytes`. The body was not
+    /// captured (`request_body` and `request.body_length` stay `None`).
+    #[serde(default)]
+    pub request_body_over_limit: bool,
+
+    /// True when the response body exceeded `max_body_bytes`. The body was not
+    /// captured (`response_body` and `response.body_length` stay `None`).
+    #[serde(default)]
+    pub response_body_over_limit: bool,
+
     /// The protocol negotiated via the Upgrade header (e.g. "websocket", "h2c").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upgrade_protocol: Option<String>,
@@ -131,6 +141,8 @@ impl HttpTransaction {
             connection_id: None,
             sequence_number: None,
             was_upgraded: false,
+            request_body_over_limit: false,
+            response_body_over_limit: false,
             upgrade_protocol: None,
             violations: Vec::new(),
         }
@@ -168,6 +180,28 @@ mod tests {
             tx2.request.headers.get(key).and_then(|v| v.to_str().ok()),
             expected
         );
+        Ok(())
+    }
+
+    #[test]
+    fn over_limit_flags_roundtrip_and_default_false() -> anyhow::Result<()> {
+        let mut tx = make_test_transaction();
+        tx.request_body_over_limit = true;
+        tx.response_body_over_limit = true;
+
+        let s = serde_json::to_string(&tx)?;
+        let tx2: HttpTransaction = serde_json::from_str(&s)?;
+        assert!(tx2.request_body_over_limit);
+        assert!(tx2.response_body_over_limit);
+
+        // Records written before the flags existed deserialize to false.
+        let mut v: serde_json::Value = serde_json::from_str(&s)?;
+        let obj = v.as_object_mut().expect("transaction serializes as object");
+        obj.remove("request_body_over_limit");
+        obj.remove("response_body_over_limit");
+        let tx3: HttpTransaction = serde_json::from_value(v)?;
+        assert!(!tx3.request_body_over_limit);
+        assert!(!tx3.response_body_over_limit);
         Ok(())
     }
 

--- a/lint-http-proxy/src/proxy/body.rs
+++ b/lint-http-proxy/src/proxy/body.rs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Bounded body collection shared by the proxy request handlers.
+//!
+//! Interim guard until the body pipeline streams (#1b): bodies are still
+//! buffered fully in memory, but never beyond `general.max_body_bytes`.
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, LengthLimitError, Limited};
+
+/// Why a bounded body collection failed.
+pub(super) enum CollectLimitedError {
+    /// The body exceeded the configured limit. Nothing was collected.
+    OverLimit,
+    /// The underlying body errored before the limit was reached.
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Collect a body into memory, enforcing `limit` on the total data bytes.
+///
+/// Trailer frames are not counted against the limit. A body of exactly
+/// `limit` bytes succeeds; the first data frame that pushes the total past
+/// `limit` yields [`CollectLimitedError::OverLimit`].
+pub(super) async fn collect_limited<B>(
+    body: B,
+    limit: usize,
+) -> Result<(Bytes, Option<hyper::HeaderMap>), CollectLimitedError>
+where
+    B: hyper::body::Body,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    match Limited::new(body, limit).collect().await {
+        Ok(collected) => {
+            let trailers = collected.trailers().cloned();
+            Ok((collected.to_bytes(), trailers))
+        }
+        Err(e) if e.downcast_ref::<LengthLimitError>().is_some() => {
+            Err(CollectLimitedError::OverLimit)
+        }
+        Err(e) => Err(CollectLimitedError::Other(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::Full;
+
+    #[tokio::test]
+    async fn under_limit_returns_bytes() {
+        let body = Full::new(Bytes::from_static(b"hello"));
+        let (bytes, trailers) = match collect_limited(body, 16).await {
+            Ok(v) => v,
+            Err(_) => panic!("expected success under limit"),
+        };
+        assert_eq!(&bytes[..], b"hello");
+        assert!(trailers.is_none());
+    }
+
+    #[tokio::test]
+    async fn exactly_at_limit_passes() {
+        let body = Full::new(Bytes::from_static(b"12345678"));
+        let (bytes, _) = match collect_limited(body, 8).await {
+            Ok(v) => v,
+            Err(_) => panic!("expected success exactly at limit"),
+        };
+        assert_eq!(bytes.len(), 8);
+    }
+
+    #[tokio::test]
+    async fn over_limit_is_distinguished() {
+        let body = Full::new(Bytes::from_static(b"123456789"));
+        match collect_limited(body, 8).await {
+            Err(CollectLimitedError::OverLimit) => {}
+            Err(CollectLimitedError::Other(e)) => panic!("expected OverLimit, got Other: {e}"),
+            Ok(_) => panic!("expected OverLimit, got success"),
+        }
+    }
+
+    /// A body that errors before producing any data.
+    struct FailingBody;
+
+    impl hyper::body::Body for FailingBody {
+        type Data = Bytes;
+        type Error = std::io::Error;
+
+        fn poll_frame(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+            std::task::Poll::Ready(Some(Err(std::io::Error::other("simulated body error"))))
+        }
+    }
+
+    #[tokio::test]
+    async fn body_error_maps_to_other() {
+        match collect_limited(FailingBody, 8).await {
+            Err(CollectLimitedError::Other(e)) => {
+                assert!(e.to_string().contains("simulated body error"));
+            }
+            Err(CollectLimitedError::OverLimit) => panic!("expected Other, got OverLimit"),
+            Ok(_) => panic!("expected Other, got success"),
+        }
+    }
+}

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -14,6 +14,7 @@ use tracing::{error, warn};
 
 use crate::capture::CaptureWriter;
 
+use super::body::{collect_limited, CollectLimitedError};
 use super::connect::handle_connect;
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
 use super::websocket::{handle_websocket_upgrade, is_websocket_upgrade};
@@ -122,6 +123,8 @@ async fn build_and_write_transaction(
     response_headers: Option<hyper::HeaderMap<hyper::header::HeaderValue>>,
     duration_ms: u64,
     req_body: Option<bytes::Bytes>,
+    request_body_over_limit: bool,
+    response_body_over_limit: bool,
 ) {
     let mut tx = crate::http_transaction::HttpTransaction::new(
         client_id.clone(),
@@ -134,6 +137,8 @@ async fn build_and_write_transaction(
         tx.request.body_length = Some(b.len() as u64);
         tx.request_body = Some(b);
     }
+    tx.request_body_over_limit = request_body_over_limit;
+    tx.response_body_over_limit = response_body_over_limit;
     tx.response = Some(crate::http_transaction::ResponseInfo {
         status,
         version: "HTTP/1.1".into(),
@@ -218,15 +223,37 @@ where
 
     let body = req.into_body();
     let captures = &shared.captures;
+    let max_body_bytes = shared.cfg.general.max_body_bytes;
 
-    let (body_bytes, req_trailers) = match body.collect().await {
-        Ok(collected) => {
-            let trailers = collected.trailers().cloned();
-            (collected.to_bytes(), trailers)
+    let (body_bytes, req_trailers) = match collect_limited(body, max_body_bytes).await {
+        Ok((bytes, trailers)) => (bytes, trailers),
+        Err(CollectLimitedError::OverLimit) => {
+            warn!("request body exceeds max_body_bytes ({})", max_body_bytes);
+            let msg = "request body exceeds max_body_bytes";
+            let resp = Response::builder()
+                .status(413)
+                .body(Full::new(Bytes::from(msg)).boxed())
+                .unwrap_or_else(|_| Response::new(Full::new(Bytes::from(msg)).boxed()));
+            let duration = started.elapsed().as_millis() as u64;
+            build_and_write_transaction(
+                captures,
+                &client_id,
+                method.as_str(),
+                &uri_str,
+                &req_headers,
+                req_version.clone(),
+                413,
+                None,
+                duration,
+                None,
+                true,
+                false,
+            )
+            .await;
+            return Ok(resp);
         }
-        Err(e) => {
-            let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
-            error!("failed to collect request body: {}", boxed);
+        Err(CollectLimitedError::Other(e)) => {
+            error!("failed to collect request body: {}", e);
             let resp = Response::builder()
                 .status(500)
                 .body(Full::new(Bytes::from("request body collect error")).boxed())
@@ -245,6 +272,8 @@ where
                 None,
                 duration,
                 None,
+                false,
+                false,
             )
             .await;
             return Ok(resp);
@@ -275,6 +304,8 @@ where
                 None,
                 duration,
                 Some(body_bytes.clone()),
+                false,
+                false,
             )
             .await;
             return Ok(resp);
@@ -327,6 +358,8 @@ where
                 None,
                 duration,
                 Some(body_bytes.clone()),
+                false,
+                false,
             )
             .await;
             return Ok(resp);
@@ -337,41 +370,67 @@ where
     let headers = resp.headers().clone();
     // Capture the upstream response version before consuming the body
     let resp_ver = format_http_version(resp.version());
-    let (resp_body_bytes, resp_trailers) = match resp.into_body().collect().await {
-        Ok(collected) => {
-            let trailers = collected.trailers().cloned();
-            (collected.to_bytes(), trailers)
-        }
-        Err(e) => {
-            let boxed: Box<dyn std::error::Error + Send + Sync> = e.into();
-            let body = Full::new(Bytes::from(format!(
-                "upstream body collect error: {}",
-                boxed
-            )))
-            .boxed();
-            let resp = Response::builder()
-                .status(500)
-                .body(body)
-                .unwrap_or_else(|_| {
-                    Response::new(Full::new(Bytes::from("upstream error")).boxed())
-                });
-            let duration = started.elapsed().as_millis() as u64;
-            build_and_write_transaction(
-                captures,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &req_headers,
-                req_version.clone(),
-                500,
-                None,
-                duration,
-                Some(body_bytes.clone()),
-            )
-            .await;
-            return Ok(resp);
-        }
-    };
+    let (resp_body_bytes, resp_trailers) =
+        match collect_limited(resp.into_body(), max_body_bytes).await {
+            Ok((bytes, trailers)) => (bytes, trailers),
+            Err(CollectLimitedError::OverLimit) => {
+                warn!(
+                    "upstream response body exceeds max_body_bytes ({})",
+                    max_body_bytes
+                );
+                let msg = "upstream response exceeds max_body_bytes";
+                let resp = Response::builder()
+                    .status(502)
+                    .body(Full::new(Bytes::from(msg)).boxed())
+                    .unwrap_or_else(|_| Response::new(Full::new(Bytes::from(msg)).boxed()));
+                let duration = started.elapsed().as_millis() as u64;
+                // Record the upstream's real status and headers; the body was
+                // discarded, so only the over-limit marker explains its absence.
+                build_and_write_transaction(
+                    captures,
+                    &client_id,
+                    method.as_str(),
+                    &uri_str,
+                    &req_headers,
+                    req_version.clone(),
+                    status,
+                    Some(headers.clone()),
+                    duration,
+                    Some(body_bytes.clone()),
+                    false,
+                    true,
+                )
+                .await;
+                return Ok(resp);
+            }
+            Err(CollectLimitedError::Other(e)) => {
+                let body =
+                    Full::new(Bytes::from(format!("upstream body collect error: {}", e))).boxed();
+                let resp = Response::builder()
+                    .status(500)
+                    .body(body)
+                    .unwrap_or_else(|_| {
+                        Response::new(Full::new(Bytes::from("upstream error")).boxed())
+                    });
+                let duration = started.elapsed().as_millis() as u64;
+                build_and_write_transaction(
+                    captures,
+                    &client_id,
+                    method.as_str(),
+                    &uri_str,
+                    &req_headers,
+                    req_version.clone(),
+                    500,
+                    None,
+                    duration,
+                    Some(body_bytes.clone()),
+                    false,
+                    false,
+                )
+                .await;
+                return Ok(resp);
+            }
+        };
 
     let duration = started.elapsed().as_millis() as u64;
 
@@ -839,6 +898,120 @@ mod tests {
         .await?;
 
         assert_eq!(resp.status().as_u16(), 500);
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn request_body_over_limit_returns_413_and_marks_capture() -> anyhow::Result<()> {
+        let mut cfg = crate::config::Config::default();
+        cfg.general.max_body_bytes = 8;
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+
+        // Never reaches an upstream: the limit trips while collecting the body.
+        let req = Request::builder()
+            .method("POST")
+            .uri("http://127.0.0.1:9/upload")
+            .body(Full::new(Bytes::from(vec![b'a'; 64])))?;
+
+        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
+            "127.0.0.1:12345".parse()?,
+        ));
+        let resp = handle_http_logic(
+            req,
+            shared.clone(),
+            conn_metadata,
+            hyper::http::uri::Scheme::HTTP,
+        )
+        .await?;
+        assert_eq!(resp.status().as_u16(), 413);
+
+        let entries = read_capture(&tmp).await?;
+        let v = &entries[0];
+        assert_eq!(v["response"]["status"].as_u64(), Some(413));
+        assert_eq!(v["request_body_over_limit"].as_bool(), Some(true));
+        assert_eq!(v["response_body_over_limit"].as_bool(), Some(false));
+        assert!(v["request"]["body_length"].is_null());
+
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn response_body_over_limit_returns_502_and_keeps_upstream_status() -> anyhow::Result<()>
+    {
+        let mock = MockServer::start().await;
+        Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("x-upstream", "yes")
+                    .set_body_bytes(vec![b'b'; 64]),
+            )
+            .mount(&mock)
+            .await;
+
+        let mut cfg = crate::config::Config::default();
+        cfg.general.max_body_bytes = 8;
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+
+        let req = make_request_with_headers("GET", mock.uri(), None)?;
+        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
+            "127.0.0.1:12345".parse()?,
+        ));
+        let resp = handle_request(
+            req,
+            shared.clone(),
+            conn_metadata,
+            hyper::http::uri::Scheme::HTTP,
+        )
+        .await?;
+        assert_eq!(resp.status().as_u16(), 502);
+
+        // The capture records the upstream's real status and headers; only the
+        // marker explains the missing body.
+        let entries = read_capture(&tmp).await?;
+        let v = &entries[0];
+        assert_eq!(v["response"]["status"].as_u64(), Some(200));
+        assert_eq!(v["response_body_over_limit"].as_bool(), Some(true));
+        assert_eq!(v["request_body_over_limit"].as_bool(), Some(false));
+        assert!(v["response"]["body_length"].is_null());
+
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn response_body_exactly_at_limit_passes() -> anyhow::Result<()> {
+        let mock = MockServer::start().await;
+        Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![b'c'; 8]))
+            .mount(&mock)
+            .await;
+
+        let mut cfg = crate::config::Config::default();
+        cfg.general.max_body_bytes = 8;
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+
+        let req = make_request_with_headers("GET", mock.uri(), None)?;
+        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
+            "127.0.0.1:12345".parse()?,
+        ));
+        let resp = handle_request(
+            req,
+            shared.clone(),
+            conn_metadata,
+            hyper::http::uri::Scheme::HTTP,
+        )
+        .await?;
+        assert_eq!(resp.status().as_u16(), 200);
+
+        let entries = read_capture(&tmp).await?;
+        let v = &entries[0];
+        assert_eq!(v["response"]["body_length"].as_u64(), Some(8));
+        assert_eq!(v["response_body_over_limit"].as_bool(), Some(false));
+
         let _ = fs::remove_file(&tmp).await;
         Ok(())
     }

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -5,7 +5,7 @@
 //! HTTP/3 (QUIC) accept loop and per-stream request handling.
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::{Request, Response, Uri};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -249,16 +249,64 @@ async fn handle_h3_request(
 
     let started = Instant::now();
 
-    // Collect the request body from the h3 stream
+    let method = req.method().clone();
+    let uri_str = req.uri().to_string();
+    let req_headers = req.headers().clone();
+
+    let client_ip = conn_metadata.remote_addr.ip();
+    let user_agent = req_headers
+        .get("user-agent")
+        .and_then(|v: &hyper::header::HeaderValue| v.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+    let client_id = crate::state::ClientIdentifier::new(client_ip, user_agent);
+
+    // Collect the request body from the h3 stream, bounded by max_body_bytes.
+    let max_body_bytes = shared.cfg.general.max_body_bytes;
     let mut req_body = Vec::new();
-    while let Some(chunk) = stream.recv_data().await? {
+    let mut req_body_over_limit = false;
+    'collect: while let Some(chunk) = stream.recv_data().await? {
         let mut buf = chunk;
+        if req_body.len() + buf.remaining() > max_body_bytes {
+            req_body_over_limit = true;
+            break 'collect;
+        }
         while buf.has_remaining() {
             let bytes = buf.chunk();
             req_body.extend_from_slice(bytes);
             let len = bytes.len();
             buf.advance(len);
         }
+    }
+    if req_body_over_limit {
+        warn!(
+            "HTTP/3 request body exceeds max_body_bytes ({})",
+            max_body_bytes
+        );
+        let duration = started.elapsed().as_millis() as u64;
+        record_h3_error(
+            &shared.captures,
+            &client_id,
+            method.as_str(),
+            &uri_str,
+            &req_headers,
+            None,
+            413,
+            None,
+            duration,
+            &conn_metadata,
+            stream_id as u32,
+            true,
+            false,
+        )
+        .await;
+        let resp = Response::builder().status(413).body(()).unwrap();
+        stream.send_response(resp).await?;
+        stream
+            .send_data(Bytes::from("request body exceeds max_body_bytes"))
+            .await?;
+        stream.finish().await?;
+        return Ok(());
     }
     let req_body_bytes = Bytes::from(req_body);
 
@@ -298,18 +346,6 @@ async fn handle_h3_request(
             .unwrap_or_else(|_| Uri::from_static("https://localhost/"))
     };
 
-    let method = req.method().clone();
-    let uri_str = req.uri().to_string();
-    let req_headers = req.headers().clone();
-
-    let client_ip = conn_metadata.remote_addr.ip();
-    let user_agent = req_headers
-        .get("user-agent")
-        .and_then(|v: &hyper::header::HeaderValue| v.to_str().ok())
-        .unwrap_or("unknown")
-        .to_string();
-    let client_id = crate::state::ClientIdentifier::new(client_ip, user_agent);
-
     // Build upstream request (forwarded over TCP via the existing hyper client)
     let mut builder = Request::builder().method(method.clone()).uri(uri.clone());
     for (name, value) in req_headers.iter() {
@@ -335,11 +371,14 @@ async fn handle_h3_request(
         method: &str,
         uri_str: &str,
         req_headers: &hyper::HeaderMap,
-        req_body: &Bytes,
+        req_body: Option<&Bytes>,
         status: u16,
+        resp_headers: Option<&hyper::HeaderMap>,
         duration_ms: u64,
         conn_metadata: &crate::connection::ConnectionMetadata,
         sequence_number: u32,
+        request_body_over_limit: bool,
+        response_body_over_limit: bool,
     ) {
         let mut tx = crate::http_transaction::HttpTransaction::new(
             client_id.clone(),
@@ -348,12 +387,16 @@ async fn handle_h3_request(
         );
         tx.request.headers = req_headers.clone();
         tx.request.version = "HTTP/3".to_string();
-        tx.request.body_length = Some(req_body.len() as u64);
-        tx.request_body = Some(req_body.clone());
+        if let Some(b) = req_body {
+            tx.request.body_length = Some(b.len() as u64);
+            tx.request_body = Some(b.clone());
+        }
+        tx.request_body_over_limit = request_body_over_limit;
+        tx.response_body_over_limit = response_body_over_limit;
         tx.response = Some(crate::http_transaction::ResponseInfo {
             status,
             version: "HTTP/3".into(),
-            headers: hyper::HeaderMap::new(),
+            headers: resp_headers.cloned().unwrap_or_default(),
             body_length: None,
             trailers: None,
         });
@@ -376,11 +419,14 @@ async fn handle_h3_request(
                 method.as_str(),
                 &uri_str,
                 &req_headers,
-                &req_body_bytes,
+                Some(&req_body_bytes),
                 502,
+                None,
                 duration,
                 &conn_metadata,
                 stream_id as u32,
+                false,
+                false,
             )
             .await;
             let resp = Response::builder().status(502).body(()).unwrap();
@@ -397,37 +443,71 @@ async fn handle_h3_request(
     let resp_headers = resp.headers().clone();
     let resp_ver = format_http_version(resp.version());
 
-    // Collect response body and trailers (matching TCP path)
-    let (resp_body_bytes, resp_trailers) = match resp.into_body().collect().await {
-        Ok(collected) => {
-            let trailers = collected.trailers().cloned();
-            (collected.to_bytes(), trailers)
-        }
-        Err(e) => {
-            error!("HTTP/3 upstream body collect error: {}", e);
-            let duration = started.elapsed().as_millis() as u64;
-            record_h3_error(
-                &shared.captures,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &req_headers,
-                &req_body_bytes,
-                502,
-                duration,
-                &conn_metadata,
-                stream_id as u32,
-            )
-            .await;
-            let resp = Response::builder().status(502).body(()).unwrap();
-            stream.send_response(resp).await?;
-            stream
-                .send_data(Bytes::from(format!("upstream body error: {}", e)))
-                .await?;
-            stream.finish().await?;
-            return Ok(());
-        }
-    };
+    // Collect response body and trailers (matching TCP path), bounded by
+    // max_body_bytes.
+    let (resp_body_bytes, resp_trailers) =
+        match super::body::collect_limited(resp.into_body(), max_body_bytes).await {
+            Ok((bytes, trailers)) => (bytes, trailers),
+            Err(super::body::CollectLimitedError::OverLimit) => {
+                warn!(
+                    "HTTP/3 upstream response body exceeds max_body_bytes ({})",
+                    max_body_bytes
+                );
+                let duration = started.elapsed().as_millis() as u64;
+                // Record the upstream's real status and headers; the
+                // over-limit marker explains the missing body.
+                record_h3_error(
+                    &shared.captures,
+                    &client_id,
+                    method.as_str(),
+                    &uri_str,
+                    &req_headers,
+                    Some(&req_body_bytes),
+                    status,
+                    Some(&resp_headers),
+                    duration,
+                    &conn_metadata,
+                    stream_id as u32,
+                    false,
+                    true,
+                )
+                .await;
+                let resp = Response::builder().status(502).body(()).unwrap();
+                stream.send_response(resp).await?;
+                stream
+                    .send_data(Bytes::from("upstream response exceeds max_body_bytes"))
+                    .await?;
+                stream.finish().await?;
+                return Ok(());
+            }
+            Err(super::body::CollectLimitedError::Other(e)) => {
+                error!("HTTP/3 upstream body collect error: {}", e);
+                let duration = started.elapsed().as_millis() as u64;
+                record_h3_error(
+                    &shared.captures,
+                    &client_id,
+                    method.as_str(),
+                    &uri_str,
+                    &req_headers,
+                    Some(&req_body_bytes),
+                    502,
+                    None,
+                    duration,
+                    &conn_metadata,
+                    stream_id as u32,
+                    false,
+                    false,
+                )
+                .await;
+                let resp = Response::builder().status(502).body(()).unwrap();
+                stream.send_response(resp).await?;
+                stream
+                    .send_data(Bytes::from(format!("upstream body error: {}", e)))
+                    .await?;
+                stream.finish().await?;
+                return Ok(());
+            }
+        };
 
     let duration = started.elapsed().as_millis() as u64;
 

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -4,6 +4,7 @@
 
 //! HTTP proxy server implementation with request forwarding and capture.
 
+mod body;
 mod connect;
 mod hop_by_hop;
 mod http;

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -11,10 +11,11 @@ use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
 use std::sync::Arc;
 use tokio::time::Instant;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::capture::CaptureWriter;
 
+use super::body::{collect_limited, CollectLimitedError};
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
 use super::pipeline::ProtocolEventPipeline;
 use super::Shared;
@@ -123,9 +124,10 @@ pub(super) async fn handle_websocket_upgrade(
     }
 
     let tx_id = tx.id;
-    shared.pipeline().commit(tx).await;
 
     if status == 101 {
+        shared.pipeline().commit(tx).await;
+
         // Extract the server-side upgraded IO
         let server_upgraded = hyper::upgrade::on(&mut upstream_resp);
 
@@ -168,11 +170,31 @@ pub(super) async fn handle_websocket_upgrade(
 
         Ok(resp)
     } else {
-        // Upstream did not accept the upgrade; return the response normally
-        let resp_body = match upstream_resp.into_body().collect().await {
-            Ok(collected) => collected.to_bytes(),
-            Err(_) => Bytes::new(),
+        // Upstream did not accept the upgrade; return the response normally,
+        // bounded by max_body_bytes.
+        let max_body_bytes = shared.cfg.general.max_body_bytes;
+        let resp_body = match collect_limited(upstream_resp.into_body(), max_body_bytes).await {
+            Ok((bytes, _trailers)) => bytes,
+            Err(CollectLimitedError::OverLimit) => {
+                warn!(
+                    "websocket non-101 response body exceeds max_body_bytes ({})",
+                    max_body_bytes
+                );
+                tx.response_body_over_limit = true;
+                if let Some(r) = tx.response.as_mut() {
+                    r.body_length = None;
+                }
+                shared.pipeline().commit(tx).await;
+                let msg = "upstream response exceeds max_body_bytes";
+                let resp = Response::builder()
+                    .status(502)
+                    .body(Full::new(Bytes::from(msg)).boxed())
+                    .unwrap_or_else(|_| Response::new(Full::new(Bytes::from(msg)).boxed()));
+                return Ok(resp);
+            }
+            Err(CollectLimitedError::Other(_)) => Bytes::new(),
         };
+        shared.pipeline().commit(tx).await;
 
         let mut resp_builder = Response::builder().status(status);
         let connection_hop_headers =
@@ -823,6 +845,83 @@ mod tests {
 
         // Server returned 400, so proxy should forward it
         assert_eq!(resp.status().as_u16(), 400);
+
+        let _ = server_task.await;
+        let _ = tokio::fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handle_websocket_upgrade_non_101_over_limit_returns_502() -> anyhow::Result<()> {
+        // Plain HTTP server rejecting the upgrade with an 11-byte body, which
+        // exceeds the configured 4-byte limit.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+
+        let server_task = tokio::spawn(async move {
+            if let Ok((socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = socket.readable().await;
+                let _ = socket.try_read(&mut buf);
+                let resp = b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\nBad Request";
+                let _ = socket.try_write(resp);
+            }
+        });
+
+        let mut cfg = crate::config::Config::default();
+        cfg.general.max_body_bytes = 4;
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+
+        let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
+        let upstream_req = Request::builder()
+            .method("GET")
+            .uri(uri.clone())
+            .header("connection", "Upgrade")
+            .header("upgrade", "websocket")
+            .body(Full::new(Bytes::new()))?;
+
+        let fake_on_upgrade = hyper::upgrade::on(
+            Request::builder()
+                .method("GET")
+                .uri("http://fake/")
+                .body(Full::new(Bytes::new()).boxed())
+                .unwrap(),
+        );
+
+        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
+            "127.0.0.1:12345".parse()?,
+        ));
+        let started = Instant::now();
+        let client_id =
+            crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
+
+        let resp = handle_websocket_upgrade(
+            upstream_req,
+            fake_on_upgrade,
+            &uri,
+            &hyper::http::uri::Scheme::HTTP,
+            &started,
+            &client_id,
+            &Method::GET,
+            &uri.to_string(),
+            &hyper::HeaderMap::new(),
+            "HTTP/1.1",
+            Bytes::new(),
+            None,
+            shared,
+            conn_metadata,
+        )
+        .await?;
+
+        assert_eq!(resp.status().as_u16(), 502);
+
+        // The capture keeps the upstream's real status; the marker explains
+        // the missing body.
+        let content = tokio::fs::read_to_string(&tmp).await?;
+        let v: serde_json::Value = serde_json::from_str(content.trim())?;
+        assert_eq!(v["response"]["status"].as_u64(), Some(400));
+        assert_eq!(v["response_body_over_limit"].as_bool(), Some(true));
+        assert!(v["response"]["body_length"].is_null());
 
         let _ = server_task.await;
         let _ = tokio::fs::remove_file(&tmp).await;

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -203,6 +203,51 @@ async fn h3_get(
     Ok((status, headers, body))
 }
 
+/// Send a single HTTP/3 POST request with a body via quinn+h3, return status
+/// and response body. Mirrors [`h3_get`].
+async fn h3_request_with_body(
+    endpoint: &quinn::Endpoint,
+    h3_addr: SocketAddr,
+    uri: &str,
+    body: &[u8],
+) -> anyhow::Result<(u16, Vec<u8>)> {
+    use bytes::Buf;
+
+    let conn = endpoint.connect(h3_addr, "localhost")?.await?;
+    let (mut driver, mut send_request) = h3::client::new(h3_quinn::Connection::new(conn)).await?;
+
+    let driver_handle = tokio::spawn(async move {
+        futures_util::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+
+    let req = http::Request::builder().method("POST").uri(uri).body(())?;
+    let mut stream = send_request.send_request(req).await?;
+    stream
+        .send_data(bytes::Bytes::copy_from_slice(body))
+        .await?;
+    stream.finish().await?;
+
+    let resp = stream.recv_response().await?;
+    let status = resp.status().as_u16();
+
+    let mut resp_body = Vec::new();
+    while let Some(chunk) = stream.recv_data().await? {
+        let mut buf = chunk;
+        while buf.has_remaining() {
+            let b = buf.chunk();
+            resp_body.extend_from_slice(b);
+            let len = b.len();
+            buf.advance(len);
+        }
+    }
+
+    drop(stream);
+    drop(send_request);
+    let _ = driver_handle.await;
+
+    Ok((status, resp_body))
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -460,6 +505,105 @@ async fn h3_multiple_requests_on_same_connection_increment_sequence() -> anyhow:
     assert_eq!(records[1]["sequence_number"].as_u64(), Some(1));
 
     // Cleanup
+    endpoint.close(0u32.into(), b"done");
+    handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&cert_path).await;
+    let _ = tokio::fs::remove_file(&key_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn h3_request_body_over_limit_returns_413() -> anyhow::Result<()> {
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
+        start_proxy_with_h3(Some(Box::new(|cfg| {
+            cfg.general.max_body_bytes = 16;
+        })))
+        .await?;
+
+    let endpoint = build_h3_client(&cert_path)?;
+    // The limit trips while collecting the request body, before any upstream
+    // contact, so no mock server is needed.
+    let (status, _body) =
+        h3_request_with_body(&endpoint, h3_addr, "http://127.0.0.1:9/upload", &[b'a'; 64]).await?;
+    assert_eq!(status, 413);
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let content = tokio::fs::read_to_string(&captures_path).await?;
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        !lines.is_empty(),
+        "over-limit transaction should be captured"
+    );
+
+    let v: serde_json::Value = serde_json::from_str(lines[0])?;
+    assert_eq!(v["response"]["status"].as_u64(), Some(413));
+    assert_eq!(v["request_body_over_limit"].as_bool(), Some(true));
+    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3"));
+    assert!(v["request"]["body_length"].is_null());
+
+    endpoint.close(0u32.into(), b"done");
+    handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&cert_path).await;
+    let _ = tokio::fs::remove_file(&key_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn h3_response_body_over_limit_returns_502() -> anyhow::Result<()> {
+    let mock = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/big"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("x-upstream", "yes")
+                .set_body_bytes(vec![b'b'; 64]),
+        )
+        .mount(&mock)
+        .await;
+
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
+        start_proxy_with_h3(Some(Box::new(|cfg| {
+            cfg.general.max_body_bytes = 16;
+        })))
+        .await?;
+
+    let endpoint = build_h3_client(&cert_path)?;
+    let uri = format!("http://127.0.0.1:{}/big", mock.address().port());
+
+    let (status, _headers, _body) = h3_get(&endpoint, h3_addr, &uri, &[]).await?;
+    assert_eq!(status, 502);
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // The capture records the upstream's real status; the marker explains the
+    // missing body.
+    let content = tokio::fs::read_to_string(&captures_path).await?;
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        !lines.is_empty(),
+        "over-limit transaction should be captured"
+    );
+
+    let v: serde_json::Value = serde_json::from_str(lines[0])?;
+    assert_eq!(v["response"]["status"].as_u64(), Some(200));
+    assert_eq!(v["response_body_over_limit"].as_bool(), Some(true));
+    assert!(v["response"]["body_length"].is_null());
+    // The upstream's real response headers are recorded even though the body
+    // was discarded (headers serialize as ordered [name, value] pairs).
+    let resp_headers = v["response"]["headers"]
+        .as_array()
+        .expect("response headers serialize as an array");
+    assert!(
+        resp_headers.iter().any(|pair| {
+            pair.get(0).and_then(|n| n.as_str()) == Some("x-upstream")
+                && pair.get(1).and_then(|val| val.as_str()) == Some("yes")
+        }),
+        "captured response should retain the upstream x-upstream header: {resp_headers:?}"
+    );
+
     endpoint.close(0u32.into(), b"done");
     handle.abort();
     let _ = tokio::fs::remove_file(&captures_path).await;


### PR DESCRIPTION
Bodies were collected fully into memory with no size limit at five sites across the H1/H2, H3, and WebSocket handlers — unbounded memory per transaction. Until the pipeline streams (#1b), enforce a configurable cap (general.max_body_bytes, default 64 MiB) at every collect site via a shared collect_limited helper built on http_body_util::Limited:

- Over-limit request bodies are rejected with 413 (H1/H2 and the H3 recv_data loop, which is capped inline).
- Over-limit response bodies abort the exchange with 502; the capture records the upstream's real status and headers (H3's record_h3_error gained a resp_headers param so its over-limit capture matches the H1 path).
- Either way the transaction carries new request_body_over_limit / response_body_over_limit markers (additive, serde-defaulted — no capture schema version bump) and the body fields stay None, which all body-reading rules already tolerate.

The WebSocket non-101 commit moves into both status branches so the marker can be set before the transaction is written.
