### PR TITLE
Restructure the binary into clap subcommands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,14 +8,14 @@ SPDX-License-Identifier: ISC
 Actionable guidance for AI coding agents working in `lint-http` (TLS-terminating HTTP(S) forward proxy + lint engine + JSONL capture writer).
 
 ## Big picture architecture
-- Startup wiring is in `src/main.rs`: parse `--config`, call `Config::load_from_path`, build `CaptureWriter`, run proxy.
+- Startup wiring is in `src/main.rs`: parse the CLI (clap subcommands; the `run` command carries `--config`), then `run_app` calls `Config::load_from_path`, validates rules, builds `CaptureWriter`, and runs the proxy. A bare `--config` is a deprecated alias for `run`.
 - Runtime flow: client traffic enters `src/proxy.rs` → transaction is built (`src/http_transaction.rs`) → violations computed in `src/lint.rs` using `src/rules/` → capture appended by `src/capture.rs`.
 - TLS MITM and CA management live in `src/ca.rs`; CA cert is exposed at `/_lint_http/cert`.
 - Stateful checks use `src/state.rs`; rules do not query store directly, they consume precomputed history from `src/queries/`.
 - Query strategy is centrally mapped in `src/queries/mapping.rs` (`ByResource` default, specific rules can opt into `ByOrigin`).
 
 ## Commands and CI expectations
-- Run locally: `cargo run -- --config config_example.toml`
+- Run locally: `cargo run -- run --config config_example.toml`
 - Format: `cargo fmt`
 - Lint: `cargo lint` (alias for strict clippy with `-D warnings`)
 - Tests: `cargo test`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ lint-http inspects HTTP(S) traffic, runs protocol best-practice checks (rules), 
 1) Build and run (recommended for development):
 
 ```bash
-cargo run -- --config config_example.toml
+cargo run -- run --config config_example.toml
 ```
 
 2) Basic HTTP usage:
@@ -52,11 +52,15 @@ Notes:
 
 ## Configuration
 
-The proxy is configured via a TOML file passed with `--config`.
+The proxy is configured via a TOML file passed to the `run` subcommand with
+`--config`.
 
 ```bash
-lint-http --config config.toml
+lint-http run --config config.toml
 ```
+
+(A bare `lint-http --config config.toml` still works as a deprecated alias for
+`run` and prints a warning; prefer the `run` form.)
 
 Refer to `docs/configuration.md` for full options, including TLS settings and rule configuration.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,19 +6,27 @@ SPDX-License-Identifier: ISC
 
 # Configuration
 
-`lint-http` is configured using a TOML file. You must provide this file using the `--config` CLI argument.
+`lint-http` is configured using a TOML file. You provide this file to the `run`
+subcommand using the `--config` CLI argument.
 
 ## Command-Line Options
 
-- `--config <PATH>`: Path to TOML configuration file (mandatory)
-- `-h, --help`: Print help
+`lint-http` uses subcommands; today the only one is `run`, which starts the
+intercepting proxy:
+
+- `run --config <PATH>`: Path to TOML configuration file (mandatory)
+- `-h, --help`: Print help (works on the binary and on `run`)
 - `-V, --version`: Print version
 
 Example:
 
 ```bash
-lint-http --config config.toml
+lint-http run --config config.toml
 ```
+
+For backwards compatibility, a bare `lint-http --config config.toml` is still
+accepted as a deprecated alias for `run` (it prints a warning); prefer the
+`run` form.
 
 ## Configuration File Structure
 

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -2,24 +2,53 @@
 //
 // SPDX-License-Identifier: ISC
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
 
 use lint_http::{capture, config, proxy, rules};
 
 #[derive(Parser, Debug)]
