### PR TITLE
Strip hop-by-hop request headers before forwarding upstream

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -214,27 +214,47 @@ pub(super) async fn exchange(
     }
 }
 
-/// Build the upstream request line + headers (method, URI, client headers
-/// minus `suppress_headers`), leaving the body for the caller to attach — the
-/// exchange path uses a boxed [`ClientBody`], the WebSocket path a raw
-/// `Full<Bytes>` for its own upgrade connection.
+/// Build the upstream request line + headers (method, URI, client headers minus
+/// `suppress_headers`), leaving the body for the caller to attach — the exchange
+/// path uses a boxed [`ClientBody`], the WebSocket path a raw `Full<Bytes>` for
+/// its own upgrade connection.
+///
+/// When `strip_hop_by_hop` is set, RFC 7230 §6.1 hop-by-hop request headers
+/// (and any header the client names in `Connection:`) are dropped instead of
+/// relayed to the origin — the request-side mirror of [`filter_response_headers`].
+/// The WebSocket path passes `false`: its handshake relies on `Connection` /
+/// `Upgrade` reaching the upstream, exactly as the response side preserves them
+/// for a `101`.
 pub(super) fn upstream_request_builder(
     method: &Method,
     uri: &Uri,
     headers: &HeaderMap,
     shared: &Arc<Shared>,
+    strip_hop_by_hop: bool,
 ) -> hyper::http::request::Builder {
     let mut builder = Request::builder().method(method).uri(uri);
+    let connection_hop_headers = if strip_hop_by_hop {
+        parse_connection_tokens(headers.get(hyper::header::CONNECTION))
+    } else {
+        std::collections::HashSet::new()
+    };
     for (name, value) in headers.iter() {
-        if !shared
+        // `HeaderName::as_str()` is already lowercase, so it can be matched
+        // against the (lowercase) hop-by-hop set directly without normalizing.
+        let name_str = name.as_str();
+        if strip_hop_by_hop && is_hop_by_hop_header(name_str, &connection_hop_headers) {
+            continue;
+        }
+        if shared
             .cfg
             .tls
             .suppress_headers
             .iter()
-            .any(|h| h.eq_ignore_ascii_case(name.as_str()))
+            .any(|h| h.eq_ignore_ascii_case(name_str))
         {
-            builder = builder.header(name, value);
+            continue;
         }
+        builder = builder.header(name, value);
     }
     builder
 }
@@ -246,7 +266,7 @@ pub(super) fn build_upstream_request(
     body: ClientBody,
     shared: &Arc<Shared>,
 ) -> Result<Request<ClientBody>, hyper::http::Error> {
-    upstream_request_builder(method, uri, headers, shared).body(body)
+    upstream_request_builder(method, uri, headers, shared, true).body(body)
 }
 
 /// Filter response headers before returning them to the client. For 101
@@ -260,8 +280,8 @@ pub(super) fn filter_response_headers(headers: &HeaderMap, status: u16) -> Heade
     let connection_hop_headers = parse_connection_tokens(headers.get(hyper::header::CONNECTION));
     let mut out = HeaderMap::new();
     for (name, value) in headers.iter() {
-        let name_str = name.as_str().to_ascii_lowercase();
-        if is_hop_by_hop_header(&name_str, &connection_hop_headers) {
+        // `HeaderName::as_str()` is already lowercase (no normalization needed).
+        if is_hop_by_hop_header(name.as_str(), &connection_hop_headers) {
             continue;
         }
         out.append(name.clone(), value.clone());

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -233,33 +233,38 @@ where
                         return Ok(error_resp(500, "request body collect error"));
                     }
                 };
