### PR TITLE
Cookies 

### DIFF
--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -348,6 +348,12 @@ pub fn parse_auth_params(s: &str) -> Result<std::collections::HashMap<String, St
 /// suitable for inclusion in violation messages.
 pub fn parse_nc_hex(s: &str) -> Result<u64, String> {
     let s = s.trim();
+    // RFC 7616 gives `nc` no ABNF at all. § 3.4 introduces it as "the hexadecimal
+    // count" and never fixes its width; the sentence below is the only place in the
+    // document that does. It sits in § 3.5, about Authentication-Info, but the same
+    // section requires that field's nc to be the one from the client's request — so
+    // it is one value with one width, and this is where the width is written down.
+    // cite(RFC 7616 § 3.5): "For historical reasons, the nc value MUST be exactly 8 hexadecimal digits."
     if s.len() != 8 {
         return Err("nc must be exactly 8 hex digits".into());
     }

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -226,18 +226,23 @@ pub fn parse_set_cookie(
 
     let domain = domain_attr.unwrap_or(default_domain);
 
-    // determine default path per RFC 6265 §5.1.4
+    // The branches below are § 5.1.4's numbered steps, in its order.
+    // cite(RFC 6265 § 5.1.4): "The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:"
     let default_path =
         if let Some(p) = crate::helpers::uri::extract_path_from_request_target(request_uri) {
+            // Step 2. Quoted here only as its tail: the step opens "If the uri-path is
+            // empty or if the first character of the uri-" and the document's line
+            // break lands inside `uri-path`, so the sentence cannot be quoted whole.
+            // cite(RFC 6265 § 5.1.4): "output %x2F ("/") and skip the remaining steps."
             if !p.starts_with('/') {
                 "/".into()
             } else {
-                // if path contains no more than one '/', default is '/'
+                // cite(RFC 6265 § 5.1.4): "If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step."
                 let slash_count = p.matches('/').count();
                 if slash_count <= 1 {
                     "/".into()
                 } else {
-                    // strip everything after the right-most '/'
+                    // cite(RFC 6265 § 5.1.4): "Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/")."
                     if let Some(pos) = p.rfind('/') {
                         if pos == 0 {
                             "/".into()

--- a/lint-http-rules/src/helpers/domain.rs
+++ b/lint-http-rules/src/helpers/domain.rs
@@ -43,6 +43,7 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
     }
 
     // Validate labels
+    // cite(RFC 1035 § 2.3.4): "names 255 octets or less"
     if s.len() > 255 {
         return Err("domain total length exceeds 255 characters".into());
     }
@@ -51,11 +52,22 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
         if label.is_empty() {
             return Err("domain contains empty label".into());
         }
+        // cite(RFC 1035 § 2.3.1): "Labels must be 63 characters or less."
         if label.len() > 63 {
             return Err("domain label exceeds 63 characters".into());
         }
         let first = label.chars().next().expect("label verified non-empty");
         let last = label.chars().next_back().expect("label verified non-empty");
+        // Only the hyphen is checked at the ends, not "starts with a letter". That is
+        // not an oversight: § 2.3.1's rule was letter-first, and RFC 1123 changed it.
+        // A label may open with a digit, and `1.example.com` is not our business to
+        // reject — so the quote below is deliberately the clause about the *end* and
+        // the interior, which is the part this branch actually enforces.
+        // cite(RFC 1035 § 2.3.1): "end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
+        // (RFC 1123's § 2.1 heading is the old indented style with no trailing period,
+        // which the section resolver does not match, so this cite names the document
+        // and lets the sentence locate itself.)
+        // cite(RFC 1123): "the restriction on the first character is relaxed to allow either a letter or a digit."
         if first == '-' || last == '-' {
             return Err("domain label must not start or end with '-'".into());
         }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -213,6 +213,37 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
       line: 67
+- label: RFC 1035
+  url: https://www.rfc-editor.org/rfc/rfc1035.txt
+  type: text/plain
+  fragments:
+  - label: lint-http-rules/src/helpers/domain.rs
+    section: § 2.3.1
+    snippet: Labels must be 63 characters or less.
+    cited_by:
+    - file: lint-http-rules/src/helpers/domain.rs
+      line: 55
+  - label: lint-http-rules/src/helpers/domain.rs (2)
+    section: § 2.3.1
+    snippet: end with a letter or digit, and have as interior characters only letters, digits, and hyphen.
+    cited_by:
+    - file: lint-http-rules/src/helpers/domain.rs
+      line: 66
+  - label: lint-http-rules/src/helpers/domain.rs (3)
+    section: § 2.3.4
+    snippet: names 255 octets or less
+    cited_by:
+    - file: lint-http-rules/src/helpers/domain.rs
+      line: 46
+- label: RFC 1123
+  url: https://www.rfc-editor.org/rfc/rfc1123.txt
+  type: text/plain
+  fragments:
+  - label: lint-http-rules/src/helpers/domain.rs
+    snippet: the restriction on the first character is relaxed to allow either a letter or a digit.
+    cited_by:
+    - file: lint-http-rules/src/helpers/domain.rs
+      line: 70
 - label: RFC 2045
   url: https://www.rfc-editor.org/rfc/rfc2045.txt
   type: text/plain

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -327,6 +327,30 @@ sources:
     - file: lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
       line: 108
   - label: lint-http-rules/src/helpers/cookie.rs (3)
+    section: § 5.1.4
+    snippet: If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 240
+  - label: lint-http-rules/src/helpers/cookie.rs (4)
+    section: § 5.1.4
+    snippet: Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 245
+  - label: lint-http-rules/src/helpers/cookie.rs (5)
+    section: § 5.1.4
+    snippet: 'The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:'
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 230
+  - label: lint-http-rules/src/helpers/cookie.rs (6)
+    section: § 5.1.4
+    snippet: output %x2F ("/") and skip the remaining steps.
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 236
+  - label: lint-http-rules/src/helpers/cookie.rs (7)
     section: § 5.2.4
     snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
     cited_by:
@@ -558,6 +582,12 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc7616.txt
   type: text/plain
   fragments:
+  - label: lint-http-rules/src/helpers/auth.rs
+    section: § 3.5
+    snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
+    cited_by:
+    - file: lint-http-rules/src/helpers/auth.rs
+      line: 356
   - label: message_digest_auth_validity
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque.'


### PR DESCRIPTION
Cite the cookie domain limits (and the case the code rightly ignores) and the default-path steps.

