### PR TITLE
Bound connections and shut down gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1999,6 +2000,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ lint-http-rules = { path = "lint-http-rules" }
 
 # Shared third-party dependencies (versions kept in lockstep across crates)
 tokio = { version = "1.52", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 hyper = { version = "1.10.1", features = ["full"] }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/config_example.toml
+++ b/config_example.toml
@@ -16,6 +16,12 @@ captures_include_body = false
 # abort the exchange with 502. The captured transaction is marked with
 # request_body_over_limit / response_body_over_limit. Default: 64 MiB.
 # max_body_bytes = 67108864
+# Maximum simultaneous live TCP connections; further connections wait for a
+# slot rather than being accepted unboundedly. Default: 1024.
+# max_connections = 1024
+# On shutdown (Ctrl-C), seconds to wait for in-flight handlers to drain before
+# exiting anyway. Default: 30.
+# shutdown_timeout_seconds = 30
 # Maximum protocol events per connection/session key for protocol-level rules
 # (e.g. WebSocket frame sequencing). Larger values let rules detect violations
 # across more frames but use more memory. Default: 200.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,8 @@ ttl_seconds = 300                 # How long to keep state records
 captures_seed = false             # Seed state from captures file on startup
 captures_include_body = false     # When true, captured bodies are included in the captures JSONL (base64). Default: false
 max_body_bytes = 67108864         # Max body bytes buffered per request/response. Default: 64 MiB
+max_connections = 1024            # Max simultaneous live TCP connections. Default: 1024
+shutdown_timeout_seconds = 30     # Seconds to drain in-flight handlers on Ctrl-C. Default: 30
 ```
 
 - **listen**: The IP address and port the proxy should bind to.
@@ -46,6 +48,8 @@ max_body_bytes = 67108864         # Max body bytes buffered per request/response
   - Setting up elaborate testing scenarios with mocked previous states
   - Default is `false` (disabled).
 - **max_body_bytes**: Maximum number of body bytes the proxy will buffer per request or response (default: 64 MiB). Over-limit request bodies are rejected with `413`; over-limit response bodies abort the exchange with `502`. Either way the captured transaction is marked with `request_body_over_limit` / `response_body_over_limit` and the body itself is not captured.
+- **max_connections**: Maximum number of simultaneous live TCP connections the proxy will serve (default: 1024). Additional connections wait for a slot rather than being accepted unboundedly, bounding resource use under burst load.
+- **shutdown_timeout_seconds**: On graceful shutdown (Ctrl-C), how many seconds to wait for in-flight handlers to drain before exiting anyway (default: 30). The capture file is flushed and fsynced as part of shutdown, so the last records are never truncated.
 
 ### TLS Configuration (Mandatory)
 

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -49,6 +49,17 @@ pub struct GeneralConfig {
     #[serde(default = "default_max_body_bytes")]
     pub max_body_bytes: usize,
 
+    /// Maximum number of simultaneous live TCP connections the proxy will
+    /// serve. Further connections wait for a slot rather than being accepted
+    /// unboundedly (default: 1024).
+    #[serde(default = "default_max_connections")]
+    pub max_connections: usize,
+
+    /// On shutdown (Ctrl-C), how many seconds to wait for in-flight handlers
+    /// to drain before exiting anyway (default: 30).
+    #[serde(default = "default_shutdown_timeout_seconds")]
+    pub shutdown_timeout_seconds: u64,
+
     /// Optional HTTP/3 (QUIC) listen address, e.g. "127.0.0.1:3443".
     /// When set, a QUIC/HTTP3 endpoint is started alongside the TCP listener.
     /// Requires TLS to be enabled.
@@ -81,6 +92,14 @@ const fn default_max_body_bytes() -> usize {
     64 * 1024 * 1024
 }
 
+const fn default_max_connections() -> usize {
+    1024
+}
+
+const fn default_shutdown_timeout_seconds() -> u64 {
+    30
+}
+
 fn default_listen() -> String {
     "127.0.0.1:3000".to_string()
 }
@@ -104,6 +123,8 @@ impl Default for GeneralConfig {
             captures_seed: default_captures_seed(),
             captures_include_body: default_captures_include_body(),
             max_body_bytes: default_max_body_bytes(),
+            max_connections: default_max_connections(),
+            shutdown_timeout_seconds: default_shutdown_timeout_seconds(),
             h3_listen: None,
             h3_server_name: None,
         }

--- a/lint-http-proxy/Cargo.toml
+++ b/lint-http-proxy/Cargo.toml
@@ -29,6 +29,7 @@ lint-http-core = { workspace = true }
 lint-http-rules = { workspace = true }
 
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 hyper = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -32,7 +32,7 @@ async fn run_app(args: Args) -> anyhow::Result<()> {
     )
     .await?;
 
-    // Start proxy and return its result (no signal handling here).
+    // Start the proxy; `run_proxy` wires Ctrl-C to a graceful shutdown.
     proxy::run_proxy(addr, capture_writer, cfg).await
 }
 

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -10,6 +10,7 @@ use hyper::{Request, Response, Uri};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 
 use crate::ca::CertificateAuthority;
@@ -95,8 +96,22 @@ pub(super) fn init_h3_endpoint(
 
 /// Accept loop for an already-bound QUIC endpoint.  Each incoming connection
 /// is handled in a spawned task through the same pipeline as TCP traffic.
-pub(super) async fn run_h3_accept_loop(endpoint: quinn::Endpoint, shared: Arc<Shared>) {
-    while let Some(incoming) = endpoint.accept().await {
+/// Returns when `shutdown` is cancelled (or the endpoint stops yielding), after
+/// asking the endpoint to close and waiting for in-flight connections to idle,
+/// bounded by `shutdown_timeout_seconds`.
+pub(super) async fn run_h3_accept_loop(
+    endpoint: quinn::Endpoint,
+    shared: Arc<Shared>,
+    shutdown: CancellationToken,
+) {
+    loop {
+        let incoming = tokio::select! {
+            _ = shutdown.cancelled() => break,
+            incoming = endpoint.accept() => match incoming {
+                Some(incoming) => incoming,
+                None => break,
+            },
+        };
         let shared = shared.clone();
         tokio::spawn(async move {
             match incoming.await {
@@ -112,6 +127,11 @@ pub(super) async fn run_h3_accept_loop(endpoint: quinn::Endpoint, shared: Arc<Sh
             }
         });
     }
+
+    // Stop accepting, signal peers, and let in-flight connections drain.
+    endpoint.close(0u32.into(), b"shutting down");
+    let drain = std::time::Duration::from_secs(shared.cfg.general.shutdown_timeout_seconds);
+    let _ = tokio::time::timeout(drain, endpoint.wait_idle()).await;
 }
 
 /// Handle a single HTTP/3 connection: accept request streams, forward upstream,

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -28,7 +28,11 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
-use tracing::{error, info};
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
 
 use crate::ca::CertificateAuthority;
 use crate::capture::CaptureWriter;
@@ -58,20 +62,58 @@ pub async fn run_proxy(
     captures: CaptureWriter,
     cfg: Arc<Config>,
 ) -> anyhow::Result<()> {
-    // Default behavior: no accept limit (runs forever)
-    run_proxy_with_limit(listen, captures, cfg, None).await
+    // Translate Ctrl-C into a cancellation the accept loop and handlers observe.
+    let shutdown = CancellationToken::new();
+    {
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                info!("ctrl-c received, shutting down");
+                shutdown.cancel();
+            }
+        });
+    }
+    run_proxy_inner(listen, captures, cfg, None, shutdown).await
 }
 
 /// Testable variant of `run_proxy` that accepts an optional `accept_limit`.
 /// When `accept_limit` is `Some(n)`, the accept loop will accept `n` connections
-/// and then return after accepting the Nth connection. Connection handlers are
-/// spawned asynchronously and may still be running when this function returns,
-/// allowing tests to deterministically bound how many connections are accepted.
+/// and then return. Used by tests to deterministically bound accepts; the
+/// shutdown sequence still runs (stop accepting, drain handlers, flush
+/// captures) before returning.
 pub async fn run_proxy_with_limit(
     listen: SocketAddr,
     captures: CaptureWriter,
     cfg: Arc<Config>,
     accept_limit: Option<usize>,
+) -> anyhow::Result<()> {
+    run_proxy_inner(
+        listen,
+        captures,
+        cfg,
+        accept_limit,
+        CancellationToken::new(),
+    )
+    .await
+}
+
+/// Variant that runs until `shutdown` is cancelled (or Ctrl-C is wired by the
+/// caller). Lets shutdown integration tests drive graceful shutdown directly.
+pub async fn run_proxy_with_shutdown(
+    listen: SocketAddr,
+    captures: CaptureWriter,
+    cfg: Arc<Config>,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()> {
+    run_proxy_inner(listen, captures, cfg, None, shutdown).await
+}
+
+async fn run_proxy_inner(
+    listen: SocketAddr,
+    captures: CaptureWriter,
+    cfg: Arc<Config>,
+    accept_limit: Option<usize>,
+    shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
     let https = HttpsConnectorBuilder::new()
         .with_native_roots()?
@@ -121,15 +163,25 @@ pub async fn run_proxy_with_limit(
         }
     }
 
-    // Spawn background cleanup task
+    // Connection bound and drain budget. Read before `cfg` moves into `Shared`.
+    let max_connections = cfg.general.max_connections;
+    let shutdown_timeout = Duration::from_secs(cfg.general.shutdown_timeout_seconds);
+    let semaphore = Arc::new(Semaphore::new(max_connections));
+
+    // Spawn background cleanup task, cancellable so shutdown can join it.
     let state_cleanup = state.clone();
     let pe_store_cleanup = protocol_event_store.clone();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+    let cleanup_shutdown = shutdown.clone();
+    let cleanup_handle = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
         loop {
-            interval.tick().await;
-            state_cleanup.cleanup_expired();
-            pe_store_cleanup.cleanup_expired();
+            tokio::select! {
+                _ = interval.tick() => {
+                    state_cleanup.cleanup_expired();
+                    pe_store_cleanup.cleanup_expired();
+                }
+                _ = cleanup_shutdown.cancelled() => break,
+            }
         }
     });
 
@@ -164,12 +216,13 @@ pub async fn run_proxy_with_limit(
     });
 
     // Start HTTP/3 (QUIC) accept loop if an endpoint was created.
-    if let Some(endpoint) = h3_endpoint {
+    let h3_handle = h3_endpoint.map(|endpoint| {
         let shared_h3 = shared.clone();
+        let shutdown_h3 = shutdown.clone();
         tokio::spawn(async move {
-            run_h3_accept_loop(endpoint, shared_h3).await;
-        });
-    }
+            run_h3_accept_loop(endpoint, shared_h3, shutdown_h3).await;
+        })
+    });
 
     // Use a manual TcpListener accept loop to preserve the remote address and
     // avoid relying on the removed `make_service_fn` helper in hyper v1.
@@ -179,24 +232,40 @@ pub async fn run_proxy_with_limit(
     let executor = TokioExecutor::new();
     let server_builder = AutoConnBuilder::new(executor);
 
-    // Accept loop with optional limit
+    // Accept loop, bounded by the connection semaphore and interruptible by
+    // shutdown. Each accepted connection holds an owned permit for its lifetime,
+    // so the semaphore doubles as the drain barrier below.
     let mut remaining = accept_limit;
     loop {
-        // If we're limited and have reached zero, stop accepting
         if let Some(0) = remaining {
             break;
         }
 
-        let (stream, remote_addr) = listener.accept().await?;
+        // Reserve a slot first, so we never accept beyond `max_connections`.
+        let permit = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            permit = semaphore.clone().acquire_owned() => permit?,
+        };
 
-        // Decrement remaining if present
-        if let Some(ref mut n) = remaining {
+        let (stream, remote_addr) = tokio::select! {
+            _ = shutdown.cancelled() => {
+                drop(permit);
+                break;
+            }
+            accepted = listener.accept() => accepted?,
+        };
+
+        if let Some(n) = remaining.as_mut() {
             *n -= 1;
         }
 
         let shared = shared.clone();
         let builder_clone = server_builder.clone();
+        let shutdown_conn = shutdown.clone();
         tokio::spawn(async move {
+            // Released when this task ends; the drain waits on all permits.
+            let _permit = permit;
             let conn_metadata = Arc::new(crate::connection::ConnectionMetadata::new(remote_addr));
             let service = service_fn(move |req: Request<Incoming>| {
                 let shared = shared.clone();
@@ -214,13 +283,47 @@ pub async fn run_proxy_with_limit(
             });
 
             let io = TokioIo::new(stream);
-            if let Err(e) = builder_clone
-                .serve_connection_with_upgrades(io, service)
-                .await
-            {
-                error!(%e, "connection error");
+            let conn = builder_clone.serve_connection_with_upgrades(io, service);
+            tokio::pin!(conn);
+            tokio::select! {
+                res = conn.as_mut() => {
+                    if let Err(e) = res {
+                        error!(%e, "connection error");
+                    }
+                }
+                _ = shutdown_conn.cancelled() => {
+                    // Finish in-flight requests but stop reading new ones.
+                    conn.as_mut().graceful_shutdown();
+                    if let Err(e) = conn.await {
+                        error!(%e, "connection error after graceful shutdown");
+                    }
+                }
             }
         });
+    }
+
+    // Graceful shutdown: stop accepting (done), cancel handlers, then drain.
+    shutdown.cancel();
+
+    // Wait until every connection task has released its permit (acquiring the
+    // full set proves the count is back to zero), bounded by the timeout.
+    let drain = semaphore.acquire_many(max_connections.min(u32::MAX as usize) as u32);
+    if timeout(shutdown_timeout, drain).await.is_err() {
+        warn!(
+            timeout_s = shutdown_timeout.as_secs(),
+            "shutdown drain timed out; some connections did not finish"
+        );
+    }
+
+    let _ = cleanup_handle.await;
+    if let Some(handle) = h3_handle {
+        let _ = handle.await;
+    }
+
+    // Flush, fsync, and join the capture writer last, after all handlers that
+    // could write to it have drained, so no capture line is lost or truncated.
+    if let Err(e) = shared.captures.shutdown().await {
+        warn!(error = %e, "failed to shut down capture writer");
     }
 
     Ok(())
@@ -339,6 +442,51 @@ mod tests {
         let res = tokio::time::timeout(std::time::Duration::from_secs(5), task).await??;
         assert!(res.is_ok());
         // Drop the stream now that the proxy has accepted it
+        drop(stream_opt);
+
+        let _ = fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_proxy_with_shutdown_drains_and_returns() -> anyhow::Result<()> {
+        use tokio::net::TcpStream;
+
+        let l = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = l.local_addr()?;
+        drop(l);
+
+        let (shared, tmp, cw) =
+            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+
+        let shutdown = CancellationToken::new();
+        let cfg_clone = shared.cfg.clone();
+        let cw_clone = cw.clone();
+        let shutdown_for_task = shutdown.clone();
+        let task = tokio::spawn(async move {
+            run_proxy_with_shutdown(addr, cw_clone, cfg_clone, shutdown_for_task).await
+        });
+
+        // Connect so a handler is live and holding a permit, then let the proxy
+        // accept it before we ask it to shut down.
+        let mut stream_opt: Option<TcpStream> = None;
+        for _ in 0..100 {
+            match TcpStream::connect(addr).await {
+                Ok(s) => {
+                    stream_opt = Some(s);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+            }
+        }
+        assert!(stream_opt.is_some(), "failed to connect to proxy");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Cancellation should stop accepting, drain the live connection via
+        // graceful shutdown, flush captures, and return Ok within the timeout.
+        shutdown.cancel();
+        let res = tokio::time::timeout(std::time::Duration::from_secs(5), task).await??;
+        assert!(res.is_ok());
         drop(stream_opt);
 
         let _ = fs::remove_file(&tmp).await;


### PR DESCRIPTION
The accept loop spawned a task per connection with no cap, nothing handled Ctrl-C, and on exit nothing drained in-flight handlers or flushed the capture file — the last capture lines were at the mercy of the (now removed) per-write flush.

Add a tokio Semaphore (general.max_connections, default 1024) bounding live TCP connections; each accepted connection holds an owned permit for its lifetime, so the semaphore doubles as the drain barrier. run_proxy wires tokio::signal::ctrl_c to a CancellationToken handed to the accept loops, the cleanup task, and every handler. The accept loop selects the token against accept; each handler selects it against the connection future and calls hyper's UpgradeableConnection::graceful_shutdown on cancel. Shutdown then stops accepting, cancels, drains via acquire_many bounded by general.shutdown_timeout_seconds (default 30), joins the cleanup/H3 tasks, and calls captures.shutdown() so no capture tail is truncated. H3 stops via endpoint.close + wait_idle.

Entry points split into a private run_proxy_inner; new run_proxy_with_shutdown lets a test drive graceful shutdown.
