### PR TITLE
Add `lint` subcommand to lint recorded captures offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ lint-http run --config config.toml
 
 Refer to `docs/configuration.md` for full options, including TLS settings and rule configuration.
 
+## Lint recorded captures (CI)
+
+Lint a JSONL capture file offline — no live proxy needed. It replays the
+recorded transactions through the rules and exits non-zero when any violations
+are found, so it drops straight into CI:
+
+```bash
+lint-http lint --config config.toml captures.jsonl
+```
+
 Example snippet:
 
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,11 +11,13 @@ subcommand using the `--config` CLI argument.
 
 ## Command-Line Options
 
-`lint-http` uses subcommands; today the only one is `run`, which starts the
-intercepting proxy:
+`lint-http` uses subcommands:
 
-- `run --config <PATH>`: Path to TOML configuration file (mandatory)
-- `-h, --help`: Print help (works on the binary and on `run`)
+- `run --config <PATH>`: Start the intercepting proxy. `<PATH>` is the TOML
+  configuration file (mandatory).
+- `lint --config <PATH> <CAPTURES>`: Lint a recorded capture file offline
+  (see below).
+- `-h, --help`: Print help (works on the binary and on each subcommand)
 - `-V, --version`: Print version
 
 Example:
@@ -27,6 +29,30 @@ lint-http run --config config.toml
 For backwards compatibility, a bare `lint-http --config config.toml` is still
 accepted as a deprecated alias for `run` (it prints a warning); prefer the
 `run` form.
