### PR TITLE
Store transactions as Arc through the state and query layer

### DIFF
--- a/lint-http-core/src/state.rs
+++ b/lint-http-core/src/state.rs
@@ -32,13 +32,18 @@ struct ResourceKey {
     resource: String,
 }
 
+/// A stored transaction, shared via `Arc` so the deques and every read clone a
+/// refcount bump rather than deep-copying the whole transaction. Reads hand
+/// these out; rules still observe `&HttpTransaction` through `TransactionHistory`.
+pub type SharedTransaction = Arc<crate::http_transaction::HttpTransaction>;
+
 /// Thread-safe store for transaction state with bounded history.
 ///
 /// Each `(client, resource)` key maps to a bounded ring-buffer of recent
 /// transactions (newest first).  The `queries` module reads from this store;
 /// lint rules never access it directly.
 pub struct StateStore {
-    store: Arc<RwLock<HashMap<ResourceKey, VecDeque<crate::http_transaction::HttpTransaction>>>>,
+    store: Arc<RwLock<HashMap<ResourceKey, VecDeque<SharedTransaction>>>>,
     /// Index mapping resource string to list of clients that have entries for
     /// that resource.  Used to efficiently support cross-client history
     /// queries without scanning every key in `store`.
@@ -78,7 +83,9 @@ impl StateStore {
             Ok(mut store) => {
                 let was_new = store.get(&key).is_none();
                 let deque = store.entry(key.clone()).or_insert_with(VecDeque::new);
-                deque.push_front(tx.clone());
+                // One deep clone into an `Arc`; every later read clones only the
+                // `Arc` (a refcount bump) instead of the whole transaction.
+                deque.push_front(Arc::new(tx.clone()));
                 if deque.len() > self.max_history {
                     deque.pop_back();
                 }
@@ -114,7 +121,7 @@ impl StateStore {
         &self,
         client: &ClientIdentifier,
         resource: &str,
-    ) -> Option<crate::http_transaction::HttpTransaction> {
+    ) -> Option<SharedTransaction> {
         let key = ResourceKey {
             client: client.clone(),
             resource: resource.to_string(),
@@ -130,11 +137,7 @@ impl StateStore {
     }
 
     /// Retrieve the full bounded history for this client+resource (newest first).
-    pub fn get_history(
-        &self,
-        client: &ClientIdentifier,
-        resource: &str,
-    ) -> Vec<crate::http_transaction::HttpTransaction> {
+    pub fn get_history(&self, client: &ClientIdentifier, resource: &str) -> Vec<SharedTransaction> {
         let key = ResourceKey {
             client: client.clone(),
             resource: resource.to_string(),
@@ -156,10 +159,7 @@ impl StateStore {
     /// timestamp.  This is useful for rules that need to observe behaviour that
     /// crosses client boundaries, such as ensuring `private` responses are not
     /// reused by other clients.
-    pub fn get_history_for_resource(
-        &self,
-        resource: &str,
-    ) -> Vec<crate::http_transaction::HttpTransaction> {
+    pub fn get_history_for_resource(&self, resource: &str) -> Vec<SharedTransaction> {
         // Clone the client list from the index first, then release the index
         // lock before acquiring the store lock to avoid lock-order inversion.
         let clients = match self.resource_index.read() {
@@ -192,10 +192,7 @@ impl StateStore {
     /// Collect all transactions for a given client across all resources (newest first per resource).
     ///
     /// Used by origin-based queries that need to scan across URIs.
-    pub fn collect_for_client(
-        &self,
-        client: &ClientIdentifier,
-    ) -> Vec<crate::http_transaction::HttpTransaction> {
+    pub fn collect_for_client(&self, client: &ClientIdentifier) -> Vec<SharedTransaction> {
         match self.store.read() {
             Ok(store) => store
                 .iter()
@@ -210,10 +207,7 @@ impl StateStore {
     }
 
     /// Retrieve all transactions that share the given `connection_id`.
-    pub fn get_history_for_connection(
-        &self,
-        connection_id: Uuid,
-    ) -> Vec<crate::http_transaction::HttpTransaction> {
+    pub fn get_history_for_connection(&self, connection_id: Uuid) -> Vec<SharedTransaction> {
         let keys = match self.connection_index.read() {
             Ok(idx) => match idx.get(&connection_id) {
                 Some(k) => k.clone(),
@@ -352,6 +346,7 @@ mod tests {
         let prev = prev.ok_or_else(|| anyhow::anyhow!("expected record to exist"))?;
         let resp = prev
             .response
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("expected response"))?;
         assert_eq!(resp.status, 200);
         assert_eq!(

--- a/lint-http-core/src/transaction_history.rs
+++ b/lint-http-core/src/transaction_history.rs
@@ -10,15 +10,20 @@
 //! independently in the future.
 
 use crate::http_transaction::HttpTransaction;
+use std::sync::Arc;
 
 /// Pre-queried transaction history passed to rules.
 ///
 /// Contains zero or more previous transactions for a given query scope,
 /// ordered **newest first**.  Rules use the convenience helpers to inspect
 /// the history without knowing how it was produced.
+///
+/// Entries are held as `Arc<HttpTransaction>` so the state/query layer can hand
+/// out cheap refcounted clones instead of deep-copying each transaction; rules
+/// still observe `&HttpTransaction` through the helpers below.
 #[derive(Debug, Clone)]
 pub struct TransactionHistory {
-    entries: Vec<HttpTransaction>,
+    entries: Vec<Arc<HttpTransaction>>,
 }
 
 impl TransactionHistory {
@@ -30,7 +35,7 @@ impl TransactionHistory {
     }
 
     /// Create a history from a pre-sorted (newest-first) list of transactions.
-    pub fn new(entries: Vec<HttpTransaction>) -> Self {
+    pub fn new(entries: Vec<Arc<HttpTransaction>>) -> Self {
         // callers are expected to supply entries newest-first.  in debug
         // builds we check that invariant so regressions are caught early.
         #[cfg(debug_assertions)]
@@ -47,17 +52,25 @@ impl TransactionHistory {
         Self { entries }
     }
 
+    /// Build a history from owned transactions (newest-first), wrapping each in
+    /// an `Arc`. Convenience for callers that hold owned transactions (tests,
+    /// fixtures); the state/query layer uses [`Self::new`] with already-`Arc`'d
+    /// entries so reads never deep-copy.
+    pub fn from_transactions(entries: Vec<HttpTransaction>) -> Self {
+        Self::new(entries.into_iter().map(Arc::new).collect())
+    }
+
     /// Return the most recent previous transaction, if any.
     ///
     /// This is the direct replacement for the old `previous: Option<&HttpTransaction>`
     /// parameter that rules used to receive.
     pub fn previous(&self) -> Option<&HttpTransaction> {
-        self.entries.first()
+        self.entries.first().map(|tx| tx.as_ref())
     }
 
     /// Iterate over all entries, newest first.
     pub fn iter(&self) -> impl Iterator<Item = &HttpTransaction> {
-        self.entries.iter()
+        self.entries.iter().map(|tx| tx.as_ref())
     }
 
     /// Number of entries in the history.
@@ -92,7 +105,7 @@ mod tests {
         // timestamp than tx2.  This avoids debug assertions in debug builds.
         tx1.timestamp = tx2.timestamp + chrono::Duration::seconds(1);
 
-        let h = TransactionHistory::new(vec![tx1.clone(), tx2.clone()]);
+        let h = TransactionHistory::from_transactions(vec![tx1.clone(), tx2.clone()]);
 
         assert!(!h.is_empty());
         assert_eq!(h.len(), 2);
@@ -104,7 +117,7 @@ mod tests {
     #[test]
     fn previous_returns_first_entry() {
         let tx = crate::test_helpers::make_test_transaction();
-        let h = TransactionHistory::new(vec![tx.clone()]);
+        let h = TransactionHistory::from_transactions(vec![tx.clone()]);
         assert_eq!(h.previous().unwrap().id, tx.id);
     }
 }

--- a/lint-http-proxy/tests/integration_captures_seed.rs
+++ b/lint-http-proxy/tests/integration_captures_seed.rs
@@ -78,7 +78,7 @@ enabled = false
     let prev = state.get_previous(&client, uri);
     if seed_enabled {
         assert!(prev.is_some(), "State should be seeded");
-        assert_eq!(prev.unwrap().response.unwrap().status, 200);
+        assert_eq!(prev.unwrap().response.as_ref().unwrap().status, 200);
     } else {
         assert!(prev.is_none(), "State should not be seeded");
     }

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -463,8 +463,10 @@ mod tests {
         let mut t2 = t2;
         t2.timestamp = ts - chrono::Duration::seconds(10);
         // history newest first order is provided by constructor
-        let history =
-            crate::transaction_history::TransactionHistory::new(vec![t2.clone(), t1.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            t2.clone(),
+            t1.clone(),
+        ]);
         let store = build_cookie_store(&history, ts);
         assert_eq!(store.len(), 1);
         assert_eq!(store[0].value, "two");
@@ -478,7 +480,7 @@ mod tests {
             &[("set-cookie", "b=1; Domain=example.com; Path=/foo")],
         );
         tx.timestamp = ts - chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![tx]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx]);
         let store = build_cookie_store(&history, ts);
         assert_eq!(store.len(), 1);
         let c = &store[0];
@@ -530,7 +532,8 @@ mod tests {
         t2.timestamp = ts - chrono::Duration::seconds(5);
 
         // newest-first: t2 happened later than t1
-        let history = crate::transaction_history::TransactionHistory::new(vec![t2, t1]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![t2, t1]);
 
         let store = build_cookie_store(&history, ts);
         // second cookie expired immediately, so no live cookies remain

--- a/lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
+++ b/lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
@@ -175,7 +175,7 @@ mod tests {
                 let mut p = make_prev_resp(status, ar);
                 // set previous request URI to same resource to simulate stateful match
                 p.request.uri = tx.request.uri.clone();
-                crate::transaction_history::TransactionHistory::new(vec![p])
+                crate::transaction_history::TransactionHistory::from_transactions(vec![p])
             }
             None => crate::transaction_history::TransactionHistory::empty(),
         };
@@ -205,7 +205,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()]),
             &cfg,
         );
         assert!(v.is_some());
@@ -274,7 +274,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()]),
             &cfg,
         );
         assert!(v.is_some());
@@ -304,7 +304,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()]),
             &cfg,
         );
         // Be lenient: if the request Range header is non-utf8, do not raise a violation when Accept-Ranges was present
@@ -333,7 +333,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()]),
             &cfg,
         );
         // If Range header itself is not valid UTF-8, the rule should not emit a misleading violation about Accept-Ranges

--- a/lint-http-rules/src/rules/client_patch_method_content_type_match.rs
+++ b/lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -254,7 +254,7 @@ mod tests {
         }
 
         let history = match prev {
-            Some(p) => crate::transaction_history::TransactionHistory::new(vec![p.clone()]),
+            Some(p) => crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()]),
             None => crate::transaction_history::TransactionHistory::empty(),
         };
         let v = rule.check_transaction(&tx, &history, &cfg);
@@ -296,7 +296,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());
@@ -323,7 +323,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_some());
@@ -350,7 +350,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_some());
@@ -379,7 +379,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());
@@ -406,7 +406,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());
@@ -433,7 +433,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());
@@ -460,7 +460,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());
@@ -487,7 +487,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         // whitespace-only header triggers empty token detection and thus a violation
@@ -516,7 +516,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_some());
@@ -541,7 +541,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         // malformed Content-Type is delegated to other rules; this rule should not emit a violation
@@ -576,7 +576,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_some());
@@ -604,7 +604,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());
@@ -629,7 +629,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &cfg,
         );
         assert!(v.is_none());

