### PR TITLE
Header-syntax helpers & pointer fixes 

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -830,7 +830,12 @@ pub fn validate_quoted_string(val: &str) -> Result<(), String> {
     while i + 1 < bytes.len() {
         let b = bytes[i];
         if prev_backslash {
-            // escaped char allowed
+            // A backslash does not make anything quotable. The escaped octet has its
+            // own set, and it is not the same as qdtext's: SP and VCHAR and HTAB and
+            // obs-text may follow a backslash, the remaining controls may not.
+            if !(b == b'\t' || (0x20..=0x7e).contains(&b) || b >= 0x80) {
+                return Err(format!("Invalid quoted-pair in quoted-string: '{}'", val));
+            }
             prev_backslash = false;
         } else if b == b'\\' {
             prev_backslash = true;
@@ -1511,6 +1516,30 @@ mod tests {
     }
 
     // Quoted-string helper tests
+    /// `qdtext` and `quoted-pair` allow different octets after their respective
+    /// positions, and a backslash does not widen the set to "anything".
+    #[test]
+    fn quoted_pair_octet_is_constrained() {
+        // HTAB / SP / VCHAR / obs-text may follow a backslash.
+        assert!(validate_quoted_string("\"\\\t\"").is_ok());
+        assert!(validate_quoted_string("\"\\ \"").is_ok());
+        assert!(validate_quoted_string("\"\\a\"").is_ok());
+        assert!(validate_quoted_string("\"\\\u{80}\"").is_ok());
+        // The other controls may not, escaped or otherwise.
+        assert!(validate_quoted_string("\"\\\u{1}\"").is_err());
+        assert!(validate_quoted_string("\"\\\n\"").is_err());
+        assert!(validate_quoted_string("\"\\\u{7f}\"").is_err());
+    }
+
+    /// HTTP's `qdtext` admits HTAB and obs-text, which is the opposite of the
+    /// Structured Fields String rule -- same shape, different document.
+    #[test]
+    fn qdtext_admits_htab_and_obs_text() {
+        assert!(validate_quoted_string("\"a\tb\"").is_ok());
+        assert!(validate_quoted_string("\"caf\u{e9}\"").is_ok());
+        assert!(validate_quoted_string("\"a\u{1}b\"").is_err());
+    }
+
     #[test]
     fn validate_quoted_string_control_char_reports_violation() {
         let s = "\"bad\x01str\"";

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -100,7 +100,27 @@ pub fn get_header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str>
 /// avoids comparing partial header values.
 ///
 /// This is handy when rules need to compare the *effective* string value of a
-/// possibly-multiple header field (e.g. cookies, Vary dimensions, etc.).
+/// possibly-multiple header field (e.g. Upgrade, Vary dimensions, etc.).
+///
+/// The `", "` is not a house style. § 5.3 permits the combining, names the comma
+/// as the separator, and then says which of comma and comma-SP to use, so all
+/// three of the decisions in this function are in one sentence. The in-order
+/// append is the same sentence: order is significant, so `get_all`'s order is
+/// preserved rather than sorted or deduplicated.
+///
+/// **This is not valid for every field, and the RFC names the exception.** The
+/// doc comment here used to offer "cookies" as an example, which is precisely
+/// backwards: `Set-Cookie` does not use list syntax and cannot be combined into
+/// one field value at all. No caller passes it today. Do not add one -- for that
+/// field, iterate the lines.
+///
+/// The `|` inside the second quote is not a typo and must not be tidied. That
+/// sentence sits in one of the RFC's indented note blocks, whose gutter markers
+/// survive extraction, so the `|` is genuinely part of what the document says as
+/// far as verification is concerned.
+///
+// cite(RFC 9110 § 5.3): "A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP."
+// cite(RFC 9110 § 5.3): "Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields."
 pub fn get_all_header_values(headers: &HeaderMap, name: &str) -> Option<String> {
     let mut iter = headers.get_all(name).iter();
     // Return None if header is absent.
@@ -204,6 +224,22 @@ pub fn extract_strong_validators_from_response(
 /// Parse a comma-separated list of header values (e.g., Connection, Transfer-Encoding).
 ///
 /// This iterator splits by comma, trims whitespace, and skips empty parts.
+///
+/// "Skips empty parts" is the interesting one, and it is a requirement rather
+/// than a convenience: `a,,b` is a two-element list, not a malformed one, and the
+/// seventy-odd callers that reach this are all recipients. A sender must not
+/// produce empty elements (§ 5.6.1.1), which is a different rule for a different
+/// party -- so a *rule* wanting to flag `a,,b` as bad output cannot ask this
+/// function, because by the time it answers, the evidence is gone.
+///
+/// § 5.6.1.2 bounds the requirement -- ignore "a reasonable number", but not so
+/// many that it becomes a denial-of-service vector -- and this imposes no cap.
+/// That is deliberate rather than overlooked: the bound protects a recipient from
+/// the cost of the ignoring, and `split` + `filter` is linear with no
+/// amplification. There is nothing here to exhaust.
+///
+// cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
+// cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
 pub fn parse_list_header(val: &str) -> impl Iterator<Item = &str> {
     val.split(',').map(|s| s.trim()).filter(|s| !s.is_empty())
 }

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -35,27 +35,49 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
     let mut first_val: Option<u128> = None;
     let mut first_raw: String = String::new();
 
-    for (i, hv) in entries.iter().enumerate() {
+    for hv in entries.iter() {
         let s = hv.to_str().map_err(|_| ContentLengthError::NonUtf8)?;
-        let t = s.trim();
 
-        // cite(RFC 9110 § 8.6): "Content-Length = 1*DIGIT"
-        if t.is_empty() || !t.chars().all(|c| c.is_ascii_digit()) {
-            return Err(ContentLengthError::InvalidCharacter(s.to_string()));
+        // A single field line may itself carry a comma-separated list, and that is
+        // not automatically a violation. The sentence below makes `5, 5` valid and
+        // says what it means: one value, 5. Splitting here is what keeps this
+        // function's answer the same for a message however its field lines were
+        // merged -- two `Content-Length: 5` lines and one `Content-Length: 5, 5`
+        // line are the same message by § 5.3, and used to get opposite answers.
+        //
+        // cite(RFC 9112 § 6.3): "If a message is received without Transfer-Encoding and with an invalid Content-Length header field, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error, unless the field value can be successfully parsed as a comma-separated list (Section 5.6.1 of [HTTP]), all values in the list are valid, and all values in the list are the same (in which case, the message is processed with that single value used as the Content-Length field value)."
+        let mut saw_value = false;
+        for t in parse_list_header(s) {
+            saw_value = true;
+
+            // cite(RFC 9110 § 8.6): "Content-Length = 1*DIGIT"
+            if !t.chars().all(|c| c.is_ascii_digit()) {
+                return Err(ContentLengthError::InvalidCharacter(s.to_string()));
+            }
+
+            let n = t
+                .parse::<u128>()
+                .map_err(|_| ContentLengthError::TooLarge(s.to_string()))?;
+
+            match first_val {
+                None => {
+                    first_val = Some(n);
+                    first_raw = s.to_string();
+                }
+                Some(f) if f != n => {
+                    return Err(ContentLengthError::MultipleValuesDiffer(
+                        first_raw,
+                        s.to_string(),
+                    ));
+                }
+                _ => {}
+            }
         }
 
-        let n = t
-            .parse::<u128>()
-            .map_err(|_| ContentLengthError::TooLarge(s.to_string()))?;
-
-        if i == 0 {
-            first_val = Some(n);
-            first_raw = s.to_string();
-        } else if Some(n) != first_val {
-            return Err(ContentLengthError::MultipleValuesDiffer(
-                first_raw,
-                s.to_string(),
-            ));
+        // An empty field line has no values to be "all the same", and one is not a
+        // list of none: `Content-Length:` is simply not `1*DIGIT`.
+        if !saw_value {
+            return Err(ContentLengthError::InvalidCharacter(s.to_string()));
         }
     }
 
@@ -1551,6 +1573,50 @@ mod tests {
     }
 
     // Quoted-string helper tests
+    /// Two `Content-Length: 5` field lines and one `Content-Length: 5, 5` line are
+    /// the same message -- § 5.3 lets a recipient combine the former into the
+    /// latter -- so they must get the same answer. They used to get opposite ones.
+    #[test]
+    fn content_length_comma_list_matches_repeated_field_lines() {
+        fn one(raw: &str) -> Result<Option<u128>, ContentLengthError> {
+            let mut h = HeaderMap::new();
+            h.append(
+                "content-length",
+                raw.parse::<hyper::header::HeaderValue>().unwrap(),
+            );
+            validate_content_length(&h)
+        }
+        fn many(raws: &[&str]) -> Result<Option<u128>, ContentLengthError> {
+            let mut h = HeaderMap::new();
+            for r in raws {
+                h.append(
+                    "content-length",
+                    r.parse::<hyper::header::HeaderValue>().unwrap(),
+                );
+            }
+            validate_content_length(&h)
+        }
+
+        assert_eq!(one("5, 5"), Ok(Some(5)));
+        assert_eq!(one("5,5"), Ok(Some(5)));
+        assert_eq!(one("5, 5"), many(&["5", "5"]));
+
+        // Differing values are an unrecoverable error either way round.
+        assert!(matches!(
+            one("5, 6"),
+            Err(ContentLengthError::MultipleValuesDiffer(_, _))
+        ));
+        assert!(matches!(
+            many(&["5", "6"]),
+            Err(ContentLengthError::MultipleValuesDiffer(_, _))
+        ));
+
+        // Still not a list of digits.
+        assert!(one("").is_err());
+        assert!(one("5, x").is_err());
+        assert!(one("abc").is_err());
+    }
+
     /// `qdtext` and `quoted-pair` allow different octets after their respective
     /// positions, and a backslash does not widen the set to "anything".
     #[test]

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -252,11 +252,20 @@ pub fn get_cache_control_max_age(headers: &HeaderMap) -> Option<i64> {
 }
 
 /// Strip an optional weak (`W/`) prefix from an ETag value, leaving the
-/// quoted-string intact.  Comparison logic for conditional requests often
-/// treats weak and strong validators as equivalent (RFC 9111 §5.3.2) so the
-/// normalized form is useful for rule implementations.
+/// quoted-string intact.
+///
+/// Reducing both sides to their opaque-tag and comparing those character by
+/// character *is* weak comparison -- that is the sentence below, and it is the
+/// only thing this function is good for. It must not be used to prepare a strong
+/// comparison: the `W/` it discards is exactly what strong comparison turns on.
+///
+/// The pointer that stood here read "RFC 9111 §5.3.2". RFC 9111 § 5.3 is
+/// Expires and has no § 5.3.2 -- the section numbering goes straight to § 5.4,
+/// Pragma. So it was not merely the wrong document, it named nothing at all.
 ///
 /// The resulting string is trimmed but otherwise returned verbatim.
+///
+// cite(RFC 9110 § 8.8.3.2): "two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak"."
 pub fn normalize_etag(s: &str) -> String {
     let trimmed = s.trim();
     if trimmed.len() >= 2 && (trimmed.starts_with("W/") || trimmed.starts_with("w/")) {
@@ -913,10 +922,23 @@ pub fn valid_qvalue(s: &str) -> bool {
     false
 }
 
-/// Validate an RFC 5987 `ext-value` (e.g. `UTF-8''%e2%82%ac%20rates`).
+/// Validate an RFC 8187 `ext-value` (e.g. `UTF-8''%e2%82%ac%20rates`).
 /// Returns Ok(()) if the value matches the expected pattern and contains
 /// only allowed characters/percent-escapes, or Err(msg) describing the
 /// problem.
+///
+/// This said RFC 5987, which RFC 8187 obsoletes and moved to Historic. The
+/// pointer is worth correcting and worth not overstating: the two documents'
+/// `ext-value`, `value-chars`, `pct-encoded` and `attr-char` productions are
+/// byte-for-byte identical, so nothing here changed meaning when the reference
+/// did. What 8187 changed is elsewhere -- the ISO-8859-1 requirement is gone,
+/// and it stopped trying to define a generic `parameter` rule.
+///
+/// The `charset` is checked only for being ASCII and quote-free, which is far
+/// looser than `mime-charset`, so that production is deliberately not quoted
+/// below -- it would describe a check this function does not make.
+///
+// cite(RFC 8187 § 3.2.1): "ext-value = charset  "'" [ language ] "'" value-chars"
 pub fn validate_ext_value(val: &str) -> Result<(), String> {
     // Must contain at least two single quotes separating charset, optional language, and value-chars
     let first_quote = val
@@ -947,8 +969,14 @@ pub fn validate_ext_value(val: &str) -> Result<(), String> {
 
     let mut i = 0usize;
     let bytes = value_chars.as_bytes();
+    // cite(RFC 8187 § 3.2.1): "value-chars   = *( pct-encoded / attr-char )"
     while i < bytes.len() {
         let b = bytes[i];
+        // This branch is why `%` is absent from the attr-char table below rather
+        // than merely unreachable in it: a `%` here is always the start of an
+        // escape, and the two productions do not overlap.
+        //
+        // cite(RFC 8187 § 3.2.1): "pct-encoded   = "%" HEXDIG HEXDIG"
         if b == b'%' {
             // Expect two hex digits
             if i + 2 >= bytes.len() {
@@ -963,11 +991,17 @@ pub fn validate_ext_value(val: &str) -> Result<(), String> {
             continue;
         }
         let ch = bytes[i] as char;
-        // attr-char per RFC 5987: ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        // The table carried a `'%'` for as long as it has existed, under a comment
+        // claiming it was RFC 5987's attr-char. It was not: both documents spell
+        // this production identically and both exclude `%`, along with `*` and `'`.
+        // It was dead as well as wrong -- the branch above consumes every `%` before
+        // this arm is reached -- so removing it moved no test.
+        //
+        // cite(RFC 8187 § 3.2.1): "attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )"
         if ch.is_ascii_alphanumeric()
             || matches!(
                 ch,
-                '!' | '#' | '$' | '%' | '&' | '+' | '-' | '.' | '^' | '_' | '`' | '|' | '~'
+                '!' | '#' | '$' | '&' | '+' | '-' | '.' | '^' | '_' | '`' | '|' | '~'
             )
         {
             i += 1;
@@ -1616,6 +1650,26 @@ mod tests {
         let res = validate_addr_spec("local@-example.com");
         assert!(res.is_err());
         assert!(res.unwrap_err().contains("invalid domain"));
+    }
+
+    /// `%` is not an attr-char. It reaches this function only as the opening of a
+    /// `pct-encoded`, and the branch handling that runs first -- so a `%` that is
+    /// not two hex digits is an incomplete escape, never a literal.
+    #[test]
+    fn percent_is_only_ever_an_escape() {
+        assert!(validate_ext_value("UTF-8''%41").is_ok());
+        assert!(validate_ext_value("UTF-8''a%20b").is_ok());
+        assert!(validate_ext_value("UTF-8''%").is_err());
+        assert!(validate_ext_value("UTF-8''a%b").is_err());
+        assert!(validate_ext_value("UTF-8''100%").is_err());
+    }
+
+    /// The three characters `token` has and `attr-char` does not.
+    #[test]
+    fn attr_char_excludes_star_quote_and_percent() {
+        assert!(validate_ext_value("UTF-8''a*b").is_err());
+        assert!(validate_ext_value("UTF-8''a{b").is_err());
+        assert!(validate_ext_value("UTF-8''ok-name.ext~1").is_ok());
     }
 
     #[test]

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -674,6 +674,21 @@ pub fn is_nominated_by_connection(name: &str, connection_header_value: Option<&s
 /// This supports simple comment removal as used in headers like `User-Agent`.
 /// It handles backslash escapes and nested parentheses. Returns `Err` if
 /// comments are unbalanced or the input contains control characters.
+///
+/// `depth` is not a convenience for tracking parentheses -- it is the production
+/// below being self-referential. `comment` appears inside its own definition, so
+/// a comment may contain a comment, and a single "seen an open paren" flag would
+/// be wrong rather than merely coarse: `(a (b) c)` would end at the first `)`
+/// and leak ` c)` into the output.
+///
+/// `ctext` excludes the parentheses themselves (%x21-27 stops before `(` at
+/// %x28, and %x2A-5B resumes after `)` at %x29), which is what makes the
+/// counting sound -- an unescaped paren inside a comment can only ever be
+/// structure, never text. The escape handling below is the other half of that:
+/// `quoted-pair` is in `comment`'s definition too, so `\(` is text.
+///
+// cite(RFC 9110 § 5.6.5): "comment        = "(" *( ctext / quoted-pair / comment ) ")""
+// cite(RFC 9110 § 5.6.5): "ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text"
 pub fn strip_comments(val: &str) -> Result<String, String> {
     let bytes = val.as_bytes();
     let mut res = String::with_capacity(val.len());
@@ -818,6 +833,15 @@ pub fn split_semicolons_respecting_quotes(s: &str) -> Vec<&str> {
 /// Validate a quoted-string per HTTP rules: must start and end with DQUOTE, support backslash escapes,
 /// must not contain unescaped control characters (except HTAB). Returns Ok(()) on success, Err(msg)
 /// on failure.
+///
+/// The two octet sets below are worth reading side by side, because the whole
+/// function is the difference between them. `qdtext` is what may appear bare;
+/// `quoted-pair` is what may appear after a backslash. HTAB and obs-text are in
+/// both -- HTTP is not Structured Fields, and the same-looking helper in
+/// `structured_fields.rs` is right to reject exactly what this one accepts.
+///
+// cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
+// cite(RFC 9110 § 5.6.4): "qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text"
 pub fn validate_quoted_string(val: &str) -> Result<(), String> {
     let bytes = val.as_bytes();
     if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
@@ -833,6 +857,8 @@ pub fn validate_quoted_string(val: &str) -> Result<(), String> {
             // A backslash does not make anything quotable. The escaped octet has its
             // own set, and it is not the same as qdtext's: SP and VCHAR and HTAB and
             // obs-text may follow a backslash, the remaining controls may not.
+            //
+            // cite(RFC 9110 § 5.6.4): "quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )"
             if !(b == b'\t' || (0x20..=0x7e).contains(&b) || b >= 0x80) {
                 return Err(format!("Invalid quoted-pair in quoted-string: '{}'", val));
             }
@@ -876,6 +902,15 @@ pub fn quoted_string_inner_trimmed_is_empty(val: &str) -> Result<bool, String> {
 /// - Returns `Ok(inner_string)` on success or `Err(msg)` if the input is not a valid quoted-string.
 ///
 /// This helper centralizes quoted-string unescaping to avoid duplication across rules.
+///
+/// Unlike its neighbours, the sentence below is not a grammar -- it is an
+/// instruction about what a recipient must *do*, and every caller here is a
+/// recipient. It also says why the substitution is unconditional: the octet
+/// following the backslash, not some interpretation of it, which is why there is
+/// no escape table in this function and should never be one. `\n` in a
+/// quoted-string is the letter n.
+///
+// cite(RFC 9110 § 5.6.4): "Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash."
 pub fn unescape_quoted_string(val: &str) -> Result<String, String> {
     validate_quoted_string(val)?;
     let bytes = val.as_bytes();

--- a/lint-http-rules/src/helpers/ipv6.rs
+++ b/lint-http-rules/src/helpers/ipv6.rs
@@ -16,7 +16,14 @@
 ///
 /// Returns `None` when the bracket is unmatched, the inner part is empty, or the
 /// trailing part is present but not in the form `:digits`.
+///
+/// The sentence cited below is about the brackets and nothing else, which is all
+/// this function decides. `IP-literal = "[" ( IPv6address / IPvFuture ) "]"` is
+/// deliberately *not* quoted here: the inner text is handed back unexamined, so
+/// quoting a production that constrains it would claim a check that happens --
+/// when it happens at all -- in the caller.
 pub fn parse_bracketed_ipv6(s: &str) -> Option<(&str, Option<&str>)> {
+    // cite(RFC 3986 § 3.2.2): "A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]")."
     if !s.starts_with('[') {
         return None;
     }
@@ -59,6 +66,16 @@ pub fn parse_port_str(port: &str) -> Option<u16> {
 /// Detects an unbracketed IPv6-ish string that contains a port-like suffix,
 /// e.g., `fe80::1:80` — callers should treat these as violations for headers
 /// where IPv6+port must be bracketed.
+///
+/// This is the same sentence as `parse_bracketed_ipv6`'s, read the other way
+/// round: the brackets are what distinguish an IPv6 literal host, so a bare
+/// `fe80::1:80` cannot be one, and the trailing `:80` is unreachable as a port
+/// because nothing marks where the address stopped. The second sentence is why
+/// the answer is knowable at all -- brackets appear nowhere else in the syntax,
+/// so their absence is not ambiguous.
+///
+// cite(RFC 3986 § 3.2.2): "A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]")."
+// cite(RFC 3986 § 3.2.2): "This is the only place where square bracket characters are allowed in the URI syntax."
 pub fn looks_like_unbracketed_ipv6_with_port(s: &str) -> bool {
     // Conservative check: ensure trailing ':<digits>' exists and the part before the last ':'
     // parses as an IPv6 address. This avoids misclassifying strings like "::1" as having a

--- a/lint-http-rules/src/helpers/language.rs
+++ b/lint-http-rules/src/helpers/language.rs
@@ -10,6 +10,16 @@
 /// It accepts private-use tags (e.g., "x-custom") and registered tags such as
 /// "en", "en-US", "zh-Hant", etc.
 ///
+/// What is cited below is § 2.1's prose and not its ABNF, and the permissiveness
+/// is the whole reason. The ABNF is normative here -- § 2.1 presents it as the
+/// syntax of a language tag, with none of the disclaiming RFC 9651 attaches to
+/// its own -- but it says far more than this function checks: `language =
+/// 2*3ALPHA / 4ALPHA / 5*8ALPHA`, a `region` of exactly 2ALPHA or 3DIGIT, a fixed
+/// list of grandfathered tags. Quoting any of that here would claim a check that
+/// is not performed. The prose states the few properties that are actually
+/// enforced -- subtags are alphanumeric, hyphen-separated, at most eight
+/// characters, and no whitespace -- and each sits on the line that enforces it.
+///
 /// Returns Ok(()) if the tag looks like a valid language tag, Err(msg) otherwise.
 pub fn validate_language_tag(tag: &str) -> Result<(), String> {
     let s = tag.trim();
@@ -18,26 +28,36 @@ pub fn validate_language_tag(tag: &str) -> Result<(), String> {
     }
 
     // Reject control chars or whitespace inside tag
+    // cite(RFC 5646 § 2.1): "Whitespace is not permitted in a language tag."
     if s.chars().any(|c| c.is_control() || c.is_whitespace()) {
         return Err("language tag contains control characters or whitespace".into());
     }
 
     // Only allow ASCII alphanumerics and hyphen
+    // cite(RFC 5646 § 2.1): "Subtags, in turn, are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen ("-", [Unicode] U+002D)."
     if let Some(c) = s.chars().find(|c| !c.is_ascii_alphanumeric() && *c != '-') {
         return Err(format!("invalid character '{}' in language tag", c));
     }
 
     // Hyphen placement checks: leading or trailing hyphens are invalid here;
     // consecutive hyphens are rejected below as empty subtags in the split loop.
+    //
+    // The sentence does not say "no leading hyphen" anywhere -- it says a tag is
+    // made of one or more subtags and that a hyphen is what separates them, which
+    // leaves a leading, trailing or doubled hyphen describing a subtag that is not
+    // there. That is the whole basis for these two checks and the empty-subtag one
+    // below, so it is quoted rather than the stronger sentence we might prefer.
+    //
+    // cite(RFC 5646 § 2.1): "A language tag is composed from a sequence of one or more "subtags", each of which refines or narrows the range of language identified by the overall tag."
     if s.starts_with('-') || s.ends_with('-') {
         return Err("invalid hyphen placement in language tag".into());
     }
 
-    // Subtag length checks (1..=8) per RFC 5646
     for sub in s.split('-') {
         if sub.is_empty() {
             return Err("empty subtag in language tag".into());
         }
+        // cite(RFC 5646 § 2.1): "All subtags have a maximum length of eight characters."
         if sub.len() > 8 {
             return Err(format!("subtag '{}' is too long (max 8 chars)", sub));
         }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -711,25 +711,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1062
+      line: 1098
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1003
+      line: 1039
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1041
+      line: 1077
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1034
+      line: 1070
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -941,7 +941,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 20
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 659
+      line: 695
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
@@ -949,7 +949,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 72
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 686
+      line: 722
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -1017,7 +1017,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 970
+      line: 1006
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 78
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -1027,60 +1027,84 @@ sources:
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 126
+      line: 146
     - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
       line: 44
   - label: lint-http-rules/src/helpers/headers.rs (3)
+    section: § 5.3
+    snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 122
+  - label: lint-http-rules/src/helpers/headers.rs (4)
+    section: § 5.3
+    snippet: Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 123
+  - label: lint-http-rules/src/helpers/headers.rs (5)
+    section: § 5.6.1.2
+    snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 242
+  - label: lint-http-rules/src/helpers/headers.rs (6)
+    section: § 5.6.1.2
+    snippet: Empty elements do not contribute to the count of elements present.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 241
+  - label: lint-http-rules/src/helpers/headers.rs (7)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 935
-  - label: lint-http-rules/src/helpers/headers.rs (4)
+      line: 971
+  - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 866
-  - label: lint-http-rules/src/helpers/headers.rs (5)
+      line: 902
+  - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 883
-  - label: lint-http-rules/src/helpers/headers.rs (6)
+      line: 919
+  - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 865
-  - label: lint-http-rules/src/helpers/headers.rs (7)
+      line: 901
+  - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.6.5
     snippet: comment        = "(" *( ctext / quoted-pair / comment ) ")"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 712
-  - label: lint-http-rules/src/helpers/headers.rs (8)
+      line: 748
+  - label: lint-http-rules/src/helpers/headers.rs (12)
     section: § 5.6.5
     snippet: ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 713
-  - label: lint-http-rules/src/helpers/headers.rs (9)
+      line: 749
+  - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 596
-  - label: lint-http-rules/src/helpers/headers.rs (10)
+      line: 632
+  - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 8.3.1
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1274
+      line: 1310
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
-  - label: lint-http-rules/src/helpers/headers.rs (11)
+  - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
@@ -1088,20 +1112,20 @@ sources:
       line: 53
     - file: lint-http-rules/src/rules/message_content_length.rs
       line: 27
-  - label: lint-http-rules/src/helpers/headers.rs (12)
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 8.8.3
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1233
+      line: 1269
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (13)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 290
+      line: 326
   - label: lint-http-rules/src/helpers/status.rs
     section: § 15.4
     snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
@@ -1461,13 +1485,13 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 371
+      line: 407
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 381
+      line: 417
   - label: message_age_header_numeric
     section: § 5.1
     snippet: The Age field value is a non-negative integer, representing time in seconds

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -702,6 +702,34 @@ sources:
       line: 30
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 87
+- label: RFC 8187
+  url: https://www.rfc-editor.org/rfc/rfc8187.txt
+  type: text/plain
+  fragments:
+  - label: lint-http-rules/src/helpers/headers.rs
+    section: § 3.2.1
+    snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1000
+  - label: lint-http-rules/src/helpers/headers.rs (2)
+    section: § 3.2.1
+    snippet: ext-value = charset  "'" [ language ] "'" value-chars
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 941
+  - label: lint-http-rules/src/helpers/headers.rs (3)
+    section: § 3.2.1
+    snippet: pct-encoded   = "%" HEXDIG HEXDIG
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 979
+  - label: lint-http-rules/src/helpers/headers.rs (4)
+    section: § 3.2.1
+    snippet: value-chars   = *( pct-encoded / attr-char )
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 972
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -913,7 +941,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 20
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 628
+      line: 637
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
@@ -921,7 +949,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 72
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 655
+      line: 664
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -989,7 +1017,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 899
+      line: 908
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 78
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -1007,13 +1035,13 @@ sources:
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 565
+      line: 574
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 8.3.1
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1178
+      line: 1212
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
   - label: lint-http-rules/src/helpers/headers.rs (5)
@@ -1029,9 +1057,15 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1137
+      line: 1171
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
+  - label: lint-http-rules/src/helpers/headers.rs (7)
+    section: § 8.8.3.2
+    snippet: two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak".
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 268
   - label: lint-http-rules/src/helpers/status.rs
     section: § 15.4
     snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
@@ -1391,13 +1425,13 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 340
+      line: 349
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 350
+      line: 359
   - label: message_age_header_numeric
     section: § 5.1
     snippet: The Age field value is a non-negative integer, representing time in seconds

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -711,25 +711,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1040
+      line: 1062
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 981
+      line: 1003
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1019
+      line: 1041
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1012
+      line: 1034
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -941,7 +941,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 20
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 637
+      line: 659
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
@@ -949,7 +949,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 72
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 664
+      line: 686
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -1017,7 +1017,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 948
+      line: 970
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 78
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -1027,7 +1027,7 @@ sources:
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 104
+      line: 126
     - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
       line: 44
   - label: lint-http-rules/src/helpers/headers.rs (3)
@@ -1035,49 +1035,49 @@ sources:
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 913
+      line: 935
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 844
+      line: 866
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 861
+      line: 883
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 843
+      line: 865
   - label: lint-http-rules/src/helpers/headers.rs (7)
     section: § 5.6.5
     snippet: comment        = "(" *( ctext / quoted-pair / comment ) ")"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 690
+      line: 712
   - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.6.5
     snippet: ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 691
+      line: 713
   - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 574
+      line: 596
   - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 8.3.1
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1252
+      line: 1274
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
   - label: lint-http-rules/src/helpers/headers.rs (11)
@@ -1085,7 +1085,7 @@ sources:
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 42
+      line: 53
     - file: lint-http-rules/src/rules/message_content_length.rs
       line: 27
   - label: lint-http-rules/src/helpers/headers.rs (12)
@@ -1093,7 +1093,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1211
+      line: 1233
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
   - label: lint-http-rules/src/helpers/headers.rs (13)
@@ -1101,7 +1101,7 @@ sources:
     snippet: two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 268
+      line: 290
   - label: lint-http-rules/src/helpers/status.rs
     section: § 15.4
     snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
@@ -1461,13 +1461,13 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 349
+      line: 371
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 359
+      line: 381
   - label: message_age_header_numeric
     section: § 5.1
     snippet: The Age field value is a non-negative integer, representing time in seconds
@@ -1598,6 +1598,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
       line: 31
+  - label: lint-http-rules/src/helpers/headers.rs
+    section: § 6.3
+    snippet: If a message is received without Transfer-Encoding and with an invalid Content-Length header field, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error, unless the field value can be successfully parsed as a comma-separated list (Section 5.6.1 of [HTTP]), all values in the list are valid, and all values in the list are the same (in which case, the message is processed with that single value used as the Content-Length field value).
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 48
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -288,6 +288,48 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 27
+  - label: lint-http-rules/src/helpers/ipv6.rs
+    section: § 3.2.2
+    snippet: A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]").
+    cited_by:
+    - file: lint-http-rules/src/helpers/ipv6.rs
+      line: 26
+    - file: lint-http-rules/src/helpers/ipv6.rs
+      line: 77
+  - label: lint-http-rules/src/helpers/ipv6.rs (2)
+    section: § 3.2.2
+    snippet: This is the only place where square bracket characters are allowed in the URI syntax.
+    cited_by:
+    - file: lint-http-rules/src/helpers/ipv6.rs
+      line: 78
+- label: RFC 5646
+  url: https://www.rfc-editor.org/rfc/rfc5646.txt
+  type: text/plain
+  fragments:
+  - label: lint-http-rules/src/helpers/language.rs
+    section: § 2.1
+    snippet: A language tag is composed from a sequence of one or more "subtags", each of which refines or narrows the range of language identified by the overall tag.
+    cited_by:
+    - file: lint-http-rules/src/helpers/language.rs
+      line: 51
+  - label: lint-http-rules/src/helpers/language.rs (2)
+    section: § 2.1
+    snippet: All subtags have a maximum length of eight characters.
+    cited_by:
+    - file: lint-http-rules/src/helpers/language.rs
+      line: 60
+  - label: lint-http-rules/src/helpers/language.rs (3)
+    section: § 2.1
+    snippet: Subtags, in turn, are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen ("-", [Unicode] U+002D).
+    cited_by:
+    - file: lint-http-rules/src/helpers/language.rs
+      line: 37
+  - label: lint-http-rules/src/helpers/language.rs (4)
+    section: § 2.1
+    snippet: Whitespace is not permitted in a language tag.
+    cited_by:
+    - file: lint-http-rules/src/helpers/language.rs
+      line: 31
 - label: RFC 5789
   url: https://www.rfc-editor.org/rfc/rfc5789.txt
   type: text/plain

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -711,25 +711,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1000
+      line: 1005
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 941
+      line: 946
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 979
+      line: 984
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 972
+      line: 977
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -1017,7 +1017,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 908
+      line: 913
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 78
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -1041,7 +1041,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1212
+      line: 1217
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
   - label: lint-http-rules/src/helpers/headers.rs (5)
@@ -1057,7 +1057,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1171
+      line: 1176
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
   - label: lint-http-rules/src/helpers/headers.rs (7)

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -711,25 +711,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1005
+      line: 1040
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 946
+      line: 981
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 984
+      line: 1019
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 977
+      line: 1012
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -1017,7 +1017,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 913
+      line: 948
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 78
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -1031,20 +1031,56 @@ sources:
     - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
       line: 44
   - label: lint-http-rules/src/helpers/headers.rs (3)
+    section: § 5.6.4
+    snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 913
+  - label: lint-http-rules/src/helpers/headers.rs (4)
+    section: § 5.6.4
+    snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 844
+  - label: lint-http-rules/src/helpers/headers.rs (5)
+    section: § 5.6.4
+    snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 861
+  - label: lint-http-rules/src/helpers/headers.rs (6)
+    section: § 5.6.4
+    snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 843
+  - label: lint-http-rules/src/helpers/headers.rs (7)
+    section: § 5.6.5
+    snippet: comment        = "(" *( ctext / quoted-pair / comment ) ")"
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 690
+  - label: lint-http-rules/src/helpers/headers.rs (8)
+    section: § 5.6.5
+    snippet: ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 691
+  - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 574
-  - label: lint-http-rules/src/helpers/headers.rs (4)
+  - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 8.3.1
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1217
+      line: 1252
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
-  - label: lint-http-rules/src/helpers/headers.rs (5)
+  - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
@@ -1052,15 +1088,15 @@ sources:
       line: 42
     - file: lint-http-rules/src/rules/message_content_length.rs
       line: 27
-  - label: lint-http-rules/src/helpers/headers.rs (6)
+  - label: lint-http-rules/src/helpers/headers.rs (12)
     section: § 8.8.3
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1176
+      line: 1211
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (7)
+  - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:


### PR DESCRIPTION
Language validator, quoted-string/comment walkers, field-line merging, the three permissive helpers; fix two mis-named pointers and one that named nothing; correct the backslash-quoting rule.

