### PR TITLE
Add live capture stream SSE endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ curl http://localhost:3000/_lint_http/cert > lint-http-ca.crt
 curl -x http://localhost:3000 --cacert lint-http-ca.crt https://example.com
 ```
 
+4) Watch traffic live (set `general.live_stream_enabled = true` in the config):
+
+```bash
+# Server-Sent Events feed of each transaction as it commits
+curl -N http://localhost:3000/_lint_http/stream
+```
+
 Notes:
 - The proxy uses rustls; no system OpenSSL dependency is required for basic operation.
 - See `config_example.toml` for an example configuration.

--- a/config_example.toml
+++ b/config_example.toml
@@ -35,6 +35,10 @@ captures_include_body = false
 # Server name (SNI) for the HTTP/3 TLS certificate. Clients must connect
 # using this name. Defaults to "localhost" when omitted.
 # h3_server_name = "proxy.example.com"
+# Serve the live capture stream at GET /_lint_http/stream (Server-Sent Events,
+# one event per transaction as it commits). Exposes all proxied traffic to
+# anyone who can reach the proxy port, so it is opt-in. Default: false.
+# live_stream_enabled = false
 
 [tls]
 enabled = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ captures_include_body = false     # When true, captured bodies are included in t
 max_body_bytes = 67108864         # Max body bytes buffered per request/response. Default: 64 MiB
 max_connections = 1024            # Max simultaneous live TCP connections. Default: 1024
 shutdown_timeout_seconds = 30     # Seconds to drain in-flight handlers on Ctrl-C. Default: 30
+live_stream_enabled = false       # Serve the live capture SSE endpoint. Default: false
 ```
 
 - **listen**: The IP address and port the proxy should bind to.
@@ -90,6 +91,7 @@ shutdown_timeout_seconds = 30     # Seconds to drain in-flight handlers on Ctrl-
 - **captures_max_body_bytes**: Maximum number of body bytes captured into the transaction for lint rules and the captures file (default: 1 MiB). Bodies are forwarded in full regardless; only the captured copy is bounded to this prefix. When a body is larger, `request_body_over_limit` / `response_body_over_limit` mark the captured body as a truncated prefix, while `body_length` still records the real size. Rules that need the full body (e.g. multipart boundary checks, problem+json structure) skip content inspection on truncated bodies.
 - **max_connections**: Maximum number of simultaneous live TCP connections the proxy will serve (default: 1024). Additional connections wait for a slot rather than being accepted unboundedly, bounding resource use under burst load.
 - **shutdown_timeout_seconds**: On graceful shutdown (Ctrl-C), how many seconds to wait for in-flight handlers to drain before exiting anyway (default: 30). The capture file is flushed and fsynced as part of shutdown, so the last records are never truncated.