--- a/lint-http-rules/src/rules/semantic_cache_coherence.rs
+++ b/lint-http-rules/src/rules/semantic_cache_coherence.rs
@@ -184,7 +184,7 @@ mod tests {
             &[("date", "Wed, 21 Oct 2015 08:28:00 GMT")],
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule.check_transaction(&curr, &history, &cfg,).is_none());
     }
 
@@ -203,7 +203,7 @@ mod tests {
             &[("date", "Wed, 21 Oct 2015 07:28:00 GMT")],
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(&curr, &history, &cfg);
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("appears stale"));
@@ -224,7 +224,7 @@ mod tests {
             &[("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")],
         );
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(&curr, &history, &cfg);
         assert!(v.is_some());
     }
@@ -236,7 +236,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/foo", 200, &[]);
         let mut curr = make_resp_tx("https://example.com/foo", 200, &[]);
         curr.timestamp = prev.timestamp + chrono::Duration::seconds(1);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule.check_transaction(&curr, &history, &cfg,).is_none());
     }
 

--- a/lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
@@ -343,7 +343,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type", "content-length"]),
         );
         assert!(v.is_none());
@@ -358,7 +358,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_some());
@@ -374,7 +374,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["x-foo"]),
         );
         assert!(v.is_some());
@@ -393,7 +393,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_some());
@@ -409,7 +409,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_none());
@@ -424,7 +424,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
         );
         assert!(v.is_none());
