### PR TITLE
De-flake integration-test startup with an env-overridable deadline

### DIFF
--- a/lint-http-proxy/tests/common/mod.rs
+++ b/lint-http-proxy/tests/common/mod.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: ISC
 
+// Shared integration-test helpers; each test binary uses a different subset.
+#![allow(dead_code)]
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -12,6 +15,18 @@ use tokio::time::sleep;
 use lint_http::capture::CaptureWriter;
 use lint_http::config::Config;
 use lint_http::proxy::run_proxy;
+
+/// Deadline budget for the integration-test startup polls. Generous by default
+/// because startup races a saturated CI/dev CPU (the spawned proxy task may not
+/// be scheduled for a while); override with `LINT_HTTP_TEST_STARTUP_TIMEOUT_SECS`
+/// on slower machines.
+pub fn startup_timeout() -> Duration {
+    let secs = std::env::var("LINT_HTTP_TEST_STARTUP_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(30);
+    Duration::from_secs(secs)
+}
 
 // Minimal helper: start run_proxy and wait until it is accepting and CA files exist
 pub async fn start_run_proxy_and_wait(
@@ -37,7 +52,7 @@ pub async fn start_run_proxy_and_wait(
     });
 
     // Wait for server to accept connections
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + startup_timeout();
     loop {
         if Instant::now() > deadline {
             return Err(anyhow::anyhow!("timeout waiting for proxy to start"));
@@ -63,7 +78,7 @@ pub async fn start_run_proxy_and_wait(
             .unwrap_or_else(|| "ca.key".into());
         let cert_path = std::path::PathBuf::from(cert_path);
         let key_path = std::path::PathBuf::from(key_path);
-        let deadline2 = Instant::now() + Duration::from_secs(5);
+        let deadline2 = Instant::now() + startup_timeout();
         loop {
             if cert_path.exists() && key_path.exists() {
                 break;

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -16,6 +16,9 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use lint_http::capture::CaptureWriter;
 use lint_http::config::Config;
 
+mod common;
+use common::startup_timeout;
+
 /// Build a quinn client endpoint that trusts the CA at `ca_cert_path` and
 /// advertises ALPN `h3`.
 fn build_h3_client(ca_cert_path: &std::path::Path) -> anyhow::Result<quinn::Endpoint> {
@@ -94,7 +97,7 @@ async fn start_proxy_with_h3(
     });
 
     // Wait for TCP listener
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + startup_timeout();
     loop {
         if std::time::Instant::now() > deadline {
             return Err(anyhow::anyhow!("timeout waiting for proxy TCP"));
@@ -108,7 +111,7 @@ async fn start_proxy_with_h3(
     }
 
     // Wait for CA files
-    let deadline2 = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline2 = std::time::Instant::now() + startup_timeout();
     loop {
         if cert_path.exists() && key_path.exists() {
             break;
@@ -121,7 +124,7 @@ async fn start_proxy_with_h3(
 
     // Wait for the H3/QUIC listener to be ready by probing with a connect attempt
     let probe_endpoint = build_h3_client(&cert_path)?;
-    let deadline3 = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline3 = std::time::Instant::now() + startup_timeout();
     loop {
         if std::time::Instant::now() > deadline3 {
             return Err(anyhow::anyhow!("timeout waiting for H3/QUIC listener"));


### PR DESCRIPTION
Integration tests spawn the proxy as a task and poll it for readiness up to a hardcoded 5s deadline. Under a saturated CI/dev CPU the task isn't scheduled in time, so the poll times out ("timeout waiting for proxy to start" / "…TCP" / "…H3/QUIC listener") — a flake that forced manual deadline bumps repeatedly.

Add a shared `common::startup_timeout()` (default 30s, override with LINT_HTTP_TEST_STARTUP_TIMEOUT_SECS) and point all five startup poll deadlines at it (two in common/mod.rs, three in proxy_h3_integration.rs, which now pulls in the common module). The root cause is deadline-too-short under starvation, not the poll mechanism, so a readiness signal — which would starve identically and add a ready-channel to the public run_proxy API for a test-only benefit — was deliberately avoided. Test-only; no production code changes. Response-read and protocol-idle timeouts are a different failure mode and left untouched.
