### PR TITLE
Enforce clippy cognitive-complexity across the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ authors = ["Alexandre Gomes Gaigalas <alganet@gmail.com>"]
 license = "ISC"
 repository = "https://github.com/alganet/lint-http"
 
+# Clippy lints enforced across every workspace crate. cognitive_complexity is a
+# nursery (allow-by-default) lint; enabling it here makes the threshold in
+# clippy.toml actually bite, so function complexity can't silently grow.
+[workspace.lints.clippy]
+cognitive_complexity = "warn"
+
 [workspace.dependencies]
 # Internal crates
 lint-http-core = { path = "lint-http-core" }

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,4 +3,11 @@
 # SPDX-License-Identifier: ISC
 
 disallowed-methods = []
+
+# Deliberately above clippy's default of 25. The rules crate is dominated by
+# flat RFC parsers (linear byte scans with early-return error branches) whose
+# complexity is inherent — forcing them under 25 would mean threading parser
+# state across artificial helper boundaries, hurting readability. 30 still bites
+# on genuinely tangled functions (mixed parsing + multi-branch policy, god-style
+# entry points) without penalizing honest parsers.
 cognitive-complexity-threshold = 30

--- a/lint-http-core/Cargo.toml
+++ b/lint-http-core/Cargo.toml
@@ -33,3 +33,6 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/lint-http-proxy/Cargo.toml
+++ b/lint-http-proxy/Cargo.toml
@@ -70,3 +70,6 @@ lint-http-core = { workspace = true, features = ["test-utils"] }
 wiremock = { workspace = true }
 rstest = { workspace = true }
 http = { workspace = true }
+
+[lints]
+workspace = true

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -171,21 +171,7 @@ async fn run_proxy_inner(
     ));
 
     // Seed state from captures file if enabled
-    if cfg.general.captures_seed {
-        match crate::capture::load_captures(&cfg.general.captures).await {
-            Ok(records) => {
-                let count = records.len();
-                for record in &records {
-                    state.seed_from_transaction(record);
-                }
-                info!(count, "seeded state from captures");
-            }
-            Err(e) => {
-                // Log warning but don't fail startup
-                tracing::warn!(error = %e, "failed to load captures for seeding");
-            }
-        }
-    }
+    seed_state_from_captures(&cfg, &state).await;
 
     // Connection bound and drain budget. Read before `cfg` moves into `Shared`.
     let max_connections = cfg.general.max_connections;
@@ -290,39 +276,7 @@ async fn run_proxy_inner(
         tokio::spawn(async move {
             // Released when this task ends; the drain waits on all permits.
             let _permit = permit;
-            let conn_metadata = Arc::new(crate::connection::ConnectionMetadata::new(remote_addr));
-            let service = service_fn(move |req: Request<Incoming>| {
-                let shared = shared.clone();
-                let conn_metadata = conn_metadata.clone();
-                let fut: ServiceFuture = Box::pin(async move {
-                    handle_request(
-                        req,
-                        shared.clone(),
-                        conn_metadata.clone(),
-                        hyper::http::uri::Scheme::HTTP,
-                    )
-                    .await
-                });
-                fut
-            });
-
-            let io = TokioIo::new(stream);
-            let conn = builder_clone.serve_connection_with_upgrades(io, service);
-            tokio::pin!(conn);
-            tokio::select! {
-                res = conn.as_mut() => {
-                    if let Err(e) = res {
-                        error!(%e, "connection error");
-                    }
-                }
-                _ = shutdown_conn.cancelled() => {
-                    // Finish in-flight requests but stop reading new ones.
-                    conn.as_mut().graceful_shutdown();
-                    if let Err(e) = conn.await {
-                        error!(%e, "connection error after graceful shutdown");
-                    }
-                }
-            }
+            serve_connection(stream, remote_addr, shared, builder_clone, shutdown_conn).await;
         });
     }
 
@@ -351,6 +305,75 @@ async fn run_proxy_inner(
     }
 
     Ok(())
