### PR TITLE
Drop lock-poison boilerplate by moving stores to parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "chrono",
  "httpdate",
  "hyper",
+ "parking_lot",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bytes = "1"
 base64 = "0.22"
 sha1 = "0.11"
 linkme = "0.3"
+parking_lot = "0.12"
 
 # TLS Support
 tokio-rustls = "0.26.4"

--- a/lint-http-core/Cargo.toml
+++ b/lint-http-core/Cargo.toml
@@ -30,6 +30,7 @@ base64 = { workspace = true }
 httpdate = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/lint-http-core/src/protocol_event_store.rs
+++ b/lint-http-core/src/protocol_event_store.rs
@@ -11,8 +11,9 @@
 
 use crate::protocol_event::ProtocolEvent;
 use chrono::Utc;
+use parking_lot::RwLock;
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -39,62 +40,46 @@ impl ProtocolEventStore {
     /// The event is indexed by `connection_id`.  WebSocket frame events are
     /// additionally indexed by `session_id`.
     pub fn record_event(&self, event: &ProtocolEvent) {
-        // Index by connection_id
-        if let Ok(mut store) = self.by_connection.write() {
-            let deque = store
-                .entry(event.connection_id)
-                .or_insert_with(VecDeque::new);
+        // Index by connection_id. Scoped so the guard drops before we acquire
+        // the by_session lock below — the two are never held at once.
+        {
+            let mut store = self.by_connection.write();
+            let deque = store.entry(event.connection_id).or_default();
             deque.push_front(event.clone());
             if deque.len() > self.max_events_per_key {
                 deque.pop_back();
             }
-        } else {
-            tracing::warn!("ProtocolEventStore by_connection lock poisoned during write");
-            return;
         }
 
         // Additionally index WebSocket frame events by session_id
         if let crate::protocol_event::ProtocolEventKind::WebSocketFrame { session_id, .. } =
             &event.kind
         {
-            if let Ok(mut store) = self.by_session.write() {
-                let deque = store.entry(*session_id).or_insert_with(VecDeque::new);
-                deque.push_front(event.clone());
-                if deque.len() > self.max_events_per_key {
-                    deque.pop_back();
-                }
-            } else {
-                tracing::warn!("ProtocolEventStore by_session lock poisoned during write");
+            let mut store = self.by_session.write();
+            let deque = store.entry(*session_id).or_default();
+            deque.push_front(event.clone());
+            if deque.len() > self.max_events_per_key {
+                deque.pop_back();
             }
         }
     }
 
     /// Retrieve event history for a connection (newest first).
     pub fn get_history_for_connection(&self, connection_id: Uuid) -> Vec<ProtocolEvent> {
-        match self.by_connection.read() {
-            Ok(store) => store
-                .get(&connection_id)
-                .map(|dq| dq.iter().cloned().collect())
-                .unwrap_or_default(),
-            Err(_) => {
-                tracing::warn!("ProtocolEventStore by_connection lock poisoned during read");
-                Vec::new()
-            }
-        }
+        self.by_connection
+            .read()
+            .get(&connection_id)
+            .map(|dq| dq.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Retrieve event history for a WebSocket session (newest first).
     pub fn get_history_for_session(&self, session_id: Uuid) -> Vec<ProtocolEvent> {
-        match self.by_session.read() {
-            Ok(store) => store
-                .get(&session_id)
-                .map(|dq| dq.iter().cloned().collect())
-                .unwrap_or_default(),
-            Err(_) => {
-                tracing::warn!("ProtocolEventStore by_session lock poisoned during read");
-                Vec::new()
-            }
-        }
+        self.by_session
+            .read()
+            .get(&session_id)
+            .map(|dq| dq.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Remove expired events from the store.
@@ -110,20 +95,17 @@ impl ProtocolEventStore {
         map: &Arc<RwLock<HashMap<Uuid, VecDeque<ProtocolEvent>>>>,
         ttl: chrono::Duration,
     ) {
-        if let Ok(mut store) = map.write() {
-            for deque in store.values_mut() {
-                deque.retain(|evt| {
-                    let age = Utc::now().signed_duration_since(evt.timestamp);
-                    if age < chrono::Duration::zero() {
-                        return false;
-                    }
-                    age <= ttl
-                });
-            }
-            store.retain(|_, dq| !dq.is_empty());
-        } else {
-            tracing::warn!("ProtocolEventStore lock poisoned during cleanup");
+        let mut store = map.write();
+        for deque in store.values_mut() {
+            deque.retain(|evt| {
+                let age = Utc::now().signed_duration_since(evt.timestamp);
+                if age < chrono::Duration::zero() {
+                    return false;
+                }
+                age <= ttl
+            });
         }
+        store.retain(|_, dq| !dq.is_empty());
     }
 }
 
@@ -243,31 +225,5 @@ mod tests {
         h2.join().unwrap();
 
         assert!(!store.get_history_for_connection(conn).is_empty());
-    }
-
-    #[test]
-    fn poisoned_connection_lock_returns_empty() {
-        let store = ProtocolEventStore::new(300, 100);
-        let arc = store.by_connection.clone();
-        let handle = std::thread::spawn(move || {
-            let _guard = arc.write().unwrap();
-            panic!("intentional poison");
-        });
-        let _ = handle.join();
-
-        assert!(store.get_history_for_connection(Uuid::new_v4()).is_empty());
-    }
-
-    #[test]
-    fn poisoned_session_lock_returns_empty() {
-        let store = ProtocolEventStore::new(300, 100);
-        let arc = store.by_session.clone();
-        let handle = std::thread::spawn(move || {
-            let _guard = arc.write().unwrap();
-            panic!("intentional poison");
-        });
-        let _ = handle.join();
-
-        assert!(store.get_history_for_session(Uuid::new_v4()).is_empty());
     }
 }

--- a/lint-http-core/src/state.rs
+++ b/lint-http-core/src/state.rs
@@ -5,10 +5,11 @@
 //! State management for cross-transaction HTTP analysis.
 
 use chrono::Utc;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -78,40 +79,34 @@ impl StateStore {
 
         // Update the main store first, then release its lock before updating
         // secondary indexes.  This avoids nested lock acquisition which could
-        // deadlock with readers that access indexes then the store.
-        let is_new = match self.store.write() {
-            Ok(mut store) => {
-                let was_new = store.get(&key).is_none();
-                let deque = store.entry(key.clone()).or_insert_with(VecDeque::new);
-                // One deep clone into an `Arc`; every later read clones only the
-                // `Arc` (a refcount bump) instead of the whole transaction.
-                deque.push_front(Arc::new(tx.clone()));
-                if deque.len() > self.max_history {
-                    deque.pop_back();
-                }
-                was_new
+        // deadlock with readers that access indexes then the store.  The block
+        // scopes the store guard so it drops before the index writes below.
+        let is_new = {
+            let mut store = self.store.write();
+            let was_new = store.get(&key).is_none();
+            let deque = store.entry(key.clone()).or_default();
+            // One deep clone into an `Arc`; every later read clones only the
+            // `Arc` (a refcount bump) instead of the whole transaction.
+            deque.push_front(Arc::new(tx.clone()));
+            if deque.len() > self.max_history {
+                deque.pop_back();
             }
-            Err(_) => {
-                tracing::warn!("StateStore lock poisoned during write");
-                return;
-            }
+            was_new
         };
 
         if is_new {
-            if let Ok(mut idx) = self.resource_index.write() {
-                let clients = idx.entry(key.resource.clone()).or_insert_with(Vec::new);
-                if !clients.iter().any(|c| c == &key.client) {
-                    clients.push(key.client.clone());
-                }
+            let mut idx = self.resource_index.write();
+            let clients = idx.entry(key.resource.clone()).or_default();
+            if !clients.iter().any(|c| c == &key.client) {
+                clients.push(key.client.clone());
             }
         }
 
         if let Some(conn_id) = tx.connection_id {
-            if let Ok(mut idx) = self.connection_index.write() {
-                let keys = idx.entry(conn_id).or_insert_with(Vec::new);
-                if !keys.contains(&key) {
-                    keys.push(key);
-                }
+            let mut idx = self.connection_index.write();
+            let keys = idx.entry(conn_id).or_default();
+            if !keys.contains(&key) {
+                keys.push(key);
             }
         }
     }
@@ -127,13 +122,10 @@ impl StateStore {
             resource: resource.to_string(),
         };
 
-        match self.store.read() {
-            Ok(store) => store.get(&key).and_then(|dq| dq.front().cloned()),
-            Err(_) => {
-                tracing::warn!("StateStore lock poisoned during read");
-                None
-            }
-        }
+        self.store
+            .read()
+            .get(&key)
+            .and_then(|dq| dq.front().cloned())
     }
 
     /// Retrieve the full bounded history for this client+resource (newest first).
@@ -143,16 +135,11 @@ impl StateStore {
             resource: resource.to_string(),
         };
 
-        match self.store.read() {
-            Ok(store) => store
-                .get(&key)
-                .map(|dq| dq.iter().cloned().collect())
-                .unwrap_or_default(),
-            Err(_) => {
-                tracing::warn!("StateStore lock poisoned during read");
-                Vec::new()
-            }
-        }
+        self.store
+            .read()
+            .get(&key)
+            .map(|dq| dq.iter().cloned().collect())
+            .unwrap_or_default()
     }
     /// Retrieve the full bounded history across **all clients** for the given
     /// resource string.  The returned vector is sorted newest-first by
@@ -162,16 +149,17 @@ impl StateStore {
     pub fn get_history_for_resource(&self, resource: &str) -> Vec<SharedTransaction> {
         // Clone the client list from the index first, then release the index
         // lock before acquiring the store lock to avoid lock-order inversion.
-        let clients = match self.resource_index.read() {
-            Ok(idx) => match idx.get(resource) {
+        let clients = {
+            let idx = self.resource_index.read();
+            match idx.get(resource) {
                 Some(c) => c.clone(),
                 None => return Vec::new(),
-            },
-            Err(_) => return Vec::new(),
+            }
         };
 
         let mut entries = Vec::new();
-        if let Ok(store) = self.store.read() {
+        {
+            let store = self.store.read();
             for client in &clients {
                 let key = ResourceKey {
                     client: client.clone(),
@@ -193,34 +181,27 @@ impl StateStore {
     ///
     /// Used by origin-based queries that need to scan across URIs.
     pub fn collect_for_client(&self, client: &ClientIdentifier) -> Vec<SharedTransaction> {
-        match self.store.read() {
-            Ok(store) => store
-                .iter()
-                .filter(|(k, _)| &k.client == client)
-                .flat_map(|(_, dq)| dq.iter().cloned())
-                .collect(),
-            Err(_) => {
-                tracing::warn!("StateStore lock poisoned during read");
-                Vec::new()
-            }
-        }
+        self.store
+            .read()
+            .iter()
+            .filter(|(k, _)| &k.client == client)
+            .flat_map(|(_, dq)| dq.iter().cloned())
+            .collect()
     }
 
     /// Retrieve all transactions that share the given `connection_id`.
     pub fn get_history_for_connection(&self, connection_id: Uuid) -> Vec<SharedTransaction> {
-        let keys = match self.connection_index.read() {
-            Ok(idx) => match idx.get(&connection_id) {
+        let keys = {
+            let idx = self.connection_index.read();
+            match idx.get(&connection_id) {
                 Some(k) => k.clone(),
                 None => return Vec::new(),
-            },
-            Err(_) => {
-                tracing::warn!("StateStore connection_index lock poisoned during read");
-                return Vec::new();
             }
         };
 
         let mut entries = Vec::new();
-        if let Ok(store) = self.store.read() {
+        {
+            let store = self.store.read();
             for key in &keys {
                 if let Some(dq) = store.get(key) {
                     for tx in dq.iter() {
@@ -238,7 +219,9 @@ impl StateStore {
     pub fn cleanup_expired(&self) {
         let mut removed_keys: Vec<ResourceKey> = Vec::new();
 
-        if let Ok(mut store) = self.store.write() {
+        // Scope the store guard so it drops before the index writes below.
+        {
+            let mut store = self.store.write();
             let ttl_chrono = chrono::Duration::from_std(self.ttl)
                 .unwrap_or_else(|_| chrono::Duration::seconds(0));
 
@@ -261,14 +244,12 @@ impl StateStore {
                     true
                 }
             });
-        } else {
-            tracing::warn!("StateStore lock poisoned during cleanup");
-            return;
         }
 
         // Update indexes outside the store lock scope to avoid nested locking.
         if !removed_keys.is_empty() {
-            if let Ok(mut idx) = self.resource_index.write() {
+            {
+                let mut idx = self.resource_index.write();
                 for key in &removed_keys {
                     if let Some(clients) = idx.get_mut(&key.resource) {
                         clients.retain(|c| c != &key.client);
@@ -279,7 +260,8 @@ impl StateStore {
                 }
             }
 
-            if let Ok(mut idx) = self.connection_index.write() {
+            {
+                let mut idx = self.connection_index.write();
                 idx.retain(|_conn_id, keys| {
                     keys.retain(|k| !removed_keys.contains(k));
                     !keys.is_empty()
@@ -467,7 +449,7 @@ mod tests {
         eprintln!("recorded");
         // index should contain mapping
         {
-            let idx = store.resource_index.read().unwrap();
+            let idx = store.resource_index.read();
             assert!(idx
                 .get(resource)
                 .map(|v| v.contains(&client))
@@ -483,7 +465,7 @@ mod tests {
         eprintln!("cleanup done");
         assert!(store.get_previous(&client, resource).is_none());
         // index should no longer have resource
-        let idx2 = store.resource_index.read().unwrap();
+        let idx2 = store.resource_index.read();
         assert!(!idx2.contains_key(resource));
         eprintln!("cleanup test end");
     }
@@ -643,25 +625,6 @@ mod tests {
     }
 
     #[test]
-    fn get_previous_handles_poisoned_lock() {
-        let store = StateStore::new(300, 10);
-        let client = make_client();
-        let resource = "http://example.com/resource";
-
-        // Poison the lock by panicking while holding a write lock in another thread.
-        let store_arc = store.store.clone();
-        let handle = thread::spawn(move || {
-            let _guard = store_arc.write().unwrap();
-            panic!("intentional panic to poison lock");
-        });
-        let _ = handle.join(); // ignore the panic result
-
-        // Now attempting to read should hit the poisoned branch and return None
-        let res = store.get_previous(&client, resource);
-        assert!(res.is_none());
-    }
-
-    #[test]
     fn bounded_history_evicts_oldest() {
         let store = StateStore::new(300, 3);
         let client = make_client();
@@ -797,96 +760,9 @@ mod tests {
         tx.connection_id = Some(conn_id);
         store.record_transaction(&tx);
 
-        let idx = store.connection_index.read().unwrap();
+        let idx = store.connection_index.read();
         assert!(idx.contains_key(&conn_id));
         assert!(!idx.get(&conn_id).unwrap().is_empty());
-    }
-
-    #[test]
-    fn get_history_for_connection_handles_poisoned_connection_index() {
-        let store = StateStore::new(300, 10);
-
-        // Poison the connection_index lock
-        let idx_arc = store.connection_index.clone();
-        let handle = thread::spawn(move || {
-            let _guard = idx_arc.write().unwrap();
-            panic!("intentional panic to poison connection_index lock");
-        });
-        let _ = handle.join();
-
-        // Should return empty vec instead of panicking
-        let history = store.get_history_for_connection(uuid::Uuid::new_v4());
-        assert!(history.is_empty());
-    }
-
-    #[test]
-    fn record_transaction_handles_poisoned_store_lock() {
-        let store = StateStore::new(300, 10);
-        let client = make_client();
-
-        // Poison the store lock
-        let store_arc = store.store.clone();
-        let handle = thread::spawn(move || {
-            let _guard = store_arc.write().unwrap();
-            panic!("intentional panic to poison store lock");
-        });
-        let _ = handle.join();
-
-        // Should not panic, just log warning
-        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        tx.client = client.clone();
-        tx.request.uri = "http://example.com/x".to_string();
-        store.record_transaction(&tx);
-    }
-
-    #[test]
-    fn get_history_handles_poisoned_lock() {
-        let store = StateStore::new(300, 10);
-        let client = make_client();
-
-        // Poison the store lock
-        let store_arc = store.store.clone();
-        let handle = thread::spawn(move || {
-            let _guard = store_arc.write().unwrap();
-            panic!("intentional panic to poison store lock");
-        });
-        let _ = handle.join();
-
-        let history = store.get_history(&client, "http://example.com/x");
-        assert!(history.is_empty());
-    }
-
-    #[test]
-    fn collect_for_client_handles_poisoned_lock() {
-        let store = StateStore::new(300, 10);
-        let client = make_client();
-
-        // Poison the store lock
-        let store_arc = store.store.clone();
-        let handle = thread::spawn(move || {
-            let _guard = store_arc.write().unwrap();
-            panic!("intentional panic to poison store lock");
-        });
-        let _ = handle.join();
-
-        let results = store.collect_for_client(&client);
-        assert!(results.is_empty());
-    }
-
-    #[test]
-    fn cleanup_expired_handles_poisoned_lock() {
-        let store = StateStore::new(300, 10);
-
-        // Poison the store lock
-        let store_arc = store.store.clone();
-        let handle = thread::spawn(move || {
-            let _guard = store_arc.write().unwrap();
-            panic!("intentional panic to poison store lock");
-        });
-        let _ = handle.join();
-
-        // Should not panic
-        store.cleanup_expired();
     }
 
     #[test]
@@ -903,7 +779,7 @@ mod tests {
 
         // connection_index should have an entry
         {
-            let idx = store.connection_index.read().unwrap();
+            let idx = store.connection_index.read();
             assert!(idx.contains_key(&conn_id));
         }
 
@@ -912,7 +788,7 @@ mod tests {
         store.cleanup_expired();
 
         // connection_index should be pruned
-        let idx = store.connection_index.read().unwrap();
+        let idx = store.connection_index.read();
         assert!(
             !idx.contains_key(&conn_id),
             "connection_index should be pruned after cleanup"
@@ -934,7 +810,7 @@ mod tests {
             store.record_transaction(&tx);
         }
 
-        let idx = store.connection_index.read().unwrap();
+        let idx = store.connection_index.read();
         // Should only have one key entry (same resource key)
         assert_eq!(idx.get(&conn_id).unwrap().len(), 1);
     }


### PR DESCRIPTION
StateStore and ProtocolEventStore wrapped their maps in std::sync::RwLock, which poisons on a panic-while-holding. Coping with that required ten explicit poison-recovery branches across the two stores — each degrading a poisoned lock to a warn plus an empty/early result, one of them (the old get_history_for_resource) silently swallowing with no warning at all — plus eight tests whose only job was to poison a lock and assert the recovery.

parking_lot::RwLock has no poisoning (a panicking thread simply unlocks on unwind), so every recovery branch collapses to a direct guard and the eight poison tests go away. Lock acquisitions that previously released one lock before taking another are wrapped in explicit blocks so the guards still drop at the same points (parking_lot guards live to end of scope), keeping hold times narrow and never holding two store locks at once.

These are best-effort lint-history caches feeding advisory rules; dropping poisoning is a simplification, not a behavior loss. parking_lot was already in the tree transitively via tokio, so it resolves to a single copy.
