### PR TITLE
 First citations for the code beneath the rules, and a forwarding fix

### DIFF
--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -121,9 +121,11 @@ fn parse_varint_at(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
 
 // ── Frame observer state machine ─────────────────────────────────────
 
-/// HTTP/3 frame type: SETTINGS (RFC 9114 §7.2.4).
+/// HTTP/3 frame type: SETTINGS.
+// cite(RFC 9114 § 7.2.4): "The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate"
 const H3_FRAME_SETTINGS: u64 = 0x04;
-/// HTTP/3 frame type: MAX_PUSH_ID (RFC 9114 §7.2.7).
+/// HTTP/3 frame type: MAX_PUSH_ID.
+// cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
 const H3_FRAME_MAX_PUSH_ID: u64 = 0x0D;
 /// HTTP/3 unidirectional stream type for the control stream (RFC 9114 §6.2.1).
 const H3_STREAM_TYPE_CONTROL: u64 = 0x00;

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -274,6 +274,10 @@ pub(super) fn build_upstream_request(
 /// headers are essential to the handshake); otherwise hop-by-hop headers are
 /// stripped. `append` preserves repeated headers (e.g. `set-cookie`).
 pub(super) fn filter_response_headers(headers: &HeaderMap, status: u16) -> HeaderMap {
+    // Why 101 escapes the hop-by-hop strip below: Upgrade is a connection-specific
+    // field an intermediary would normally remove, and a 101 is the one response
+    // that cannot survive losing it.
+    // cite(RFC 9110 § 15.2.2): "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field"
     if status == 101 {
         return headers.clone();
     }

--- a/lint-http-proxy/src/proxy/hop_by_hop.rs
+++ b/lint-http-proxy/src/proxy/hop_by_hop.rs
@@ -17,6 +17,7 @@
 // surviving the hop -- it is the hint telling a recipient what metadata was lost
 // when an intermediary dropped the trailer section. We forward trailers, so
 // stripping the field that announces them was self-defeating.
+// cite(RFC 9110 § 7.6.1): "Furthermore, intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics."
 pub(super) static HOP_BY_HOP_HEADERS: &[&str] = &[
     "connection",
     "keep-alive",
@@ -48,7 +49,10 @@ pub(super) fn parse_connection_tokens(
     let mut set = std::collections::HashSet::new();
     if let Some(conn_val) = val {
         if let Ok(conn_str) = conn_val.to_str() {
+            // cite(RFC 9110 § 7.6.1): "Connection = #connection-option connection-option = token"
             for token in conn_str.split(',') {
+                // The lowercasing is the sentence below; the set is matched case-insensitively.
+                // cite(RFC 9110 § 7.6.1): "Connection options are case-insensitive."
                 let trimmed = token.trim().to_ascii_lowercase();
                 if !trimmed.is_empty() {
                     set.insert(trimmed);
@@ -63,6 +67,9 @@ pub(super) fn is_hop_by_hop_header(
     name: &str,
     connection_hop_headers: &std::collections::HashSet<String>,
 ) -> bool {
+    // The `connection_hop_headers` half is the nomination clause: whatever Connection
+    // named is hop-by-hop for this message, on top of the table's fixed set.
+    // cite(RFC 9110 § 7.6.1): "Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message)."
     connection_hop_headers.contains(name) || HOP_BY_HOP_HEADERS.contains(&name)
 }
 

--- a/lint-http-proxy/src/proxy/hop_by_hop.rs
+++ b/lint-http-proxy/src/proxy/hop_by_hop.rs
@@ -7,16 +7,26 @@
 //! These helpers are shared by the HTTP/1.1+H2, WebSocket relay, and HTTP/3
 //! handlers when building responses to forward to the client.
 
-// RFC 7230 Section 6.1: Hop-by-hop headers must not be forwarded by proxies.
+// Fields an intermediary removes before forwarding, whether or not the sender
+// nominated them in Connection. The first five are the list RFC 9110 § 7.6.1
+// gives; `connection` is removed by the same section's separate instruction to
+// drop the Connection field itself after acting on it. Proxy-Authenticate and
+// Proxy-Authorization are not § 7.6.1's, and are justified one entry down.
+//
+// `Trailer` is deliberately absent: § 7.6.1 does not list it, and § 6.6.2 has it
+// surviving the hop -- it is the hint telling a recipient what metadata was lost
+// when an intermediary dropped the trailer section. We forward trailers, so
+// stripping the field that announces them was self-defeating.
 pub(super) static HOP_BY_HOP_HEADERS: &[&str] = &[
     "connection",
     "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
+    "proxy-connection",
     "te",
-    "trailer",
     "transfer-encoding",
     "upgrade",
+    // Not § 7.6.1's list: these two are single-hop by their own definition.
+    "proxy-authenticate",
+    "proxy-authorization",
 ];
 
 /// Convert hyper::Version into the textual HTTP-version token used in start/status lines.

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -168,10 +168,10 @@ pub fn parse_set_cookie(
             }
             "path" => {
                 if let Some(v) = val_opt {
-                    // RFC 6265 §5.2.4: if the attribute-value does not start
-                    // with "/", the user agent SHOULD ignore the attribute and
-                    // use the default-path instead.  We mirror that behaviour by
-                    // only assigning when the value is syntactically valid.
+                    // The user agent ignores such an attribute and uses the
+                    // default-path instead.  We mirror that by only assigning
+                    // when the value is syntactically valid.
+                    // cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
                     if v.starts_with('/') {
                         path_attr = Some(v.to_string());
                     }

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -39,6 +39,7 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
         let s = hv.to_str().map_err(|_| ContentLengthError::NonUtf8)?;
         let t = s.trim();
 
+        // cite(RFC 9110 § 8.6): "Content-Length = 1*DIGIT"
         if t.is_empty() || !t.chars().all(|c| c.is_ascii_digit()) {
             return Err(ContentLengthError::InvalidCharacter(s.to_string()));
         }
@@ -100,6 +101,7 @@ pub fn get_all_header_values(headers: &HeaderMap, name: &str) -> Option<String> 
 pub fn inm_matches_known(inm: &str, known: &str) -> bool {
     fn normalize(s: &str) -> &str {
         let s = s.trim();
+        // cite(RFC 9110 § 13.1.2): "A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match"
         if let Some(rest) = s.strip_prefix("W/") {
             rest.trim()
         } else {
@@ -1040,9 +1042,10 @@ fn validate_domain(domain: &str) -> bool {
     true
 }
 
-/// Validate an entity-tag (ETag) value per RFC 9110 §7.6 and §7.8. Accepts '*' or an entity-tag
+/// Validate an entity-tag (ETag) value. Accepts '*' or an entity-tag
 /// which may be weak (prefix 'W/'). Returns Ok(()) on success or Err(msg) describing the problem.
 pub fn validate_entity_tag(val: &str) -> Result<(), String> {
+    // cite(RFC 9110 § 8.8.3): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
     let s = val.trim();
     if s == "*" {
         return Ok(());
@@ -1083,6 +1086,7 @@ pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
         .trim();
     let params = parts.next().map(|p| p.trim()).filter(|p| !p.is_empty());
 
+    // cite(RFC 9110 § 8.3.1): "media-type = type "/" subtype parameters"
     if !media.contains('/') {
         return Err(format!(
             "Invalid media-type '{}': missing '/' between type and subtype",

--- a/lint-http-rules/src/helpers/status.rs
+++ b/lint-http-rules/src/helpers/status.rs
@@ -4,6 +4,7 @@
 
 /// Returns true if `status` is a redirection status (3xx).
 pub fn is_redirection_status(status: u16) -> bool {
+    // cite(RFC 9110 § 15.4): "The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request."
     (300..=399).contains(&status)
 }
 

--- a/lint-http-rules/src/helpers/token.rs
+++ b/lint-http-rules/src/helpers/token.rs
@@ -4,6 +4,7 @@
 
 /// Helpers for RFC `token` (tchar) validation used by multiple rules.
 pub fn is_tchar(c: char) -> bool {
+    // cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
     c.is_ascii_alphanumeric()
         || matches!(
             c,

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -140,6 +140,7 @@ pub fn validate_origin_value(s: &str) -> Option<String> {
 pub fn extract_authority_from_request_target(s: &str) -> Option<String> {
     let s_trim = s.trim();
 
+    // cite(RFC 9112 § 3.2): "request-target = origin-form / absolute-form / authority-form / asterisk-form"
     if s_trim.is_empty() || s_trim == "*" || s_trim.starts_with('/') {
         return None;
     }
@@ -202,6 +203,7 @@ pub fn extract_host_from_request_target(s: &str) -> Option<String> {
 pub fn extract_path_from_request_target(s: &str) -> Option<String> {
     let s_trim = s.trim();
 
+    // cite(RFC 9112 § 3.2): "request-target = origin-form / absolute-form / authority-form / asterisk-form"
     if s_trim == "*" {
         return None;
     }

--- a/lint-http-rules/src/helpers/websocket.rs
+++ b/lint-http-rules/src/helpers/websocket.rs
@@ -25,6 +25,7 @@ pub fn compute_accept(key: &str) -> Option<String> {
     let key_trim = key.trim();
     // decode key to ensure it is 16 bytes long
     match base64::engine::general_purpose::STANDARD.decode(key_trim) {
+        // cite(RFC 6455 § 4.1): "The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded"
         Ok(bytes) if bytes.len() == 16 => {
             let mut hasher = sha1::Sha1::new();
             hasher.update(key_trim.as_bytes());

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -295,6 +295,14 @@ sources:
       line: 106
     - file: lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
       line: 108
+  - label: lint-http-rules/src/helpers/cookie.rs (3)
+    section: § 5.2.4
+    snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 174
+    - file: lint-http-rules/src/rules/message_cookie_path_validity.rs
+      line: 56
   - label: message_cookie_attribute_consistency
     section: § 4.1.1
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
@@ -331,12 +339,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_cookie_domain_validity.rs
       line: 50
-  - label: message_cookie_path_validity
-    section: § 5.2.4
-    snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
-    cited_by:
-    - file: lint-http-rules/src/rules/message_cookie_path_validity.rs
-      line: 56
   - label: stateful_cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
@@ -745,6 +747,14 @@ sources:
       line: 28
     - file: lint-http-rules/src/rules/message_user_agent_token_valid.rs
       line: 39
+  - label: lint-http-proxy/src/proxy/exchange.rs
+    section: § 15.2.2
+    snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
+    cited_by:
+    - file: lint-http-proxy/src/proxy/exchange.rs
+      line: 280
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 42
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -1137,12 +1147,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 34
-  - label: stateful_101_switching_protocols
-    section: § 15.2.2
-    snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
-    cited_by:
-    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 42
   - label: stateful_authentication_failure_loop
     section: § 15.5.2
     snippet: If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.
@@ -1289,10 +1293,14 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
       line: 29
-  - label: client_request_target_form_checks
+  - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 143
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 206
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 30
   - label: message_content_length_vs_transfer_encoding
@@ -1347,6 +1355,22 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc9114.txt
   type: text/plain
   fragments:
+  - label: lint-http-proxy/src/h3_instrument.rs
+    section: § 7.2.4
+    snippet: The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 125
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 48
+  - label: lint-http-proxy/src/h3_instrument.rs (2)
+    section: § 7.2.7
+    snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 128
+    - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+      line: 40
   - label: message_http3_host_authority_consistency
     section: § 4.3
     snippet: Pseudo-header fields are not HTTP fields.
@@ -1369,18 +1393,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
       line: 31
-  - label: stateful_http3_max_push_id
-    section: § 7.2.7
-    snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
-    cited_by:
-    - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 40
-  - label: stateful_http3_settings_frame
-    section: § 7.2.4
-    snippet: The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate
-    cited_by:
-    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 48
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.txt
   type: text/plain

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -761,6 +761,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 210
+  - label: lint-http-rules/src/helpers/token.rs
+    section: § 5.6.2
+    snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+    cited_by:
+    - file: lint-http-rules/src/helpers/token.rs
+      line: 7
   - label: message_accept_and_content_type_negotiation
     section: § 15.5.7
     snippet: The 406 (Not Acceptable) status code indicates that the target resource does not have a current representation that would be acceptable to the user agent

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -755,6 +755,30 @@ sources:
       line: 280
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs
+    section: § 7.6.1
+    snippet: 'Connection = #connection-option connection-option = token'
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 52
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
+    section: § 7.6.1
+    snippet: Connection options are case-insensitive.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 55
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (3)
+    section: § 7.6.1
+    snippet: Furthermore, intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 20
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
+    section: § 7.6.1
+    snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 72
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -385,10 +385,12 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc6455.txt
   type: text/plain
   fragments:
-  - label: client_sec_websocket_headers_consistency
+  - label: lint-http-rules/src/helpers/websocket.rs
     section: § 4.1
     snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded
     cited_by:
+    - file: lint-http-rules/src/helpers/websocket.rs
+      line: 28
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
       line: 28
   - label: stateful_websocket_frame_opcode_sequence
@@ -761,6 +763,50 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 210
+  - label: lint-http-rules/src/helpers/headers.rs
+    section: § 13.1.2
+    snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 104
+    - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
+      line: 44
+  - label: lint-http-rules/src/helpers/headers.rs (2)
+    section: § 8.3.1
+    snippet: media-type = type "/" subtype parameters
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1089
+    - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
+      line: 90
+  - label: lint-http-rules/src/helpers/headers.rs (3)
+    section: § 8.6
+    snippet: Content-Length = 1*DIGIT
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 42
+    - file: lint-http-rules/src/rules/message_content_length.rs
+      line: 27
+  - label: lint-http-rules/src/helpers/headers.rs (4)
+    section: § 8.8.3
+    snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1048
+    - file: lint-http-rules/src/rules/message_etag_syntax.rs
+      line: 58
+  - label: lint-http-rules/src/helpers/status.rs
+    section: § 15.4
+    snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
+    cited_by:
+    - file: lint-http-rules/src/helpers/status.rs
+      line: 7
+    - file: lint-http-rules/src/rules/server_3xx_vs_request_method.rs
+      line: 37
+    - file: lint-http-rules/src/rules/server_response_location_on_redirect.rs
+      line: 35
+    - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
+      line: 41
   - label: lint-http-rules/src/helpers/token.rs
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
@@ -861,12 +907,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_content_encoding_iana_registered.rs
       line: 103
-  - label: message_content_length
-    section: § 8.6
-    snippet: Content-Length = 1*DIGIT
-    cited_by:
-    - file: lint-http-rules/src/rules/message_content_length.rs
-      line: 27
   - label: message_content_location_and_uri_consistency
     section: § 8.7
     snippet: Content-Location = absolute-URI / partial-URI
@@ -878,12 +918,6 @@ sources:
     snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
     cited_by:
     - file: lint-http-rules/src/rules/message_content_type_iana_registered.rs
-      line: 90
-  - label: message_content_type_well_formed
-    section: § 8.3.1
-    snippet: media-type = type "/" subtype parameters
-    cited_by:
-    - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
   - label: message_date_and_time_headers_consistency
     section: § 5.6.7
@@ -899,12 +933,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_date_and_time_headers_consistency.rs
       line: 36
-  - label: message_etag_syntax
-    section: § 8.8.3
-    snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
-    cited_by:
-    - file: lint-http-rules/src/rules/message_etag_syntax.rs
-      line: 58
   - label: message_extension_headers_registered
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
@@ -931,12 +959,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_if_modified_since_date_format.rs
       line: 48
-  - label: message_if_none_match_etag_syntax
-    section: § 13.1.2
-    snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
-    cited_by:
-    - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
-      line: 44
   - label: message_if_unmodified_since_date_format
     section: § 13.1.4
     snippet: If-Unmodified-Since = HTTP-date
@@ -1039,16 +1061,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_200_vs_204_body_consistency.rs
       line: 30
-  - label: server_3xx_vs_request_method
-    section: § 15.4
-    snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
-    cited_by:
-    - file: lint-http-rules/src/rules/server_3xx_vs_request_method.rs
-      line: 37
-    - file: lint-http-rules/src/rules/server_response_location_on_redirect.rs
-      line: 35
-    - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
-      line: 41
   - label: server_accept_ranges_values_valid
     section: § 14.3
     snippet: Accept-Ranges     = acceptable-ranges acceptable-ranges = 1#range-unit


### PR DESCRIPTION
Cites the transcribed-grammar helpers (the tchar table every token check stands on, plus six reuse quotes) and the proxy for the first time. Fixes a real forwarding bug — Proxy-Connection relayed to the origin, Trailer wrongly stripped — then cites the four sentences the hop-by-hop filter is built from.