### PR TITLE
Make `cargo lint` pass again

### DIFF
--- a/lint-http-core/src/state.rs
+++ b/lint-http-core/src/state.rs
@@ -246,7 +246,7 @@ impl StateStore {
         let ttl_chrono =
             chrono::Duration::from_std(self.ttl).unwrap_or_else(|_| chrono::Duration::seconds(0));
 
-        for (_key, deque) in inner.store.iter_mut() {
+        for deque in inner.store.values_mut() {
             deque.retain(|tx| {
                 let age = Utc::now().signed_duration_since(tx.timestamp);
                 // If timestamp is in the future (age < 0), treat as expired (remove)

--- a/lint-http-rules/src/rules/client_patch_method_content_type_match.rs
+++ b/lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -32,10 +32,7 @@ impl Rule for ClientPatchMethodContentTypeMatch {
 
         // Need a previous response to discover Accept-Patch advertisement
         let prev = history.previous()?;
-        let resp = match &prev.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = prev.response.as_ref()?;
 
         // Collect valid media-types advertised in Accept-Patch
         let mut advertised: Vec<String> = Vec::new();

--- a/lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
+++ b/lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
@@ -36,10 +36,7 @@ impl Rule for ClientPreferHeaderAndPreferenceApplied {
             return None;
         }
 
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // If a Preference-Applied header exists (even if non-UTF8), treat as present
         if resp

--- a/lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
+++ b/lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -25,10 +25,7 @@ impl Rule for MessageAcceptAndContentTypeNegotiation {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check when request has Accept and response has Content-Type
         let accept = crate::helpers::headers::get_header_str(&tx.request.headers, "accept");
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
         let content_type = crate::helpers::headers::get_header_str(&resp.headers, "content-type")?;
 
         // If server already returned 406 Not Acceptable, don't flag

--- a/lint-http-rules/src/rules/message_accept_ranges_and_206_consistency.rs
+++ b/lint-http-rules/src/rules/message_accept_ranges_and_206_consistency.rs
@@ -23,10 +23,7 @@ impl Rule for MessageAcceptRangesAnd206Consistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         if resp.status != 206 {
             return None;

--- a/lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
@@ -23,10 +23,7 @@ impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
 

--- a/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -23,10 +23,7 @@ impl Rule for MessageAccessControlAllowOriginValid {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
 

--- a/lint-http-rules/src/rules/message_age_header_numeric.rs
+++ b/lint-http-rules/src/rules/message_age_header_numeric.rs
@@ -24,10 +24,7 @@ impl Rule for MessageAgeHeaderNumeric {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for val in resp.headers.get_all("age").iter() {
             let s = match val.to_str() {

--- a/lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
+++ b/lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
@@ -24,10 +24,7 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Collect tokens from ALL header fields (multiple header fields should be considered)
         let mut ce_set = std::collections::HashSet::new();

--- a/lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
+++ b/lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
@@ -24,10 +24,7 @@ impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Collect CSP frame-ancestors info across header fields
         let mut csp_found = false;
@@ -103,11 +100,9 @@ impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
             return None;
         }
 
+        // Absent or non-utf8 -> let the dedicated rule report it.
         let xfo_val =
-            match crate::helpers::headers::get_header_str(&resp.headers, "x-frame-options") {
-                Some(v) => v.trim(),
-                None => return None, // non-utf8 -> let dedicated rule report
-            };
+            crate::helpers::headers::get_header_str(&resp.headers, "x-frame-options")?.trim();
 
         // Recognize canonical forms
         if xfo_val.eq_ignore_ascii_case("DENY") {

--- a/lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
+++ b/lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
@@ -23,10 +23,7 @@ impl Rule for MessageCookieAttributeConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("set-cookie").iter() {
             let s = match hv.to_str() {

--- a/lint-http-rules/src/rules/message_cookie_domain_validity.rs
+++ b/lint-http-rules/src/rules/message_cookie_domain_validity.rs
@@ -23,10 +23,7 @@ impl Rule for MessageCookieDomainValidity {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("set-cookie").iter() {
             let s = match hv.to_str() {

--- a/lint-http-rules/src/rules/message_cookie_path_validity.rs
+++ b/lint-http-rules/src/rules/message_cookie_path_validity.rs
@@ -23,10 +23,7 @@ impl Rule for MessageCookiePathValidity {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("set-cookie").iter() {
             let s = match hv.to_str() {

--- a/lint-http-rules/src/rules/message_expires_and_cache_control_consistency.rs
+++ b/lint-http-rules/src/rules/message_expires_and_cache_control_consistency.rs
@@ -28,10 +28,7 @@ impl Rule for MessageExpiresAndCacheControlConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // If either header is missing, nothing to check
         let mut has_expires = false;

--- a/lint-http-rules/src/rules/message_link_header_validity.rs
+++ b/lint-http-rules/src/rules/message_link_header_validity.rs
@@ -24,10 +24,7 @@ impl Rule for MessageLinkHeaderValidity {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers (Link is meaningful on responses / 103 Early Hints)
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("link").iter() {
             let val = match hv.to_str() {

--- a/lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
@@ -25,10 +25,7 @@ impl Rule for MessagePermissionsPolicyDirectivesValid {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only inspect responses (server header)
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("permissions-policy").iter() {
             // Non-UTF8 value is a violation

--- a/lint-http-rules/src/rules/message_preference_applied_header_valid.rs
+++ b/lint-http-rules/src/rules/message_preference_applied_header_valid.rs
@@ -24,10 +24,7 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only meaningful when a response is present
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Build a map of preferences from the request (name -> optional value)
         let mut req_prefs = std::collections::HashMap::<String, Option<String>>::new();

--- a/lint-http-rules/src/rules/message_problem_details_structure.rs
+++ b/lint-http-rules/src/rules/message_problem_details_structure.rs
@@ -23,10 +23,7 @@ impl Rule for MessageProblemDetailsStructure {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Only consider responses that indicate an error or problem (4xx/5xx)
         if resp.status < 400 {

--- a/lint-http-rules/src/rules/message_range_and_content_range_consistency.rs
+++ b/lint-http-rules/src/rules/message_range_and_content_range_consistency.rs
@@ -23,10 +23,7 @@ impl Rule for MessageRangeAndContentRangeConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
         let has_range_request = tx.request.headers.get("range").is_some();

--- a/lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
+++ b/lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -24,10 +24,7 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("refresh").iter() {
             let s = match hv.to_str() {

--- a/lint-http-rules/src/rules/message_response_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/message_response_body_length_accuracy.rs
@@ -23,10 +23,7 @@ impl Rule for MessageResponseBodyLengthAccuracy {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // If any Content-Length header(s) are present, validate each value and compare
         use hyper::header::CONTENT_LENGTH;

--- a/lint-http-rules/src/rules/message_retry_after_date_or_delay.rs
+++ b/lint-http-rules/src/rules/message_retry_after_date_or_delay.rs
@@ -24,10 +24,7 @@ impl Rule for MessageRetryAfterDateOrDelay {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Iterate all Retry-After header occurrences; each value must be either
         // a non-negative integer (delta-seconds) or an IMF-fixdate (HTTP-date)

--- a/lint-http-rules/src/rules/message_strict_transport_security_validity.rs
+++ b/lint-http-rules/src/rules/message_strict_transport_security_validity.rs
@@ -24,10 +24,7 @@ impl Rule for MessageStrictTransportSecurityValidity {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applicable to responses
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("strict-transport-security").iter() {
             let v = match hv.to_str() {

--- a/lint-http-rules/src/rules/message_sunset_and_deprecation_consistency.rs
+++ b/lint-http-rules/src/rules/message_sunset_and_deprecation_consistency.rs
@@ -26,10 +26,7 @@ impl Rule for MessageSunsetAndDeprecationConsistency {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only applies to responses
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Get Sunset header (HTTP-date) if present and parseable
         let sunset_opt = match crate::helpers::headers::get_header_str(&resp.headers, "sunset") {

--- a/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+++ b/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
@@ -23,10 +23,7 @@ impl Rule for MessageTimingAllowOriginValidity {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
 

--- a/lint-http-rules/src/rules/semantic_cache_coherence.rs
+++ b/lint-http-rules/src/rules/semantic_cache_coherence.rs
@@ -35,10 +35,7 @@ impl Rule for SemanticCacheCoherence {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // ignore 304 responses, they have no representation body of their own
         if resp.status == 304 {

--- a/lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
@@ -87,10 +87,7 @@ impl Rule for SemanticHeadResponseHeadersMatchGet {
             return None;
         }
 
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let prev = history.previous()?;
         if !prev.request.method.eq_ignore_ascii_case("GET") {
@@ -102,10 +99,7 @@ impl Rule for SemanticHeadResponseHeadersMatchGet {
             return None;
         }
 
-        let prev_resp = match &prev.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let prev_resp = prev.response.as_ref()?;
 
         // Parse config only after the cheap method/response/history guards above —
         // non-HEAD transactions (the common case) skip the allocation entirely.

--- a/lint-http-rules/src/rules/semantic_options_method_capabilities.rs
+++ b/lint-http-rules/src/rules/semantic_options_method_capabilities.rs
@@ -28,10 +28,7 @@ impl Rule for SemanticOptionsMethodCapabilities {
             return None;
         }
 
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // RFC 9110 §9.3.7: "A server generating a successful response to OPTIONS
         // SHOULD send any header that might indicate optional features

--- a/lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
@@ -27,10 +27,7 @@ impl Rule for SemanticOriginMatchingForCors {
         let headers = &req.headers;
 
         // Nothing to do if request did not include Origin header
-        let origin = match crate::helpers::headers::get_header_str(headers, "origin") {
-            Some(o) => o.trim(),
-            None => return None,
-        };
+        let origin = crate::helpers::headers::get_header_str(headers, "origin")?.trim();
 
         // Validate origin syntax using shared helper (handles "null" and serialized origins).
         if let Some(reason) = crate::helpers::uri::validate_origin_value(origin) {
@@ -41,10 +38,7 @@ impl Rule for SemanticOriginMatchingForCors {
             });
         }
 
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Check for Access-Control-Allow-Origin header in response
         let mut acao_values: Vec<String> = Vec::new();

--- a/lint-http-rules/src/rules/semantic_post_creates_resource.rs
+++ b/lint-http-rules/src/rules/semantic_post_creates_resource.rs
@@ -27,10 +27,7 @@ impl Rule for SemanticPostCreatesResource {
         if !tx.request.method.eq_ignore_ascii_case("POST") {
             return None;
         }
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
         // only worry about successful (2xx) responses; other statuses have independent semantics

--- a/lint-http-rules/src/rules/semantic_status_code_semantics.rs
+++ b/lint-http-rules/src/rules/semantic_status_code_semantics.rs
@@ -23,10 +23,7 @@ impl Rule for SemanticStatusCodeSemantics {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
 

--- a/lint-http-rules/src/rules/semantic_trace_method_echo.rs
+++ b/lint-http-rules/src/rules/semantic_trace_method_echo.rs
@@ -60,10 +60,7 @@ impl Rule for SemanticTraceMethodEcho {
             });
         }
 
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // RFC 9110 §9.3.8 uses SHOULD for successful TRACE responses.
         // Do not enforce message/http for non-success responses.

--- a/lint-http-rules/src/rules/server_200_vs_204_body_consistency.rs
+++ b/lint-http-rules/src/rules/server_200_vs_204_body_consistency.rs
@@ -23,10 +23,7 @@ impl Rule for Server200Vs204BodyConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Only consider 200 responses
         if resp.status != 200 {

--- a/lint-http-rules/src/rules/server_3xx_vs_request_method.rs
+++ b/lint-http-rules/src/rules/server_3xx_vs_request_method.rs
@@ -29,10 +29,7 @@ impl Rule for Server3xxVsRequestMethod {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
 

--- a/lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
@@ -25,10 +25,7 @@ impl Rule for ServerAcceptRangesValuesValid {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let val = crate::helpers::headers::get_header_str(&resp.headers, "accept-ranges")?;
 

--- a/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -25,10 +25,7 @@ impl Rule for ServerAltSvcHeaderSyntax {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("alt-svc").iter() {
             let s = match hv.to_str() {

--- a/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -82,10 +82,7 @@ impl Rule for ServerAltSvcProtocolIanaRegistered {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("alt-svc").iter() {
             let s = match hv.to_str() {

--- a/lint-http-rules/src/rules/server_content_security_policy_validity.rs
+++ b/lint-http-rules/src/rules/server_content_security_policy_validity.rs
@@ -30,10 +30,7 @@ impl Rule for ServerContentSecurityPolicyValidity {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         use crate::helpers::token::find_invalid_token_char;
 

--- a/lint-http-rules/src/rules/server_deprecation_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_deprecation_header_syntax.rs
@@ -24,10 +24,7 @@ impl Rule for ServerDeprecationHeaderSyntax {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let mut vals = Vec::new();
         for hv in resp.headers.get_all("deprecation").iter() {

--- a/lint-http-rules/src/rules/server_must_revalidate_and_immutable_mismatch.rs
+++ b/lint-http-rules/src/rules/server_must_revalidate_and_immutable_mismatch.rs
@@ -27,10 +27,7 @@ impl Rule for ServerMustRevalidateAndImmutableMismatch {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Collect all cache-control directive tokens across header fields
         let mut found_must_revalidate = false;

--- a/lint-http-rules/src/rules/server_patch_accept_patch_header.rs
+++ b/lint-http-rules/src/rules/server_patch_accept_patch_header.rs
@@ -30,10 +30,7 @@ impl Rule for ServerPatchAcceptPatchHeader {
             return None;
         }
 
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // If Accept-Patch header absent -> warn
         let mut found = false;

--- a/lint-http-rules/src/rules/server_priority_and_cacheability_consistency.rs
+++ b/lint-http-rules/src/rules/server_priority_and_cacheability_consistency.rs
@@ -23,10 +23,7 @@ impl Rule for ServerPriorityAndCacheabilityConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Only consider responses that include a Priority header field.
         // Prefer the first ASCII-valid field value when multiple header fields exist.

--- a/lint-http-rules/src/rules/server_problem_details_content_type.rs
+++ b/lint-http-rules/src/rules/server_problem_details_content_type.rs
@@ -23,10 +23,7 @@ impl Rule for ServerProblemDetailsContentType {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Only consider responses that indicate an error or problem (4xx/5xx)
         if resp.status < 400 {

--- a/lint-http-rules/src/rules/server_response_location_on_redirect.rs
+++ b/lint-http-rules/src/rules/server_response_location_on_redirect.rs
@@ -23,10 +23,7 @@ impl Rule for ServerResponseLocationOnRedirect {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
 

--- a/lint-http-rules/src/rules/server_status_and_caching_semantics.rs
+++ b/lint-http-rules/src/rules/server_status_and_caching_semantics.rs
@@ -26,10 +26,7 @@ impl Rule for ServerStatusAndCachingSemantics {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
 

--- a/lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
+++ b/lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
@@ -29,10 +29,7 @@ impl Rule for ServerVaryAndCacheConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Detect Vary: * across all Vary header fields
         let mut saw_star = false;

--- a/lint-http-rules/src/rules/server_vary_header_valid.rs
+++ b/lint-http-rules/src/rules/server_vary_header_valid.rs
@@ -25,10 +25,7 @@ impl Rule for ServerVaryHeaderValid {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Track whether '*' appears and count effective tokens across all header fields
         let mut saw_star = false;

--- a/lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
@@ -24,10 +24,7 @@ impl Rule for ServerXFrameOptionsValueValid {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check response headers
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
 

--- a/lint-http-rules/src/rules/server_x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/server_x_xss_protection_value_valid.rs
@@ -23,10 +23,7 @@ impl Rule for ServerXXssProtectionValueValid {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
         let count = headers.get_all("x-xss-protection").iter().count();

--- a/lint-http-rules/src/rules/stateful_103_early_hints_before_final.rs
+++ b/lint-http-rules/src/rules/stateful_103_early_hints_before_final.rs
@@ -27,10 +27,7 @@ impl Rule for Stateful103EarlyHintsBeforeFinal {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to responses with status 103
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
         if resp.status != 103 {
             return None;
         }

--- a/lint-http-rules/src/rules/stateful_range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/stateful_range_request_and_caching.rs
@@ -59,13 +59,10 @@ impl Rule for StatefulRangeRequestAndCaching {
             }
         });
 
-        let prev_resp = match prev_206 {
-            Some(p) => match &p.response {
-                Some(r) => r,
-                None => return None, // should not happen but be safe
-            },
-            None => return None,
-        };
+        // The second `?` should never fire: `prev_206` was found by matching a 206
+        // status, which it could not have done without a response. It stays as a
+        // guard rather than an unwrap.
+        let prev_resp = prev_206?.response.as_ref()?;
 
         // determine if the prior 206 had a validator we could use
         // ignore weak ETags since they cannot be placed in If-Range.

--- a/lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
+++ b/lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
@@ -34,10 +34,7 @@ impl Rule for StatefulRedirectChainValidity {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         let status = resp.status;
         // Consider redirection/creation status codes that may include Location
@@ -47,18 +44,15 @@ impl Rule for StatefulRedirectChainValidity {
 
         // No Location -> nothing to validate here (other rules handle presence)
         let mut loc_iter = resp.headers.get_all("location").iter();
-        let first_loc = match loc_iter.next() {
-            Some(hv) => match hv.to_str() {
-                Ok(s) => s.trim().to_string(),
-                Err(_) => {
-                    return Some(Violation {
-                        rule: self.id().into(),
-                        severity: config.severity,
-                        message: "Location header value is not valid UTF-8".into(),
-                    })
-                }
-            },
-            None => return None,
+        let first_loc = match loc_iter.next()?.to_str() {
+            Ok(s) => s.trim().to_string(),
+            Err(_) => {
+                return Some(Violation {
+                    rule: self.id().into(),
+                    severity: config.severity,
+                    message: "Location header value is not valid UTF-8".into(),
+                })
+            }
         };
 
         // Helper: compare request-target path+query (if present) with a Location

--- a/lint-http-rules/src/rules/stateful_websocket_handshake_validity.rs
+++ b/lint-http-rules/src/rules/stateful_websocket_handshake_validity.rs
@@ -48,10 +48,7 @@ impl Rule for StatefulWebsocketHandshakeValidity {
         }
 
         // If there's no response, nothing to validate here
-        let resp = match &tx.response {
-            Some(r) => r,
-            None => return None,
-        };
+        let resp = tx.response.as_ref()?;
 
         // Response status must be 101
         if resp.status != 101 {


### PR DESCRIPTION
`cargo lint` -- the alias CI actually runs, `clippy --workspace --all-features --all-targets -- -D warnings` -- exits 101 on main. It has for a while: the failing line's blame is `Correctedness adjustments`, and that commit fails identically, so this predates the recent dependency work rather than following from it.

It reports one error, and that number is misleading. `-D warnings` promotes everything, and clippy stops at the first crate that fails, so `lint-http-core` erroring on one `for_kv_map` hid 57 `question_mark` warnings in `lint-http-rules` that never got compiled. Fixing only what the output names would have produced a second red build with 57 errors in it. There are 58 problems, not one.

The `for_kv_map` is a one-liner: `for (_key, deque) in store.iter_mut()` discards the key, so it is `store.values_mut()`.

The 57 are all the same defensive shape at the top of a `check_transaction` --

    let resp = match &tx.response { Some(r) => r, None => return None };

-- which is `tx.response.as_ref()?`, since the function already returns `Option`. Fifty of those, plus two on `prev.response`, are byte-identical and were rewritten by exact match on the whole block rather than a loose regex; the other five are one-offs and were done by hand: two `get_header_str(...)?` chains, a nested `match` in `stateful_range_request_and_caching`, and `stateful_redirect_chain_validity`, whose inner `Err` arm returns a violation and therefore stays a match.

Worth writing down, because it is why `cargo clippy --fix` cannot do this and why the diff is not what the tool suggests: **clippy's own suggestion does not compile.** It offers `&tx.response?`, which is E0507 -- `tx.response` is behind a shared reference and `?` would move out of it. The lint is right that this is a `?`; its fix is wrong, and `--fix` declines to apply it. `.as_ref()?` is the form that works.

Behaviour is unchanged -- `?` on an `Option` in an `Option`-returning function is what the match already did -- and the two comments that carried real information (the non-utf8 hand-off, and "should not happen but be safe") are preserved as prose rather than dropped with the arms they sat on. 53 files, 167 lines lighter, all 3953 tests pass, and `cargo lint` exits 0.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