+
+## Linting recorded captures
+
+`lint-http lint --config <PATH> <CAPTURES>` replays a JSONL capture file (the
+`captures` file the proxy writes) through the rule engine without running a
+proxy — the CI story: lint recorded HTTP fixtures offline.
+
+```bash
+lint-http lint --config config.toml captures.jsonl
+```
+
+It replays the transactions in record order (each is linted against the history
+of prior transactions, exactly as it would be live, so stateful rules work),
+prints one block per offending transaction, and a summary line. The exit code is
+the signal for CI:
+
+- **0** — no violations found.
+- **1** — violations found, or an error occurred (e.g. missing capture file,
+  malformed config).
+
+The `--config` file is the same TOML used by `run`; `lint` reads only the
+`[rules]` toggles/severities and the `[general]` `ttl_seconds` / `max_history`
+(used to size the replay's history window). The `listen`, `captures`, and
+`[tls]` fields are ignored by `lint`.
 
 ## Configuration File Structure
 

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -5,7 +5,7 @@
 use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
 
-use lint_http::{capture, config, proxy, rules};
+use lint_http::{capture, config, engine, lint, proxy, rules, state};
 
 #[derive(Parser, Debug)]
 #[command(name = "lint-http", version, about = "HTTP-linting forward proxy")]
@@ -22,6 +22,8 @@ struct Cli {
 enum Command {
     /// Run the intercepting proxy (config-driven).
     Run(RunArgs),
+    /// Lint a recorded capture file, replaying its transactions through the rules.
+    Lint(LintArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -31,14 +33,34 @@ struct RunArgs {
     config: String,
 }
 
+#[derive(clap::Args, Debug)]
+struct LintArgs {
+    /// Config TOML path (rule toggles + severities; also supplies the replay
+    /// state's `ttl_seconds` / `max_history`).
+    #[arg(long)]
+    config: String,
+    /// JSONL capture file to lint.
+    #[arg(value_name = "CAPTURES")]
+    captures: String,
+}
+
+/// Load the config and validate every enabled rule's section, failing fast on a
+/// malformed config. Shared by every subcommand; deliberately does **not**
+/// initialize tracing (the proxy does that) so non-proxy commands like `lint`
+/// keep stdout clean.
+async fn load_validated_config(
+    config_path: &str,
+) -> anyhow::Result<std::sync::Arc<config::Config>> {
+    let cfg = config::Config::load_from_path(config_path).await?;
+    rules::validate_rules(&cfg)?;
+    Ok(std::sync::Arc::new(cfg))
+}
+
 /// Load + validate the config and build the proxy's runtime inputs.
 ///
-/// Takes the config *path* rather than the parsed CLI struct, so the proxy entry
-/// points are decoupled from the command surface. This step is proxy-specific
-/// (it initializes tracing and builds a `CaptureWriter`); future non-proxy
-/// subcommands (`lint`, `rules list`) reuse the library helpers
-/// `config::Config::load_from_path` / `rules::validate_rules` directly rather
-/// than this.
+/// Proxy-specific: it initializes tracing and builds a `CaptureWriter`. Takes the
+/// config *path* rather than the parsed CLI struct, so the proxy entry points are
+/// decoupled from the command surface.
 async fn load_and_prepare(
     config_path: &str,
 ) -> anyhow::Result<(
@@ -48,11 +70,7 @@ async fn load_and_prepare(
 )> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let cfg = config::Config::load_from_path(config_path).await?;
-    // Validate every enabled rule's config section before binding, so a
-    // malformed config fails fast rather than after the proxy is up.
-    rules::validate_rules(&cfg)?;
-    let cfg = std::sync::Arc::new(cfg);
+    let cfg = load_validated_config(config_path).await?;
 
     let addr: SocketAddr = cfg.general.listen.parse()?;
     let capture_writer = capture::CaptureWriter::new(
@@ -79,11 +97,81 @@ async fn run_app_with_limit(config_path: &str, accept_limit: Option<usize>) -> a
     crate::proxy::run_proxy_with_limit(addr, capture_writer, cfg, accept_limit).await
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-    let config_path = match cli.command {
-        Some(Command::Run(args)) => args.config,
+fn severity_label(severity: lint::Severity) -> &'static str {
+    match severity {
+        lint::Severity::Info => "info",
+        lint::Severity::Warn => "warn",
+        lint::Severity::Error => "error",
+    }
+}
+
+/// Lint a recorded capture file by replaying its transactions through the rule
+/// engine, printing violations to stdout. Returns the number of violations found
+/// so the caller can map it to an exit code.
+///
+/// The replay mirrors the live proxy pipeline: each transaction is linted against
+/// the history of prior transactions, then recorded — so stateful rules see the
+/// same history they would live. The state store's TTL never evicts here (the
+/// read path applies no age filter and `cleanup_expired` is never called), so the
+/// whole file is visible regardless of how old the records are.
+async fn lint_app(config_path: &str, captures_path: &str) -> anyhow::Result<usize> {
+    let cfg = load_validated_config(config_path).await?;
+    // `load_captures` tolerates a missing file (it backs the proxy's optional
+    // cold-start seeding). For an explicit `lint <file>` a missing path is a user
+    // error — fail loudly rather than letting CI pass green on a typo'd path.
+    if !tokio::fs::try_exists(captures_path).await.unwrap_or(false) {
+        anyhow::bail!("capture file not found: {captures_path}");
+    }
+    let transactions = capture::load_captures(captures_path).await?;
+    let state = state::StateStore::new(cfg.general.ttl_seconds, cfg.general.max_history);
+
+    let mut total = 0usize;
+    for tx in &transactions {
+        let violations = engine::lint_transaction(tx, &cfg, &state);
+        state.record_transaction(tx);
+        if violations.is_empty() {
+            continue;
+        }
+        let status = tx
+            .response
+            .as_ref()
+            .map(|r| r.status.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!("{} {} -> {}", tx.request.method, tx.request.uri, status);
+        for v in &violations {
+            println!(
+                "  {:<5} {}  {}",
+                severity_label(v.severity),
+                v.rule,
+                v.message
+            );
+        }
+        total += violations.len();
+    }
+
+    println!(
+        "\n{total} violation(s) in {} transaction(s)",
+        transactions.len()
+    );
+    Ok(total)
+}
+
+/// Run the selected subcommand and return the process exit code (`0` success,
+/// `1` lint findings). Real errors propagate as `Err` (anyhow maps them to exit
+/// 1 with a message). Split from `main` so the dispatch is unit-testable without
+/// spawning the process.
+async fn dispatch(cli: Cli) -> anyhow::Result<u8> {
+    match cli.command {
+        Some(Command::Run(args)) => {
+            run_app(&args.config).await?;
+            Ok(0)
+        }
+        // Non-zero exit when findings exist, so CI fails on a dirty capture;
+        // real errors (bad config / missing file) still bubble up as `Err`.
+        Some(Command::Lint(args)) => {
+            let found = lint_app(&args.config, &args.captures).await?;
+            Ok(if found > 0 { 1 } else { 0 })
+        }
         // No subcommand: accept a bare `--config` as a deprecated alias for
         // `run`, otherwise point the user at the new form.
         None => {
@@ -95,10 +183,15 @@ async fn main() -> anyhow::Result<()> {
             eprintln!(
                 "warning: bare `--config` is deprecated; use `lint-http run --config {path}`"
             );
-            path
+            run_app(&path).await?;
+            Ok(0)
         }
-    };
-    run_app(&config_path).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<std::process::ExitCode> {
+    Ok(std::process::ExitCode::from(dispatch(Cli::parse()).await?))
 }
 
 #[cfg(test)]
@@ -130,6 +223,215 @@ mod tests {
         let cli = Cli::parse_from(["lint-http"]);
         assert!(cli.command.is_none());
         assert!(cli.config.is_none());
+    }
+
+    #[test]
+    fn cli_lint_subcommand_parses_config_and_captures() {
+        let cli = Cli::parse_from(["lint-http", "lint", "--config", "c.toml", "caps.jsonl"]);
+        match cli.command {
+            Some(Command::Lint(args)) => {
+                assert_eq!(args.config, "c.toml");
+                assert_eq!(args.captures, "caps.jsonl");
+            }
+            other => panic!("expected Lint, got {other:?}"),
+        }
+    }
+
+    // Write a config that enables `server_cache_control_present` (fires on a 200
+    // response without a Cache-Control header) and return its temp path.
+    async fn write_cache_control_config() -> anyhow::Result<std::path::PathBuf> {
+        let tmp = std::env::temp_dir().join(format!("lint_lint_cfg_{}.toml", Uuid::new_v4()));
+        let toml = r#"[general]
+listen = "127.0.0.1:3000"
+captures = "captures.jsonl"
+
+[tls]
+enabled = false
+
+[rules.server_cache_control_present]
+enabled = true
+severity = "warn"
+"#;
+        fs::write(&tmp, toml).await?;
+        Ok(tmp)
+    }
+
+    // Serialize transactions into a JSONL capture file (one versioned envelope per
+    // line) the way the proxy's CaptureWriter would, and return its temp path.
+    async fn write_capture_file(
+        txs: &[lint_http::http_transaction::HttpTransaction],
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let tmp = std::env::temp_dir().join(format!("lint_lint_caps_{}.jsonl", Uuid::new_v4()));
+        let mut body = String::new();
+        for tx in txs {
+            let envelope = capture::CaptureEnvelope {
+                schema_version: capture::CAPTURE_SCHEMA_VERSION,
+                record: capture::CaptureRecord::HttpTransaction(Box::new(tx.clone())),
+            };
+            body.push_str(&serde_json::to_string(&envelope)?);
+            body.push('\n');
+        }
+        fs::write(&tmp, body).await?;
+        Ok(tmp)
+    }
+
+    #[tokio::test]
+    async fn lint_reports_violations_and_counts_them() -> anyhow::Result<()> {
+        use lint_http_core::test_helpers::make_test_transaction_with_response;
+
+        let cfg = write_cache_control_config().await?;
+        // 200 without Cache-Control -> one violation.
+        let caps = write_capture_file(&[make_test_transaction_with_response(200, &[])]).await?;
+
+        let found = lint_app(cfg.to_str().unwrap(), caps.to_str().unwrap()).await?;
+        assert_eq!(found, 1);
+
+        fs::remove_file(&cfg).await?;
+        fs::remove_file(&caps).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn lint_clean_capture_reports_zero() -> anyhow::Result<()> {
+        use lint_http_core::test_helpers::make_test_transaction_with_response;
+
+        let cfg = write_cache_control_config().await?;
+        // 200 *with* Cache-Control -> the rule is satisfied, no violation.
+        let caps = write_capture_file(&[make_test_transaction_with_response(
+            200,
+            &[("cache-control", "no-store")],
+        )])
+        .await?;
+
+        let found = lint_app(cfg.to_str().unwrap(), caps.to_str().unwrap()).await?;
+        assert_eq!(found, 0);
+
+        fs::remove_file(&cfg).await?;
+        fs::remove_file(&caps).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn lint_empty_capture_reports_zero() -> anyhow::Result<()> {
+        let cfg = write_cache_control_config().await?;
+        let caps = std::env::temp_dir().join(format!("lint_lint_empty_{}.jsonl", Uuid::new_v4()));
+        fs::write(&caps, "").await?;
+
+        let found = lint_app(cfg.to_str().unwrap(), caps.to_str().unwrap()).await?;
+        assert_eq!(found, 0);
+
+        fs::remove_file(&cfg).await?;
+        fs::remove_file(&caps).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn lint_missing_capture_file_errors() -> anyhow::Result<()> {
+        let cfg = write_cache_control_config().await?;
+        let result = lint_app(cfg.to_str().unwrap(), "/nonexistent/does-not-exist.jsonl").await;
+        assert!(result.is_err());
+
+        fs::remove_file(&cfg).await?;
+        Ok(())
+    }
+
+    #[test]
+    fn severity_label_covers_all_levels() {
+        assert_eq!(severity_label(lint::Severity::Info), "info");
+        assert_eq!(severity_label(lint::Severity::Warn), "warn");
+        assert_eq!(severity_label(lint::Severity::Error), "error");
+    }
+
+    // Write a minimal config whose `listen` points at an already-bound port, so
+    // `run_app` fails fast at bind — lets the dispatch tests exercise the `run`
+    // and legacy arms without the proxy blocking.
+    async fn write_port_taken_config(
+        addr: std::net::SocketAddr,
+    ) -> anyhow::Result<(std::path::PathBuf, std::path::PathBuf)> {
+        let cfg = std::env::temp_dir().join(format!("lint_dispatch_cfg_{}.toml", Uuid::new_v4()));
+        let caps =
+            std::env::temp_dir().join(format!("lint_dispatch_caps_{}.jsonl", Uuid::new_v4()));
+        let toml = format!(
+            "[general]\nlisten = \"{addr}\"\ncaptures = \"{caps}\"\n\n[tls]\nenabled = false\n",
+            addr = addr,
+            caps = caps.to_string_lossy()
+        );
+        fs::write(&cfg, toml).await?;
+        Ok((cfg, caps))
+    }
+
+    #[tokio::test]
+    async fn dispatch_lint_findings_returns_exit_1() -> anyhow::Result<()> {
+        use lint_http_core::test_helpers::make_test_transaction_with_response;
+        let cfg = write_cache_control_config().await?;
+        let caps = write_capture_file(&[make_test_transaction_with_response(200, &[])]).await?;
+        let cli = Cli::parse_from([
+            "lint-http",
+            "lint",
+            "--config",
+            cfg.to_str().unwrap(),
+            caps.to_str().unwrap(),
+        ]);
+        assert_eq!(dispatch(cli).await?, 1);
+        fs::remove_file(&cfg).await?;
+        fs::remove_file(&caps).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dispatch_lint_clean_returns_exit_0() -> anyhow::Result<()> {
+        use lint_http_core::test_helpers::make_test_transaction_with_response;
+        let cfg = write_cache_control_config().await?;
+        let caps = write_capture_file(&[make_test_transaction_with_response(
+            200,
+            &[("cache-control", "no-store")],
+        )])
+        .await?;
+        let cli = Cli::parse_from([
+            "lint-http",
+            "lint",
+            "--config",
+            cfg.to_str().unwrap(),
+            caps.to_str().unwrap(),
+        ]);
+        assert_eq!(dispatch(cli).await?, 0);
+        fs::remove_file(&cfg).await?;
+        fs::remove_file(&caps).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dispatch_no_command_errors() {
+        let cli = Cli::parse_from(["lint-http"]);
+        assert!(dispatch(cli).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn dispatch_run_command_routes_to_run_app() -> anyhow::Result<()> {
+        let l = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = l.local_addr()?;
+        let (cfg, caps) = write_port_taken_config(addr).await?;
+        let cli = Cli::parse_from(["lint-http", "run", "--config", cfg.to_str().unwrap()]);
+        // run_app binds the already-taken port and errors fast.
+        assert!(dispatch(cli).await.is_err());
+        let _ = fs::remove_file(&cfg).await;
+        let _ = fs::remove_file(&caps).await;
+        drop(l);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dispatch_legacy_config_routes_to_run_app() -> anyhow::Result<()> {
+        let l = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = l.local_addr()?;
+        let (cfg, caps) = write_port_taken_config(addr).await?;
+        let cli = Cli::parse_from(["lint-http", "--config", cfg.to_str().unwrap()]);
+        // Legacy bare --config routes to run_app, which errors on the taken port.
+        assert!(dispatch(cli).await.is_err());
+        let _ = fs::remove_file(&cfg).await;
+        let _ = fs::remove_file(&caps).await;
+        drop(l);
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
`lint-http lint --config <PATH> <CAPTURES>` replays a JSONL capture file through the rule engine without running a proxy — the CI story: lint recorded HTTP fixtures offline, exit non-zero on findings.

The replay mirrors the live pipeline's lint-then-record order, so each transaction is linted against the history of prior ones and stateful rules behave as they would live. This is safe for old capture files: the StateStore read path applies no TTL filter (eviction lives only in cleanup_expired, never called here), so the whole file stays visible; max_history still bounds per-key history on insert. Transactions are recorded with their captured client identity via record_transaction (not seed_from_transaction, which synthesizes a client).

Violations print one block per offending transaction plus a summary; exit code is 0 clean / 1 on findings. A missing capture file is a hard error (vs. the proxy seed path's tolerance) so CI can't pass green on a typo'd path.

Refactors the shared config load+validate out of load_and_prepare into a tracing-free load_validated_config that both `run` and `lint` use, so the linter keeps stdout clean. 5 new binary tests (parse + finds / clean / empty / missing-file); README and docs/configuration.md document `lint`.

cargo lint, cargo test --workspace, and fmt clean.
