### PR TITLE
QUIC varint & proxy claims

### DIFF
--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -27,6 +27,36 @@ pub type EventSink = Arc<dyn Fn(ProtocolEventKind) + Send + Sync>;
 
 // ── QUIC variable-length integer helpers ─────────────────────────────
 
+/// The encoded length in bytes of a QUIC variable-length integer, read from
+/// the first byte.
+///
+/// The shift is not a trick. The two most significant bits hold the *base-2
+/// logarithm* of the length, so `1 << prefix` is the length itself and the
+/// only lengths that exist are 1, 2, 4 and 8.
+fn varint_len(first: u8) -> usize {
+    1usize << (first >> 6)
+}
+
+/// The value of a complete QUIC variable-length integer.
+///
+/// `bytes` must be exactly one encoded integer -- `varint_len` bytes of it.
+/// The mask per length is the other half of the same sentence: the two bits
+/// that carried the length are not part of the value, leaving 6, 14, 30 or 62
+/// usable bits.
+fn varint_value(bytes: &[u8]) -> u64 {
+    match bytes.len() {
+        1 => u64::from(bytes[0] & 0x3F),
+        2 => u64::from(u16::from_be_bytes([bytes[0], bytes[1]]) & 0x3FFF),
+        4 => u64::from(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) & 0x3FFF_FFFF),
+        8 => {
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(bytes);
+            u64::from_be_bytes(arr) & 0x3FFF_FFFF_FFFF_FFFF
+        }
+        _ => unreachable!("varint_value takes a varint_len-sized slice"),
+    }
+}
+
 /// Incremental parser for QUIC variable-length integers (RFC 9000 §16).
 ///
 /// Feed one byte at a time; the parser returns `Some(value)` once the
@@ -59,31 +89,14 @@ impl VarIntReader {
         self.len += 1;
 
         if self.len == 1 {
-            self.expected = 1 << (byte >> 6);
+            self.expected = varint_len(byte);
         }
 
         if self.len < self.expected {
             return None;
         }
 
-        let value = match self.expected {
-            1 => u64::from(self.buf[0] & 0x3F),
-            2 => {
-                let v = u16::from_be_bytes([self.buf[0], self.buf[1]]);
-                u64::from(v & 0x3FFF)
-            }
-            4 => {
-                let v = u32::from_be_bytes([self.buf[0], self.buf[1], self.buf[2], self.buf[3]]);
-                u64::from(v & 0x3FFF_FFFF)
-            }
-            8 => {
-                let v = u64::from_be_bytes(self.buf);
-                v & 0x3FFF_FFFF_FFFF_FFFF
-            }
-            _ => unreachable!(),
-        };
-
-        Some(value)
+        Some(varint_value(&self.buf[..self.expected]))
     }
 }
 
@@ -93,30 +106,11 @@ fn parse_varint_at(buf: &[u8], pos: usize) -> Option<(u64, usize)> {
     if pos >= buf.len() {
         return None;
     }
-    let first = buf[pos];
-    let len = 1usize << (first >> 6);
+    let len = varint_len(buf[pos]);
     if pos + len > buf.len() {
         return None;
     }
-    let value = match len {
-        1 => u64::from(first & 0x3F),
-        2 => {
-            let v = u16::from_be_bytes([buf[pos], buf[pos + 1]]);
-            u64::from(v & 0x3FFF)
-        }
-        4 => {
-            let v = u32::from_be_bytes([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]]);
-            u64::from(v & 0x3FFF_FFFF)
-        }
-        8 => {
-            let mut arr = [0u8; 8];
-            arr.copy_from_slice(&buf[pos..pos + 8]);
-            let v = u64::from_be_bytes(arr);
-            v & 0x3FFF_FFFF_FFFF_FFFF
-        }
-        _ => unreachable!(),
-    };
-    Some((value, len))
+    Some((varint_value(&buf[pos..pos + len]), len))
 }
 
 // ── Frame observer state machine ─────────────────────────────────────

