### PR TITLE
Lint and capture error and failed-handshake transactions

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -21,7 +21,6 @@ use tokio::time::Instant;
 use tracing::{error, warn};
 use uuid::Uuid;
 
-use crate::capture::CaptureWriter;
 use crate::state::ClientIdentifier;
 
 use super::body::{collect_limited, CollectLimitedError};
@@ -68,7 +67,6 @@ pub(super) async fn exchange(
     shared: &Arc<Shared>,
     started: Instant,
 ) -> ProxiedResponse {
-    let captures = &shared.captures;
     let max_body_bytes = shared.cfg.general.max_body_bytes;
 
     let upstream_req =
@@ -77,7 +75,7 @@ pub(super) async fn exchange(
             Err(e) => {
                 error!("failed to build upstream request: {}", e);
                 let duration = started.elapsed().as_millis() as u64;
-                record_exchange_error(captures, &req, 500, None, duration, false).await;
+                record_exchange_error(shared, &req, 500, None, duration, false).await;
                 return error_response(500, format!("request build error: {}", e));
             }
         };
@@ -86,7 +84,7 @@ pub(super) async fn exchange(
         Ok(r) => r,
         Err(e) => {
             let duration = started.elapsed().as_millis() as u64;
-            record_exchange_error(captures, &req, 502, None, duration, false).await;
+            record_exchange_error(shared, &req, 502, None, duration, false).await;
             return error_response(502, format!("upstream error: {}", e));
         }
     };
@@ -107,7 +105,7 @@ pub(super) async fn exchange(
                 // Record the upstream's real status and headers; the body was
                 // discarded, so only the over-limit marker explains its absence.
                 record_exchange_error(
-                    captures,
+                    shared,
                     &req,
                     status,
                     Some(upstream_headers.clone()),
@@ -120,7 +118,7 @@ pub(super) async fn exchange(
             Err(CollectLimitedError::Other(e)) => {
                 error!("upstream body collect error: {}", e);
                 let duration = started.elapsed().as_millis() as u64;
-                record_exchange_error(captures, &req, 500, None, duration, false).await;
+                record_exchange_error(shared, &req, 500, None, duration, false).await;
                 return error_response(500, format!("upstream body collect error: {}", e));
             }
         };
@@ -232,7 +230,7 @@ fn error_response(status: u16, body: String) -> ProxiedResponse {
 /// [`ProxiedRequest`] is in hand. The request body has already been collected,
 /// so `request_body_over_limit` is always `false` here.
 async fn record_exchange_error(
-    captures: &CaptureWriter,
+    shared: &Arc<Shared>,
     req: &ProxiedRequest,
     status: u16,
     response_headers: Option<HeaderMap>,
@@ -240,7 +238,7 @@ async fn record_exchange_error(
     response_body_over_limit: bool,
 ) {
     record_error_transaction(
-        captures,
+        shared,
         &req.client_id,
         req.method.as_str(),
         &req.uri_str,
@@ -258,14 +256,15 @@ async fn record_exchange_error(
     .await;
 }
 
-/// Build a minimal `HttpTransaction` (request + response status only) and write
-/// it straight to captures, bypassing lint and state recording. Used on the
-/// error paths where the upstream exchange never completes normally. Shared by
-/// both transports; the caller supplies the transport's version string,
-/// connection id, and sequence number.
+/// Build a minimal `HttpTransaction` (request + response status only) and route
+/// it through the full pipeline (lint → state record → capture), so error
+/// exchanges are linted and enter `TransactionHistory` like any other traffic.
+/// Used on the error paths where the upstream exchange never completes
+/// normally. Shared by both transports; the caller supplies the transport's
+/// version string, connection id, and sequence number.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn record_error_transaction(
-    captures: &CaptureWriter,
+    shared: &Arc<Shared>,
     client_id: &ClientIdentifier,
     method: &str,
     uri_str: &str,
@@ -303,7 +302,6 @@ pub(super) async fn record_error_transaction(
     tx.timing = crate::http_transaction::TimingInfo { duration_ms };
     tx.connection_id = Some(connection_id);
     tx.sequence_number = Some(sequence_number);
-    if let Err(e) = captures.write_transaction(tx).await {
-        warn!(error = %e, "failed to write transaction capture");
-    }
+    // Lint, record to state, and capture — error exchanges are real traffic.
+    shared.pipeline().commit(tx).await;
 }

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -172,7 +172,6 @@ where
         None
     };
 
-    let captures = &shared.captures;
     let max_body_bytes = shared.cfg.general.max_body_bytes;
 
     let (body_bytes, req_trailers) = match collect_limited(req.into_body(), max_body_bytes).await {
@@ -181,7 +180,7 @@ where
             warn!("request body exceeds max_body_bytes ({})", max_body_bytes);
             let duration = started.elapsed().as_millis() as u64;
             record_error_transaction(
-                captures,
+                &shared,
                 &client_id,
                 method.as_str(),
                 &uri_str,
@@ -203,7 +202,7 @@ where
             error!("failed to collect request body: {}", e);
             let duration = started.elapsed().as_millis() as u64;
             record_error_transaction(
-                captures,
+                &shared,
                 &client_id,
                 method.as_str(),
                 &uri_str,
@@ -234,7 +233,7 @@ where
                         error!("failed to build upstream request: {}", e);
                         let duration = started.elapsed().as_millis() as u64;
                         record_error_transaction(
-                            captures,
+                            &shared,
                             &client_id,
                             method.as_str(),
                             &uri_str,
@@ -382,6 +381,14 @@ mod tests {
         let s = fs::read_to_string(&tmp).await?;
         let v: serde_json::Value = serde_json::from_str(s.trim())?;
         assert_eq!(v["response"]["status"].as_u64(), Some(502));
+
+        // The errored exchange is also recorded into history, so stateful rules
+        // can see failure traffic (not just successful exchanges).
+        let client =
+            crate::state::ClientIdentifier::new("127.0.0.1".parse()?, "unknown".to_string());
+        let history = shared.state.get_history(&client, "http://127.0.0.1:9/");
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].response.as_ref().unwrap().status, 502);
 
         let _ = fs::remove_file(&tmp).await;
         Ok(())

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -303,7 +303,7 @@ async fn handle_h3_request(
         );
         let duration = started.elapsed().as_millis() as u64;
         record_error_transaction(
-            &shared.captures,
+            &shared,
             &client_id,
             method.as_str(),
             &uri_str,

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -16,6 +16,7 @@ use tracing::{error, warn};
 use crate::capture::CaptureWriter;
 
 use super::body::{collect_limited, CollectLimitedError};
+use super::exchange::record_error_transaction;
 use super::hop_by_hop::{format_http_version, parse_connection_tokens};
 use super::pipeline::ProtocolEventPipeline;
 use super::Shared;
@@ -60,14 +61,19 @@ pub(super) async fn handle_websocket_upgrade(
         Ok(s) => s,
         Err(e) => {
             error!("websocket upstream connect error: {}", e);
-            let body = Full::new(Bytes::from(format!("websocket upstream error: {}", e))).boxed();
-            let resp = Response::builder()
-                .status(502)
-                .body(body)
-                .unwrap_or_else(|_| {
-                    Response::new(Full::new(Bytes::from("upstream error")).boxed())
-                });
-            return Ok(resp);
+            record_handshake_failure(
+                &shared,
+                client_id,
+                method,
+                uri_str,
+                req_headers,
+                req_version,
+                &body_bytes,
+                &conn_metadata,
+                started,
+            )
+            .await;
+            return Ok(upstream_error_response(&e));
         }
     };
 
@@ -76,14 +82,19 @@ pub(super) async fn handle_websocket_upgrade(
         Ok(r) => r,
         Err(e) => {
             error!("websocket upstream request error: {}", e);
-            let body = Full::new(Bytes::from(format!("websocket upstream error: {}", e))).boxed();
-            let resp = Response::builder()
-                .status(502)
-                .body(body)
-                .unwrap_or_else(|_| {
-                    Response::new(Full::new(Bytes::from("upstream error")).boxed())
-                });
-            return Ok(resp);
+            record_handshake_failure(
+                &shared,
+                client_id,
+                method,
+                uri_str,
+                req_headers,
+                req_version,
+                &body_bytes,
+                &conn_metadata,
+                started,
+            )
+            .await;
+            return Ok(upstream_error_response(&e));
         }
     };
 
@@ -206,6 +217,52 @@ pub(super) async fn handle_websocket_upgrade(
 
         Ok(resp)
     }
+}
+
+/// Build the 502 returned to the client when a WebSocket upstream handshake
+/// fails (connect or request-send error).
+fn upstream_error_response(e: impl std::fmt::Display) -> Response<BoxBody<Bytes, Infallible>> {
+    let body = Full::new(Bytes::from(format!("websocket upstream error: {}", e))).boxed();
+    Response::builder()
+        .status(502)
+        .body(body)
+        .unwrap_or_else(|_| Response::new(Full::new(Bytes::from("upstream error")).boxed()))
+}
+
+/// Record a transaction for a WebSocket handshake that failed before the
+/// upstream produced any response, so the request is not silently lost. Routes
+/// through the pipeline (lint → state → capture) and consumes one sequence
+/// number, matching the success path.
+#[allow(clippy::too_many_arguments)]
+async fn record_handshake_failure(
+    shared: &Arc<Shared>,
+    client_id: &crate::state::ClientIdentifier,
+    method: &Method,
+    uri_str: &str,
+    req_headers: &hyper::HeaderMap,
+    req_version: &str,
+    body_bytes: &Bytes,
+    conn_metadata: &crate::connection::ConnectionMetadata,
+    started: &Instant,
+) {
+    let duration = started.elapsed().as_millis() as u64;
+    record_error_transaction(
+        shared,
+        client_id,
+        method.as_str(),
+        uri_str,
+        req_headers,
+        req_version,
+        502,
+        None,
+        duration,
+        Some(body_bytes.clone()),
+        conn_metadata.id,
+        conn_metadata.next_sequence_number(),
+        false,
+        false,
+    )
+    .await;
 }
 
 /// Open a direct TCP (or TLS) connection to the upstream host and perform
@@ -469,6 +526,15 @@ mod tests {
         )
     }
 
+    /// Whether a captured transaction's request headers (serialized as ordered
+    /// `[name, value]` pairs) contain `name`.
+    fn captured_request_has_header(v: &serde_json::Value, name: &str) -> bool {
+        v["request"]["headers"]
+            .as_array()
+            .map(|pairs| pairs.iter().any(|p| p[0] == name))
+            .unwrap_or(false)
+    }
+
     #[test]
     fn is_websocket_upgrade_detects_valid_upgrade() {
         let req = Request::builder()
@@ -721,7 +787,7 @@ mod tests {
     async fn handle_websocket_upgrade_upstream_connect_error() -> anyhow::Result<()> {
         // Test that handle_websocket_upgrade returns 502 when upstream is unreachable
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
 
         // Build a request targeting a closed port
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
@@ -751,6 +817,8 @@ mod tests {
         let started = Instant::now();
         let client_id =
             crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
+        let mut req_headers = hyper::HeaderMap::new();
+        req_headers.insert("x-test", "1".parse()?);
 
         let resp = handle_websocket_upgrade(
             upstream_req,
@@ -761,7 +829,7 @@ mod tests {
             &client_id,
             &Method::GET,
             &uri.to_string(),
-            &hyper::HeaderMap::new(),
+            &req_headers,
             "HTTP/1.1",
             Bytes::new(),
             None,
@@ -771,6 +839,17 @@ mod tests {
         .await?;
 
         assert_eq!(resp.status().as_u16(), 502);
+
+        // The failed handshake is now captured rather than silently dropped,
+        // preserving the request headers.
+        cw.flush().await?;
+        let content = tokio::fs::read_to_string(&tmp).await?;
+        let v: serde_json::Value = serde_json::from_str(content.trim())?;
+        assert_eq!(v["response"]["status"].as_u64(), Some(502));
+        assert!(
+            captured_request_has_header(&v, "x-test"),
+            "captured request should preserve request headers"
+        );
 
         let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
@@ -1128,7 +1207,7 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let upstream_req = Request::builder()
@@ -1152,6 +1231,8 @@ mod tests {
         let started = Instant::now();
         let client_id =
             crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
+        let mut req_headers = hyper::HeaderMap::new();
+        req_headers.insert("x-test", "1".parse()?);
 
         let resp = handle_websocket_upgrade(
             upstream_req,
@@ -1162,7 +1243,7 @@ mod tests {
             &client_id,
             &Method::GET,
             &uri.to_string(),
-            &hyper::HeaderMap::new(),
+            &req_headers,
             "HTTP/1.1",
             Bytes::new(),
             None,
@@ -1173,6 +1254,16 @@ mod tests {
 
         // Server dropped connection, send_request should fail -> 502
         assert_eq!(resp.status().as_u16(), 502);
+
+        // The failed handshake is captured rather than silently dropped.
+        cw.flush().await?;
+        let content = tokio::fs::read_to_string(&tmp).await?;
+        let v: serde_json::Value = serde_json::from_str(content.trim())?;
+        assert_eq!(v["response"]["status"].as_u64(), Some(502));
+        assert!(
+            captured_request_has_header(&v, "x-test"),
+            "captured request should preserve request headers"
+        );
 
         let _ = server_task.await;
         let _ = tokio::fs::remove_file(&tmp).await;


### PR DESCRIPTION
Error transactions and failed WebSocket handshakes were observability holes: the unified record_error_transaction wrote captures directly, skipping the pipeline, so 413/500/502 exchanges were never linted and never entered TransactionHistory; and the two upstream-failure arms of handle_websocket_upgrade synthesized a 502 with no transaction at all, losing the request entirely.

Route record_error_transaction through shared.pipeline().commit (lint -> state record -> capture) instead of a direct capture write; its first parameter becomes &Arc<Shared> and the http/http3/exchange call sites follow. Build and commit a 502 transaction for both WS handshake-failure arms via a record_handshake_failure helper, preserving the request half and consuming one sequence number to match the success path.

This is safe: the engine scope-filters rules by tx.response.is_some(), response-reading rules defensively handle a minimal response, and record_transaction is keyed on (client, request.uri) — so linting and recording synthetic error transactions cannot panic or corrupt state, and several rules already rely on 4xx/5xx being present in history.

The two WS failure tests now assert the capture is written with the request headers, and the http upstream-error test asserts the errored exchange enters history.