@@ -452,7 +452,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -468,7 +468,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -495,7 +495,7 @@ mod tests {
         // prev had non-utf8 'etag' -> treated as present -> HEAD missing it should be a violation
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_some());
@@ -534,7 +534,7 @@ mod tests {
         // Both present but non-UTF8 -> rule should be lenient and not report a violation
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -549,7 +549,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -641,7 +641,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_some());
@@ -658,7 +658,7 @@ mod tests {
         // 'x-foo' is not in the configured headers list -> should be ignored
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -673,7 +673,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
         );
         assert!(v.is_none());
@@ -688,7 +688,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
         );
         assert!(v.is_none());
@@ -703,7 +703,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_none());
@@ -718,7 +718,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
         );
         assert!(v.is_none());
@@ -733,7 +733,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
         );
         assert!(v.is_some());
@@ -752,7 +752,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -779,7 +779,7 @@ mod tests {
         // presence detected, but values are not compared when one side is non-UTF8
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -794,7 +794,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type"]),
         );
         assert!(v.is_some());
@@ -810,7 +810,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["accept-encoding"]),
         );
         assert!(v.is_some());
@@ -887,7 +887,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -903,7 +903,7 @@ mod tests {
         // validate_content_length on prev will error -> rule must be lenient
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_none());
@@ -918,7 +918,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &head,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());