-            let upstream_req = match upstream_request_builder(&method, &uri, &req_headers, &shared)
-                .body(Full::new(body_bytes.clone()))
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    error!("failed to build upstream request: {}", e);
-                    let duration = started.elapsed().as_millis() as u64;
-                    record_error_transaction(
-                        &shared,
-                        &client_id,
-                        method.as_str(),
-                        &uri_str,
-                        &req_headers,
-                        &req_version,
-                        500,
-                        None,
-                        duration,
-                        Some(body_bytes.clone()),
-                        conn_metadata.id,
-                        conn_metadata.next_sequence_number(),
-                        false,
-                        false,
-                    )
-                    .await;
-                    return Ok(error_resp(500, &format!("request build error: {}", e)));
-                }
-            };
+            // Preserve hop-by-hop headers for the upstream handshake: the
+            // WebSocket upgrade depends on `Connection`/`Upgrade` reaching the
+            // origin (the request-side analog of the 101 carve-out in
+            // `filter_response_headers`).
+            let upstream_req =
+                match upstream_request_builder(&method, &uri, &req_headers, &shared, false)
+                    .body(Full::new(body_bytes.clone()))
+                {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!("failed to build upstream request: {}", e);
+                        let duration = started.elapsed().as_millis() as u64;
+                        record_error_transaction(
+                            &shared,
+                            &client_id,
+                            method.as_str(),
+                            &uri_str,
+                            &req_headers,
+                            &req_version,
+                            500,
+                            None,
+                            duration,
+                            Some(body_bytes.clone()),
+                            conn_metadata.id,
+                            conn_metadata.next_sequence_number(),
+                            false,
+                            false,
+                        )
+                        .await;
+                        return Ok(error_resp(500, &format!("request build error: {}", e)));
+                    }
+                };
             return handle_websocket_upgrade(
                 upstream_req,
                 client_on_upgrade,

--- a/lint-http-proxy/tests/proxy_request_headers.rs
+++ b/lint-http-proxy/tests/proxy_request_headers.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Integration test for request-side hop-by-hop header filtering: a forward
+//! proxy must not relay RFC 7230 §6.1 hop-by-hop request headers (nor headers
+//! the client names in `Connection:`) to the origin.
+
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tokio::time::sleep;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use lint_http::config::Config;
+
+mod common;
+use common::start_run_proxy_and_wait;
+
+#[tokio::test]
+async fn request_side_hop_by_hop_headers_are_stripped() -> anyhow::Result<()> {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/x"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&mock)
+        .await;
+
+    let mut cfg = Config::default();
+    cfg.tls.enabled = false;
+    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // Drive a plaintext forward-proxy request carrying a static hop-by-hop
+    // header (`Proxy-Authorization`), a dynamically-marked one (`X-Custom`, named
+    // in `Connection:`), and a normal header (`X-Keep`) that must pass through.
+    let mut client = TcpStream::connect(addr).await?;
+    let req = format!(
+        "GET http://127.0.0.1:{port}/x HTTP/1.1\r\n\
+         Host: 127.0.0.1:{port}\r\n\
+         Proxy-Authorization: secret\r\n\
+         Connection: x-custom\r\n\
+         X-Custom: drop-me\r\n\
+         X-Keep: keep-me\r\n\
+         \r\n",
+        port = mock.address().port()
+    );
+    client.write_all(req.as_bytes()).await?;
+
+    // The upstream records the forwarded request as soon as the proxy relays it;
+    // poll until it arrives rather than parsing the proxy's response.
+    let mut attempts = 0u32;
+    let reqs = loop {
+        attempts += 1;
+        let r = mock.received_requests().await.unwrap_or_default();
+        if !r.is_empty() || attempts > 40 {
+            break r;
+        }
+        sleep(Duration::from_millis(50)).await;
+    };
+    assert_eq!(reqs.len(), 1, "upstream should have received the request");
+    let got = &reqs[0];
+
+    // The normal header is forwarded.
+    assert!(
+        got.headers.contains_key("x-keep"),
+        "a non-hop-by-hop header should reach the origin"
+    );
+    // A static hop-by-hop request header is stripped.
+    assert!(
+        !got.headers.contains_key("proxy-authorization"),
+        "Proxy-Authorization must not be relayed to the origin"
+    );
+    // A header named in the client's `Connection:` is stripped (dynamic case).
+    assert!(
+        !got.headers.contains_key("x-custom"),
+        "a header listed in Connection: must be stripped"
+    );
+
+    handle.abort();
+    let _ = tokio::fs::remove_file(&cap_path).await;
+    Ok(())
+}


### PR DESCRIPTION
A forward proxy must not relay RFC 7230 §6.1 hop-by-hop request headers (`Connection`, `Keep-Alive`, `TE`, `Transfer-Encoding`, `Upgrade`, `Trailer`, `Proxy-Authenticate`, `Proxy-Authorization`, and any header the client names in `Connection:`) to the origin verbatim. Previously these were filtered only on responses; the upstream request builder stripped only the user's `suppress_headers`.

- `upstream_request_builder` gains a `strip_hop_by_hop` flag and reuses the existing `is_hop_by_hop_header` / `parse_connection_tokens` helpers — the request-side mirror of `filter_response_headers`. The normal exchange path (`build_upstream_request`, shared by H1/H2/H3) passes `true`, so the fix lands once for all transports.
- The WebSocket handshake passes `false`: its upgrade depends on `Connection`/`Upgrade` reaching the origin, the request-side analog of the 101 carve-out on the response side.
- Drop the now-redundant per-header `to_ascii_lowercase()` on both the request and response sides: `HeaderName::as_str()` is already lowercase, so it can be matched against the lowercase hop-by-hop set directly.

Tests: a new integration test asserts a normal header reaches the origin while `Proxy-Authorization` and a `Connection:`-named token are stripped (covering both the static list and the dynamic `Connection` parsing). The existing WebSocket relay test guards the carve-out — its 101 handshake only succeeds if `Connection`/`Upgrade` still reach the upstream.