+}
+
+/// Seed in-memory state from the captures file when `captures_seed` is enabled.
+/// Load failures are logged but never fail startup. Extracted from
+/// `run_proxy_inner` to keep it within the cognitive-complexity budget.
+async fn seed_state_from_captures(cfg: &Config, state: &crate::state::StateStore) {
+    if !cfg.general.captures_seed {
+        return;
+    }
+    match crate::capture::load_captures(&cfg.general.captures).await {
+        Ok(records) => {
+            let count = records.len();
+            for record in &records {
+                state.seed_from_transaction(record);
+            }
+            info!(count, "seeded state from captures");
+        }
+        Err(e) => {
+            // Log warning but don't fail startup
+            tracing::warn!(error = %e, "failed to load captures for seeding");
+        }
+    }
+}
+
+/// Serve a single accepted TCP connection until it closes or `shutdown` fires.
+///
+/// Extracted from the accept loop so `run_proxy_inner` stays within the
+/// cognitive-complexity budget: this owns the per-connection service wiring and
+/// the run-vs-graceful-shutdown select.
+async fn serve_connection(
+    stream: tokio::net::TcpStream,
+    remote_addr: SocketAddr,
+    shared: Arc<Shared>,
+    builder: AutoConnBuilder<TokioExecutor>,
+    shutdown: CancellationToken,
+) {
+    let conn_metadata = Arc::new(crate::connection::ConnectionMetadata::new(remote_addr));
+    let service = service_fn(move |req: Request<Incoming>| {
+        let shared = shared.clone();
+        let conn_metadata = conn_metadata.clone();
+        let fut: ServiceFuture = Box::pin(async move {
+            handle_request(
+                req,
+                shared.clone(),
+                conn_metadata.clone(),
+                hyper::http::uri::Scheme::HTTP,
+            )
+            .await
+        });
+        fut
+    });
+
+    let io = TokioIo::new(stream);
+    let conn = builder.serve_connection_with_upgrades(io, service);
+    tokio::pin!(conn);
+    tokio::select! {
+        res = conn.as_mut() => {
+            if let Err(e) = res {
+                error!(%e, "connection error");
+            }
+        }
+        _ = shutdown.cancelled() => {
+            // Finish in-flight requests but stop reading new ones.
+            conn.as_mut().graceful_shutdown();
+            if let Err(e) = conn.await {
+                error!(%e, "connection error after graceful shutdown");
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lint-http-rules/Cargo.toml
+++ b/lint-http-rules/Cargo.toml
@@ -35,3 +35,6 @@ clap = { workspace = true }
 lint-http-core = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true }
 rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/lint-http-rules/src/rules/message_forwarded_header_validity.rs
+++ b/lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -6,6 +6,172 @@ use crate::lint::Violation;
 use crate::rules::Rule;
 use std::net::IpAddr;
 
+/// Validate a `for=`/`by=` node identifier (RFC 7239 §6): `unknown`, an
+/// IP[:port], a bracketed IPv6[:port], or an obfuscated token. Returns the
+/// error message on failure, `None` when valid. Extracted from
+/// `validate_element` so the dispatcher stays within the complexity budget.
+fn validate_node_identifier(name: &str, value: &str) -> Option<String> {
+    use crate::helpers::token::find_invalid_token_char;
+
+    // value may be 'unknown', an obfuscated token, or an addr (IPv4/IPv6) optionally with port
+    if value.eq_ignore_ascii_case("unknown") {
+        return None;
+    }
+
+    // IPv6 in brackets: [2001:db8::1] or [2001:db8::1]:port
+    if value.starts_with('[') {
+        let Some(end) = value.find(']') else {
+            return Some(format!(
+                "Invalid IPv6 bracketed address in Forwarded '{}' parameter: {}",
+                name, value
+            ));
+        };
+        let inside = &value[1..end];
+        if inside.is_empty() {
+            return Some(format!("Empty IPv6 address in Forwarded '{}' parameter", name));
+        }
+        if inside.parse::<IpAddr>().is_err() {
+            return Some(format!(
+                "Invalid IPv6 address in Forwarded '{}' parameter: {}",
+                name, inside
+            ));
+        }
+        // optionally validate port after ']' if present
+        let rest = &value[end + 1..];
+        if !rest.is_empty() && !rest.starts_with(':') {
+            return Some(format!(
+                "Invalid IPv6 port syntax in Forwarded '{}' parameter: {}",
+                name, value
+            ));
+        }
+        if let Some(port) = rest.strip_prefix(':') {
+            if port.is_empty() || port.parse::<u16>().is_err() {
+                return Some(format!(
+                    "Invalid port '{}' in Forwarded '{}' parameter",
+                    port, name
+                ));
+            }
+        }
+        return None;
+    }
+
+    // Possibly contains a colon for IPv4:port or token:port. Split on the last ':'
+    if let Some(idx) = value.rfind(':') {
+        let (host, port_part) = value.split_at(idx);
+        let port = &port_part[1..];
+        if !port.is_empty() && port.parse::<u16>().is_err() {
+            return Some(format!(
+                "Invalid port '{}' in Forwarded '{}' parameter",
+                port, name
+            ));
+        }
+        // try parsing host as IP
+        if host.parse::<IpAddr>().is_ok() {
+            return None;
+        }
+        // else treat as obfuscated token - must follow token grammar
+        if let Some(c) = find_invalid_token_char(host) {
+            return Some(format!(
+                "Invalid obfuscated token '{}' in Forwarded '{}' parameter",
+                c, name
+            ));
+        }
+        return None;
+    }
+
+    // No port and not bracketed; try parse as IP
+    if value.parse::<IpAddr>().is_ok() {
+        return None;
+    }
+
+    // If this looks like a dotted IPv4 (digits and dots only) but failed to parse,
+    // that's an invalid IPv4 address (common misconfiguration)
+    if value.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return Some(format!(
+            "Invalid IPv4 address in Forwarded '{}' parameter: {}",
+            name, value
+        ));
+    }
+
+    // Otherwise obfuscated token (must be token)
+    if let Some(c) = find_invalid_token_char(value) {
+        return Some(format!(
+            "Invalid obfuscated token '{}' in Forwarded '{}' parameter",
+            c, name
+        ));
+    }
+    None
+}
+
+/// Validate a `host=` value (RFC 7239 §6): a host or host:port, or a bracketed
+/// IPv6[:port]. Returns the error message on failure, `None` when valid.
+/// Extracted alongside [`validate_node_identifier`] to keep the dispatcher flat.
+fn validate_host_param(value: &str) -> Option<String> {
+    use crate::helpers::token::find_invalid_token_char;
+
+    // If bracketed IPv6, validate
+    if value.starts_with('[') {
+        let Some(end) = value.find(']') else {
+            return Some(format!(
+                "Invalid IPv6 bracketed address in Forwarded 'host' parameter: {}",
+                value
+            ));
+        };
+        let inside = &value[1..end];
+        if inside.parse::<IpAddr>().is_err() {
+            return Some(format!(
+                "Invalid IPv6 address in Forwarded 'host' parameter: {}",
+                inside
+            ));
+        }
+        // optionally validate port
+        let rest = &value[end + 1..];
+        if !rest.is_empty() && !rest.starts_with(':') {
+            return Some(format!(
+                "Invalid host port syntax in Forwarded 'host' parameter: {}",
+                value
+            ));
+        }
+        if let Some(port) = rest.strip_prefix(':') {
+            if port.is_empty() || port.parse::<u16>().is_err() {
+                return Some(format!(
+                    "Invalid port '{}' in Forwarded 'host' parameter",
+                    port
+                ));
+            }
+        }
+        return None;
+    }
+
+    // host may include port
+    if let Some(idx) = value.rfind(':') {
+        let (host, port_part) = value.split_at(idx);
+        let port = &port_part[1..];
+        if !port.is_empty() && port.parse::<u16>().is_err() {
+            return Some(format!(
+                "Invalid port '{}' in Forwarded 'host' parameter",
+                port
+            ));
+        }
+        // host part may be a reg-name; ensure token-ish
+        if let Some(c) = find_invalid_token_char(host) {
+            return Some(format!(
+                "Invalid host '{}' in Forwarded 'host' parameter (invalid char '{}')",
+                host, c
+            ));
+        }
+        return None;
+    }
+
+    if let Some(c) = find_invalid_token_char(value) {
+        return Some(format!(
+            "Invalid host '{}' in Forwarded 'host' parameter (invalid char '{}')",
+            value, c
+        ));
+    }
+    None
+}
+
 pub struct MessageForwardedHeaderValidity;
 
 impl Rule for MessageForwardedHeaderValidity {
@@ -129,131 +295,11 @@ impl Rule for MessageForwardedHeaderValidity {
                 let value = value_owned.as_deref().unwrap_or(raw_value);
 
                 if name_lc == "for" || name_lc == "by" {
-                    // value may be 'unknown', an obfuscated token, or an addr (IPv4/IPv6) optionally with port
-                    if value.eq_ignore_ascii_case("unknown") {
-                        // ok
-                        continue;
-                    }
-
-                    // IPv6 in brackets: [2001:db8::1] or [2001:db8::1]:port
-                    if value.starts_with('[') {
-                        // must contain closing ']'
-                        if let Some(end) = value.find(']') {
-                            let inside = &value[1..end];
-                            if inside.is_empty() {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "Empty IPv6 address in Forwarded '{}' parameter",
-                                        name
-                                    ),
-                                });
-                            }
-                            if inside.parse::<IpAddr>().is_err() {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "Invalid IPv6 address in Forwarded '{}' parameter: {}",
-                                        name, inside
-                                    ),
-                                });
-                            }
-                            // optionally validate port after ']' if present
-                            let rest = &value[end + 1..];
-                            if !rest.is_empty() && !rest.starts_with(':') {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "Invalid IPv6 port syntax in Forwarded '{}' parameter: {}",
-                                        name, value
-                                    ),
-                                });
-                            }
-                            if let Some(port) = rest.strip_prefix(':') {
-                                if port.is_empty() || port.parse::<u16>().is_err() {
-                                    return Some(Violation {
-                                        rule: self.id().into(),
-                                        severity: config.severity,
-                                        message: format!(
-                                            "Invalid port '{}' in Forwarded '{}' parameter",
-                                            port, name
-                                        ),
-                                    });
-                                }
-                            }
-                            continue;
-                        } else {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!("Invalid IPv6 bracketed address in Forwarded '{}' parameter: {}", name, value),
-                            });
-                        }
-                    }
-
-                    // Possibly contains a colon for IPv4:port or token:port. Try parsing host:port by splitting last ':'
-                    if let Some(idx) = value.rfind(':') {
-                        let (host_part, port_part) = value.split_at(idx);
-                        let host = host_part;
-                        let port = &port_part[1..];
-                        if !port.is_empty() && port.parse::<u16>().is_err() {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid port '{}' in Forwarded '{}' parameter",
-                                    port, name
-                                ),
-                            });
-                        }
-                        // try parsing host as IP
-                        if host.parse::<IpAddr>().is_ok() {
-                            continue;
-                        }
-                        // else treat as obfuscated token - must follow token grammar
-                        if let Some(c) = crate::helpers::token::find_invalid_token_char(host) {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid obfuscated token '{}' in Forwarded '{}' parameter",
-                                    c, name
-                                ),
-                            });
-                        }
-                        continue;
-                    }
-
-                    // No port and not bracketed; try parse as IP
-                    if value.parse::<IpAddr>().is_ok() {
-                        continue;
-                    }
-
-                    // If this looks like a dotted IPv4 (digits and dots only) but failed to parse,
-                    // that's an invalid IPv4 address (common misconfiguration)
-                    if value.chars().all(|c| c.is_ascii_digit() || c == '.') {
+                    if let Some(message) = validate_node_identifier(name, value) {
                         return Some(Violation {
                             rule: self.id().into(),
                             severity: config.severity,
-                            message: format!(
-                                "Invalid IPv4 address in Forwarded '{}' parameter: {}",
-                                name, value
-                            ),
-                        });
-                    }
-
-                    // Otherwise obfuscated token (must be token)
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
-                        return Some(Violation {
-                            rule: self.id().into(),
-                            severity: config.severity,
-                            message: format!(
-                                "Invalid obfuscated token '{}' in Forwarded '{}' parameter",
-                                c, name
-                            ),
+                            message,
                         });
                     }
                     continue;