--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -30,9 +30,15 @@ pub type EventSink = Arc<dyn Fn(ProtocolEventKind) + Send + Sync>;
 /// The encoded length in bytes of a QUIC variable-length integer, read from
 /// the first byte.
 ///
-/// The shift is not a trick. The two most significant bits hold the *base-2
-/// logarithm* of the length, so `1 << prefix` is the length itself and the
-/// only lengths that exist are 1, 2, 4 and 8.
+/// The shift is not a trick, and the sentence below is why: the two most
+/// significant bits hold the *base-2 logarithm* of the length, so `1 << prefix`
+/// is the length itself and the only lengths that can exist are 1, 2, 4 and 8.
+/// The second sentence is what licenses `varint_value`'s four arms and no
+/// others -- and note it also rules out a "minimal encoding" assumption, which
+/// § 16 spends a later paragraph forbidding: 0x4025 and 0x25 both mean 37.
+///
+// cite(RFC 9000 § 16): "The QUIC variable-length integer encoding reserves the two most significant bits of the first byte to encode the base-2 logarithm of the integer encoding length in bytes.  The integer value is encoded on the remaining bits, in network byte order."
+// cite(RFC 9000 § 16): "This means that integers are encoded on 1, 2, 4, or 8 bytes and can encode 6-, 14-, 30-, or 62-bit values, respectively."
 fn varint_len(first: u8) -> usize {
     1usize << (first >> 6)
 }
@@ -121,7 +127,8 @@ const H3_FRAME_SETTINGS: u64 = 0x04;
 /// HTTP/3 frame type: MAX_PUSH_ID.
 // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
 const H3_FRAME_MAX_PUSH_ID: u64 = 0x0D;
-/// HTTP/3 unidirectional stream type for the control stream (RFC 9114 §6.2.1).
+/// HTTP/3 unidirectional stream type for the control stream.
+// cite(RFC 9114 § 6.2.1): "A control stream is indicated by a stream type of 0x00."
 const H3_STREAM_TYPE_CONTROL: u64 = 0x00;
 
 /// Maximum payload we buffer for a single frame.  Frames larger than this
@@ -461,15 +468,57 @@ mod tests {
         assert_eq!(r.feed(bytes[7]), Some(151_288_809_941_952_652));
     }
 
+    /// Every worked example RFC 9000 states, against both decoders.
+    ///
+    /// The four `varint_Nbyte` tests above are already this document's vectors --
+    /// 0x25, 0x7bbd, 0x9d7f3e7d and 0xc2197c5eff14e88c are A.1's, written in hex
+    /// with the provenance left off. This says where they come from, adds the one
+    /// the set was missing, and runs them through `parse_varint_at` too, which
+    /// had never seen them.
+    ///
+    /// The last vector is the interesting one: 0x4025 is 37 encoded on two bytes
+    /// rather than one. A minimal-encoding assumption anywhere in the decoder
+    /// would pass every other case here and fail this one.
+    ///
+    /// The cite names no section, and that is not laziness. This sentence is in
+    /// Appendix A.1, and no appendix is addressable: a `§` selector compares a
+    /// *digit* prefix, so the `A. Pseudocode` node the parser does build can
+    /// never be selected, and `A.1.` is not recognised as a heading at all --
+    /// it has no "Appendix" prefix to match on. `§ A` and `§ A.1` both resolve
+    /// to nothing. Omitting the section is the documented way through: the
+    /// quote locates itself in the whole document, and verification is exactly
+    /// as strong.
+    ///
+    // cite(RFC 9000): "For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025)."
     #[test]
