### PR TITLE
Extract a shared request-handling core for H1/H2 and H3

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Transport-agnostic request-handling core shared by the H1/H2 and H3
+//! handlers.
+//!
+//! Each transport's handler does its own front half — reading the request and
+//! its body in protocol-specific ways — then hands a [`ProxiedRequest`] to
+//! [`exchange`], which forwards upstream, collects the response, builds and
+//! commits the [`HttpTransaction`], and returns a [`ProxiedResponse`] the
+//! transport delivers in its own way. This keeps lint coverage, capture, and
+//! header handling identical across protocols instead of relying on two copies
+//! staying in sync.
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{HeaderMap, Method, Request, Uri};
+use std::sync::Arc;
+use tokio::time::Instant;
+use tracing::{error, warn};
+use uuid::Uuid;
+
+use crate::capture::CaptureWriter;
+use crate::state::ClientIdentifier;
+
+use super::body::{collect_limited, CollectLimitedError};
+use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
+use super::Shared;
+
+/// The post-front-half request inputs both transports compute, ready for the
+/// shared upstream exchange.
+pub(super) struct ProxiedRequest {
+    pub method: Method,
+    /// Absolute URI used for the upstream request line.
+    pub uri: Uri,
+    /// Value recorded in `tx.request.uri` — the transport's original request
+    /// target (H1 keeps the possibly origin-form `req.uri()`; not `uri`).
+    pub uri_str: String,
+    /// Original client request headers; suppression is applied only when
+    /// building the upstream request.
+    pub headers: HeaderMap,
+    /// Request version string ("HTTP/1.1", "HTTP/3", …).
+    pub version: String,
+    pub body: Bytes,
+    pub trailers: Option<HeaderMap>,
+    pub client_id: ClientIdentifier,
+    pub connection_id: Uuid,
+    pub sequence_number: u32,
+}
+
+/// What the transport should deliver to the client. Headers are already
+/// hop-by-hop filtered (with the 101 carve-out); they are empty for
+/// proxy-generated error responses.
+pub(super) struct ProxiedResponse {
+    pub status: u16,
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+
+/// Forward `req` upstream, collect the response, build + commit the
+/// transaction, and return the response to deliver. Internal errors (upstream
+/// failure, over-limit / failed response body, request build failure) are
+/// recorded directly to captures (bypassing lint/state, as before) and turned
+/// into a proxy error `ProxiedResponse`.
+pub(super) async fn exchange(
+    req: ProxiedRequest,
+    shared: &Arc<Shared>,
+    started: Instant,
+) -> ProxiedResponse {
+    let captures = &shared.captures;
+    let max_body_bytes = shared.cfg.general.max_body_bytes;
+
+    let upstream_req =
+        match build_upstream_request(&req.method, &req.uri, &req.headers, &req.body, shared) {
+            Ok(r) => r,
+            Err(e) => {
+                error!("failed to build upstream request: {}", e);
+                let duration = started.elapsed().as_millis() as u64;
+                record_exchange_error(captures, &req, 500, None, duration, false).await;
+                return error_response(500, format!("request build error: {}", e));
+            }
+        };
+
+    let resp = match shared.client.request(upstream_req).await {
+        Ok(r) => r,
+        Err(e) => {
+            let duration = started.elapsed().as_millis() as u64;
+            record_exchange_error(captures, &req, 502, None, duration, false).await;
+            return error_response(502, format!("upstream error: {}", e));
+        }
+    };
+
+    let status = resp.status().as_u16();
+    let upstream_headers = resp.headers().clone();
+    let resp_ver = format_http_version(resp.version());
+
+    let (resp_body_bytes, resp_trailers) =
+        match collect_limited(resp.into_body(), max_body_bytes).await {
+            Ok((bytes, trailers)) => (bytes, trailers),
+            Err(CollectLimitedError::OverLimit) => {
+                warn!(
+                    "upstream response body exceeds max_body_bytes ({})",
+                    max_body_bytes
+                );
+                let duration = started.elapsed().as_millis() as u64;
+                // Record the upstream's real status and headers; the body was
+                // discarded, so only the over-limit marker explains its absence.
+                record_exchange_error(
+                    captures,
+                    &req,
+                    status,
+                    Some(upstream_headers.clone()),
+                    duration,
+                    true,
+                )
+                .await;
+                return error_response(502, "upstream response exceeds max_body_bytes".to_string());
+            }
+            Err(CollectLimitedError::Other(e)) => {
+                error!("upstream body collect error: {}", e);
+                let duration = started.elapsed().as_millis() as u64;
+                record_exchange_error(captures, &req, 500, None, duration, false).await;
+                return error_response(500, format!("upstream body collect error: {}", e));
+            }
+        };
+
+    let duration = started.elapsed().as_millis() as u64;
+
+    // Read everything the client response needs from the upstream headers
+    // before they are moved into the recorded transaction below.
+    let out_headers = filter_response_headers(&upstream_headers, status);
+    let (was_upgraded, upgrade_protocol) = if status == 101 {
+        let proto = upstream_headers
+            .get("upgrade")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        (true, proto)
+    } else {
+        (false, None)
+    };
+
+    let mut tx = crate::http_transaction::HttpTransaction::new(
+        req.client_id,
+        req.method.as_str().to_string(),
+        req.uri_str,
+    );
+    tx.request.headers = req.headers;
+    tx.request.version = req.version;
+    tx.request.body_length = Some(req.body.len() as u64);
+    tx.request.trailers = req.trailers;
+    tx.request_body = Some(req.body);
+
+    tx.response = Some(crate::http_transaction::ResponseInfo {
+        status,
+        version: resp_ver,
+        headers: upstream_headers,
+        body_length: Some(resp_body_bytes.len() as u64),
+        trailers: resp_trailers,
+    });
+    tx.response_body = Some(resp_body_bytes.clone());
+    tx.timing = crate::http_transaction::TimingInfo {
+        duration_ms: duration,
+    };
+    tx.connection_id = Some(req.connection_id);
+    tx.sequence_number = Some(req.sequence_number);
+    tx.was_upgraded = was_upgraded;
+    tx.upgrade_protocol = upgrade_protocol;
+
+    shared.pipeline().commit(tx).await;
+
+    ProxiedResponse {
+        status,
+        headers: out_headers,
+        body: resp_body_bytes,
+    }
+}
+
+/// Build the upstream request, copying client headers except those configured
+/// in `suppress_headers`.
+pub(super) fn build_upstream_request(
+    method: &Method,
+    uri: &Uri,
+    headers: &HeaderMap,
+    body: &Bytes,
+    shared: &Arc<Shared>,
+) -> Result<Request<Full<Bytes>>, hyper::http::Error> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    for (name, value) in headers.iter() {
+        if !shared
+            .cfg
+            .tls
+            .suppress_headers
+            .iter()
+            .any(|h| h.eq_ignore_ascii_case(name.as_str()))
+        {
+            builder = builder.header(name, value);
+        }
+    }
+    builder.body(Full::new(body.clone()))
+}
+
+/// Filter response headers before returning them to the client. For 101
+/// Switching Protocols all headers are preserved (the Connection/Upgrade
+/// headers are essential to the handshake); otherwise hop-by-hop headers are
+/// stripped. `append` preserves repeated headers (e.g. `set-cookie`).
+pub(super) fn filter_response_headers(headers: &HeaderMap, status: u16) -> HeaderMap {
+    if status == 101 {
+        return headers.clone();
+    }
+    let connection_hop_headers = parse_connection_tokens(headers.get(hyper::header::CONNECTION));
+    let mut out = HeaderMap::new();
+    for (name, value) in headers.iter() {
+        let name_str = name.as_str().to_ascii_lowercase();
+        if is_hop_by_hop_header(&name_str, &connection_hop_headers) {
+            continue;
+        }
+        out.append(name.clone(), value.clone());
+    }
+    out
+}
+
+fn error_response(status: u16, body: String) -> ProxiedResponse {
+    ProxiedResponse {
+        status,
+        headers: HeaderMap::new(),
+        body: Bytes::from(body),
+    }
+}
+
+/// Record an error transaction from inside [`exchange`], where the full
+/// [`ProxiedRequest`] is in hand. The request body has already been collected,
+/// so `request_body_over_limit` is always `false` here.
+async fn record_exchange_error(
+    captures: &CaptureWriter,
+    req: &ProxiedRequest,
+    status: u16,
+    response_headers: Option<HeaderMap>,
+    duration_ms: u64,
+    response_body_over_limit: bool,
+) {
+    record_error_transaction(
+        captures,
+        &req.client_id,
+        req.method.as_str(),
+        &req.uri_str,
+        &req.headers,
+        &req.version,
+        status,
+        response_headers,
+        duration_ms,
+        Some(req.body.clone()),
+        req.connection_id,
+        req.sequence_number,
+        false,
+        response_body_over_limit,
+    )
+    .await;
+}
+
+/// Build a minimal `HttpTransaction` (request + response status only) and write
+/// it straight to captures, bypassing lint and state recording. Used on the
+/// error paths where the upstream exchange never completes normally. Shared by
+/// both transports; the caller supplies the transport's version string,
+/// connection id, and sequence number.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn record_error_transaction(
+    captures: &CaptureWriter,
+    client_id: &ClientIdentifier,
+    method: &str,
+    uri_str: &str,
+    req_headers: &HeaderMap,
+    version: &str,
+    status: u16,
+    response_headers: Option<HeaderMap>,
+    duration_ms: u64,
+    req_body: Option<Bytes>,
+    connection_id: Uuid,
+    sequence_number: u32,
+    request_body_over_limit: bool,
+    response_body_over_limit: bool,
+) {
+    let mut tx = crate::http_transaction::HttpTransaction::new(
+        client_id.clone(),
+        method.to_string(),
+        uri_str.to_string(),
+    );
+    tx.request.headers = req_headers.clone();
+    tx.request.version = version.to_string();
+    if let Some(b) = req_body {
+        tx.request.body_length = Some(b.len() as u64);
+        tx.request_body = Some(b);
+    }
+    tx.request_body_over_limit = request_body_over_limit;
+    tx.response_body_over_limit = response_body_over_limit;
+    tx.response = Some(crate::http_transaction::ResponseInfo {
+        status,
+        version: version.to_string(),
+        headers: response_headers.unwrap_or_default(),
+        body_length: None,
+        trailers: None,
+    });
+    tx.timing = crate::http_transaction::TimingInfo { duration_ms };
+    tx.connection_id = Some(connection_id);
+    tx.sequence_number = Some(sequence_number);
+    if let Err(e) = captures.write_transaction(tx).await {
+        warn!(error = %e, "failed to write transaction capture");
+    }
+}

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -12,11 +12,10 @@ use std::sync::Arc;
 use tokio::time::Instant;
 use tracing::{error, warn};
 
