### PR TITLE
Precompute the enabled rule set once per Config

### DIFF
--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -239,10 +239,12 @@ async fn lint_app(config_path: &str, captures_path: &str) -> anyhow::Result<usiz
     }
     let transactions = capture::load_captures(captures_path).await?;
     let state = state::StateStore::new(cfg.general.ttl_seconds, cfg.general.max_history);
+    // Precompute the enabled rule set once, then reuse it across the replay.
+    let engine = engine::PreparedEngine::new(&cfg);
 
     let mut total = 0usize;
     for tx in &transactions {
-        let violations = engine::lint_transaction(tx, &cfg, &state);
+        let violations = engine.lint_transaction(tx, &cfg, &state);
         state.record_transaction(tx);
         if violations.is_empty() {
             continue;

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -81,6 +81,10 @@ pub(super) struct Shared {
     pub(super) protocol_event_store: Arc<crate::protocol_event_store::ProtocolEventStore>,
     pub(super) ca: Option<Arc<CertificateAuthority>>,
     pub(super) quic_transport_params: Option<crate::protocol_event::QuicTransportParameters>,
+    /// Enabled rule set precomputed once from `cfg` (immutable after startup),
+    /// so per-transaction/-event dispatch skips disabled rules without a
+    /// per-rule config lookup. Shared by both pipelines.
+    pub(super) engine: Arc<crate::engine::PreparedEngine>,
     /// Connection bound, shared with the accept loops. The detached WebSocket
     /// relay acquires a permit from this so live sessions are counted against
     /// `max_connections` and waited on by the shutdown drain barrier.
@@ -224,6 +228,9 @@ async fn run_proxy_inner(
         (None, None)
     };
 
+    // Precompute the enabled rule set once; cfg is immutable from here on.
+    let engine = Arc::new(crate::engine::PreparedEngine::new(&cfg));
+
     let shared = Arc::new(Shared {
         client,
         captures,
@@ -232,6 +239,7 @@ async fn run_proxy_inner(
         protocol_event_store,
         ca,
         quic_transport_params,
+        engine,
         semaphore: semaphore.clone(),
         shutdown: shutdown.clone(),
     });

--- a/lint-http-proxy/src/proxy/pipeline.rs
+++ b/lint-http-proxy/src/proxy/pipeline.rs
@@ -19,6 +19,7 @@ use tracing::warn;
 
 use crate::capture::CaptureWriter;
 use crate::config::Config;
+use crate::engine::PreparedEngine;
 use crate::http_transaction::HttpTransaction;
 use crate::lint::Violation;
 use crate::protocol_event::ProtocolEvent;
@@ -30,6 +31,7 @@ use super::Shared;
 /// Orchestrates the per-transaction cycle: lint, record to state, write the
 /// capture line.
 pub(super) struct TransactionPipeline {
+    engine: Arc<PreparedEngine>,
     cfg: Arc<Config>,
     state: Arc<StateStore>,
     captures: CaptureWriter,
@@ -41,7 +43,7 @@ impl TransactionPipeline {
     /// cannot be re-committed or mutated after capture; returns the
     /// violations for callers that need them.
     pub(super) async fn commit(&self, mut tx: HttpTransaction) -> Vec<Violation> {
-        tx.violations = crate::engine::lint_transaction(&tx, &self.cfg, &self.state);
+        tx.violations = self.engine.lint_transaction(&tx, &self.cfg, &self.state);
         self.state.record_transaction(&tx);
         // Extract violations before moving the transaction into the writer.
         let violations = tx.violations.clone();
@@ -56,19 +58,26 @@ impl TransactionPipeline {
 /// store. Cloneable so concurrent relay tasks can each own one.
 #[derive(Clone)]
 pub(super) struct ProtocolEventPipeline {
+    engine: Arc<PreparedEngine>,
     cfg: Arc<Config>,
     store: Arc<ProtocolEventStore>,
 }
 
 impl ProtocolEventPipeline {
-    pub(super) fn new(cfg: Arc<Config>, store: Arc<ProtocolEventStore>) -> Self {
-        Self { cfg, store }
+    pub(super) fn new(
+        engine: Arc<PreparedEngine>,
+        cfg: Arc<Config>,
+        store: Arc<ProtocolEventStore>,
+    ) -> Self {
+        Self { engine, cfg, store }
     }
 
     /// Lint `event`, then record it — in that order. Returns the violations
     /// so callers can log or collect them.
     pub(super) fn commit(&self, event: &ProtocolEvent) -> Vec<Violation> {
-        let violations = crate::lint_protocol::lint_protocol_event(event, &self.cfg, &self.store);
+        let violations = self
+            .engine
+            .lint_protocol_event(event, &self.cfg, &self.store);
         self.store.record_event(event);
         violations
     }
@@ -77,6 +86,7 @@ impl ProtocolEventPipeline {
 impl Shared {
     pub(super) fn pipeline(&self) -> TransactionPipeline {
         TransactionPipeline {
+            engine: self.engine.clone(),
             cfg: self.cfg.clone(),
             state: self.state.clone(),
             captures: self.captures.clone(),
@@ -84,7 +94,11 @@ impl Shared {
     }
 
     pub(super) fn protocol_event_pipeline(&self) -> ProtocolEventPipeline {
-        ProtocolEventPipeline::new(self.cfg.clone(), self.protocol_event_store.clone())
+        ProtocolEventPipeline::new(
+            self.engine.clone(),
+            self.cfg.clone(),
+            self.protocol_event_store.clone(),
+        )
     }
 }
 

--- a/lint-http-proxy/src/proxy/test_support.rs
+++ b/lint-http-proxy/src/proxy/test_support.rs
@@ -46,6 +46,7 @@ pub(super) async fn make_shared_with_cfg(
     let protocol_event_store = StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
         300, 100,
     ));
+    let engine = StdArc::new(crate::engine::PreparedEngine::new(&cfg));
     let shared = StdArc::new(Shared {
         client,
         captures: cw.clone(),
@@ -54,6 +55,7 @@ pub(super) async fn make_shared_with_cfg(
         protocol_event_store,
         ca,
         quic_transport_params: None,
+        engine,
         semaphore: StdArc::new(tokio::sync::Semaphore::new(1024)),
         shutdown: tokio_util::sync::CancellationToken::new(),
     });

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -521,8 +521,11 @@ mod tests {
     use uuid::Uuid;
 
     fn test_pe_pipeline() -> ProtocolEventPipeline {
+        let cfg = StdArc::new(crate::config::Config::default());
+        let engine = StdArc::new(crate::engine::PreparedEngine::new(&cfg));
         ProtocolEventPipeline::new(
-            StdArc::new(crate::config::Config::default()),
+            engine,
+            cfg,
             StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
                 300, 100,
             )),

--- a/lint-http-proxy/tests/proxy_websocket_relay.rs
+++ b/lint-http-proxy/tests/proxy_websocket_relay.rs
@@ -133,11 +133,21 @@ async fn websocket_upgrade_through_proxy_captures_session() -> anyhow::Result<()
     drop(write);
     drop(read);
 
-    // Give the proxy time to write the session capture
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    // Read captures file
-    let content = tokio::fs::read_to_string(&captures_path).await?;
+    // The relay writes the session capture asynchronously after the close
+    // handshake, and the capture writer flushes on its own schedule, so poll
+    // until both the 101 transaction and the websocket session land rather than
+    // relying on a fixed sleep (which races on a slow/loaded CI runner).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let content = loop {
+        let content = tokio::fs::read_to_string(&captures_path)
+            .await
+            .unwrap_or_default();
+        let records = content.lines().filter(|l| !l.trim().is_empty()).count();
+        if records >= 2 || std::time::Instant::now() > deadline {
+            break content;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    };
     let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
 
     // Should have at least 2 records: the 101 transaction and the websocket session

--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -4,85 +4,144 @@
 
 //! Transaction lint dispatch.
 //!
-//! `lint_transaction` iterates the rule catalogue, building each rule's
-//! required cross-transaction history lazily from the [`StateStore`], and
-//! collects the violations. It sits *above* the rule catalogue and the query
-//! layer (it references both), so it lives in the rules crate rather than with
-//! the [`Violation`](crate::lint::Violation) data type in core.
+//! [`PreparedEngine`] precomputes the enabled rule set once per [`Config`]
+//! (immutable after startup), then dispatches transactions and protocol events
+//! against it — building each rule's required cross-transaction history lazily
+//! from the [`StateStore`] and collecting the violations. It sits *above* the
+//! rule catalogue and the query layer (it references both), so it lives in the
+//! rules crate rather than with the [`Violation`](crate::lint::Violation) data
+//! type in core.
 
 use crate::config::Config;
 use crate::lint::Violation;
+use crate::rules::{ProtocolRule, Rule};
 
-/// Lint an entire `HttpTransaction`.
+/// The enabled rule set for one [`Config`], precomputed once so per-transaction
+/// dispatch cost is proportional to the *enabled* rules rather than the full
+/// catalogue. `is_enabled` is a pure function of the (immutable) config, so the
+/// per-scope intersection is computed at construction instead of on every
+/// transaction. Build once and reuse for the lifetime of the config.
+pub struct PreparedEngine {
+    /// Enabled rules for a full transaction (response collected).
+    enabled_full: Vec<&'static dyn Rule>,
+    /// Enabled rules for a request-only transaction (Server-scoped excluded).
+    enabled_request_only: Vec<&'static dyn Rule>,
+    /// Enabled protocol-event rules (consumed by `lint_protocol_event`).
+    pub(crate) enabled_protocol: Vec<&'static dyn ProtocolRule>,
+}
+
+impl PreparedEngine {
+    /// Intersect the catalogue's precomputed scope views with `cfg.is_enabled`,
+    /// once. The per-rule `parse_rule_config` check inside each rule stays as a
+    /// harmless belt-and-suspenders.
+    pub fn new(cfg: &Config) -> Self {
+        let enabled = |r: &&'static dyn Rule| cfg.is_enabled(r.id());
+        Self {
+            enabled_full: crate::rules::RULES
+                .iter()
+                .copied()
+                .filter(enabled)
+                .collect(),
+            enabled_request_only: crate::rules::REQUEST_ONLY_RULES
+                .iter()
+                .copied()
+                .filter(enabled)
+                .collect(),
+            enabled_protocol: crate::rules::PROTOCOL_RULES
+                .iter()
+                .copied()
+                .filter(|r| cfg.is_enabled(r.id()))
+                .collect(),
+        }
+    }
+
+    /// Lint an entire `HttpTransaction` against the enabled rule set.
+    pub fn lint_transaction(
+        &self,
+        tx: &crate::http_transaction::HttpTransaction,
+        cfg: &Config,
+        state: &crate::state::StateStore,
+    ) -> Vec<Violation> {
+        let mut out = Vec::new();
+
+        let mut history_by_resource: Option<crate::transaction_history::TransactionHistory> = None;
+        let mut history_by_origin: Option<crate::transaction_history::TransactionHistory> = None;
+        // separate cache for ByResourceAll queries to avoid mixing with
+        // per-client histories.  If a ByResource rule runs first its history was
+        // already computed and stored in `history_by_resource`; using that same
+        // value for ByResourceAll would omit other clients' entries.
+        let mut history_by_resource_all_clients: Option<
+            crate::transaction_history::TransactionHistory,
+        > = None;
+        let mut history_by_connection: Option<crate::transaction_history::TransactionHistory> =
+            None;
+        // Rules that don't read history (the vast majority) are dispatched
+        // against this shared empty history instead of an unused per-resource
+        // query.
+        let empty_history = crate::transaction_history::TransactionHistory::empty();
+
+        // Cache origin extraction since it's used by any rule requiring ByOrigin
+        let origin = crate::helpers::uri::extract_origin_if_absolute(&tx.request.uri);
+
+        // Enabled rules only — disabled rules were filtered out at construction.
+        // `Server` rules are excluded when the response isn't collected yet
+        // (mirrors `crate::rules::rules_for_scope`, see `Rule::scope`).
+        let scoped = if tx.response.is_some() {
+            &self.enabled_full
+        } else {
+            &self.enabled_request_only
+        };
+        for rule in scoped {
+            let history = match crate::rules::query_type_for(rule.id()) {
+                Some(crate::queries::QueryType::ByResource) => history_by_resource
+                    .get_or_insert_with(|| {
+                        crate::queries::by_resource::by_resource(state, &tx.client, &tx.request.uri)
+                    }),
+                Some(crate::queries::QueryType::ByOrigin) => {
+                    history_by_origin.get_or_insert_with(|| {
+                        if let Some(o) = &origin {
+                            crate::queries::by_origin::by_origin(state, &tx.client, o)
+                        } else {
+                            crate::transaction_history::TransactionHistory::empty()
+                        }
+                    })
+                }
+                Some(crate::queries::QueryType::ByResourceAll) => history_by_resource_all_clients
+                    .get_or_insert_with(|| {
+                        crate::queries::by_resource_all_clients::by_resource_all_clients(
+                            state,
+                            &tx.request.uri,
+                        )
+                    }),
+                Some(crate::queries::QueryType::ByConnection) => history_by_connection
+                    .get_or_insert_with(|| {
+                        if let Some(conn_id) = tx.connection_id {
+                            crate::queries::by_connection::by_connection(state, conn_id)
+                        } else {
+                            crate::transaction_history::TransactionHistory::empty()
+                        }
+                    }),
+                // Rule reads no history.
+                None => &empty_history,
+            };
+
+            out.extend(rule.check_transaction(tx, history, cfg));
+        }
+
+        out
+    }
+}
+
+/// Lint an entire `HttpTransaction`. Convenience one-shot: builds a
+/// [`PreparedEngine`] for `cfg` and dispatches once. Hot paths (the proxy
+/// pipeline, the offline `lint` subcommand) build a `PreparedEngine` once and
+/// reuse it; this wrapper is for tests and one-off callers.
 pub fn lint_transaction(
     tx: &crate::http_transaction::HttpTransaction,
     cfg: &Config,
     state: &crate::state::StateStore,
 ) -> Vec<Violation> {
-    let mut out = Vec::new();
-
-    let mut history_by_resource: Option<crate::transaction_history::TransactionHistory> = None;
-    let mut history_by_origin: Option<crate::transaction_history::TransactionHistory> = None;
-    // separate cache for ByResourceAll queries to avoid mixing with
-    // per-client histories.  If a ByResource rule runs first its history was
-    // already computed and stored in `history_by_resource`; using that same
-    // value for ByResourceAll would omit other clients' entries.
-    let mut history_by_resource_all_clients: Option<
-        crate::transaction_history::TransactionHistory,
-    > = None;
-    let mut history_by_connection: Option<crate::transaction_history::TransactionHistory> = None;
-    // Rules that don't read history (the vast majority) are dispatched against
-    // this shared empty history instead of an unused per-resource query.
-    let empty_history = crate::transaction_history::TransactionHistory::empty();
-
-    // Cache origin extraction since it's used by any rule requiring ByOrigin
-    let origin = crate::helpers::uri::extract_origin_if_absolute(&tx.request.uri);
-
-    // Dispatch only the rules whose scope matches the transaction shape:
-    // `Server` rules are skipped when the response has not been collected yet.
-    // See `Rule::scope` for the contract.
-    for rule in crate::rules::rules_for_scope(tx.response.is_some()) {
-        if !cfg.is_enabled(rule.id()) {
-            continue;
-        }
-        let history = match crate::rules::query_type_for(rule.id()) {
-            Some(crate::queries::QueryType::ByResource) => {
-                history_by_resource.get_or_insert_with(|| {
-                    crate::queries::by_resource::by_resource(state, &tx.client, &tx.request.uri)
-                })
-            }
-            Some(crate::queries::QueryType::ByOrigin) => {
-                history_by_origin.get_or_insert_with(|| {
-                    if let Some(o) = &origin {
-                        crate::queries::by_origin::by_origin(state, &tx.client, o)
-                    } else {
-                        crate::transaction_history::TransactionHistory::empty()
-                    }
-                })
-            }
-            Some(crate::queries::QueryType::ByResourceAll) => history_by_resource_all_clients
-                .get_or_insert_with(|| {
-                    crate::queries::by_resource_all_clients::by_resource_all_clients(
-                        state,
-                        &tx.request.uri,
-                    )
-                }),
-            Some(crate::queries::QueryType::ByConnection) => history_by_connection
-                .get_or_insert_with(|| {
-                    if let Some(conn_id) = tx.connection_id {
-                        crate::queries::by_connection::by_connection(state, conn_id)
-                    } else {
-                        crate::transaction_history::TransactionHistory::empty()
-                    }
-                }),
-            // Rule reads no history.
-            None => &empty_history,
-        };
-
-        out.extend(rule.check_transaction(tx, history, cfg));
-    }
-
-    out
+    PreparedEngine::new(cfg).lint_transaction(tx, cfg, state)
 }
 
 #[cfg(test)]
@@ -90,6 +149,54 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::test_helpers::{disable_rule, make_test_config_with_enabled_rules};
+
+    #[test]
+    fn prepared_engine_keeps_only_enabled_rules() {
+        // Enable two Server-scoped rules and one Client-scoped rule. The full
+        // set keeps all three; the request-only set keeps just the Client rule —
+        // exercising both the enabled filter and the Server-scope exclusion.
+        let cfg = make_test_config_with_enabled_rules(&[
+            "server_cache_control_present", // Server
+            "server_etag_or_last_modified", // Server
+            "client_user_agent_present",    // Client (survives into request-only)
+        ]);
+        let engine = PreparedEngine::new(&cfg);
+
+        assert_eq!(engine.enabled_full.len(), 3);
+        assert!(engine.enabled_full.iter().all(|r| cfg.is_enabled(r.id())));
+        // Only the non-Server rule survives into the request-only set; the
+        // assertion is non-vacuous because that set is non-empty here.
+        assert_eq!(engine.enabled_request_only.len(), 1);
+        assert!(engine
+            .enabled_request_only
+            .iter()
+            .all(|r| !matches!(r.scope(), crate::rules::RuleScope::Server)));
+
+        // An empty config enables nothing.
+        let empty = PreparedEngine::new(&Config::default());
+        assert_eq!(empty.enabled_full.len(), 0);
+        assert_eq!(empty.enabled_protocol.len(), 0);
+    }
+
+    #[test]
+    fn prepared_and_free_dispatch_agree() {
+        let state = crate::state::StateStore::new(300, 10);
+        let cfg = make_test_config_with_enabled_rules(&[
+            "server_cache_control_present",
+            "client_user_agent_present",
+        ]);
+        let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+
+        let via_free = lint_transaction(&tx, &cfg, &state);
+        let via_prepared = PreparedEngine::new(&cfg).lint_transaction(&tx, &cfg, &state);
+
+        let ids = |vs: &[Violation]| {
+            let mut v: Vec<_> = vs.iter().map(|x| x.rule.clone()).collect();
+            v.sort();
+            v
+        };
+        assert_eq!(ids(&via_free), ids(&via_prepared));
+    }
 
     #[test]
     fn lint_response_rules_emit_when_enabled() {

--- a/lint-http-rules/src/lint_protocol.rs
+++ b/lint-http-rules/src/lint_protocol.rs
@@ -9,23 +9,26 @@
 //! [`ProtocolEvent`](crate::protocol_event::ProtocolEvent) instances.
 
 use crate::config::Config;
+use crate::engine::PreparedEngine;
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory};
 use crate::protocol_event_store::ProtocolEventStore;
 
-/// Lint a single protocol event against all enabled protocol rules.
-pub fn lint_protocol_event(
-    event: &ProtocolEvent,
-    cfg: &Config,
-    event_store: &ProtocolEventStore,
-) -> Vec<Violation> {
-    let mut out = Vec::new();
+impl PreparedEngine {
+    /// Lint a single protocol event against the enabled protocol rules
+    /// (disabled rules were filtered out when the engine was built).
+    pub fn lint_protocol_event(
+        &self,
+        event: &ProtocolEvent,
+        cfg: &Config,
+        event_store: &ProtocolEventStore,
+    ) -> Vec<Violation> {
+        let mut out = Vec::new();
 
-    // Lazily computed history for this connection.
-    let mut history_by_connection: Option<ProtocolEventHistory> = None;
+        // Lazily computed history for this connection.
+        let mut history_by_connection: Option<ProtocolEventHistory> = None;
 
-    for rule in crate::rules::PROTOCOL_RULES.iter() {
-        if cfg.is_enabled(rule.id()) {
+        for rule in &self.enabled_protocol {
             let history = history_by_connection.get_or_insert_with(|| {
                 let entries = event_store.get_history_for_connection(event.connection_id);
                 ProtocolEventHistory::new(entries)
@@ -33,9 +36,20 @@ pub fn lint_protocol_event(
 
             out.extend(rule.check_event(event, history, cfg));
         }
-    }
 
-    out
+        out
+    }
+}
+
+/// Lint a single protocol event against all enabled protocol rules.
+/// Convenience one-shot: builds a [`PreparedEngine`] for `cfg`; hot paths build
+/// one once and call [`PreparedEngine::lint_protocol_event`] instead.
+pub fn lint_protocol_event(
+    event: &ProtocolEvent,
+    cfg: &Config,
+    event_store: &ProtocolEventStore,
+) -> Vec<Violation> {
+    PreparedEngine::new(cfg).lint_protocol_event(event, cfg, event_store)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Dispatch previously iterated all ~179 in-scope rules per transaction and ran `cfg.is_enabled(rule.id())` (a HashMap lookup) on each — repeated for every transaction and every protocol event, and redundant with the lookup each enabled rule then does inside its own `parse_rule_config`. `is_enabled` is a pure function of the immutable startup `Config`, so the enabled set can be computed once.

A new `engine::PreparedEngine` intersects the catalogue's precomputed scope views (`RULES` / `REQUEST_ONLY_RULES` / `PROTOCOL_RULES`) with `cfg.is_enabled` at construction, holding the enabled rules per scope. Dispatch then iterates only enabled rules — behavior-identical (same id-sorted order), the disabled filtering just moves from per-transaction to once-per-config. The `Rule` trait is untouched; each rule's in-body `parse_rule_config` stays as a harmless belt-and-suspenders, and the 13 custom-config rules' section re-parsing is left for a later, measured pass.

Consumers build it once: `Shared` carries an `Arc<PreparedEngine>` (built in `run_proxy_inner`) threaded into both pipelines, and the offline `lint` subcommand builds one before its replay loop. The free `engine::lint_transaction` / `lint_protocol::lint_protocol_event` are kept as thin one-shot wrappers (build an engine, dispatch once) so existing tests and one-off callers compile unchanged.

Measured via the `lint` subcommand over a 500k-transaction capture with a minimal config (2 of 184 rules enabled): ~5.5s -> ~2.3s (~2.3x), the saved time being the ~177 skipped per-rule lookups per transaction.

Tests: `prepared_engine_keeps_only_enabled_rules` (enabled filter + Server-scope exclusion, with a non-empty request-only set) and `prepared_and_free_dispatch_agree` (method and free wrapper produce identical violations).