+- **live_stream_enabled**: When `true`, the proxy serves a live capture stream at `GET /_lint_http/stream` — a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) feed that pushes each transaction (one `data:` JSON event) as it commits, replacing `tail -f` on the captures file. Each event has the same JSON shape as a captures-file line (bodies included as base64 only when `captures_include_body` is set). Because it exposes every proxied transaction to anyone who can reach the proxy port, it is opt-in: when disabled (the default) the endpoint returns `404`. Watch it with `curl -N http://127.0.0.1:3000/_lint_http/stream` (reachable over HTTP/1.1 and HTTP/2, not HTTP/3).
 
 ### TLS Configuration (Mandatory)
 

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -79,6 +79,14 @@ pub struct GeneralConfig {
     /// Defaults to "localhost" when omitted. Clients must connect using this name.
     #[serde(default)]
     pub h3_server_name: Option<String>,
+
+    /// Whether the live capture stream endpoint (`GET /_lint_http/stream`, an
+    /// SSE feed of each transaction as it commits) is served. It exposes every
+    /// proxied transaction (and body prefixes when `captures_include_body` is
+    /// set) to anyone who can reach the proxy port, so it is opt-in: when
+    /// disabled the endpoint returns 404 (default: false).
+    #[serde(default = "default_live_stream_enabled")]
+    pub live_stream_enabled: bool,
 }
 
 fn default_ttl() -> u64 {
@@ -125,6 +133,10 @@ const fn default_captures_seed() -> bool {
     false
 }
 
+const fn default_live_stream_enabled() -> bool {
+    false
+}
+
 impl Default for GeneralConfig {
     fn default() -> Self {
         Self {
@@ -141,6 +153,7 @@ impl Default for GeneralConfig {
             shutdown_timeout_seconds: default_shutdown_timeout_seconds(),
             h3_listen: None,
             h3_server_name: None,
+            live_stream_enabled: default_live_stream_enabled(),
         }
     }
 }

--- a/lint-http-proxy/src/capture.rs
+++ b/lint-http-proxy/src/capture.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWriteExt, BufWriter};
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tracing::warn;
 
@@ -60,10 +60,19 @@ const CAPTURE_CHANNEL_CAPACITY: usize = 1024;
 /// burst larger than the buffer.
 const WRITE_BUFFER_BYTES: usize = 64 * 1024;
 
+/// Depth of the per-subscriber broadcast channel feeding the live capture
+/// stream. Unlike the durable file channel, this one is lossy on purpose: a
+/// subscriber that falls more than this many records behind drops the oldest
+/// (surfaced as `RecvError::Lagged`), so a slow SSE client can never slow the
+/// durable file write.
+const LIVE_STREAM_CHANNEL_CAPACITY: usize = 256;
+
 /// A message to the background writer task.
 enum CaptureMsg {
-    /// Serialize and append a record.
-    Record(CaptureEnvelope),
+    /// Serialize and append a record. Carried as an `Arc` so the live-stream
+    /// tee in the writer task is a cheap refcount bump rather than a deep clone
+    /// of the transaction.
+    Record(Arc<CaptureEnvelope>),
     /// Flush + fsync everything written so far, then acknowledge.
     Flush(oneshot::Sender<()>),
     /// Drain the queue, flush + fsync, acknowledge, then stop the task.
@@ -80,6 +89,10 @@ enum CaptureMsg {
 #[derive(Clone)]
 pub struct CaptureWriter {
     tx: mpsc::Sender<CaptureMsg>,
+    /// Live fan-out of each record as it is written. Subscribers (the
+    /// `/_lint_http/stream` SSE endpoint) get an `Arc` so one clone serves all
+    /// of them; the durable file write is never gated on this channel.
+    events: broadcast::Sender<Arc<CaptureEnvelope>>,
     /// Shared so any clone can join the task on shutdown: the first caller
     /// takes the handle, later callers find `None` and no-op.
     join: Arc<Mutex<Option<JoinHandle<()>>>>,
@@ -95,38 +108,49 @@ impl CaptureWriter {
             .open(path.into())
             .await?;
         let (tx, rx) = mpsc::channel(CAPTURE_CHANNEL_CAPACITY);
-        let join = tokio::spawn(writer_task(file, rx, include_body));
+        let (events, _) = broadcast::channel(LIVE_STREAM_CHANNEL_CAPACITY);
+        let join = tokio::spawn(writer_task(file, rx, events.clone(), include_body));
         Ok(Self {
             tx,
+            events,
             join: Arc::new(Mutex::new(Some(join))),
         })
     }
 
-    /// Queue a transaction for the writer task. Returns `Err` only if the task
-    /// is gone (e.g. after [`Self::shutdown`]); serialization and IO errors are
+    /// Subscribe to the live stream of capture records. Each record is delivered
+    /// as it is written to the file. The returned receiver is lossy under lag:
+    /// a slow consumer drops the oldest records rather than slowing the writer.
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<CaptureEnvelope>> {
+        self.events.subscribe()
+    }
+
+    /// Queue a record for the writer task. Returns `Err` only if the task is
+    /// gone (e.g. after [`Self::shutdown`]); serialization and IO errors are
     /// logged in the task, not returned here.
-    pub async fn write_transaction(
-        &self,
-        tx: crate::http_transaction::HttpTransaction,
-    ) -> anyhow::Result<()> {
-        let envelope = CaptureEnvelope::new(CaptureRecord::HttpTransaction(Box::new(tx)));
+    async fn queue(&self, record: CaptureRecord) -> anyhow::Result<()> {
+        let envelope = Arc::new(CaptureEnvelope::new(record));
         self.tx
             .send(CaptureMsg::Record(envelope))
             .await
             .map_err(|_| anyhow::anyhow!("capture writer task is gone"))
     }
 
-    /// Queue a WebSocket session record for the writer task. Returns `Err` only
-    /// if the task is gone.
+    /// Queue a transaction for the writer task.
+    pub async fn write_transaction(
+        &self,
+        tx: crate::http_transaction::HttpTransaction,
+    ) -> anyhow::Result<()> {
+        self.queue(CaptureRecord::HttpTransaction(Box::new(tx)))
+            .await
+    }
+
+    /// Queue a WebSocket session record for the writer task.
     pub async fn write_websocket_session(
         &self,
         session: crate::websocket_session::WebSocketSession,
     ) -> anyhow::Result<()> {
-        let envelope = CaptureEnvelope::new(CaptureRecord::WebsocketSession(Box::new(session)));
-        self.tx
-            .send(CaptureMsg::Record(envelope))
+        self.queue(CaptureRecord::WebsocketSession(Box::new(session)))
             .await
-            .map_err(|_| anyhow::anyhow!("capture writer task is gone"))
     }
 
     /// Block until every record queued so far is flushed and fsynced to disk.
@@ -163,6 +187,7 @@ impl CaptureWriter {
 async fn writer_task(
     file: tokio::fs::File,
     mut rx: mpsc::Receiver<CaptureMsg>,
+    events: broadcast::Sender<Arc<CaptureEnvelope>>,
     include_body: bool,
 ) {
     let mut writer = BufWriter::with_capacity(WRITE_BUFFER_BYTES, file);
@@ -177,6 +202,13 @@ async fn writer_task(
         while let Some(msg) = next {
             match msg {
                 CaptureMsg::Record(envelope) => {
+                    // Tee to live subscribers before the durable write. The clone
+                    // is a cheap `Arc` refcount bump; skip it (and the ring-buffer
+                    // push) when nobody is listening. `send` never blocks and a
+                    // lagging subscriber drops records rather than slowing us.
+                    if events.receiver_count() > 0 {
+                        let _ = events.send(envelope.clone());
+                    }
                     write_record(&mut writer, &envelope, include_body).await;
                 }
                 CaptureMsg::Flush(ack) => acks.push(ack),
@@ -211,7 +243,7 @@ async fn write_record(
     envelope: &CaptureEnvelope,
     include_body: bool,
 ) {
-    let line = match serialize_line(envelope, include_body) {
+    let line = match serialize_record(envelope, include_body) {
         Ok(line) => line,
         Err(e) => {
             warn!(error = %e, "failed to serialize capture record");
@@ -239,12 +271,16 @@ async fn flush_and_sync(writer: &mut BufWriter<tokio::fs::File>) {
     }
 }
 
-/// Serialize an envelope to a single JSONL line. For transaction records,
-/// request/response bodies are base64-injected when `include_body` is set and
-/// stripped otherwise (defensive — body fields are skipped by serde by
+/// Serialize an envelope to a single JSON object string. For transaction
+/// records, request/response bodies are base64-injected when `include_body` is
+/// set and stripped otherwise (defensive — body fields are skipped by serde by
 /// default). WebSocket sessions carry no separately-skipped bodies and
-/// serialize directly.
-fn serialize_line(envelope: &CaptureEnvelope, include_body: bool) -> serde_json::Result<String> {
+/// serialize directly. Shared by the file writer (one JSONL line) and the live
+/// SSE stream, so the on-disk and on-wire JSON shapes are identical.
+pub(crate) fn serialize_record(
+    envelope: &CaptureEnvelope,
+    include_body: bool,
+) -> serde_json::Result<String> {
     let tx = match &envelope.record {
         CaptureRecord::HttpTransaction(tx) => tx.as_ref(),
         CaptureRecord::WebsocketSession(_) => return serde_json::to_string(envelope),
@@ -736,6 +772,48 @@ mod tests {
             }
             other => panic!("expected websocket_session, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn subscribe_receives_written_record() -> anyhow::Result<()> {
+        let tmp = std::env::temp_dir().join(format!("lint_stream_sub_{}.jsonl", Uuid::new_v4()));
+        let cw = CaptureWriter::new(tmp.clone(), false).await?;
+
+        let mut rx = cw.subscribe();
+
+        use crate::test_helpers::make_test_transaction;
+        let tx = make_test_transaction();
+        let id = tx.id;
+        cw.write_transaction(tx).await?;
+        cw.flush().await?;
+
+        let env = rx.recv().await?;
+        match &env.record {
+            CaptureRecord::HttpTransaction(t) => assert_eq!(t.id, id),
+            other => panic!("expected http_transaction, got {other:?}"),
+        }
+
+        fs::remove_file(&tmp).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn write_without_subscriber_still_writes_file() -> anyhow::Result<()> {
+        let tmp = std::env::temp_dir().join(format!("lint_stream_nosub_{}.jsonl", Uuid::new_v4()));
+        let cw = CaptureWriter::new(tmp.clone(), false).await?;
+
+        // No `subscribe()` call: the broadcast tee must be skipped and the
+        // durable write must proceed unaffected.
+        use crate::test_helpers::make_test_transaction;
+        cw.write_transaction(make_test_transaction()).await?;
+        cw.flush().await?;
+
+        let s = fs::read_to_string(&tmp).await?;
+        let v: Value = serde_json::from_str(s.trim())?;
+        assert_eq!(v["request"]["method"].as_str(), Some("GET"));
+
+        fs::remove_file(&tmp).await?;
+        Ok(())
     }
 
     #[tokio::test]

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -84,6 +84,12 @@ where
         }
     }
 
+    // Live capture stream (SSE). Gated by general.live_stream_enabled; returns
+    // 404 when disabled, mirroring the cert endpoint's gating shape.
+    if req.uri().path() == "/_lint_http/stream" && req.method() == Method::GET {
+        return Ok(super::stream::stream_response(&shared));
+    }
+
     handle_http_logic(req, shared, conn_metadata, scheme).await
 }
 
@@ -109,7 +115,7 @@ where
 }
 
 /// Build a boxed plaintext error response (status + message body, no headers).
-fn error_resp(status: u16, msg: &str) -> Response<ResponseBody> {
+pub(super) fn error_resp(status: u16, msg: &str) -> Response<ResponseBody> {
     let body = Bytes::from(msg.to_string());
     Response::builder()
         .status(status)

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -11,6 +11,7 @@ mod hop_by_hop;
 mod http;
 mod http3;
 mod pipeline;
+mod stream;
 mod tee_body;
 #[cfg(test)]
 mod test_support;

--- a/lint-http-proxy/src/proxy/stream.rs
+++ b/lint-http-proxy/src/proxy/stream.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The `/_lint_http/stream` live capture endpoint: a Server-Sent Events feed
+//! that pushes each capture record as it commits, so a dev loop can watch proxy
+//! traffic in real time instead of tailing the JSONL file.
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, StreamBody};
+use hyper::body::Frame;
+use hyper::Response;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::warn;
+
+use super::{boxed_full, BoxError, ResponseBody, Shared};
+use crate::capture::serialize_record;
+
+/// Build the response for `GET /_lint_http/stream`. Returns 404 when the live
+/// stream is disabled (mirroring the cert endpoint's gated 404); otherwise a
+/// `text/event-stream` body that emits one SSE event per captured record.
+pub(super) fn stream_response(shared: &Arc<Shared>) -> Response<ResponseBody> {
+    if !shared.cfg.general.live_stream_enabled {
+        return super::http::error_resp(
+            404,
+            "live capture stream is disabled (set general.live_stream_enabled = true)",
+        );
+    }
+
+    let body = sse_body(
+        shared.captures.subscribe(),
+        shared.cfg.general.captures_include_body,
+    );
+
+    Response::builder()
+        .status(200)
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .header("Connection", "keep-alive")
+        .body(body)
+        .unwrap_or_else(|_| Response::new(boxed_full(Bytes::new())))
+}
+
+/// Turn a broadcast receiver into an SSE [`ResponseBody`]. Each record becomes a
+/// `data: <json>\n\n` event; a lagging subscriber gets a `: lagged N\n\n`
+/// comment (keeps the stream alive and signals the gap) and the stream ends when
+/// the writer closes or the client disconnects (dropping the receiver).
+fn sse_body(
+    rx: broadcast::Receiver<Arc<crate::capture::CaptureEnvelope>>,
+    include_body: bool,
+) -> ResponseBody {
+    let stream = futures_util::stream::unfold(rx, move |mut rx| async move {
+        loop {
+            match rx.recv().await {
+                Ok(env) => match serialize_record(&env, include_body) {
+                    Ok(json) => {
+                        let frame = Frame::data(Bytes::from(format!("data: {json}\n\n")));
+                        return Some((Ok::<_, BoxError>(frame), rx));
+                    }
+                    // A single unserializable record must not kill the feed.
+                    Err(e) => {
+                        warn!(error = %e, "failed to serialize capture record for SSE stream");
+                        continue;
+                    }
+                },
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    let frame = Frame::data(Bytes::from(format!(": lagged {n}\n\n")));
+                    return Some((Ok(frame), rx));
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    });
+
+    StreamBody::new(stream).boxed_unsync()
+}

--- a/lint-http-proxy/tests/proxy_live_stream.rs
+++ b/lint-http-proxy/tests/proxy_live_stream.rs
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Integration tests for the live capture stream endpoint (`/_lint_http/stream`).
+
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::sleep;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use lint_http::config::Config;
+
+mod common;
+use common::start_run_proxy_and_wait;
+
+/// Read from `stream`, accumulating into a buffer, until it contains `needle`
+/// or the deadline passes. Returns everything read so far (headers included).
+async fn read_until(
+    stream: &mut TcpStream,
+    needle: &str,
+    timeout: Duration,
+) -> anyhow::Result<String> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .ok_or_else(|| anyhow::anyhow!("timeout waiting for {needle:?}"))?;
+        let n = tokio::time::timeout(remaining, stream.read(&mut chunk)).await??;
+        if n == 0 {
+            anyhow::bail!(
+                "stream closed before {needle:?}; got: {}",
+                String::from_utf8_lossy(&buf)
+            );
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        let s = String::from_utf8_lossy(&buf);
+        if s.contains(needle) {
+            return Ok(s.into_owned());
+        }
+    }
+}
+
+#[tokio::test]
+async fn live_stream_pushes_committed_transaction() -> anyhow::Result<()> {
+    // Upstream the proxy will forward to.
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ping"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("pong"))
+        .mount(&mock)
+        .await;
+
+    let mut cfg = Config::default();
+    cfg.tls.enabled = false;
+    cfg.general.live_stream_enabled = true;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // Open the SSE stream and give the handler a moment to subscribe before any
+    // transaction commits.
+    let mut stream = TcpStream::connect(addr).await?;
+    stream
+        .write_all(b"GET /_lint_http/stream HTTP/1.1\r\nHost: proxy\r\n\r\n")
+        .await?;
+    sleep(Duration::from_millis(300)).await;
+
+    // Drive a forward-proxy request through the proxy to the upstream.
+    let mut client = TcpStream::connect(addr).await?;
+    let req = format!(
+        "GET http://127.0.0.1:{}/ping HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+        mock.address().port(),
+        mock.address().port()
+    );
+    client.write_all(req.as_bytes()).await?;
+    let mut resp = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), client.read_to_end(&mut resp)).await??;
+    assert!(
+        String::from_utf8_lossy(&resp).contains("pong"),
+        "proxied request should succeed: {}",
+        String::from_utf8_lossy(&resp)
+    );
+
+    // The committed transaction is pushed to the stream as an SSE data event.
+    let body = read_until(&mut stream, "/ping", Duration::from_secs(5)).await?;
+    assert!(body.contains("200"), "stream response status: {body}");
+    assert!(
+        body.to_lowercase().contains("text/event-stream"),
+        "stream content-type: {body}"
+    );
+    assert!(body.contains("data:"), "expected an SSE data event: {body}");
+    assert!(
+        body.contains("\"method\":\"GET\""),
+        "event should carry the transaction: {body}"
+    );
+
+    handle.abort();
+    let _ = tokio::fs::remove_file(&cap_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn live_stream_disabled_returns_404() -> anyhow::Result<()> {
+    // Default config leaves live_stream_enabled = false.
+    let mut cfg = Config::default();
+    cfg.tls.enabled = false;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let mut stream = TcpStream::connect(addr).await?;
+    stream
+        .write_all(b"GET /_lint_http/stream HTTP/1.1\r\nHost: proxy\r\nConnection: close\r\n\r\n")
+        .await?;
+    let mut resp = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut resp)).await??;
+    let s = String::from_utf8_lossy(&resp);
+    assert!(s.contains("404"), "expected 404 when disabled, got: {s}");
+
+    handle.abort();
+    let _ = tokio::fs::remove_file(&cap_path).await;
+    Ok(())
+}


### PR DESCRIPTION
`/_lint_http/stream` pushes each capture record as a Server-Sent Event the moment it commits, replacing `tail -f` on the captures file. Cashes in the fan-out seam #2 reserved on the capture-writer channel.

- The writer task tees each record to a `tokio::sync::broadcast` channel before the durable file write. Records flow through the mpsc/broadcast as `Arc<CaptureEnvelope>`, so the tee is a refcount bump, not a deep clone; the tee is skipped when no subscriber is connected. The broadcast is lossy under lag, so a slow SSE client can never slow the durable write.
- The endpoint serializes via the shared `serialize_record`, so the on-wire and on-disk JSON shapes are identical (bodies base64-injected only when `captures_include_body` is set).
- Gated by the new `general.live_stream_enabled` (default false): the stream exposes all proxied traffic, so it is opt-in and returns 404 when disabled, mirroring the cert endpoint's gating shape. Reachable over H1/H2 (not H3, as with the cert endpoint); live-only, no backfill.

Tests: unit coverage for the subscribe tee and the no-subscriber write path; integration coverage for a live event arriving and the disabled-returns-404 case. Docs updated (README, configuration.md, config_example.toml).