-use crate::capture::CaptureWriter;
-
 use super::body::{collect_limited, CollectLimitedError};
 use super::connect::handle_connect;
-use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
+use super::exchange::{build_upstream_request, exchange, record_error_transaction, ProxiedRequest};
+use super::hop_by_hop::format_http_version;
 use super::websocket::{handle_websocket_upgrade, is_websocket_upgrade};
 use super::Shared;
 
@@ -108,48 +107,13 @@ where
     handle_http_logic(req, shared, conn_metadata, scheme).await
 }
 
-/// Build a minimal `HttpTransaction` (request + response status only) and
-/// write it to the captures file.  Used on the error paths in
-/// [`handle_http_logic`] where the upstream request never completes normally.
-#[allow(clippy::too_many_arguments)]
-async fn build_and_write_transaction(
-    captures: &CaptureWriter,
-    client_id: &crate::state::ClientIdentifier,
-    method: &str,
-    uri_str: &str,
-    req_headers: &hyper::HeaderMap<hyper::header::HeaderValue>,
-    req_version: String,
-    status: u16,
-    response_headers: Option<hyper::HeaderMap<hyper::header::HeaderValue>>,
-    duration_ms: u64,
-    req_body: Option<bytes::Bytes>,
-    request_body_over_limit: bool,
-    response_body_over_limit: bool,
-) {
-    let mut tx = crate::http_transaction::HttpTransaction::new(
-        client_id.clone(),
-        method.to_string(),
-        uri_str.to_string(),
-    );
-    tx.request.headers = req_headers.clone();
-    tx.request.version = req_version;
-    if let Some(b) = req_body {
-        tx.request.body_length = Some(b.len() as u64);
-        tx.request_body = Some(b);
-    }
-    tx.request_body_over_limit = request_body_over_limit;
-    tx.response_body_over_limit = response_body_over_limit;
-    tx.response = Some(crate::http_transaction::ResponseInfo {
-        status,
-        version: "HTTP/1.1".into(),
-        headers: response_headers.unwrap_or_default(),
-        body_length: None,
-        trailers: None,
-    });
-    tx.timing = crate::http_transaction::TimingInfo { duration_ms };
-    if let Err(e) = captures.write_transaction(tx).await {
-        warn!(error = %e, "failed to write transaction capture");
-    }
+/// Build a boxed plaintext error response (status + message body, no headers).
+fn error_resp(status: u16, msg: &str) -> Response<BoxBody<Bytes, Infallible>> {
+    let body = Bytes::from(msg.to_string());
+    Response::builder()
+        .status(status)
+        .body(Full::new(body.clone()).boxed())
+        .unwrap_or_else(|_| Response::new(Full::new(body).boxed()))
 }
 
 async fn handle_http_logic<B>(
@@ -185,19 +149,6 @@ where
 
     let is_ws_upgrade = is_websocket_upgrade(&req);
 
-    let mut builder = Request::builder().method(req.method()).uri(uri.clone());
-    for (name, value) in req.headers().iter() {
-        if !shared
-            .cfg
-            .tls
-            .suppress_headers
-            .iter()
-            .any(|h| h.eq_ignore_ascii_case(name.as_str()))
-        {
-            builder = builder.header(name, value);
-        }
-    }
-
     let method = req.method().clone();
     let uri_str = req.uri().to_string();
     let req_headers = req.headers().clone();
@@ -210,112 +161,98 @@ where
         .to_string();
     let client_id = crate::state::ClientIdentifier::new(client_ip, user_agent);
 
-    // Capture request version before moving `req` into body
+    // Capture request version before moving `req` into body.
     let req_version = format_http_version(req.version());
 
-    // Extract the client OnUpgrade before consuming the request body.
-    // For WebSocket upgrades, we need this to get the upgraded client IO later.
+    // Extract the client OnUpgrade before consuming the request body; for
+    // WebSocket upgrades we need it to reach the upgraded client IO later.
     let client_on_upgrade = if is_ws_upgrade {
         Some(hyper::upgrade::on(&mut req))
     } else {
         None
     };
 
-    let body = req.into_body();
     let captures = &shared.captures;
     let max_body_bytes = shared.cfg.general.max_body_bytes;
 
-    let (body_bytes, req_trailers) = match collect_limited(body, max_body_bytes).await {
+    let (body_bytes, req_trailers) = match collect_limited(req.into_body(), max_body_bytes).await {
         Ok((bytes, trailers)) => (bytes, trailers),
         Err(CollectLimitedError::OverLimit) => {
             warn!("request body exceeds max_body_bytes ({})", max_body_bytes);
-            let msg = "request body exceeds max_body_bytes";
-            let resp = Response::builder()
-                .status(413)
-                .body(Full::new(Bytes::from(msg)).boxed())
-                .unwrap_or_else(|_| Response::new(Full::new(Bytes::from(msg)).boxed()));
             let duration = started.elapsed().as_millis() as u64;
-            build_and_write_transaction(
+            record_error_transaction(
                 captures,
                 &client_id,
                 method.as_str(),
                 &uri_str,
                 &req_headers,
-                req_version.clone(),
+                &req_version,
                 413,
                 None,
                 duration,
                 None,
+                conn_metadata.id,
+                conn_metadata.next_sequence_number(),
                 true,
                 false,
             )
             .await;
-            return Ok(resp);
+            return Ok(error_resp(413, "request body exceeds max_body_bytes"));
         }
         Err(CollectLimitedError::Other(e)) => {
             error!("failed to collect request body: {}", e);
-            let resp = Response::builder()
-                .status(500)
-                .body(Full::new(Bytes::from("request body collect error")).boxed())
-                .unwrap_or_else(|_| {
-                    Response::new(Full::new(Bytes::from("request body collect error")).boxed())
-                });
             let duration = started.elapsed().as_millis() as u64;
-            build_and_write_transaction(
+            record_error_transaction(
                 captures,
                 &client_id,
                 method.as_str(),
                 &uri_str,
                 &req_headers,
-                req_version.clone(),
+                &req_version,
                 500,
                 None,
                 duration,
                 None,
+                conn_metadata.id,
+                conn_metadata.next_sequence_number(),
                 false,
                 false,
             )
             .await;
-            return Ok(resp);
+            return Ok(error_resp(500, "request body collect error"));
         }
     };
 
-    let upstream_req = match builder.body(Full::new(body_bytes.clone())) {
-        Ok(r) => r,
-        Err(e) => {
-            error!("failed to build upstream request: {}", e);
-            let body = Full::new(Bytes::from(format!("request build error: {}", e))).boxed();
-            let resp = Response::builder()
-                .status(500)
-                .body(body)
-                .unwrap_or_else(|_| {
-                    Response::new(Full::new(Bytes::from("internal error")).boxed())
-                });
-            // record a failed capture with 500
-            let duration = started.elapsed().as_millis() as u64;
-            build_and_write_transaction(
-                captures,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &req_headers,
-                req_version.clone(),
-                500,
-                None,
-                duration,
-                Some(body_bytes.clone()),
-                false,
-                false,
-            )
-            .await;
-            return Ok(resp);
-        }
-    };
-
-    // WebSocket upgrade path: bypass LegacyClient, use direct connection with
-    // upgrade support, and spawn a relay task for frame-level capture.
+    // WebSocket upgrade path: bypass the exchange core; the WS handler builds
+    // its own upstream connection and consumes its own sequence number.
     if is_ws_upgrade {
         if let Some(client_on_upgrade) = client_on_upgrade {
+            let upstream_req =
+                match build_upstream_request(&method, &uri, &req_headers, &body_bytes, &shared) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!("failed to build upstream request: {}", e);
+                        let duration = started.elapsed().as_millis() as u64;
+                        record_error_transaction(
+                            captures,
+                            &client_id,
+                            method.as_str(),
+                            &uri_str,
+                            &req_headers,
+                            &req_version,
+                            500,
+                            None,
+                            duration,
+                            Some(body_bytes.clone()),
+                            conn_metadata.id,
+                            conn_metadata.next_sequence_number(),
+                            false,
+                            false,
+                        )
+                        .await;
+                        return Ok(error_resp(500, &format!("request build error: {}", e)));
+                    }
+                };
             return handle_websocket_upgrade(
                 upstream_req,
                 client_on_upgrade,
@@ -336,163 +273,29 @@ where
         }
     }
 
-    let resp = match shared.client.request(upstream_req).await {
-        Ok(r) => r,
-        Err(e) => {
-            let body = Full::new(Bytes::from(format!("upstream error: {}", e))).boxed();
-            let resp = Response::builder()
-                .status(502)
-                .body(body)
-                .unwrap_or_else(|_| {
-                    Response::new(Full::new(Bytes::from("upstream error")).boxed())
-                });
-            let duration = started.elapsed().as_millis() as u64;
-            build_and_write_transaction(
-                captures,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &req_headers,
-                req_version.clone(),
-                502,
-                None,
-                duration,
-                Some(body_bytes.clone()),
-                false,
-                false,
-            )
-            .await;
-            return Ok(resp);
-        }
+    // Non-WebSocket: run the shared exchange core and deliver its response.
+    let pr = ProxiedRequest {
+        method,
+        uri,
+        uri_str,
+        headers: req_headers,
+        version: req_version,
+        body: body_bytes,
+        trailers: req_trailers,
+        client_id,
+        connection_id: conn_metadata.id,
+        sequence_number: conn_metadata.next_sequence_number(),
     };
 
-    let status = resp.status().as_u16();
-    let headers = resp.headers().clone();
-    // Capture the upstream response version before consuming the body
-    let resp_ver = format_http_version(resp.version());
-    let (resp_body_bytes, resp_trailers) =
-        match collect_limited(resp.into_body(), max_body_bytes).await {
-            Ok((bytes, trailers)) => (bytes, trailers),
-            Err(CollectLimitedError::OverLimit) => {
-                warn!(
-                    "upstream response body exceeds max_body_bytes ({})",
-                    max_body_bytes
-                );
-                let msg = "upstream response exceeds max_body_bytes";
-                let resp = Response::builder()
-                    .status(502)
-                    .body(Full::new(Bytes::from(msg)).boxed())
-                    .unwrap_or_else(|_| Response::new(Full::new(Bytes::from(msg)).boxed()));
-                let duration = started.elapsed().as_millis() as u64;
-                // Record the upstream's real status and headers; the body was
-                // discarded, so only the over-limit marker explains its absence.
-                build_and_write_transaction(
-                    captures,
-                    &client_id,
-                    method.as_str(),
-                    &uri_str,
-                    &req_headers,
-                    req_version.clone(),
-                    status,
-                    Some(headers.clone()),
-                    duration,
-                    Some(body_bytes.clone()),
-                    false,
-                    true,
-                )
-                .await;
-                return Ok(resp);
-            }
-            Err(CollectLimitedError::Other(e)) => {
-                let body =
-                    Full::new(Bytes::from(format!("upstream body collect error: {}", e))).boxed();
-                let resp = Response::builder()
-                    .status(500)
-                    .body(body)
-                    .unwrap_or_else(|_| {
-                        Response::new(Full::new(Bytes::from("upstream error")).boxed())
-                    });
-                let duration = started.elapsed().as_millis() as u64;
-                build_and_write_transaction(
-                    captures,
-                    &client_id,
-                    method.as_str(),
-                    &uri_str,
-                    &req_headers,
-                    req_version.clone(),
-                    500,
-                    None,
-                    duration,
-                    Some(body_bytes.clone()),
-                    false,
-                    false,
-                )
-                .await;
-                return Ok(resp);
-            }
-        };
+    let proxied = exchange(pr, &shared, started).await;
 
-    let duration = started.elapsed().as_millis() as u64;
-
-    let mut tx = crate::http_transaction::HttpTransaction::new(
-        client_id.clone(),
-        method.as_str().to_string(),
-        uri_str.clone(),
-    );
-    tx.request.headers = req_headers.clone();
-    tx.request.version = req_version.clone();
-    // record request body and length
-    tx.request.body_length = Some(body_bytes.len() as u64);
-    tx.request.trailers = req_trailers;
-    tx.request_body = Some(body_bytes.clone());
-
-    tx.response = Some(crate::http_transaction::ResponseInfo {
-        status,
-        version: resp_ver,
-        headers: headers.clone(),
-        body_length: Some(resp_body_bytes.len() as u64),
-        trailers: resp_trailers,
-    });
-    tx.response_body = Some(resp_body_bytes.clone());
-    tx.timing = crate::http_transaction::TimingInfo {
-        duration_ms: duration,
-    };
-    tx.connection_id = Some(conn_metadata.id);
-    tx.sequence_number = Some(conn_metadata.next_sequence_number());
-    if status == 101 {
-        tx.was_upgraded = true;
-        tx.upgrade_protocol = headers
-            .get("upgrade")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+    let mut resp_builder = Response::builder().status(proxied.status);
+    for (name, value) in proxied.headers.iter() {
+        resp_builder = resp_builder.header(name, value);
     }
-
-    shared.pipeline().commit(tx).await;
-
-    let mut resp_builder = Response::builder().status(status);
-
-    if status == 101 {
-        // 101 Switching Protocols: preserve all headers including Connection
-        // and Upgrade which are essential for the upgrade handshake.
-        for (name, value) in headers.iter() {
-            resp_builder = resp_builder.header(name, value);
-        }
-    } else {
-        let connection_hop_headers =
-            parse_connection_tokens(headers.get(hyper::header::CONNECTION));
-        for (name, value) in headers.iter() {
-            let name_str = name.as_str().to_ascii_lowercase();
-            if is_hop_by_hop_header(&name_str, &connection_hop_headers) {
-                continue;
-            }
-            resp_builder = resp_builder.header(name, value);
-        }
-    }
-    let resp = resp_builder
-        .body(Full::new(resp_body_bytes.clone()).boxed())
-        .unwrap_or_else(|_| Response::new(Full::new(resp_body_bytes.clone()).boxed()));
-
-    Ok(resp)
+    Ok(resp_builder
+        .body(Full::new(proxied.body.clone()).boxed())
+        .unwrap_or_else(|_| Response::new(Full::new(proxied.body).boxed())))
 }
 
 #[cfg(test)]

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -5,8 +5,7 @@
 //! HTTP/3 (QUIC) accept loop and per-stream request handling.
 
 use bytes::Bytes;
-use http_body_util::Full;
-use hyper::{Request, Response, Uri};
+use hyper::{Response, Uri};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::time::Instant;
@@ -14,10 +13,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 
 use crate::ca::CertificateAuthority;
-use crate::capture::CaptureWriter;
 
 use super::connect::AlwaysResolves;
-use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
+use super::exchange::{exchange, record_error_transaction, ProxiedRequest};
 use super::Shared;
 
 /// QUIC transport parameter defaults for the HTTP/3 proxy.
@@ -304,17 +302,18 @@ async fn handle_h3_request(
             max_body_bytes
         );
         let duration = started.elapsed().as_millis() as u64;
-        record_h3_error(
+        record_error_transaction(
             &shared.captures,
             &client_id,
             method.as_str(),
             &uri_str,
             &req_headers,
-            None,
+            "HTTP/3",
             413,
             None,
             duration,
-            &conn_metadata,
+            None,
+            conn_metadata.id,
             stream_id as u32,
             true,
             false,
@@ -339,7 +338,8 @@ async fn handle_h3_request(
         }
     };
 
-    // Build the upstream URI
+    // Build the upstream URI from the :authority pseudo-header (falling back to
+    // Host), defaulting to HTTPS since HTTP/3 is always over TLS.
     let uri = {
         let scheme = req
             .uri()
@@ -366,215 +366,30 @@ async fn handle_h3_request(
             .unwrap_or_else(|_| Uri::from_static("https://localhost/"))
     };
 
-    // Build upstream request (forwarded over TCP via the existing hyper client)
-    let mut builder = Request::builder().method(method.clone()).uri(uri.clone());
-    for (name, value) in req_headers.iter() {
-        if !shared
-            .cfg
-            .tls
-            .suppress_headers
-            .iter()
-            .any(|h| h.eq_ignore_ascii_case(name.as_str()))
-        {
-            builder = builder.header(name, value);
-        }
-    }
-
-    let upstream_req = builder.body(Full::new(req_body_bytes.clone()))?;
-
-    /// Record a minimal error transaction on the H3 path (mirrors TCP path's
-    /// `build_and_write_transaction`).
-    #[allow(clippy::too_many_arguments)]
-    async fn record_h3_error(
-        captures: &CaptureWriter,
-        client_id: &crate::state::ClientIdentifier,
-        method: &str,
-        uri_str: &str,
-        req_headers: &hyper::HeaderMap,
-        req_body: Option<&Bytes>,
-        status: u16,
-        resp_headers: Option<&hyper::HeaderMap>,
-        duration_ms: u64,
-        conn_metadata: &crate::connection::ConnectionMetadata,
-        sequence_number: u32,
-        request_body_over_limit: bool,
-        response_body_over_limit: bool,
-    ) {
-        let mut tx = crate::http_transaction::HttpTransaction::new(
-            client_id.clone(),
-            method.to_string(),
-            uri_str.to_string(),
-        );
-        tx.request.headers = req_headers.clone();
-        tx.request.version = "HTTP/3".to_string();
-        if let Some(b) = req_body {
-            tx.request.body_length = Some(b.len() as u64);
-            tx.request_body = Some(b.clone());
-        }
-        tx.request_body_over_limit = request_body_over_limit;
-        tx.response_body_over_limit = response_body_over_limit;
-        tx.response = Some(crate::http_transaction::ResponseInfo {
-            status,
-            version: "HTTP/3".into(),
-            headers: resp_headers.cloned().unwrap_or_default(),
-            body_length: None,
-            trailers: None,
-        });
-        tx.timing = crate::http_transaction::TimingInfo { duration_ms };
-        tx.connection_id = Some(conn_metadata.id);
-        tx.sequence_number = Some(sequence_number);
-        if let Err(e) = captures.write_transaction(tx).await {
-            warn!(error = %e, "failed to write transaction capture");
-        }
-    }
-
-    let resp = match shared.client.request(upstream_req).await {
-        Ok(r) => r,
-        Err(e) => {
-            error!("HTTP/3 upstream error: {}", e);
-            let duration = started.elapsed().as_millis() as u64;
-            record_h3_error(
-                &shared.captures,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &req_headers,
-                Some(&req_body_bytes),
-                502,
-                None,
-                duration,
-                &conn_metadata,
-                stream_id as u32,
-                false,
-                false,
-            )
-            .await;
-            let resp = Response::builder().status(502).body(()).unwrap();
-            stream.send_response(resp).await?;
-            stream
-                .send_data(Bytes::from(format!("upstream error: {}", e)))
-                .await?;
-            stream.finish().await?;
-            return Ok(());
-        }
+    // Run the shared exchange core (forward, collect, lint, capture).
+    let pr = ProxiedRequest {
+        method,
+        uri,
+        uri_str,
+        headers: req_headers,
+        version: "HTTP/3".to_string(),
+        body: req_body_bytes,
+        trailers: req_trailers,
+        client_id,
+        connection_id: conn_metadata.id,
+        sequence_number: stream_id as u32,
     };
+    let proxied = exchange(pr, &shared, started).await;
 
-    let status = resp.status().as_u16();
-    let resp_headers = resp.headers().clone();
-    let resp_ver = format_http_version(resp.version());
-
-    // Collect response body and trailers (matching TCP path), bounded by
-    // max_body_bytes.
-    let (resp_body_bytes, resp_trailers) =
-        match super::body::collect_limited(resp.into_body(), max_body_bytes).await {
-            Ok((bytes, trailers)) => (bytes, trailers),
-            Err(super::body::CollectLimitedError::OverLimit) => {
-                warn!(
-                    "HTTP/3 upstream response body exceeds max_body_bytes ({})",
-                    max_body_bytes
-                );
-                let duration = started.elapsed().as_millis() as u64;
-                // Record the upstream's real status and headers; the
-                // over-limit marker explains the missing body.
-                record_h3_error(
-                    &shared.captures,
-                    &client_id,
-                    method.as_str(),
-                    &uri_str,
-                    &req_headers,
-                    Some(&req_body_bytes),
-                    status,
-                    Some(&resp_headers),
-                    duration,
-                    &conn_metadata,
-                    stream_id as u32,
-                    false,
-                    true,
-                )
-                .await;
-                let resp = Response::builder().status(502).body(()).unwrap();
-                stream.send_response(resp).await?;
-                stream
-                    .send_data(Bytes::from("upstream response exceeds max_body_bytes"))
-                    .await?;
-                stream.finish().await?;
-                return Ok(());
-            }
-            Err(super::body::CollectLimitedError::Other(e)) => {
-                error!("HTTP/3 upstream body collect error: {}", e);
-                let duration = started.elapsed().as_millis() as u64;
-                record_h3_error(
-                    &shared.captures,
-                    &client_id,
-                    method.as_str(),
-                    &uri_str,
-                    &req_headers,
-                    Some(&req_body_bytes),
-                    502,
-                    None,
-                    duration,
-                    &conn_metadata,
-                    stream_id as u32,
-                    false,
-                    false,
-                )
-                .await;
-                let resp = Response::builder().status(502).body(()).unwrap();
-                stream.send_response(resp).await?;
-                stream
-                    .send_data(Bytes::from(format!("upstream body error: {}", e)))
-                    .await?;
-                stream.finish().await?;
-                return Ok(());
-            }
-        };
-
-    let duration = started.elapsed().as_millis() as u64;
-
-    // Build transaction for linting and capture
-    let mut tx = crate::http_transaction::HttpTransaction::new(
-        client_id.clone(),
-        method.as_str().to_string(),
-        uri_str.clone(),
-    );
-    tx.request.headers = req_headers.clone();
-    tx.request.version = "HTTP/3".to_string();
-    tx.request.body_length = Some(req_body_bytes.len() as u64);
-    tx.request.trailers = req_trailers;
-    tx.request_body = Some(req_body_bytes);
-
-    tx.response = Some(crate::http_transaction::ResponseInfo {
-        status,
-        version: resp_ver,
-        headers: resp_headers.clone(),
-        body_length: Some(resp_body_bytes.len() as u64),
-        trailers: resp_trailers,
-    });
-    tx.response_body = Some(resp_body_bytes.clone());
-    tx.timing = crate::http_transaction::TimingInfo {
-        duration_ms: duration,
-    };
-    tx.connection_id = Some(conn_metadata.id);
-    tx.sequence_number = Some(stream_id as u32);
-
-    shared.pipeline().commit(tx).await;
-
-    // Send the response back over HTTP/3.
-    // HTTP/3 has no hop-by-hop headers (RFC 9114 §4.2), but the upstream
-    // response arrives via TCP and may contain them, so we still strip them.
-    let mut resp_builder = Response::builder().status(status);
-    let connection_hop_headers =
-        parse_connection_tokens(resp_headers.get(hyper::header::CONNECTION));
-    for (name, value) in resp_headers.iter() {
-        let name_str = name.as_str().to_ascii_lowercase();
-        if is_hop_by_hop_header(&name_str, &connection_hop_headers) {
-            continue;
-        }
+    // Send the response back over HTTP/3. Headers are already hop-by-hop
+    // filtered by the exchange core.
+    let mut resp_builder = Response::builder().status(proxied.status);
+    for (name, value) in proxied.headers.iter() {
         resp_builder = resp_builder.header(name, value);
     }
     let h3_resp = resp_builder.body(()).unwrap();
     stream.send_response(h3_resp).await?;
-    stream.send_data(resp_body_bytes).await?;
+    stream.send_data(proxied.body).await?;
     stream.finish().await?;
 
     Ok(())

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -6,6 +6,7 @@
 
 mod body;
 mod connect;
+mod exchange;
 mod hop_by_hop;
 mod http;
 mod http3;

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -16,7 +16,7 @@ use tracing::{error, warn};
 use crate::capture::CaptureWriter;
 
 use super::body::{collect_limited, CollectLimitedError};
-use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
+use super::hop_by_hop::{format_http_version, parse_connection_tokens};
 use super::pipeline::ProtocolEventPipeline;
 use super::Shared;
 
@@ -197,13 +197,7 @@ pub(super) async fn handle_websocket_upgrade(
         shared.pipeline().commit(tx).await;
 
         let mut resp_builder = Response::builder().status(status);
-        let connection_hop_headers =
-            parse_connection_tokens(headers.get(hyper::header::CONNECTION));
-        for (name, value) in headers.iter() {
-            let name_str = name.as_str().to_ascii_lowercase();
-            if is_hop_by_hop_header(&name_str, &connection_hop_headers) {
-                continue;
-            }
+        for (name, value) in super::exchange::filter_response_headers(&headers, status).iter() {
             resp_builder = resp_builder.header(name, value);
         }
         let resp = resp_builder


### PR DESCRIPTION
handle_http_logic and handle_h3_request were near-duplicate ~250-line god-functions: after each computed its request inputs they ran an identical forward -> collect response -> assemble HttpTransaction -> pipeline commit -> hop-by-hop filter sequence, differing only in already- computed inputs and in how the response is delivered. The two error- capture helpers were likewise parallel copies. Every divergence was a latent protocol-parity bug.

Add proxy/exchange.rs holding the transport-agnostic back half. A ProxiedRequest carries each transport's post-front-half inputs; exchange forwards upstream, collects the response (with over-limit handling), builds and commits the transaction, filters response headers, and returns a ProxiedResponse that H1 turns into a Response and H3 sends over the stream. One record_error_transaction replaces both error helpers. Each handler keeps only its protocol-specific front half (URI building, body collection, version string, sequence source, the H1-only WebSocket early return). Sequence numbers are now consumed exactly once per request in every terminal branch. Both functions drop well under the clippy cognitive-complexity default, setting up #16.

Intentional parity convergences (untested before): H1 error captures now carry connection_id/sequence_number; the H3 upstream-body-collect error becomes 500 with H1's wording; an H3 upstream-build error now yields a delivered 500; the 101 header carve-out applies uniformly.