--- a/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
@@ -525,7 +525,7 @@ mod tests {
         current.connection_id = Some(conn_id);
         current.sequence_number = Some(1);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
         let v = rule
             .check_transaction(
@@ -550,7 +550,7 @@ mod tests {
         );
         let current = crate::test_helpers::make_test_transaction_with_response(200, &[]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
             .check_transaction(
@@ -731,7 +731,7 @@ mod tests {
         current.connection_id = Some(conn_id);
         current.sequence_number = Some(1);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let rule = Stateful101SwitchingProtocols;
         assert!(rule
             .check_transaction(

--- a/lint-http-rules/src/rules/stateful_103_early_hints_before_final.rs
+++ b/lint-http-rules/src/rules/stateful_103_early_hints_before_final.rs
@@ -117,7 +117,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
@@ -141,7 +141,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
@@ -163,7 +163,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),
@@ -211,7 +211,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_103_early_hints_before_final",
             ]),

--- a/lint-http-rules/src/rules/stateful_authentication_failure_loop.rs
+++ b/lint-http-rules/src/rules/stateful_authentication_failure_loop.rs
@@ -110,7 +110,7 @@ mod tests {
         tx3.request.uri = "https://example.com/admin".to_string();
 
         // supply history newest-first; tx3 is most recent
-        let history = crate::transaction_history::TransactionHistory::new(vec![tx3, tx2, tx1]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx3, tx2, tx1]);
 
         let v = rule.check_transaction(
             &tx,
@@ -135,7 +135,7 @@ mod tests {
         let tx4 = crate::test_helpers::make_test_transaction_with_response(401, &[]);
 
         // put newest transaction first (tx4) to satisfy TransactionHistory
-        let history = crate::transaction_history::TransactionHistory::new(vec![tx4, tx3, tx2, tx1]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx4, tx3, tx2, tx1]);
 
         let v = rule.check_transaction(
             &tx,
@@ -158,7 +158,7 @@ mod tests {
         let tx3 = crate::test_helpers::make_test_transaction_with_response(401, &[]);
 
         // newest-first history
-        let history = crate::transaction_history::TransactionHistory::new(vec![tx3, tx2, tx1]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx3, tx2, tx1]);
 
         let v = rule.check_transaction(
             &tx,

--- a/lint-http-rules/src/rules/stateful_cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/stateful_cache_validation_chain.rs
@@ -269,7 +269,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "*")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -286,7 +286,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -303,7 +303,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -320,7 +320,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "W/\"a\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -337,7 +337,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "W/\"b\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -354,7 +354,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "*")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -371,7 +371,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -389,7 +389,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -406,7 +406,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -425,7 +425,7 @@ mod tests {
         ]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -446,7 +446,7 @@ mod tests {
         )]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -465,7 +465,7 @@ mod tests {
         ]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -484,7 +484,7 @@ mod tests {
         )]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -501,7 +501,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", "not-a-date")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -521,7 +521,7 @@ mod tests {
         )]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -540,7 +540,7 @@ mod tests {
         ]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -559,7 +559,7 @@ mod tests {
         ]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),
@@ -578,7 +578,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev2, prev1]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev2, prev1]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_cache_validation_chain",
             ]),