-    fn varint_8byte_example() {
-        let mut r = VarIntReader::new();
-        // From RFC 9000 §A.1: 0xC2197C5EFF14E88C → 151288809941952652
-        let bytes = [0xC2, 0x19, 0x7C, 0x5E, 0xFF, 0x14, 0xE8, 0x8C];
-        for &b in &bytes[..7] {
-            assert_eq!(r.feed(b), None);
+    fn rfc9000_a1_worked_examples() {
+        let vectors: &[(&[u8], u64)] = &[
+            (
+                &[0xC2, 0x19, 0x7C, 0x5E, 0xFF, 0x14, 0xE8, 0x8C],
+                151_288_809_941_952_652,
+            ),
+            (&[0x9D, 0x7F, 0x3E, 0x7D], 494_878_333),
+            (&[0x7B, 0xBD], 15_293),
+            (&[0x25], 37),
+            (&[0x40, 0x25], 37),
+        ];
+
+        for (bytes, expected) in vectors {
+            // fed one byte at a time
+            let mut r = VarIntReader::new();
+            let mut got = None;
+            for &b in *bytes {
+                got = r.feed(b);
+            }
+            assert_eq!(got, Some(*expected), "VarIntReader on {bytes:02X?}");
+
+            // and read from a buffer
+            assert_eq!(
+                parse_varint_at(bytes, 0),
+                Some((*expected, bytes.len())),
+                "parse_varint_at on {bytes:02X?}"
+            );
         }
-        assert_eq!(r.feed(bytes[7]), Some(151_288_809_941_952_652));
     }
 
     #[test]

--- a/lint-http-proxy/src/proxy/hop_by_hop.rs
+++ b/lint-http-proxy/src/proxy/hop_by_hop.rs
@@ -25,8 +25,21 @@ pub(super) static HOP_BY_HOP_HEADERS: &[&str] = &[
     "te",
     "transfer-encoding",
     "upgrade",
-    // Not § 7.6.1's list: these two are single-hop by their own definition.
+    // Not § 7.6.1's list, and the reason these two belong is not the reason the
+    // five above do. § 7.6.1 nowhere mentions them; each is single-hop by its own
+    // definition, in its own section, and needs its own sentence. No single quote
+    // can cover this table -- three entries, three provenances.
+    //
+    // Note what the sentences do *not* say. Neither forbids forwarding -- § 11.7.2
+    // even allows a proxy to relay credentials onward where proxies cooperatively
+    // authenticate. Removing them is therefore a decision, not compliance, and the
+    // decision is easy: this proxy never demands proxy authentication, so it is the
+    // "next inbound proxy" for any Proxy-Authorization a client sends it, and there
+    // is no cooperating hierarchy for it to pass anything to.
+    //
+    // cite(RFC 9110 § 11.7.1): "Unlike WWW-Authenticate, the Proxy-Authenticate header field applies only to the next outbound client on the response chain."
     "proxy-authenticate",
+    // cite(RFC 9110 § 11.7.2): "Unlike Authorization, the Proxy-Authorization header field applies only to the next inbound proxy that demanded authentication using the Proxy-Authenticate header field."
     "proxy-authorization",
 ];
 

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -19,11 +19,21 @@ use super::exchange::{exchange, ProxiedRequest};
 use super::Shared;
 use super::{http3_body, tee_body};
 
-/// QUIC transport parameter defaults for the HTTP/3 proxy.
+/// QUIC transport parameter values for the HTTP/3 proxy. **These are this
+/// proxy's policy, not anyone's defaults.**
 ///
-/// These are chosen to be reasonable for HTTP/3 usage per RFC 9114 / RFC 9000
-/// §18.2.  The values are recorded in a [`QuicTransportParameters`] so they
-/// can be emitted as protocol events and validated by lint rules.
+/// This said the values were "chosen to be reasonable for HTTP/3 usage per RFC
+/// 9114 / RFC 9000 §18.2", which reads as though § 18.2 endorses them. It does
+/// not. § 18.2 defines what each parameter *means* and what its absence means --
+/// that an absent or zero stream limit leaves the peer unable to open streams
+/// until a MAX_STREAMS frame arrives, and that an omitted or zero idle timeout
+/// disables the timeout entirely. That is why these must be set to something
+/// non-zero. It is not why they are 256, 8 and 30s; nothing in either document
+/// recommends a number. Those are ours, and they are uncited because there is
+/// no sentence to cite -- which is the honest answer, not a gap to fill later.
+///
+/// The values are recorded in a [`QuicTransportParameters`] so they can be
+/// emitted as protocol events and validated by lint rules.
 const QUIC_MAX_CONCURRENT_BIDI_STREAMS: u64 = 256;
 const QUIC_MAX_CONCURRENT_UNI_STREAMS: u64 = 8;
 const QUIC_MAX_IDLE_TIMEOUT_MS: u64 = 30_000;

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -23,8 +23,19 @@ use super::{boxed_full, BoxError, ResponseBody, Shared};
 
 /// Check if a request is a WebSocket upgrade request.
 ///
-/// RFC 6455 §4.1: a WebSocket handshake requires `Connection: Upgrade` (as a
-/// distinct token, possibly alongside others) and `Upgrade: websocket`.
+/// A WebSocket handshake requires `Connection: Upgrade` (as a distinct token,
+/// possibly alongside others) and `Upgrade: websocket`.
+///
+/// Both sentences say "include", not "equal", and that is the whole reason the
+/// two checks are shaped differently. Connection is a token list, so `include`
+/// means membership -- `Connection: keep-alive, Upgrade` is a valid handshake
+/// and a string compare would reject it, which is why this asks
+/// `parse_connection_tokens` rather than looking at the field value. The
+/// keyword and the token are also matched case-insensitively, which the
+/// document establishes elsewhere for each field rather than here.
+///
+// cite(RFC 6455 § 4.1): "The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword."
+// cite(RFC 6455 § 4.1): "The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token."
 pub(super) fn is_websocket_upgrade<B>(req: &Request<B>) -> bool {
     let connection_tokens = parse_connection_tokens(req.headers().get(hyper::header::CONNECTION));
     let has_upgrade = connection_tokens.contains("upgrade");
@@ -123,6 +134,14 @@ pub(super) async fn handle_websocket_upgrade(
         // A 101 has no body; a non-101 response body streams through to the
         // client but is not captured here, so record it as unknown rather than
         // falsely claiming zero length.
+        //
+        // The `Some(0)` is knowledge, not a guess -- the sentence below is what
+        // makes zero the only possible answer for a 101, and it is why the two
+        // arms are asymmetric. `None` here means "we did not look"; `Some(0)`
+        // means "there is nothing to look at". Only one of those can be said
+        // without reading the body, and only for 1xx.
+        //
+        // cite(RFC 9110 § 15.2): "A 1xx response is terminated by the end of the header section; it cannot contain content or trailers."
         body_length: if status == 101 { Some(0) } else { None },
         trailers: None,
     });
@@ -449,6 +468,17 @@ fn message_to_info(
     direction: crate::websocket_session::MessageDirection,
 ) -> crate::websocket_session::WebSocketMessageInfo {
     use crate::websocket_session::WebSocketMessageInfo;
+
+    // These numbers are the wire format, not tungstenite's enum discriminants,
+    // and this match is the only place the mapping is written down -- so it is
+    // the opcode table, restated in Rust.
+    //
+    // Quoted as one extract rather than per arm, for a plain reason: "%x9 denotes
+    // a ping" is eighteen characters and the extractor's floor is twenty. Ping and
+    // pong cannot be quoted alone, so the list is quoted whole and each arm reads
+    // its own line out of it.
+    //
+    // cite(RFC 6455 § 5.2): "%x0 denotes a continuation frame * %x1 denotes a text frame * %x2 denotes a binary frame * %x3-7 are reserved for further non-control frames * %x8 denotes a connection close * %x9 denotes a ping * %xA denotes a pong"
     let (opcode, payload_length, fin, rsv) = match msg {
         // Assembled messages: tungstenite has already defragmented, so FIN is
         // implicitly true and RSV bits are not available.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -484,6 +484,24 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc6455.txt
   type: text/plain
   fragments:
+  - label: lint-http-proxy/src/proxy/websocket.rs
+    section: § 4.1
+    snippet: The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/websocket.rs
+      line: 38
+  - label: lint-http-proxy/src/proxy/websocket.rs (2)
+    section: § 4.1
+    snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/websocket.rs
+      line: 37
+  - label: lint-http-proxy/src/proxy/websocket.rs (3)
+    section: § 5.2
+    snippet: '%x0 denotes a continuation frame * %x1 denotes a text frame * %x2 denotes a binary frame * %x3-7 are reserved for further non-control frames * %x8 denotes a connection close * %x9 denotes a ping * %xA denotes a pong'
+    cited_by:
+    - file: lint-http-proxy/src/proxy/websocket.rs
+      line: 481
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 4.1
     snippet: (as a string, not base64-decoded) with the string
@@ -940,18 +958,30 @@ sources:
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
+    section: § 11.7.1
+    snippet: Unlike WWW-Authenticate, the Proxy-Authenticate header field applies only to the next outbound client on the response chain.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 40
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
+    section: § 11.7.2
+    snippet: Unlike Authorization, the Proxy-Authorization header field applies only to the next inbound proxy that demanded authentication using the Proxy-Authenticate header field.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 42
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (3)
     section: § 7.6.1
     snippet: 'Connection = #connection-option connection-option = token'
     cited_by:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
-      line: 52
-  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
+      line: 65
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
     section: § 7.6.1
     snippet: Connection options are case-insensitive.
     cited_by:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
-      line: 55
-  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (3)
+      line: 68
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (5)
     section: § 7.6.1
     snippet: Furthermore, intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics.
     cited_by:
@@ -959,14 +989,20 @@ sources:
       line: 20
     - file: lint-http-rules/src/helpers/headers.rs
       line: 695
-  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (6)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
     cited_by:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
-      line: 72
+      line: 85
     - file: lint-http-rules/src/helpers/headers.rs
       line: 722
+  - label: lint-http-proxy/src/proxy/websocket.rs
+    section: § 15.2
+    snippet: A 1xx response is terminated by the end of the header section; it cannot contain content or trailers.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/websocket.rs
+      line: 144
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -804,6 +804,23 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc9000.txt
   type: text/plain
   fragments:
+  - label: lint-http-proxy/src/h3_instrument.rs
+    snippet: For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025).
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 492
+  - label: lint-http-proxy/src/h3_instrument.rs (2)
+    section: § 16
+    snippet: The QUIC variable-length integer encoding reserves the two most significant bits of the first byte to encode the base-2 logarithm of the integer encoding length in bytes.  The integer value is encoded on the remaining bits, in network byte order.
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 40
+  - label: lint-http-proxy/src/h3_instrument.rs (3)
+    section: § 16
+    snippet: This means that integers are encoded on 1, 2, 4, or 8 bytes and can encode 6-, 14-, 30-, or 62-bit values, respectively.
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 41
   - label: server_quic_transport_parameters
     section: § 18
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
@@ -1691,19 +1708,25 @@ sources:
   type: text/plain
   fragments:
   - label: lint-http-proxy/src/h3_instrument.rs
+    section: § 6.2.1
+    snippet: A control stream is indicated by a stream type of 0x00.
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 131
+  - label: lint-http-proxy/src/h3_instrument.rs (2)
     section: § 7.2.4
     snippet: The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 119
+      line: 125
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
       line: 48
-  - label: lint-http-proxy/src/h3_instrument.rs (2)
+  - label: lint-http-proxy/src/h3_instrument.rs (3)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 122
+      line: 128
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
       line: 40
   - label: message_http3_host_authority_consistency

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1695,7 +1695,7 @@ sources:
     snippet: The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 125
+      line: 119
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
       line: 48
   - label: lint-http-proxy/src/h3_instrument.rs (2)
@@ -1703,7 +1703,7 @@ sources:
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 128
+      line: 122
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
       line: 40
   - label: message_http3_host_authority_consistency


### PR DESCRIPTION
Decode the QUIC varint in one place, pin its encoding + tests to the RFC's vectors, give the proxy's remaining claims their sentences, stop implying the QUIC-param values came from a document.