-#[command(name = "lint-http", version)]
-struct Args {
-    /// Config TOML path (rules toggles, listen address, captures path)
+#[command(name = "lint-http", version, about = "HTTP-linting forward proxy")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// Deprecated: use `lint-http run --config <PATH>`.
+    #[arg(long, value_name = "PATH", hide = true)]
+    config: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run the intercepting proxy (config-driven).
+    Run(RunArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct RunArgs {
+    /// Config TOML path (rules toggles, listen address, captures path).
     #[arg(long)]
     config: String,
 }
 
-/// Simplified application entry point.
-async fn run_app(args: Args) -> anyhow::Result<()> {
+/// Load + validate the config and build the proxy's runtime inputs.
+///
+/// Takes the config *path* rather than the parsed CLI struct, so the proxy entry
+/// points are decoupled from the command surface. This step is proxy-specific
+/// (it initializes tracing and builds a `CaptureWriter`); future non-proxy
+/// subcommands (`lint`, `rules list`) reuse the library helpers
+/// `config::Config::load_from_path` / `rules::validate_rules` directly rather
+/// than this.
+async fn load_and_prepare(
+    config_path: &str,
+) -> anyhow::Result<(
+    SocketAddr,
+    capture::CaptureWriter,
+    std::sync::Arc<config::Config>,
+)> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let cfg = config::Config::load_from_path(&args.config).await?;
+    let cfg = config::Config::load_from_path(config_path).await?;
     // Validate every enabled rule's config section before binding, so a
     // malformed config fails fast rather than after the proxy is up.
     rules::validate_rules(&cfg)?;
@@ -32,42 +61,76 @@ async fn run_app(args: Args) -> anyhow::Result<()> {
     )
     .await?;
 
-    // Start the proxy; `run_proxy` wires Ctrl-C to a graceful shutdown.
+    Ok((addr, capture_writer, cfg))
+}
+
+/// Run the proxy until Ctrl-C / shutdown.
+async fn run_app(config_path: &str) -> anyhow::Result<()> {
+    let (addr, capture_writer, cfg) = load_and_prepare(config_path).await?;
+    // `run_proxy` wires Ctrl-C to a graceful shutdown.
     proxy::run_proxy(addr, capture_writer, cfg).await
 }
 
 // Testable variant of run_app that allows tests to pass in an accept limit so the
 // proxy returns after a bounded number of connections.
 #[cfg(test)]
-async fn run_app_with_limit(args: Args, accept_limit: Option<usize>) -> anyhow::Result<()> {
-    let _ = tracing_subscriber::fmt::try_init();
-
-    let cfg = config::Config::load_from_path(&args.config).await?;
-    rules::validate_rules(&cfg)?;
-    let cfg = std::sync::Arc::new(cfg);
-
-    let addr: SocketAddr = cfg.general.listen.parse()?;
-    let capture_writer = capture::CaptureWriter::new(
-        cfg.general.captures.clone(),
-        cfg.general.captures_include_body,
-    )
-    .await?;
-
-    // Start proxy with an accept limit for testing
+async fn run_app_with_limit(config_path: &str, accept_limit: Option<usize>) -> anyhow::Result<()> {
+    let (addr, capture_writer, cfg) = load_and_prepare(config_path).await?;
     crate::proxy::run_proxy_with_limit(addr, capture_writer, cfg, accept_limit).await
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-    run_app(args).await
+    let cli = Cli::parse();
+    let config_path = match cli.command {
+        Some(Command::Run(args)) => args.config,
+        // No subcommand: accept a bare `--config` as a deprecated alias for
+        // `run`, otherwise point the user at the new form.
+        None => {
+            let path = cli.config.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no command given; try `lint-http run --config <PATH>` (see `lint-http --help`)"
+                )
+            })?;
+            eprintln!(
+                "warning: bare `--config` is deprecated; use `lint-http run --config {path}`"
+            );
+            path
+        }
+    };
+    run_app(&config_path).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use tokio::fs;
     use uuid::Uuid;
+
+    #[test]
+    fn cli_run_subcommand_parses_config() {
+        let cli = Cli::parse_from(["lint-http", "run", "--config", "x.toml"]);
+        match cli.command {
+            Some(Command::Run(args)) => assert_eq!(args.config, "x.toml"),
+            other => panic!("expected Run, got {other:?}"),
+        }
+        assert!(cli.config.is_none());
+    }
+
+    #[test]
+    fn cli_bare_config_is_legacy_alias() {
+        let cli = Cli::parse_from(["lint-http", "--config", "x.toml"]);
+        assert!(cli.command.is_none());
+        assert_eq!(cli.config.as_deref(), Some("x.toml"));
+    }
+
+    #[test]
+    fn cli_no_args_has_no_command() {
+        let cli = Cli::parse_from(["lint-http"]);
+        assert!(cli.command.is_none());
+        assert!(cli.config.is_none());
+    }
 
     #[tokio::test]
     async fn main_cli_config_loads_toml() -> anyhow::Result<()> {
@@ -87,14 +150,11 @@ mod tests {
     "#;
         fs::write(&tmp, toml).await?;
 
-        let args = Args {
-            config: tmp
-                .to_str()
-                .ok_or_else(|| anyhow::anyhow!("config path not utf8"))?
-                .to_string(),
-        };
+        let config_path = tmp
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("config path not utf8"))?;
 
-        let cfg = config::Config::load_from_path(&args.config).await?;
+        let cfg = config::Config::load_from_path(config_path).await?;
 
         assert!(!cfg.is_enabled("server_cache_control_present"));
         assert_eq!(cfg.general.listen, "127.0.0.1:3000");
@@ -121,12 +181,10 @@ enabled = false
 "#;
         fs::write(&tmp, toml).await?;
 
-        let args = Args {
-            config: tmp.to_str().expect("valid utf8 path").to_string(),
-        };
+        let config_path = tmp.to_str().expect("valid utf8 path");
 
         // run_app must fail during rule validation, before binding any socket.
-        let result = run_app(args).await;
+        let result = run_app(config_path).await;
 
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
@@ -166,12 +224,10 @@ enabled = false
         );
         fs::write(&tmp, toml).await?;
 
-        let args = Args {
-            config: tmp.to_str().expect("valid utf8 path").to_string(),
-        };
+        let config_path = tmp.to_str().expect("valid utf8 path").to_string();
 
         // Spawn run_app_with_limit with accept_limit = 1
-        let task = tokio::spawn(async move { run_app_with_limit(args, Some(1)).await });
+        let task = tokio::spawn(async move { run_app_with_limit(&config_path, Some(1)).await });
 
         // Connect to trigger accept
         let addr: SocketAddr = format!("127.0.0.1:{}", port).parse()?;
@@ -222,12 +278,10 @@ enabled = false
         );
         tokio::fs::write(&tmp, toml).await?;
 
