### PR TITLE
Add a unified supply-chain CI gate (REUSE + cargo-deny)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,22 @@ jobs:
       - name: Check formatting of rule files
         run: rustfmt --edition 2021 --check lint-http-rules/src/rules/*.rs
 
+  supply-chain:
+    name: Supply chain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # First-party licensing: every file carries SPDX/REUSE metadata.
+      - name: REUSE compliance
+        run: pipx run reuse lint
+
+      # Third-party licensing + security advisories over the dependency tree.
+      - name: cargo-deny (advisories + licenses)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories licenses
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,6 @@ dependencies = [
  "rstest",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "sha1 0.11.0",
@@ -1614,15 +1613,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ parking_lot = "0.12"
 # TLS Support
 tokio-rustls = "0.26.4"
 rustls = "0.23.40"
-rustls-pemfile = "2.2.0"
 hyper-rustls = { version = "0.27.9", features = ["http1", "http2"] }
 hyper-util = { version = "0.1.20", features = ["server", "tokio", "client-legacy"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+# Supply-chain gate for `cargo deny check advisories licenses` (run in CI).
+
+[advisories]
+version = 2
+# RustSec advisory DB, default handling: vulnerable and yanked crates fail. Add
+# an advisory id to `ignore = [...]` here (with a comment) only when a fix is
+# pending and the exposure is understood.
+
+[licenses]
+version = 2
+# Minimal set of permissive licenses actually present in the dependency tree
+# (surveyed via `cargo metadata`). Every package's SPDX expression is satisfied
+# by one of these; anything new fails CI, forcing a deliberate decision.
+allow = ["MIT", "Apache-2.0", "ISC", "BSD-3-Clause", "Unicode-3.0", "Zlib"]

--- a/lint-http-proxy/Cargo.toml
+++ b/lint-http-proxy/Cargo.toml
@@ -48,7 +48,6 @@ sha1 = { workspace = true }
 # TLS
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 hyper-rustls = { workspace = true }
 hyper-util = { workspace = true }
 

--- a/lint-http-proxy/src/ca.rs
+++ b/lint-http-proxy/src/ca.rs
@@ -8,7 +8,8 @@ use rcgen::{
     PKCS_ECDSA_P256_SHA256,
 };
 use rustls::crypto::aws_lc_rs::sign::any_supported_type as aws_any_supported_type;
-use rustls::pki_types::PrivateKeyDer as PrivateKey;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer as PrivateKey, PrivatePkcs8KeyDer};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -113,20 +114,13 @@ impl CertificateAuthority {
         let cert_pem = cert.pem();
         let key_pem = key_pair.serialize_pem();
 
-        let certs: Vec<_> =
-            rustls_pemfile::certs(&mut cert_pem.as_bytes()).collect::<Result<Vec<_>, _>>()?;
-        let leaf_cert = certs
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("no certificates parsed from PEM"))?;
-
-        let keys: Vec<_> = rustls_pemfile::pkcs8_private_keys(&mut key_pem.as_bytes())
-            .collect::<Result<Vec<_>, _>>()?;
-        let leaf_key_bytes = keys
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("no private keys parsed from PEM"))?;
-        let leaf_key_der = PrivateKey::from(leaf_key_bytes);
+        // Parse the leaf (first PEM object of each type) via rustls-pki-types'
+        // `PemObject`, which we already depend on through rustls.
+        let leaf_cert = CertificateDer::from_pem_slice(cert_pem.as_bytes())
+            .context("no certificates parsed from PEM")?;
+        let leaf_key = PrivatePkcs8KeyDer::from_pem_slice(key_pem.as_bytes())
+            .context("no private keys parsed from PEM")?;
+        let leaf_key_der = PrivateKey::from(leaf_key);
 
         let signer = aws_any_supported_type(&leaf_key_der)
             .map_err(|e| anyhow::anyhow!("failed to create leaf key signer: {}", e))?;

--- a/lint-http-proxy/tests/proxy_connect_integration.rs
+++ b/lint-http-proxy/tests/proxy_connect_integration.rs
@@ -25,11 +25,9 @@ async fn perform_connect_and_tls_with_alpn_opt(
     inner_request: Option<&str>,
 ) -> anyhow::Result<(Option<String>, Option<Vec<u8>>)> {
     use rustls::client::ClientConfig;
-    use rustls::pki_types::ServerName;
+    use rustls::pki_types::pem::PemObject;
+    use rustls::pki_types::{CertificateDer, ServerName};
     use rustls::RootCertStore;
-    use rustls_pemfile;
-    use std::fs::File;
-    use std::io::BufReader;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     // Connect TCP
@@ -75,8 +73,8 @@ async fn perform_connect_and_tls_with_alpn_opt(
 
     // Setup TLS client config trusting ca_cert_path
     let mut root_store = RootCertStore::empty();
-    let mut f = BufReader::new(File::open(ca_cert_path)?);
-    let certs: Vec<_> = rustls_pemfile::certs(&mut f).collect::<Result<Vec<_>, _>>()?;
+    let certs: Vec<_> =
+        CertificateDer::pem_file_iter(ca_cert_path)?.collect::<Result<Vec<_>, _>>()?;
     // Pass the parsed certificate DER buffers directly to RootCertStore
     root_store.add_parsable_certificates(certs);
     let mut client_cfg = ClientConfig::builder()

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -19,13 +19,13 @@ use lint_http::config::Config;
 /// Build a quinn client endpoint that trusts the CA at `ca_cert_path` and
 /// advertises ALPN `h3`.
 fn build_h3_client(ca_cert_path: &std::path::Path) -> anyhow::Result<quinn::Endpoint> {
+    use rustls::pki_types::pem::PemObject;
+    use rustls::pki_types::CertificateDer;
     use rustls::RootCertStore;
-    use std::io::BufReader;
 
     let mut root_store = RootCertStore::empty();
-    let f = std::fs::File::open(ca_cert_path)?;
     let certs: Vec<_> =
-        rustls_pemfile::certs(&mut BufReader::new(f)).collect::<Result<Vec<_>, _>>()?;
+        CertificateDer::pem_file_iter(ca_cert_path)?.collect::<Result<Vec<_>, _>>()?;
     root_store.add_parsable_certificates(certs);
 
     let mut client_crypto = rustls::ClientConfig::builder()

--- a/lint-http-rules/src/gendocs.rs
+++ b/lint-http-rules/src/gendocs.rs
@@ -30,8 +30,15 @@ fn repo_root() -> PathBuf {
 /// Fixed license header prepended to every generated markdown file. Held
 /// constant (rather than stamped with the current date) so regenerated output
 /// is byte-for-byte stable.
+///
+/// The literal embeds an SPDX tag for the *generated* files; the
+/// `REUSE-IgnoreStart`/`REUSE-IgnoreEnd` markers stop `reuse lint` from reading
+/// it as a (malformed) license tag for this source file, whose own header is
+/// the ISC tag at the top.
+// REUSE-IgnoreStart
 const SPDX_HEADER: &str = "<!--\nSPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas \
 <alganet@gmail.com>\n\nSPDX-License-Identifier: ISC\n-->\n";
+// REUSE-IgnoreEnd
 
 /// Index sections, in render order, paired with the id prefix that selects a
 /// transaction rule into them. Protocol rules get their own trailing section;


### PR DESCRIPTION
lint-http has a large, security-adjacent dependency tree but no advisory or license gate, and although the repo practices the REUSE/SPDX discipline, nothing in CI enforced it. Add one "Supply chain" job covering both:

- `reuse lint` for first-party SPDX/licensing compliance. This surfaced one pre-existing gap: gendocs' SPDX_HEADER string literal was mis-read as a (malformed) license tag for the file itself; wrap it in REUSE-Ignore markers so the scanner skips the embedded tag.
- `cargo deny check advisories licenses` over the dependency tree, with a deny.toml allow-listing only the six permissive licenses actually present (surveyed via cargo metadata) so a new license fails CI.

cargo-deny flagged rustls-pemfile as unmaintained (RUSTSEC-2025-0134). Rather than ignore it, migrate the four call sites (the CA leaf-cert/key parsing in ca.rs plus two integration-test cert loaders) to rustls-pki-types' PemObject trait, which is already in the tree via rustls, and drop the dependency entirely. The advisory clears with no ignores, and the gate's first run leaves the dependency tree cleaner than it found it.