@@ -272,87 +318,13 @@ impl Rule for MessageForwardedHeaderValidity {
                 }
 
                 if name_lc == "host" {
-                    // host may be a host or host:port or IPv6 in brackets
-                    // basic validation: ensure no invalid control characters and token-ish content
-                    // If bracketed IPv6, validate
-                    if value.starts_with('[') {
-                        if let Some(end) = value.find(']') {
-                            let inside = &value[1..end];
-                            if inside.parse::<IpAddr>().is_err() {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "Invalid IPv6 address in Forwarded 'host' parameter: {}",
-                                        inside
-                                    ),
-                                });
-                            }
-                            // optionally validate port
-                            let rest = &value[end + 1..];
-                            if !rest.is_empty() && !rest.starts_with(':') {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!("Invalid host port syntax in Forwarded 'host' parameter: {}", value),
-                                });
-                            }
-                            if let Some(port) = rest.strip_prefix(':') {
-                                if port.is_empty() || port.parse::<u16>().is_err() {
-                                    return Some(Violation {
-                                        rule: self.id().into(),
-                                        severity: config.severity,
-                                        message: format!(
-                                            "Invalid port '{}' in Forwarded 'host' parameter",
-                                            port
-                                        ),
-                                    });
-                                }
-                            }
-                            continue;
-                        } else {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!("Invalid IPv6 bracketed address in Forwarded 'host' parameter: {}", value),
-                            });
-                        }
-                    }
-
-                    // host may include port
-                    if let Some(idx) = value.rfind(':') {
-                        let (host_part, port_part) = value.split_at(idx);
-                        let host = host_part;
-                        let port = &port_part[1..];
-                        if !port.is_empty() && port.parse::<u16>().is_err() {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid port '{}' in Forwarded 'host' parameter",
-                                    port
-                                ),
-                            });
-                        }
-                        // host part may be a reg-name; ensure token-ish
-                        if let Some(c) = crate::helpers::token::find_invalid_token_char(host) {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!("Invalid host '{}' in Forwarded 'host' parameter (invalid char '{}')", host, c),
-                            });
-                        }
-                        continue;
-                    }
-
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
+                    if let Some(message) = validate_host_param(value) {
                         return Some(Violation {
                             rule: self.id().into(),
                             severity: config.severity,
-                            message: format!("Invalid host '{}' in Forwarded 'host' parameter (invalid char '{}')", value, c),
+                            message,
                         });
                     }