-        let args = Args {
-            config: tmp.to_str().expect("valid utf8 path").to_string(),
-        };
+        let config_path = tmp.to_str().expect("valid utf8 path");
 
         // run_app should return an error because the port is already taken
-        let res = run_app(args).await;
+        let res = run_app(config_path).await;
         assert!(res.is_err());
 
         // Cleanup


### PR DESCRIPTION
`lint-http` took only `--config` and did exactly one thing (run the proxy), so the portable rule library had no CLI consumer. Add a clap-derive subcommand tree with today's behavior under `lint-http run --config <PATH>`, creating the seam that the future `lint` and `rules list` subcommands plug into.

A bare `lint-http --config <PATH>` is kept as a deprecated legacy alias (hidden flag) that warns to stderr and routes to `run`; a no-args invocation exits with a pointer to the new form. The run core moved into `run_app(config_path: &str)`, decoupled from the CLI struct, so siblings can build their own arg shapes over it; the
load -> validate_rules -> bind -> CaptureWriter -> run_proxy sequence (fail-fast before bind) is unchanged.

Tests: the 4 binary unit tests pass a path instead of `Args {…}`; 3 new parse tests cover the run / legacy-alias / no-args trees. Docs updated to make `run` canonical.

cargo lint, cargo test --workspace, and fmt clean.
