### PR TITLE
Stream HTTP/3 request bodies and bound H3 connections

### DIFF
--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -4,21 +4,20 @@
 
 //! HTTP/3 (QUIC) accept loop and per-stream request handling.
 
-use bytes::Bytes;
 use http_body_util::BodyExt;
 use hyper::{Response, Uri};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, warn};
 
 use crate::ca::CertificateAuthority;
 
 use super::connect::AlwaysResolves;
-use super::exchange::{exchange, record_error_transaction, ProxiedRequest};
-use super::tee_body;
+use super::exchange::{exchange, ProxiedRequest};
 use super::Shared;
+use super::{http3_body, tee_body};
 
 /// QUIC transport parameter defaults for the HTTP/3 proxy.
 ///
@@ -103,8 +102,20 @@ pub(super) async fn run_h3_accept_loop(
     endpoint: quinn::Endpoint,
     shared: Arc<Shared>,
     shutdown: CancellationToken,
+    semaphore: Arc<tokio::sync::Semaphore>,
 ) {
     loop {
+        // Reserve a connection slot first, so H3 never exceeds `max_connections`
+        // (shared with TCP). The permit is held for the connection's lifetime by
+        // the spawned task, so it doubles as the shutdown drain barrier.
+        let permit = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            permit = semaphore.clone().acquire_owned() => match permit {
+                Ok(p) => p,
+                Err(_) => break, // semaphore closed
+            },
+        };
         let incoming = tokio::select! {
             _ = shutdown.cancelled() => break,
             incoming = endpoint.accept() => match incoming {
@@ -114,6 +125,8 @@ pub(super) async fn run_h3_accept_loop(
         };
         let shared = shared.clone();
         tokio::spawn(async move {
+            // Released when this task ends; the drain waits on all permits.
+            let _permit = permit;
             match incoming.await {
                 Ok(conn) => {
                     let remote_addr = conn.remote_address();
@@ -260,13 +273,11 @@ fn emit_h3_protocol_event(
 /// upgrade/WebSocket handling is intentionally omitted here.
 async fn handle_h3_request(
     req: hyper::Request<()>,
-    mut stream: h3::server::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>,
+    stream: h3::server::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>,
     shared: Arc<Shared>,
     conn_metadata: Arc<crate::connection::ConnectionMetadata>,
     stream_id: u64,
 ) -> anyhow::Result<()> {
-    use bytes::Buf;
-
     let started = Instant::now();
 
     let method = req.method().clone();
@@ -280,65 +291,6 @@ async fn handle_h3_request(
         .unwrap_or("unknown")
         .to_string();
     let client_id = crate::state::ClientIdentifier::new(client_ip, user_agent);
-
-    // Collect the request body from the h3 stream, bounded by max_body_bytes.
-    let max_body_bytes = shared.cfg.general.max_body_bytes;
-    let mut req_body = Vec::new();
-    let mut req_body_over_limit = false;
-    'collect: while let Some(chunk) = stream.recv_data().await? {
-        let mut buf = chunk;
-        if req_body.len() + buf.remaining() > max_body_bytes {
-            req_body_over_limit = true;
-            break 'collect;
-        }
-        while buf.has_remaining() {
-            let bytes = buf.chunk();
-            req_body.extend_from_slice(bytes);
-            let len = bytes.len();
-            buf.advance(len);
-        }
-    }
-    if req_body_over_limit {
-        warn!(
-            "HTTP/3 request body exceeds max_body_bytes ({})",
-            max_body_bytes
-        );
-        let duration = started.elapsed().as_millis() as u64;
-        record_error_transaction(
-            &shared,
-            &client_id,
-            method.as_str(),
-            &uri_str,
-            &req_headers,
-            "HTTP/3",
-            413,
-            None,
-            duration,
-            None,
-            conn_metadata.id,
-            stream_id as u32,
-            true,
-            false,
-        )
-        .await;
-        let resp = Response::builder().status(413).body(()).unwrap();
-        stream.send_response(resp).await?;
-        stream
-            .send_data(Bytes::from("request body exceeds max_body_bytes"))
-            .await?;
-        stream.finish().await?;
-        return Ok(());
-    }
-    let req_body_bytes = Bytes::from(req_body);
-
-    // Collect request trailers (if the client sent any after the body)
-    let req_trailers = match stream.recv_trailers().await {
-        Ok(t) => t,
-        Err(e) => {
-            trace!("HTTP/3 request trailers error (non-fatal): {}", e);
-            None
-        }
-    };
 
     // Build the upstream URI from the :authority pseudo-header (falling back to
     // Host), defaulting to HTTPS since HTTP/3 is always over TLS.
@@ -368,12 +320,14 @@ async fn handle_h3_request(
             .unwrap_or_else(|_| Uri::from_static("https://localhost/"))
     };
 
-    // The H3 request body is already buffered (recv loop above); present it
-    // through the same streaming exchange interface with a pre-resolved capture
-    // (bounded to the same prefix cap as H1/H2). H3 request streaming is a
-    // follow-up.
+    // Split the bidirectional stream so the request body streams to the upstream
+    // (teed for capture) while the send half stays here to deliver the response.
+    // This mirrors the H1/H2 path: the body forwards in full and only the
+    // captured prefix is bounded by `captures_max_body_bytes` — no 413, no
+    // whole-body buffering.
+    let (mut send, recv) = stream.split();
     let prefix_cap = shared.cfg.general.captures_max_body_bytes;
-    let (body, body_done_rx) = tee_body::buffered(req_body_bytes, req_trailers, prefix_cap);
+    let (body, body_done_rx) = tee_body::tee(http3_body::boxed(recv), prefix_cap);
 
     // Run the shared exchange core (forward, collect, lint, capture).
     let pr = ProxiedRequest {
@@ -397,22 +351,22 @@ async fn handle_h3_request(
         resp_builder = resp_builder.header(name, value);
     }
     let h3_resp = resp_builder.body(()).unwrap();
-    stream.send_response(h3_resp).await?;
+    send.send_response(h3_resp).await?;
 
     // Drive the streaming response body frame-by-frame onto the QUIC stream.
     let mut body = proxied.body;
     while let Some(frame) = body.frame().await {
         let frame = frame.map_err(|e| anyhow::anyhow!("HTTP/3 response body error: {}", e))?;
         match frame.into_data() {
-            Ok(data) => stream.send_data(data).await?,
+            Ok(data) => send.send_data(data).await?,
             Err(frame) => {
                 if let Ok(trailers) = frame.into_trailers() {
-                    stream.send_trailers(trailers).await?;
+                    send.send_trailers(trailers).await?;
                 }
             }
         }
     }
-    stream.finish().await?;
+    send.finish().await?;
 
     Ok(())
 }

--- a/lint-http-proxy/src/proxy/http3_body.rs
+++ b/lint-http-proxy/src/proxy/http3_body.rs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! A [`hyper::body::Body`] adapter over the receive half of an HTTP/3
+//! `RequestStream`, so the request body streams into the shared `exchange` core
+//! (teed for capture) instead of being buffered whole. The send half stays with
+//! the handler to deliver the response — h3 lets a bidirectional request stream
+//! be `split()` so the two directions can be driven independently.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, Bytes};
+use h3::quic::RecvStream;
+use h3::server::RequestStream;
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame};
+
+use super::BoxError;
+
+type InnerBody = http_body_util::combinators::UnsyncBoxBody<Bytes, BoxError>;
+
+/// Whether the next poll reads body data, then trailers, then ends.
+enum State {
+    Data,
+    Trailers,
+    Done,
+}
+
+/// Streams the request body out of an h3 receive stream, yielding a trailers
+/// frame after the data if the client sent any.
+struct H3RequestBody<S> {
+    recv: RequestStream<S, Bytes>,
+    state: State,
+}
+
+impl<S> Body for H3RequestBody<S>
+where
+    S: RecvStream,
+{
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, BoxError>>> {
+        // `RequestStream` is `Unpin`, so poll the recv half without structural
+        // pinning (the same pattern `TeeBody` uses for its inner body).
+        let this = self.get_mut();
+        loop {
+            match this.state {
+                State::Data => match this.recv.poll_recv_data(cx) {
+                    Poll::Ready(Ok(Some(mut buf))) => {
+                        let bytes = buf.copy_to_bytes(buf.remaining());
+                        return Poll::Ready(Some(Ok(Frame::data(bytes))));
+                    }
+                    Poll::Ready(Ok(None)) => this.state = State::Trailers,
+                    Poll::Ready(Err(e)) => {
+                        this.state = State::Done;
+                        return Poll::Ready(Some(Err(Box::new(e) as BoxError)));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                State::Trailers => match this.recv.poll_recv_trailers(cx) {
+                    Poll::Ready(Ok(Some(trailers))) => {
+                        this.state = State::Done;
+                        return Poll::Ready(Some(Ok(Frame::trailers(trailers))));
+                    }
+                    Poll::Ready(Ok(None)) => {
+                        this.state = State::Done;
+                        return Poll::Ready(None);
+                    }
+                    Poll::Ready(Err(e)) => {
+                        this.state = State::Done;
+                        return Poll::Ready(Some(Err(Box::new(e) as BoxError)));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                State::Done => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+/// Box the receive half of an h3 `RequestStream` as a streaming request body,
+/// ready to be teed and forwarded to the upstream by `exchange`.
+pub(super) fn boxed<S>(recv: RequestStream<S, Bytes>) -> InnerBody
+where
+    S: RecvStream + Send + 'static,
+{
+    H3RequestBody {
+        recv,
+        state: State::Data,
+    }
+    .boxed_unsync()
+}

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -10,6 +10,7 @@ mod exchange;
 mod hop_by_hop;
 mod http;
 mod http3;
+mod http3_body;
 mod pipeline;
 mod stream;
 mod tee_body;
@@ -226,12 +227,15 @@ async fn run_proxy_inner(
         quic_transport_params,
     });
 
-    // Start HTTP/3 (QUIC) accept loop if an endpoint was created.
+    // Start HTTP/3 (QUIC) accept loop if an endpoint was created. It shares the
+    // same connection semaphore as TCP, so `max_connections` bounds both
+    // transports and the drain barrier below waits for live H3 connections too.
     let h3_handle = h3_endpoint.map(|endpoint| {
         let shared_h3 = shared.clone();
         let shutdown_h3 = shutdown.clone();
+        let semaphore_h3 = semaphore.clone();
         tokio::spawn(async move {
-            run_h3_accept_loop(endpoint, shared_h3, shutdown_h3).await;
+            run_h3_accept_loop(endpoint, shared_h3, shutdown_h3, semaphore_h3).await;
         })
     });
 

--- a/lint-http-proxy/src/proxy/tee_body.rs
+++ b/lint-http-proxy/src/proxy/tee_body.rs
@@ -7,7 +7,7 @@
 //! response/request body through the proxy without buffering it whole.
 
 use bytes::{Bytes, BytesMut};
-use http_body_util::{BodyExt, Full};
+use http_body_util::BodyExt;
 use hyper::body::{Body, Frame, SizeHint};
 use hyper::HeaderMap;
 use std::pin::Pin;
@@ -27,29 +27,6 @@ pub(super) fn tee(
 ) -> (InnerBody, oneshot::Receiver<CapturedBody>) {
     let (done, rx) = oneshot::channel();
     let body = TeeBody::new(inner, prefix_cap, done).boxed_unsync();
-    (body, rx)
-}
-
-/// Present an already-buffered body (e.g. the H3 request body) through the same
-/// streaming interface: a `Full` body plus an immediately-resolved capture
-/// bounded to the same prefix rule as [`TeeBody`].
-pub(super) fn buffered(
-    bytes: Bytes,
-    trailers: Option<HeaderMap>,
-    prefix_cap: usize,
-) -> (InnerBody, oneshot::Receiver<CapturedBody>) {
-    let total = bytes.len() as u64;
-    let truncated = bytes.len() > prefix_cap;
-    let prefix = bytes.slice(0..prefix_cap.min(bytes.len()));
-    let (done, rx) = oneshot::channel();
-    // The receiver is live (just created), so this never drops.
-    let _ = done.send(CapturedBody {
-        prefix,
-        total,
-        truncated,
-        trailers,
-    });
-    let body = Full::new(bytes).map_err(|e| match e {}).boxed_unsync();
     (body, rx)
 }
 
@@ -168,6 +145,7 @@ impl Drop for TeeBody {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http_body_util::Full;
 
     fn boxed(bytes: &'static [u8]) -> InnerBody {
         Full::new(Bytes::from_static(bytes))
@@ -203,18 +181,6 @@ mod tests {
         assert_eq!(captured.prefix, Bytes::from_static(b"hi"));
         assert_eq!(captured.total, 2);
         assert!(!captured.truncated);
-    }
-
-    #[tokio::test]
-    async fn buffered_presents_full_body_with_bounded_capture() {
-        let (body, rx) = buffered(Bytes::from_static(b"hello world"), None, 5);
-        let forwarded = body.collect().await.unwrap().to_bytes();
-        assert_eq!(forwarded, Bytes::from_static(b"hello world"));
-
-        let captured = rx.await.unwrap();
-        assert_eq!(captured.prefix, Bytes::from_static(b"hello"));
-        assert_eq!(captured.total, 11);
-        assert!(captured.truncated);
     }
 
     #[tokio::test]

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -514,34 +514,46 @@ async fn h3_multiple_requests_on_same_connection_increment_sequence() -> anyhow:
 }
 
 #[tokio::test]
-async fn h3_request_body_over_limit_returns_413() -> anyhow::Result<()> {
+async fn h3_large_request_body_streams_and_truncates_capture() -> anyhow::Result<()> {
+    let mock = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&mock)
+        .await;
+
     let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
         start_proxy_with_h3(Some(Box::new(|cfg| {
-            cfg.general.max_body_bytes = 16;
+            cfg.general.captures_max_body_bytes = 16;
         })))
         .await?;
 
     let endpoint = build_h3_client(&cert_path)?;
-    // The limit trips while collecting the request body, before any upstream
-    // contact, so no mock server is needed.
-    let (status, _body) =
-        h3_request_with_body(&endpoint, h3_addr, "http://127.0.0.1:9/upload", &[b'a'; 64]).await?;
-    assert_eq!(status, 413);
+    let uri = format!("http://127.0.0.1:{}/upload", mock.address().port());
+
+    // A 64-byte request body exceeds the 16-byte capture bound but must still
+    // be streamed to the upstream in full — no rejection, no 413.
+    let (status, _body) = h3_request_with_body(&endpoint, h3_addr, &uri, &[b'a'; 64]).await?;
+    assert_eq!(status, 200);
+
+    // The upstream received the entire body, not a truncated or rejected one.
+    let reqs = mock.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1);
+    assert_eq!(reqs[0].body.len(), 64);
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
+    // The capture holds only the bounded prefix, marked truncated, while
+    // request body_length records the real streamed total.
     let content = tokio::fs::read_to_string(&captures_path).await?;
     let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
-    assert!(
-        !lines.is_empty(),
-        "over-limit transaction should be captured"
-    );
+    assert!(!lines.is_empty(), "transaction should be captured");
 
     let v: serde_json::Value = serde_json::from_str(lines[0])?;
-    assert_eq!(v["response"]["status"].as_u64(), Some(413));
-    assert_eq!(v["request_body_over_limit"].as_bool(), Some(true));
+    assert_eq!(v["response"]["status"].as_u64(), Some(200));
     assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3"));
-    assert!(v["request"]["body_length"].is_null());
+    assert_eq!(v["request_body_over_limit"].as_bool(), Some(true));
+    assert_eq!(v["request"]["body_length"].as_u64(), Some(64));
 
     endpoint.close(0u32.into(), b"done");
     handle.abort();


### PR DESCRIPTION
Bring the HTTP/3 transport to parity with H1/H2 on the two axes it lagged.

Stream the request body (was: buffer + 413). `handle_h3_request` split the bidirectional `RequestStream` so the receive half streams the request body to the upstream — teed for a bounded capture prefix via the same `tee_body::tee` → `exchange` contract H1/H2 uses — while the send half delivers the response. The new `proxy/http3_body.rs` wraps the h3 receive half in a poll-based `hyper::body::Body` (data → trailers → done) over `poll_recv_data` / `poll_recv_trailers`. The manual `max_body_bytes` recv-loop, the 413 rejection, and the now-unused `tee_body::buffered` shim are gone: H3 forwards arbitrarily large request bodies in full, with only the captured copy bounded by `captures_max_body_bytes`.

Bound H3 connections. `run_h3_accept_loop` now takes the shared connection `Semaphore` and acquires an owned permit per QUIC connection before accepting (mirroring the TCP accept loop), holding it for the connection's lifetime. So `max_connections` bounds TCP and H3 together and the shutdown drain barrier waits for live H3 connections too — no change to the shutdown sequence itself.

Tests: replace `h3_request_body_over_limit_returns_413` (asserted the retired 413) with `h3_large_request_body_streams_and_truncates_capture` — a 64-byte body to a wiremock upstream asserts the origin received the full 64 bytes (no 413) and the capture is marked truncated with `request.body_length = 64`. The existing H3 suite guards the connection-bound change.