--- a/lint-http-rules/src/rules/stateful_conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/stateful_conditional_request_handling.rs
@@ -231,7 +231,7 @@ mod tests {
         let prev_empty = make_prev_with_headers(&[]);
         let v1 = rule.check_transaction(
             &tx1,
-            &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -246,7 +246,7 @@ mod tests {
         )]);
         let v2 = rule.check_transaction(
             &tx2,
-            &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -259,7 +259,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-match", "\"a\"")]);
         let v3 = rule.check_transaction(
             &tx3,
-            &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -274,7 +274,7 @@ mod tests {
         )]);
         let v4 = rule.check_transaction(
             &tx4,
-            &crate::transaction_history::TransactionHistory::new(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -294,7 +294,7 @@ mod tests {
         let rule = StatefulConditionalRequestHandling;
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -310,7 +310,7 @@ mod tests {
         let prev2 = make_prev_with_headers(&[("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT")]);
         let v2 = rule.check_transaction(
             &tx2,
-            &crate::transaction_history::TransactionHistory::new(vec![prev2.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -332,7 +332,7 @@ mod tests {
         // previous satisfies validator check
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -358,7 +358,7 @@ mod tests {
         let rule = StatefulConditionalRequestHandling;
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -381,7 +381,7 @@ mod tests {
         // response ETag doesn't match request conditional -> allowed
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -401,7 +401,7 @@ mod tests {
         let rule = StatefulConditionalRequestHandling;
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),

--- a/lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
@@ -222,7 +222,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/foo", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -245,7 +245,7 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -274,7 +274,7 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -293,7 +293,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/private"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -334,7 +334,7 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://other.com/", Some("a=2"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -354,7 +354,7 @@ mod tests {
         let prev = make_resp_tx("http://example.com/", Some("a=1; Path=/"), Some(ts));
         let mut tx = make_tx_with_req("http://example.com/foo", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -378,7 +378,7 @@ mod tests {
         );
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,

--- a/lint-http-rules/src/rules/stateful_cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_lifecycle.rs
@@ -315,7 +315,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("b=2"));
         tx.timestamp = ts + chrono::Duration::seconds(1);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -334,7 +334,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Secure"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -352,7 +352,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Max-Age=60"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(30);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -371,7 +371,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Max-Age=1"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(5);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -396,7 +396,7 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(20);
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -415,7 +415,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Secure"), Some(ts));
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -448,7 +448,7 @@ mod tests {
         );
         let mut tx = make_tx_with_req("http://example.com/specific", Some("a=2"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
             prev_nonsecure.clone(),
             prev_secure.clone(),
         ]);
@@ -472,7 +472,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/private"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -492,7 +492,7 @@ mod tests {
         let prev = make_resp_tx("https://example.com/", Some("a=1; Path=/foo"), Some(ts));
         let mut tx = make_tx_with_req("https://example.com/foobar", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -515,7 +515,7 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,

--- a/lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
@@ -270,7 +270,7 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Strict"),
             Some(Utc::now()),
@@ -290,7 +290,7 @@ mod tests {
     fn fetch_site_none_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Strict"),
             Some(ts),
@@ -314,7 +314,7 @@ mod tests {
     fn fetch_site_invalid_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Strict"),
             Some(ts),
@@ -339,7 +339,7 @@ mod tests {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
         // history sets cookie b; request sends cookie a
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("b=1; SameSite=Strict"),
             Some(ts),
@@ -363,7 +363,7 @@ mod tests {
     fn secure_cookie_over_http_ignored_for_samesite() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "http://example.com/",
             Some("a=1; SameSite=Strict; Secure"),
             Some(ts),
@@ -394,7 +394,7 @@ mod tests {
             Some("a=1; SameSite=Strict"),
             Some(ts),
         );
-        let history = crate::transaction_history::TransactionHistory::new(vec![htx]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![htx]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -414,7 +414,7 @@ mod tests {
     fn lax_cookie_cross_site_non_nav_reports() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Lax"),
             Some(ts),
@@ -442,7 +442,7 @@ mod tests {
     fn lax_cookie_cross_site_nav_get_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Lax"),
             Some(ts),
@@ -470,7 +470,7 @@ mod tests {
     fn lax_cookie_cross_site_nav_head_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Lax"),
             Some(ts),
@@ -498,7 +498,7 @@ mod tests {
     fn none_cookie_cross_site_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=None; Secure"),
             Some(ts),
@@ -522,7 +522,7 @@ mod tests {
     fn unspecified_treated_as_lax() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1"),
             Some(ts),
@@ -572,7 +572,7 @@ mod tests {
     fn same_site_context_allows_strict() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Strict"),
             Some(ts),
@@ -596,7 +596,7 @@ mod tests {
     fn mismatched_cookie_value_does_not_report() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_resp_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
             "https://example.com/",
             Some("a=1; SameSite=Strict"),
             Some(ts),

--- a/lint-http-rules/src/rules/stateful_digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/stateful_digest_auth_nonce_handling.rs
@@ -381,7 +381,7 @@ mod tests {
     fn opaque_mismatch() {
         let nonce1 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, Some("o1"), None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o2")));
@@ -400,7 +400,7 @@ mod tests {
     fn missing_opaque_reports() {
         let nonce1 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, Some("o1"), None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
@@ -478,7 +478,7 @@ mod tests {
         let prev_challenge = tx_resp_with_challenge(&make_challenge(&nonce1, None, None));
         let prev_request = tx_req_with_auth(&auth1);
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![prev_request, prev_challenge]);
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev_request, prev_challenge]);
         let tx = tx_req_with_auth(&auth2);
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -497,7 +497,7 @@ mod tests {
         // challenge with stale=true provides a new nonce value, which the client
         // must then reuse but reset nc to 1
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce, None, Some("true")),
             )]);
         // client correctly uses same nonce but wrong nc
@@ -521,7 +521,7 @@ mod tests {
         let prev_challenge = tx_resp_with_challenge(&make_challenge(&nonce1, Some("o1"), None));
         let prev_request = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o1")));
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![prev_request, prev_challenge]);
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev_request, prev_challenge]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000002"), Some("o1")));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -538,7 +538,7 @@ mod tests {
         let nonce1 = random_nonce();
         let nonce2 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
@@ -557,7 +557,7 @@ mod tests {
     fn missing_opaque_reports_violation() {
         let nonce1 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, Some("o123"), None),
             )]);
         // request omits opaque entirely
@@ -578,7 +578,7 @@ mod tests {
         let nonce1 = random_nonce();
         let nonce2 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, None, Some("true")),
             )]);
         // client uses different nonce entirely
@@ -601,7 +601,7 @@ mod tests {
     fn request_without_nc_is_allowed() {
         let nonce1 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, None, None));
@@ -619,7 +619,7 @@ mod tests {
     fn invalid_nc_value_reports() {
         let nonce1 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("GARBAGE"), None));
@@ -639,7 +639,7 @@ mod tests {
         let nonce1 = random_nonce();
         let nonce2 = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce1, None, Some("true")),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
@@ -659,7 +659,7 @@ mod tests {
     fn stale_correct_reset_passes() {
         let nonce = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce, None, Some("true")),
             )]);
         // correct reset
@@ -683,7 +683,7 @@ mod tests {
             401,
             &[("www-authenticate", &header)],
         );
-        let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -699,7 +699,7 @@ mod tests {
     fn no_nc_produced_no_violation() {
         let nonce = random_nonce();
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![tx_resp_with_challenge(
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
                 &make_challenge(&nonce, None, None),
             )]);
         let tx = tx_req_with_auth(&make_auth(&nonce, None, None));
@@ -723,7 +723,7 @@ mod tests {
             401,
             &[("www-authenticate", &mixed)],
         );
-        let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -746,7 +746,7 @@ mod tests {
         );
         let mut txh = crate::test_helpers::make_test_transaction_with_response(401, &[]);
         txh.response.as_mut().unwrap().headers = headers;
-        let history = crate::transaction_history::TransactionHistory::new(vec![txh]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![txh]);
         let nonce = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(

--- a/lint-http-rules/src/rules/stateful_immutable_cache_never_stale.rs
+++ b/lint-http-rules/src/rules/stateful_immutable_cache_never_stale.rs
@@ -243,7 +243,7 @@ mod tests {
     fn unrelated_history_ignored() {
         let rule = StatefulImmutableCacheNeverStale;
         let prev = make_prev_with_headers(&[("cache-control", "max-age=60")], Utc::now());
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
         let v = rule.check_transaction(
             &tx,
@@ -267,7 +267,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -296,7 +296,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -319,7 +319,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(5);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -338,7 +338,7 @@ mod tests {
         let prev = make_prev_with_headers(&[("cache-control", "max-age=60")], base);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -365,7 +365,7 @@ mod tests {
         let prev = make_prev_with_headers(&[("cache-control", "max-age=60, immutable")], base);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -394,7 +394,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         tx.timestamp = base - chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // age_val=5, elapsed clamped to 0 -> current_age=5 < freshness(50) => violation
         let v = rule.check_transaction(
             &tx,
@@ -417,7 +417,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // freshness lifetime zero, so no violation should be reported
         assert!(rule
             .check_transaction(

--- a/lint-http-rules/src/rules/stateful_max_age_directive_validity.rs
+++ b/lint-http-rules/src/rules/stateful_max_age_directive_validity.rs
@@ -194,7 +194,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(30);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -218,7 +218,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(10);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -238,7 +238,7 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx2.timestamp = base + chrono::Duration::seconds(10);
-        let history2 = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history2 = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
             rule.check_transaction(
                 &tx2,
@@ -266,7 +266,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -292,7 +292,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(5);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -315,7 +315,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(5);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -338,7 +338,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(5);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -360,7 +360,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(10);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -383,7 +383,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(10);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -411,7 +411,7 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(30);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -441,7 +441,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base;
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -467,7 +467,7 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base;
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         // age == max-age should be treated as stale; unconditional request
         // should therefore be flagged since validator exists.
         let v = rule.check_transaction(
@@ -486,7 +486,7 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx2.timestamp = base;
-        let history2 = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history2 = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
             rule.check_transaction(
                 &tx2,
@@ -512,7 +512,7 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base - chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // age computed from elapsed clamped to 0 yields fresh state; no violation expected
         let v = rule.check_transaction(
             &tx,

--- a/lint-http-rules/src/rules/stateful_must_revalidate_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_must_revalidate_enforcement.rs
@@ -213,7 +213,7 @@ mod tests {
     fn unrelated_history_ignored() {
         let rule = StatefulMustRevalidateEnforcement;
         let prev = make_prev(200, &[("cache-control", "max-age=60")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
         let v = rule.check_transaction(
             &tx,
@@ -272,7 +272,7 @@ mod tests {
         // set timestamp earlier to test clamp
         tx.timestamp = base - chrono::Duration::seconds(10);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // current_age should equal age header (5) not negative elapsed
         let v = rule.check_transaction(
             &tx,
@@ -307,7 +307,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -342,7 +342,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -365,7 +365,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -386,7 +386,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -412,7 +412,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -438,7 +438,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -465,7 +465,7 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -492,7 +492,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -518,7 +518,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base; // no elapsed time
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -544,7 +544,7 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,

--- a/lint-http-rules/src/rules/stateful_no_cache_revalidation.rs
+++ b/lint-http-rules/src/rules/stateful_no_cache_revalidation.rs
@@ -217,7 +217,7 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -241,7 +241,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -263,7 +263,7 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,

--- a/lint-http-rules/src/rules/stateful_no_store_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_no_store_enforcement.rs
@@ -300,7 +300,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -322,7 +322,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -346,7 +346,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -374,7 +374,7 @@ mod tests {
             "if-modified-since",
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -396,7 +396,7 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -427,7 +427,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -461,7 +461,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", lm)]);
         let history =
-            crate::transaction_history::TransactionHistory::new(vec![prev2.clone(), prev1.clone()]);
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -497,7 +497,7 @@ mod tests {
         // multiple values, one matching
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -521,7 +521,7 @@ mod tests {
         hm.append("if-none-match", "\"x\"".parse().unwrap());
         hm.append("if-none-match", "\"a\"".parse().unwrap());
         tx.request.headers = hm;
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -551,7 +551,7 @@ mod tests {
             "if-modified-since",
             "Sun, 06 Nov 1994 08:49:37 GMT",
         )]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,

--- a/lint-http-rules/src/rules/stateful_oauth2_code_flow.rs
+++ b/lint-http-rules/src/rules/stateful_oauth2_code_flow.rs
@@ -252,7 +252,7 @@ mod tests {
     fn callback_with_matching_state_ok() {
         let rule = StatefulOauth2CodeFlow;
         // initial auth request earlier in history
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_tx(
             "https://idp.example.com/authorize?response_type=code&state=xyz",
         )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
@@ -288,7 +288,7 @@ mod tests {
     fn auth_and_callback_with_fragments_are_handled() {
         let rule = StatefulOauth2CodeFlow;
         // auth request has fragment after query, should still record state
-        let history = crate::transaction_history::TransactionHistory::new(vec![make_tx(
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_tx(
             "https://idp.example.com/authorize?response_type=code&state=foo#frag",
         )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=foo#bar");
@@ -325,7 +325,7 @@ mod tests {
         let rule = StatefulOauth2CodeFlow;
         // auth request with empty state
         let tx1 = make_tx("https://idp.example.com/authorize?response_type=code&state=");
-        let history = crate::transaction_history::TransactionHistory::new(vec![tx1.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx1.clone()]);
         // callback with empty state should flag missing or empty
         let tx2 = make_tx("https://app.example.com/callback?code=123&state=");
         let v = rule

--- a/lint-http-rules/src/rules/stateful_private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/stateful_private_cache_visibility.rs
@@ -236,7 +236,7 @@ mod tests {
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -262,7 +262,7 @@ mod tests {
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -289,7 +289,7 @@ mod tests {
         tx.request
             .headers
             .append("if-modified-since", lm.parse().unwrap());
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -314,7 +314,7 @@ mod tests {
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,

--- a/lint-http-rules/src/rules/stateful_range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/stateful_range_request_and_caching.rs
@@ -219,7 +219,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -246,7 +246,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -275,7 +275,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -304,7 +304,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -331,7 +331,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -356,7 +356,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -380,7 +380,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),
@@ -404,7 +404,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_range_request_and_caching",
             ]),

--- a/lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
+++ b/lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
@@ -228,7 +228,7 @@ mod tests {
 
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),
@@ -297,7 +297,7 @@ mod tests {
         // previous had non-redirect status -> should NOT trigger repeated-redirect violation
         let v = rule.check_transaction(
             &tx,
-            &crate::transaction_history::TransactionHistory::new(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_redirect_chain_validity",
             ]),

--- a/lint-http-rules/src/rules/stateful_s_max_age_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_s_max_age_enforcement.rs
@@ -178,7 +178,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -203,7 +203,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(6);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -222,7 +222,7 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx2.timestamp = base + chrono::Duration::seconds(4);
-        let history2 = crate::transaction_history::TransactionHistory::new(vec![prev2]);
+        let history2 = crate::transaction_history::TransactionHistory::from_transactions(vec![prev2]);
         assert!(rule
             .check_transaction(
                 &tx2,
@@ -253,7 +253,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(20);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -283,7 +283,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -313,7 +313,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(40);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -341,7 +341,7 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(20);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -373,7 +373,7 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(5);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -404,7 +404,7 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
-        let history = crate::transaction_history::TransactionHistory::new(vec![prev]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // age clamped to 0, so current_age=0 < s_max_age -> no violation even though
         // the conditional header is present
         assert!(rule

--- a/lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
+++ b/lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
@@ -298,7 +298,7 @@ mod tests {
             ("Accept-Encoding", "deflate"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -331,7 +331,7 @@ mod tests {
             ("Accept-Encoding", "deflate"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -365,7 +365,7 @@ mod tests {
             ("Accept-Encoding", "gzip"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -391,7 +391,7 @@ mod tests {
             ("Accept-Encoding", "deflate"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -416,7 +416,7 @@ mod tests {
             ("Accept-Encoding", "gzip"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -446,7 +446,7 @@ mod tests {
             ("Accept-Encoding", "deflate"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -476,7 +476,7 @@ mod tests {
             // no Accept-Encoding header
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -513,7 +513,7 @@ mod tests {
             ("X-Foo", "baz"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -542,7 +542,7 @@ mod tests {
             ("X-Foo", "b"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -571,7 +571,7 @@ mod tests {
             ("Accept-Encoding", "deflate"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -601,7 +601,7 @@ mod tests {
             ("Accept-Encoding", "deflate"),
         ]);
 
-        let history = crate::transaction_history::TransactionHistory::new(vec![past]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -646,7 +646,7 @@ mod tests {
         ]);
 
         // newest-first: later matching entry (good) must come first
-        let history = crate::transaction_history::TransactionHistory::new(vec![good, old]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![good, old]);
         let v = rule.check_transaction(
             &tx,
             &history,


### PR DESCRIPTION
Every history read used to deep-clone whole `HttpTransaction`s (method/uri/ version strings, `HeaderMap`, client identity). With stateful rules across four query types over `max_history`-deep deques, that was up to four full clone passes per transaction — the dominant per-transaction allocation cost.

Store `Arc<HttpTransaction>` (aliased `SharedTransaction`) in the state deque so `record_transaction` does one deep clone into an `Arc` and every read clones only the `Arc` (a refcount bump). The five `StateStore` reads return `Arc`-based values; `TransactionHistory` holds `Vec<Arc<HttpTransaction>>` but its `previous`/`iter` deref back to `&HttpTransaction`, so rules are completely unchanged. The query layer is unchanged (field access auto-derefs through the `Arc`). A `from_transactions(Vec<HttpTransaction>)` convenience constructor wraps owned transactions for test fixtures; the 222 owned-literal test sites use it (production query paths keep the `Arc`-taking `new`).

The optional origin index for `by_origin` (so it stops scanning the whole client corpus) is deferred — with `Arc`, that scan is already cheap refcount bumps.

Measured via `lint` over 200k transactions sharing one (client, resource) with `max_history = 50` and a ByResource stateful rule: ~2.3s -> ~0.71s (~3.2x), the read-path deep clones collapsing to `Arc` bumps.