-
                     continue;
                 }
 

--- a/lint-http-rules/src/rules/stateful_digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/stateful_digest_auth_nonce_handling.rs
@@ -28,6 +28,92 @@ use crate::rules::Rule;
 /// Implementing this rule requires history spanning an entire origin (not just
 /// the same resource) because nonces are shared across a protection space.  The
 /// engine therefore queries transactions `ByOrigin` for this rule.
+/// Scan history (newest-first) for the most recent Digest `401` challenge and
+/// return its `(nonce, opaque, stale)` parameters. Extracted from
+/// `check_transaction` so the dispatcher stays within the complexity budget.
+fn find_last_digest_challenge(
+    history: &crate::transaction_history::TransactionHistory,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let mut nonce: Option<String> = None;
+    let mut opaque: Option<String> = None;
+    let mut stale: Option<String> = None;
+
+    for prev in history.iter() {
+        let Some(resp) = &prev.response else { continue };
+        if resp.status != 401 {
+            continue;
+        }
+        for hv2 in resp.headers.get_all("www-authenticate").iter() {
+            let Ok(val2) = hv2.to_str() else { continue };
+            let Ok(challs) = crate::helpers::auth::split_and_group_challenges(val2) else {
+                continue;
+            };
+            for chall in challs {
+                let mut parts2 = chall.splitn(2, char::is_whitespace);
+                let scheme2 = parts2.next().unwrap_or("");
+                if !scheme2.eq_ignore_ascii_case("digest") {
+                    continue;
+                }
+                let rest2 = parts2.next().unwrap_or("").trim();
+                let Ok(map2) = crate::helpers::auth::parse_auth_params(rest2) else {
+                    continue;
+                };
+                if nonce.is_none() {
+                    if let Some(n) = map2.get("nonce") {
+                        nonce = Some(n.trim_matches('"').to_string());
+                    }
+                    if let Some(o) = map2.get("opaque") {
+                        opaque = Some(o.trim_matches('"').to_string());
+                    }
+                    if let Some(st) = map2.get("stale") {
+                        stale = Some(st.trim_matches('"').to_string());
+                    }
+                }
+            }
+        }
+        if nonce.is_some() {
+            break; // we only need the most recent challenge
+        }
+    }
+
+    (nonce, opaque, stale)
+}
+
+/// Highest previously-observed nonce-count (`nc`) for `nonce` across history.
+/// Extracted alongside [`find_last_digest_challenge`] to keep the dispatcher flat.
+fn highest_nc_for_nonce(
+    history: &crate::transaction_history::TransactionHistory,
+    nonce: &str,
+) -> u64 {
+    let mut highest = 0u64;
+    for prev in history.iter() {
+        for hv3 in prev.request.headers.get_all("authorization").iter() {
+            let Ok(val3) = hv3.to_str() else { continue };
+            let mut parts3 = val3.trim().splitn(2, char::is_whitespace);
+            let scheme3 = parts3.next().unwrap_or("");
+            if !scheme3.eq_ignore_ascii_case("digest") {
+                continue;
+            }
+            let rest3 = parts3.next().unwrap_or("").trim();
+            let Ok(map3) = crate::helpers::auth::parse_auth_params(rest3) else {
+                continue;
+            };
+            let Some(prev_nonce) = map3.get("nonce") else {
+                continue;
+            };
+            if prev_nonce.trim_matches('"') != nonce {
+                continue;
+            }
+            if let Some(prev_nc) = map3.get("nc") {
+                if let Ok(prev_nc_val) = crate::helpers::auth::parse_nc_hex(prev_nc) {
+                    highest = highest.max(prev_nc_val);
+                }
+            }
+        }
+    }
+    highest
+}
+
 pub struct StatefulDigestAuthNonceHandling;
 
 impl Rule for StatefulDigestAuthNonceHandling {
@@ -78,53 +164,8 @@ impl Rule for StatefulDigestAuthNonceHandling {
             let nc_str = params.get("nc").map(|v| v.as_str());
 
             // find the most recent Digest challenge in history
-            let mut last_challenge_nonce: Option<String> = None;
-            let mut last_challenge_opaque: Option<String> = None;
-            let mut last_challenge_stale: Option<String> = None;
-
-            for prev in history.iter() {
-                if let Some(resp) = &prev.response {
-                    if resp.status == 401 {
-                        for hv2 in resp.headers.get_all("www-authenticate").iter() {
-                            if let Ok(val2) = hv2.to_str() {
-                                if let Ok(challs) =
-                                    crate::helpers::auth::split_and_group_challenges(val2)
-                                {
-                                    for chall in challs {
-                                        let mut parts2 = chall.splitn(2, char::is_whitespace);
-                                        let scheme2 = parts2.next().unwrap_or("");
-                                        if !scheme2.eq_ignore_ascii_case("digest") {
-                                            continue;
-                                        }
-                                        let rest2 = parts2.next().unwrap_or("").trim();
-                                        if let Ok(map2) =
-                                            crate::helpers::auth::parse_auth_params(rest2)
-                                        {
-                                            if last_challenge_nonce.is_none() {
-                                                if let Some(n) = map2.get("nonce") {
-                                                    last_challenge_nonce =
-                                                        Some(n.trim_matches('"').to_string());
-                                                }
-                                                if let Some(o) = map2.get("opaque") {
-                                                    last_challenge_opaque =
-                                                        Some(o.trim_matches('"').to_string());
-                                                }
-                                                if let Some(st) = map2.get("stale") {
-                                                    last_challenge_stale =
-                                                        Some(st.trim_matches('"').to_string());
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if last_challenge_nonce.is_some() {
-                            break; // we only need the most recent challenge
-                        }
-                    }
-                }
-            }
+            let (last_challenge_nonce, last_challenge_opaque, last_challenge_stale) =
+                find_last_digest_challenge(history);
 
             // 1. nonce must have been offered in a challenge
             if nonce.is_some() && last_challenge_nonce.is_none() {
@@ -187,34 +228,10 @@ impl Rule for StatefulDigestAuthNonceHandling {
                 };
 
                 // find highest previous nc for same nonce
-                let mut highest = 0u64;
-                for prev in history.iter() {
-                    for hv3 in prev.request.headers.get_all("authorization").iter() {
-                        if let Ok(val3) = hv3.to_str() {
-                            let mut parts3 = val3.trim().splitn(2, char::is_whitespace);
-                            let scheme3 = parts3.next().unwrap_or("");
-                            if !scheme3.eq_ignore_ascii_case("digest") {
-                                continue;
-                            }
-                            let rest3 = parts3.next().unwrap_or("").trim();
-                            if let Ok(map3) = crate::helpers::auth::parse_auth_params(rest3) {
-                                if let (Some(prev_nonce), Some(this_nonce)) =
-                                    (map3.get("nonce"), nonce.as_ref())
-                                {
-                                    if prev_nonce.trim_matches('"') == this_nonce.as_str() {
-                                        if let Some(prev_nc) = map3.get("nc") {
-                                            if let Ok(prev_nc_val) =
-                                                crate::helpers::auth::parse_nc_hex(prev_nc)
-                                            {
-                                                highest = highest.max(prev_nc_val);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                let highest = nonce
+                    .as_ref()
+                    .map(|n| highest_nc_for_nonce(history, n))
+                    .unwrap_or(0);
 
                 if current_nc <= highest {
                     return Some(Violation {


### PR DESCRIPTION
The cognitive_complexity lint is nursery (allow-by-default) and the workspace enabled no extra lints, so the clippy.toml threshold was dead config — it never fired. Enable it via a workspace [lints] table so cargo lint's -D warnings makes it bite (and IDEs pick it up).

Keep a deliberate, documented threshold of 30 (above the default 25): the rules crate is dominated by flat RFC parsers whose complexity is inherent, and forcing them under 25 would mean artificial helper splits or a pile of #[allow]s. 30 still flags genuinely tangled functions.

Fix the three real outliers the now-live lint surfaced by extracting self-contained helpers:

- run_proxy_inner -> serve_connection, seed_state_from_captures
- message_forwarded_header_validity -> validate_node_identifier, validate_host_param
- stateful_digest_auth_nonce_handling -> find_last_digest_challenge, highest_nc_for_nonce

Behavior-preserving; cargo lint, cargo test --workspace, and fmt clean.
