### PR TITLE
Load the outbound trust store once, shared by both TLS paths

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -111,7 +111,7 @@ pub(super) async fn exchange(
         }
     };
 
-    let resp = match shared.client.request(upstream_req).await {
+    let resp = match shared.upstream.client.request(upstream_req).await {
         Ok(r) => r,
         Err(e) => {
             let duration = started.elapsed().as_millis() as u64;

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -16,14 +16,13 @@ mod stream;
 mod tee_body;
 #[cfg(test)]
 mod test_support;
+mod upstream;
 mod websocket;
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::{service::service_fn, Request, Response};
-use hyper_rustls::HttpsConnectorBuilder;
-use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto::Builder as AutoConnBuilder;
@@ -71,10 +70,9 @@ pub(super) type BoxError = Box<dyn std::error::Error + Send + Sync>;
 pub(super) type ClientBody = http_body_util::combinators::UnsyncBoxBody<Bytes, BoxError>;
 
 pub(super) struct Shared {
-    pub(super) client: LegacyClient<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-        ClientBody,
-    >,
+    /// Outbound resources (forwarding client + shared TLS config), built once
+    /// from a single trust-store load. See [`upstream::Upstream`].
+    pub(super) upstream: upstream::Upstream,
     pub(super) captures: CaptureWriter,
     pub(super) cfg: Arc<Config>,
     pub(super) state: Arc<crate::state::StateStore>,
@@ -152,14 +150,9 @@ async fn run_proxy_inner(
     accept_limit: Option<usize>,
     shutdown: CancellationToken,
 ) -> anyhow::Result<()> {
-    let https = HttpsConnectorBuilder::new()
-        .with_native_roots()?
-        .https_or_http()
-        .enable_http1()
-        .enable_http2()
-        .build();
-    let client: LegacyClient<_, ClientBody> =
-        LegacyClient::builder(TokioExecutor::new()).build(https);
+    // Load the platform trust store once; the forwarding client and the
+    // WebSocket-upgrade path share it.
+    let upstream = upstream::Upstream::new()?;
 
     let ca = if cfg.tls.enabled {
         let cert_path = cfg.tls.ca_cert_path.as_deref().unwrap_or("ca.crt");
@@ -232,7 +225,7 @@ async fn run_proxy_inner(
     let engine = Arc::new(crate::engine::PreparedEngine::new(&cfg));
 
     let shared = Arc::new(Shared {
-        client,
+        upstream,
         captures,
         cfg,
         state,

--- a/lint-http-proxy/src/proxy/test_support.rs
+++ b/lint-http-proxy/src/proxy/test_support.rs
@@ -9,9 +9,6 @@
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::Request;
-use hyper_rustls::HttpsConnectorBuilder;
-use hyper_util::client::legacy::Client as LegacyClient;
-use hyper_util::rt::TokioExecutor;
 use std::sync::Arc as StdArc;
 use uuid::Uuid;
 
@@ -34,21 +31,14 @@ pub(super) async fn make_shared_with_cfg(
         .to_string();
     let cw = CaptureWriter::new(p.clone(), false).await?;
 
-    let https = HttpsConnectorBuilder::new()
-        .with_native_roots()?
-        .https_or_http()
-        .enable_http1()
-        .enable_http2()
-        .build();
-    let client: LegacyClient<_, super::ClientBody> =
-        LegacyClient::builder(TokioExecutor::new()).build(https);
+    let upstream = super::upstream::Upstream::new()?;
     let state = StdArc::new(crate::state::StateStore::new(300, 10));
     let protocol_event_store = StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
         300, 100,
     ));
     let engine = StdArc::new(crate::engine::PreparedEngine::new(&cfg));
     let shared = StdArc::new(Shared {
-        client,
+        upstream,
         captures: cw.clone(),
         cfg,
         state,

--- a/lint-http-proxy/src/proxy/upstream.rs
+++ b/lint-http-proxy/src/proxy/upstream.rs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The proxy's outbound shapes, built once and shared.
+//!
+//! Both the forwarding client (H1/H2, and H3-forwarded requests) and the
+//! WebSocket-upgrade connection need the system trust store. Building it here
+//! once — a single native-roots `ClientConfig` that the main client adds ALPN
+//! to and the WS path uses bare — means the trust store loads exactly once at
+//! startup instead of per WebSocket upgrade. Future outbound features (an H3
+//! upstream, connection pooling, mTLS) get a single seam to extend.
+
+use std::sync::Arc;
+
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::client::legacy::Client as LegacyClient;
+use hyper_util::rt::TokioExecutor;
+use tracing::warn;
+
+use super::ClientBody;
+
+/// Outbound connection resources, constructed once from a single trust-store
+/// load and shared across every outbound path.
+///
+/// `pub(crate)` to match the visibility of the `Shared::upstream` field that
+/// holds it; the fields below stay `pub(super)` (used only within the proxy).
+pub(crate) struct Upstream {
+    /// Forwarding client for H1/H2 (and H3-forwarded) requests.
+    pub(super) client: LegacyClient<hyper_rustls::HttpsConnector<HttpConnector>, ClientBody>,
+    /// Base TLS config: native roots, no client auth, **no ALPN**. The forwarding
+    /// client adds ALPN on top; the WebSocket upgrade path uses it bare. Shared
+    /// so the trust store is loaded a single time.
+    pub(super) tls_config: Arc<rustls::ClientConfig>,
+}
+
+impl Upstream {
+    /// Load the platform trust store once and build both outbound shapes from it.
+    pub(super) fn new() -> anyhow::Result<Self> {
+        let loaded = rustls_native_certs::load_native_certs();
+        if !loaded.errors.is_empty() {
+            warn!(errors = ?loaded.errors, "errors loading platform certificates");
+        }
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in loaded.certs {
+            roots.add(cert).ok();
+        }
+        if roots.is_empty() {
+            anyhow::bail!("no native root certificates could be loaded");
+        }
+
+        // Base config carries no ALPN: `with_tls_config` asserts that, and the
+        // WebSocket path needs it bare. The forwarding client adds h1/h2 below.
+        let base = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let tls_config = Arc::new(base.clone());
+
+        let https = HttpsConnectorBuilder::new()
+            .with_tls_config(base)
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .build();
+        let client = LegacyClient::builder(TokioExecutor::new()).build(https);
+
+        Ok(Self { client, tls_config })
+    }
+}

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -56,26 +56,28 @@ pub(super) async fn handle_websocket_upgrade(
     shared: Arc<Shared>,
     conn_metadata: Arc<crate::connection::ConnectionMetadata>,
 ) -> Result<Response<ResponseBody>, Infallible> {
-    // Connect directly to upstream with upgrade support
-    let (mut sender, _conn_handle) = match connect_upstream_for_upgrade(uri, scheme).await {
-        Ok(s) => s,
-        Err(e) => {
-            error!("websocket upstream connect error: {}", e);
-            record_handshake_failure(
-                &shared,
-                client_id,
-                method,
-                uri_str,
-                req_headers,
-                req_version,
-                &body_bytes,
-                &conn_metadata,
-                started,
-            )
-            .await;
-            return Ok(upstream_error_response(&e));
-        }
-    };
+    // Connect directly to upstream with upgrade support, reusing the shared
+    // outbound TLS config (loaded once at startup).
+    let (mut sender, _conn_handle) =
+        match connect_upstream_for_upgrade(uri, scheme, &shared.upstream.tls_config).await {
+            Ok(s) => s,
+            Err(e) => {
+                error!("websocket upstream connect error: {}", e);
+                record_handshake_failure(
+                    &shared,
+                    client_id,
+                    method,
+                    uri_str,
+                    req_headers,
+                    req_version,
+                    &body_bytes,
+                    &conn_metadata,
+                    started,
+                )
+                .await;
+                return Ok(upstream_error_response(&e));
+            }
+        };
 
     // Send the upgrade request to the upstream server
     let mut upstream_resp = match sender.send_request(upstream_req).await {
@@ -274,6 +276,7 @@ async fn record_handshake_failure(
 async fn connect_upstream_for_upgrade(
     uri: &Uri,
     fallback_scheme: &hyper::http::uri::Scheme,
+    tls_config: &Arc<rustls::ClientConfig>,
 ) -> anyhow::Result<(
     hyper::client::conn::http1::SendRequest<Full<Bytes>>,
     tokio::task::JoinHandle<Result<(), hyper::Error>>,
@@ -288,27 +291,9 @@ async fn connect_upstream_for_upgrade(
     let tcp = tokio::net::TcpStream::connect((host, port)).await?;
 
     if is_https {
-        let cert_result = rustls_native_certs::load_native_certs();
-        if !cert_result.errors.is_empty() {
-            tracing::warn!(
-                errors = ?cert_result.errors,
-                "encountered errors loading platform certificates"
-            );
-        }
-        if cert_result.certs.is_empty() {
-            return Err(anyhow::anyhow!(
-                "failed to load any platform certificates: {:?}",
-                cert_result.errors
-            ));
-        }
-        let mut root_store = rustls::RootCertStore::empty();
-        for cert in cert_result.certs {
-            root_store.add(cert).ok();
-        }
-        let tls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+        // The trust store was loaded once at startup; reuse the shared config
+        // (an `Arc` bump) instead of re-reading native certs per upgrade.
+        let connector = tokio_rustls::TlsConnector::from(tls_config.clone());
         let server_name = rustls::pki_types::ServerName::try_from(host.to_string())?;
         let tls_stream = connector.connect(server_name, tcp).await?;
 
@@ -529,6 +514,16 @@ mod tests {
             StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
                 300, 100,
             )),
+        )
+    }
+
+    /// A trust-store-free client config for the `ws://` (non-TLS) tests below —
+    /// they never reach the HTTPS branch, so an empty root store is fine.
+    fn test_tls_config() -> StdArc<rustls::ClientConfig> {
+        StdArc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
         )
     }
 
@@ -775,7 +770,9 @@ mod tests {
     #[tokio::test]
     async fn connect_upstream_for_upgrade_fails_without_host() {
         let uri: Uri = "/no-host".parse().unwrap();
-        let result = connect_upstream_for_upgrade(&uri, &hyper::http::uri::Scheme::HTTP).await;
+        let result =
+            connect_upstream_for_upgrade(&uri, &hyper::http::uri::Scheme::HTTP, &test_tls_config())
+                .await;
         assert!(result.is_err());
     }
 
@@ -786,7 +783,9 @@ mod tests {
         let port = l.local_addr().unwrap().port();
         drop(l);
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse().unwrap();
-        let result = connect_upstream_for_upgrade(&uri, &hyper::http::uri::Scheme::HTTP).await;
+        let result =
+            connect_upstream_for_upgrade(&uri, &hyper::http::uri::Scheme::HTTP, &test_tls_config())
+                .await;
         assert!(result.is_err());
     }
 
@@ -1240,7 +1239,8 @@ mod tests {
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let (mut sender, _handle) =
-            connect_upstream_for_upgrade(&uri, &hyper::http::uri::Scheme::HTTP).await?;
+            connect_upstream_for_upgrade(&uri, &hyper::http::uri::Scheme::HTTP, &test_tls_config())
+                .await?;
 
         // Verify we can send a request
         let req = Request::builder()


### PR DESCRIPTION
The forwarding client built native roots once at startup, but the WebSocket upgrade path called load_native_certs() and rebuilt a RootCertStore + ClientConfig on every upgrade — re-reading the platform trust store per handshake.

Introduce an Upstream struct (proxy/upstream.rs) that holds both outbound shapes — the forwarding client and a shared base ClientConfig — built once from a single native-roots load. The main client adds h1/h2 ALPN via HttpsConnectorBuilder::with_tls_config (which requires a no-ALPN base); the WebSocket path reuses the same Arc<ClientConfig> bare. Empty-trust-store failures now surface once at startup instead of per upgrade.

This gives one native-cert load, one outbound-TLS construction to audit, and a single seam for future outbound features (H3 upstream, pooling, mTLS).
