### PR TITLE
Gate rule-module formatting and fix accumulated drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # `cargo fmt` does not reach the rule files: they enter the crate via a
+      # build.rs-generated `#[path = "rules/*.rs"]` include that rustfmt won't
+      # follow. Format them directly so drift in the largest part of the tree
+      # is gated too.
+      - name: Check formatting of rule files
+        run: rustfmt --edition 2021 --check lint-http-rules/src/rules/*.rs
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/lint-http-rules/src/rules/client_patch_method_content_type_match.rs
+++ b/lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -254,7 +254,9 @@ mod tests {
         }
 
         let history = match prev {
-            Some(p) => crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()]),
+            Some(p) => {
+                crate::transaction_history::TransactionHistory::from_transactions(vec![p.clone()])
+            }
             None => crate::transaction_history::TransactionHistory::empty(),
         };
         let v = rule.check_transaction(&tx, &history, &cfg);

--- a/lint-http-rules/src/rules/message_forwarded_header_validity.rs
+++ b/lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -28,7 +28,10 @@ fn validate_node_identifier(name: &str, value: &str) -> Option<String> {
         };
         let inside = &value[1..end];
         if inside.is_empty() {
-            return Some(format!("Empty IPv6 address in Forwarded '{}' parameter", name));
+            return Some(format!(
+                "Empty IPv6 address in Forwarded '{}' parameter",
+                name
+            ));
         }
         if inside.parse::<IpAddr>().is_err() {
             return Some(format!(

--- a/lint-http-rules/src/rules/stateful_authentication_failure_loop.rs
+++ b/lint-http-rules/src/rules/stateful_authentication_failure_loop.rs
@@ -110,7 +110,8 @@ mod tests {
         tx3.request.uri = "https://example.com/admin".to_string();
 
         // supply history newest-first; tx3 is most recent
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx3, tx2, tx1]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx3, tx2, tx1]);
 
         let v = rule.check_transaction(
             &tx,
@@ -135,7 +136,9 @@ mod tests {
         let tx4 = crate::test_helpers::make_test_transaction_with_response(401, &[]);
 
         // put newest transaction first (tx4) to satisfy TransactionHistory
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx4, tx3, tx2, tx1]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx4, tx3, tx2, tx1,
+        ]);
 
         let v = rule.check_transaction(
             &tx,
@@ -158,7 +161,8 @@ mod tests {
         let tx3 = crate::test_helpers::make_test_transaction_with_response(401, &[]);
 
         // newest-first history
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx3, tx2, tx1]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx3, tx2, tx1]);
 
         let v = rule.check_transaction(
             &tx,

--- a/lint-http-rules/src/rules/stateful_conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/stateful_conditional_request_handling.rs
@@ -231,7 +231,9 @@ mod tests {
         let prev_empty = make_prev_with_headers(&[]);
         let v1 = rule.check_transaction(
             &tx1,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![
+                prev_empty.clone()
+            ]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -246,7 +248,9 @@ mod tests {
         )]);
         let v2 = rule.check_transaction(
             &tx2,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![
+                prev_empty.clone()
+            ]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -259,7 +263,9 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-match", "\"a\"")]);
         let v3 = rule.check_transaction(
             &tx3,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![
+                prev_empty.clone()
+            ]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),
@@ -274,7 +280,9 @@ mod tests {
         )]);
         let v4 = rule.check_transaction(
             &tx4,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![
+                prev_empty.clone()
+            ]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "stateful_conditional_request_handling",
             ]),

--- a/lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
@@ -273,8 +273,10 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            prev2.clone(),
+            prev1.clone(),
+        ]);
         assert!(rule
             .check_transaction(
                 &tx,

--- a/lint-http-rules/src/rules/stateful_cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_lifecycle.rs
@@ -395,8 +395,10 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(20);
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            prev2.clone(),
+            prev1.clone(),
+        ]);
         let v = rule.check_transaction(
             &tx,
             &history,

--- a/lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
@@ -270,11 +270,12 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Strict"),
-            Some(Utc::now()),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Strict"),
+                Some(Utc::now()),
+            )]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -290,11 +291,12 @@ mod tests {
     fn fetch_site_none_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Strict"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Strict"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -314,11 +316,12 @@ mod tests {
     fn fetch_site_invalid_skips() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Strict"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Strict"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -339,11 +342,12 @@ mod tests {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
         // history sets cookie b; request sends cookie a
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("b=1; SameSite=Strict"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("b=1; SameSite=Strict"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -363,11 +367,12 @@ mod tests {
     fn secure_cookie_over_http_ignored_for_samesite() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "http://example.com/",
-            Some("a=1; SameSite=Strict; Secure"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "http://example.com/",
+                Some("a=1; SameSite=Strict; Secure"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -414,11 +419,12 @@ mod tests {
     fn lax_cookie_cross_site_non_nav_reports() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Lax"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Lax"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -442,11 +448,12 @@ mod tests {
     fn lax_cookie_cross_site_nav_get_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Lax"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Lax"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -470,11 +477,12 @@ mod tests {
     fn lax_cookie_cross_site_nav_head_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Lax"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Lax"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -498,11 +506,12 @@ mod tests {
     fn none_cookie_cross_site_allowed() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=None; Secure"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=None; Secure"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -522,11 +531,12 @@ mod tests {
     fn unspecified_treated_as_lax() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -572,11 +582,12 @@ mod tests {
     fn same_site_context_allows_strict() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Strict"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Strict"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.request
             .headers
@@ -596,11 +607,12 @@ mod tests {
     fn mismatched_cookie_value_does_not_report() {
         let rule = StatefulCookieSameSiteEnforcement;
         let ts = Utc::now();
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
-            "https://example.com/",
-            Some("a=1; SameSite=Strict"),
-            Some(ts),
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_resp_tx(
+                "https://example.com/",
+                Some("a=1; SameSite=Strict"),
+                Some(ts),
+            )]);
         let mut tx = make_tx_with_req("https://example.com/", Some("a=2"));
         tx.request
             .headers

--- a/lint-http-rules/src/rules/stateful_digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/stateful_digest_auth_nonce_handling.rs
@@ -380,10 +380,9 @@ mod tests {
     #[test]
     fn opaque_mismatch() {
         let nonce1 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, Some("o1"), None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, Some("o1"), None)),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o2")));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -399,10 +398,9 @@ mod tests {
     #[test]
     fn missing_opaque_reports() {
         let nonce1 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, Some("o1"), None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, Some("o1"), None)),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -477,8 +475,10 @@ mod tests {
         // vector will be newest-first.
         let prev_challenge = tx_resp_with_challenge(&make_challenge(&nonce1, None, None));
         let prev_request = tx_req_with_auth(&auth1);
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![prev_request, prev_challenge]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            prev_request,
+            prev_challenge,
+        ]);
         let tx = tx_req_with_auth(&auth2);
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -496,10 +496,9 @@ mod tests {
         let nonce = random_nonce();
         // challenge with stale=true provides a new nonce value, which the client
         // must then reuse but reset nc to 1
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce, None, Some("true")),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce, None, Some("true"))),
+        ]);
         // client correctly uses same nonce but wrong nc
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000005"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
@@ -520,8 +519,10 @@ mod tests {
         // increase and the list is newest-first.
         let prev_challenge = tx_resp_with_challenge(&make_challenge(&nonce1, Some("o1"), None));
         let prev_request = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o1")));
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![prev_request, prev_challenge]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            prev_request,
+            prev_challenge,
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000002"), Some("o1")));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -537,10 +538,9 @@ mod tests {
     fn nonce_mismatch_without_stale_reports() {
         let nonce1 = random_nonce();
         let nonce2 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, None, None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, None, None)),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -556,10 +556,9 @@ mod tests {
     #[test]
     fn missing_opaque_reports_violation() {
         let nonce1 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, Some("o123"), None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, Some("o123"), None)),
+        ]);
         // request omits opaque entirely
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
@@ -577,10 +576,9 @@ mod tests {
     fn stale_challenge_with_wrong_nonce_reports() {
         let nonce1 = random_nonce();
         let nonce2 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, None, Some("true")),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, None, Some("true"))),
+        ]);
         // client uses different nonce entirely
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
@@ -600,10 +598,9 @@ mod tests {
     #[test]
     fn request_without_nc_is_allowed() {
         let nonce1 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, None, None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, None, None)),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, None, None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -618,10 +615,9 @@ mod tests {
     #[test]
     fn invalid_nc_value_reports() {
         let nonce1 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, None, None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, None, None)),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("GARBAGE"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -638,10 +634,9 @@ mod tests {
     fn stale_nonce_mismatch_reports() {
         let nonce1 = random_nonce();
         let nonce2 = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce1, None, Some("true")),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce1, None, Some("true"))),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,
@@ -658,10 +653,9 @@ mod tests {
     #[test]
     fn stale_correct_reset_passes() {
         let nonce = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce, None, Some("true")),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce, None, Some("true"))),
+        ]);
         // correct reset
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
@@ -698,10 +692,9 @@ mod tests {
     #[test]
     fn no_nc_produced_no_violation() {
         let nonce = random_nonce();
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![tx_resp_with_challenge(
-                &make_challenge(&nonce, None, None),
-            )]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            tx_resp_with_challenge(&make_challenge(&nonce, None, None)),
+        ]);
         let tx = tx_req_with_auth(&make_auth(&nonce, None, None));
         let v = StatefulDigestAuthNonceHandling.check_transaction(
             &tx,

--- a/lint-http-rules/src/rules/stateful_max_age_directive_validity.rs
+++ b/lint-http-rules/src/rules/stateful_max_age_directive_validity.rs
@@ -218,7 +218,8 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(10);
 
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         let v = rule.check_transaction(
             &tx,
             &history,
@@ -238,7 +239,8 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx2.timestamp = base + chrono::Duration::seconds(10);
-        let history2 = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
+        let history2 =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
             rule.check_transaction(
                 &tx2,
@@ -467,7 +469,8 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base;
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         // age == max-age should be treated as stale; unconditional request
         // should therefore be flagged since validator exists.
         let v = rule.check_transaction(
@@ -486,7 +489,8 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx2.timestamp = base;
-        let history2 = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
+        let history2 =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
             rule.check_transaction(
                 &tx2,

--- a/lint-http-rules/src/rules/stateful_must_revalidate_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_must_revalidate_enforcement.rs
@@ -307,7 +307,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         let v = rule.check_transaction(
             &tx,
             &history,

--- a/lint-http-rules/src/rules/stateful_no_store_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_no_store_enforcement.rs
@@ -426,8 +426,10 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            prev2.clone(),
+            prev1.clone(),
+        ]);
         assert!(rule
             .check_transaction(
                 &tx,
@@ -460,8 +462,10 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", lm)]);
-        let history =
-            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone(), prev1.clone()]);
+        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
+            prev2.clone(),
+            prev1.clone(),
+        ]);
         assert!(rule
             .check_transaction(
                 &tx,

--- a/lint-http-rules/src/rules/stateful_oauth2_code_flow.rs
+++ b/lint-http-rules/src/rules/stateful_oauth2_code_flow.rs
@@ -252,9 +252,10 @@ mod tests {
     fn callback_with_matching_state_ok() {
         let rule = StatefulOauth2CodeFlow;
         // initial auth request earlier in history
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_tx(
-            "https://idp.example.com/authorize?response_type=code&state=xyz",
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_tx(
+                "https://idp.example.com/authorize?response_type=code&state=xyz",
+            )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
         assert!(rule
             .check_transaction(
@@ -288,9 +289,10 @@ mod tests {
     fn auth_and_callback_with_fragments_are_handled() {
         let rule = StatefulOauth2CodeFlow;
         // auth request has fragment after query, should still record state
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![make_tx(
-            "https://idp.example.com/authorize?response_type=code&state=foo#frag",
-        )]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![make_tx(
+                "https://idp.example.com/authorize?response_type=code&state=foo#frag",
+            )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=foo#bar");
         assert!(rule
             .check_transaction(
@@ -325,7 +327,8 @@ mod tests {
         let rule = StatefulOauth2CodeFlow;
         // auth request with empty state
         let tx1 = make_tx("https://idp.example.com/authorize?response_type=code&state=");
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![tx1.clone()]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![tx1.clone()]);
         // callback with empty state should flag missing or empty
         let tx2 = make_tx("https://app.example.com/callback?code=123&state=");
         let v = rule

--- a/lint-http-rules/src/rules/stateful_s_max_age_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_s_max_age_enforcement.rs
@@ -222,7 +222,8 @@ mod tests {
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx2.timestamp = base + chrono::Duration::seconds(4);
-        let history2 = crate::transaction_history::TransactionHistory::from_transactions(vec![prev2]);
+        let history2 =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2]);
         assert!(rule
             .check_transaction(
                 &tx2,

--- a/lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
+++ b/lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
@@ -646,7 +646,8 @@ mod tests {
         ]);
 
         // newest-first: later matching entry (good) must come first
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![good, old]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![good, old]);
         let v = rule.check_transaction(
             &tx,
             &history,

--- a/lint-http-rules/src/rules/stateful_websocket_frame_opcode_sequence.rs
+++ b/lint-http-rules/src/rules/stateful_websocket_frame_opcode_sequence.rs
@@ -154,8 +154,8 @@ static REGISTRATION: &dyn crate::rules::ProtocolRule = &StatefulWebsocketFrameOp
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
     use crate::protocol_event::MessageDirection;
+    use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
     use chrono::Utc;
     use uuid::Uuid;
 


### PR DESCRIPTION
cargo fmt --all never reaches the 184 rule files: they enter the crate through a build.rs-generated $OUT_DIR/rule_modules.rs that declares each one with #[path = "rules/foo.rs"], and rustfmt does not follow #[path] into out-of-tree generated files. The largest part of the tree therefore had no format gate, and 49 hunks of drift had accumulated across 15 rule files (mostly the complex stateful_* rules).

Reformat those files with rustfmt over the rules glob, and add a CI step to the fmt job that runs the same check so future drift is caught. The job already installs the rustfmt component, and the workspace .rustfmt.toml (max_width 100, edition 2021) applies to the rule files via ancestor lookup. The reformatting is whitespace-only — the rules test suite is unchanged.
