### PR TITLE
Ratchet, toolchain & first H3/doc cites 

### DIFF
--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Citations file is current
         run: apycite extract --frozen
 
-      # No new rule lands without a citation, and no migrated rule regresses.
+      # Nothing in lint-http-rules lands uncited, and nothing cited regresses.
+      # The scope is the whole crate now, not just `rules/` — a helper that loses
+      # its last citation fails here too. The excludes, and the argument for each,
+      # are in apycite.toml.
       - name: Ratchet
         run: apycite ratchet
 

--- a/apycite.toml
+++ b/apycite.toml
@@ -32,20 +32,62 @@ label = "{stem}"
 match = "**/*"
 label = "{path}"
 
-# The migration, made monotone. The baseline lists the rule files that carry no
-# cite yet; CI fails if a file *enters* it — a new rule without a citation, or a
-# migrated rule that regressed. `--write` may only remove lines, so putting a file
-# back takes a human edit that a reviewer sees. The baseline only ever shrinks,
-# and shrinking it is the migration. When it is empty, the ratchet *is* the
-# permanent rule, with no second mechanism to keep in step.
+# The migration, made monotone. The baseline lists the files in scope that carry
+# no cite yet; CI fails if a file *enters* it — a new rule without a citation, or
+# a migrated rule that regressed. `--write` may only remove lines, so putting a
+# file back takes a human edit that a reviewer sees. The baseline only ever
+# shrinks, and shrinking it is the migration. When it is empty, the ratchet *is*
+# the permanent rule, with no second mechanism to keep in step.
+#
+# The scope was `lint-http-rules/src/rules/*.rs` while `helpers/` was migrating.
+# It is the whole crate now, and the baseline is *still* empty — which is the only
+# reason this widening is allowed to happen. Widening to a non-empty baseline
+# would have traded "every file in scope is cited" for "every file in scope is
+# cited eventually", and there is no second mechanism to hold the difference.
+# 208 files, 196 cited, 12 excluded below, 0 to migrate.
+#
+# `lint-http-core` and `lint-http-proxy` are deliberately still out of scope, and
+# not because their cites do not work — they do, and both crates carry some. It is
+# that 10 of 11 core files and 18 of 22 proxy files are uncited, and excluding
+# them would mean making 28 claims of "no normative content" about files nobody
+# has read for one. Two of those claims would already be false: `protocol_event.rs`
+# holds the WebSocket opcode table as prose and is citable the day it becomes an
+# enum. An exclude list is a set of assertions, so it may only ever contain
+# assertions someone checked.
 [ratchet]
-scope = "lint-http-rules/src/rules/*.rs"
+scope = "lint-http-rules/src/*.rs"
 baseline = "specs/ratchet.txt"
 
-# `mod.rs` is in that directory but is not a rule: it holds the traits, the
-# registry, and `SpecRef` itself, and enforces no sentence of any specification.
-# It can never earn a citation, so without this it would sit in the baseline
-# forever and the baseline could never empty — which is the one thing the ratchet
-# is counting down to. Excluding it is a claim that it has no normative content,
-# and this is where a reviewer sees the claim.
-exclude = ["lint-http-rules/src/rules/mod.rs"]
+# Every entry here is a claim that a file enforces no sentence of any
+# specification, and this is where a reviewer sees the claim. `*` crosses `/`, so
+# the scope above catches the whole crate and each of these has to earn its line.
+#
+# The two `mod.rs` files hold traits, registries and re-exports. `rules/mod.rs`
+# also holds `SpecRef` itself. Neither can ever earn a citation, and without these
+# they would sit in the baseline forever — so the baseline could never empty,
+# which is the one thing the ratchet is counting down to.
+#
+# `engine.rs` dispatches rules and `lint_protocol.rs` is the protocol-event
+# entry point: both decide *which* rule runs, never what any rule means.
+# `test_helpers.rs` builds fixtures. `lib.rs` is declarations.
+#
+# `gendocs.rs` mentions RFC 9110 and is still plumbing: it renders whatever
+# `SpecRef` a rule declares and formats the URL. The spec strings in it are test
+# fixtures. It enforces nothing; it prints.
+#
+# `queries/` groups stored transactions — by connection, origin, resource. The
+# one to look at twice is `by_origin.rs`, whose doc comment names RFC 6454. It
+# does not implement it: the origin arrives as a caller-supplied string and the
+# query is a URI prefix filter, so no part of `scheme + host + port` is ever
+# parsed or compared. Real origin matching lives in
+# `rules/semantic_origin_matching_for_cors.rs`, and is cited there.
+exclude = [
+    "lint-http-rules/src/rules/mod.rs",
+    "lint-http-rules/src/helpers/mod.rs",
+    "lint-http-rules/src/queries/*.rs",
+    "lint-http-rules/src/engine.rs",
+    "lint-http-rules/src/gendocs.rs",
+    "lint-http-rules/src/lib.rs",
+    "lint-http-rules/src/lint_protocol.rs",
+    "lint-http-rules/src/test_helpers.rs",
+]

--- a/docs/rules/message_http3_pseudo_headers_validity.md
+++ b/docs/rules/message_http3_pseudo_headers_validity.md
@@ -20,7 +20,8 @@ Responses MUST include exactly one `:status` pseudo-header field containing a th
 - [RFC 9114 §4.3.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1): Request Pseudo-Header Fields
 - [RFC 9114 §4.3.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.2): Response Pseudo-Header Fields
 - [RFC 9114 §4.4](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.4): The CONNECT Method
-- [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource
+- [RFC 9110 §7.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1): Determining the Target Resource (asterisk-form request target)
+- [RFC 9110 §15](https://www.rfc-editor.org/rfc/rfc9110.html#section-15): Status Codes: valid codes are in the range 100-599
 
 ## Configuration
 

--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -480,16 +480,14 @@ mod tests {
     /// rather than one. A minimal-encoding assumption anywhere in the decoder
     /// would pass every other case here and fail this one.
     ///
-    /// The cite names no section, and that is not laziness. This sentence is in
-    /// Appendix A.1, and no appendix is addressable: a `§` selector compares a
-    /// *digit* prefix, so the `A. Pseudocode` node the parser does build can
-    /// never be selected, and `A.1.` is not recognised as a heading at all --
-    /// it has no "Appendix" prefix to match on. `§ A` and `§ A.1` both resolve
-    /// to nothing. Omitting the section is the documented way through: the
-    /// quote locates itself in the whole document, and verification is exactly
-    /// as strong.
+    /// The worked examples live in Appendix A.1, and the cite names it. That was long
+    /// uncitable: a `§` selector compared a *digit* prefix, so the `A. Pseudocode` node
+    /// the parser built could never be selected, and the bare `A.1.` heading was not
+    /// recognised as a heading at all. apysource 0.5.1 fixed both, so the section is
+    /// named here and the quote is checked against the appendix it actually comes from,
+    /// not the whole document.
     ///
-    // cite(RFC 9000): "For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025)."
+    // cite(RFC 9000 § A.1): "For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025)."
     #[test]
     fn rfc9000_a1_worked_examples() {
         let vectors: &[(&[u8], u64)] = &[

--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -237,6 +237,9 @@ pub fn validate_basic_credentials(token68: &str) -> Result<(), String> {
         return Err("Basic credentials token is empty".into());
     }
     // cite(RFC 7617 § 2): "and obtains the basic-credentials by encoding this octet sequence using Base64"
+    // Erroring out on a malformed encoding is RFC 4648's own instruction, not
+    // strictness for its own sake — and RFC 7617 does not state otherwise.
+    // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(s)
         .map_err(|e| format!("Invalid base64 in Basic credentials: {}", e))?;

--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -236,10 +236,10 @@ pub fn validate_basic_credentials(token68: &str) -> Result<(), String> {
     if s.is_empty() {
         return Err("Basic credentials token is empty".into());
     }
-    // cite(RFC 7617 § 2): "and obtains the basic-credentials by encoding this octet sequence using Base64"
+    // cite(RFC 7617 § 2, label: basic-credentials base64): "and obtains the basic-credentials by encoding this octet sequence using Base64"
     // Erroring out on a malformed encoding is RFC 4648's own instruction, not
     // strictness for its own sake — and RFC 7617 does not state otherwise.
-    // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
+    // cite(RFC 4648 § 3.3, label: base64 rejects non-alphabet): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(s)
         .map_err(|e| format!("Invalid base64 in Basic credentials: {}", e))?;
@@ -295,7 +295,7 @@ pub fn validate_bearer_token(token: &str) -> Result<(), String> {
         return Err("Bearer token has empty main part".into());
     }
 
-    // cite(RFC 6750 § 2.1): "b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"=""
+    // cite(RFC 6750 § 2.1, label: bearer b64token grammar): "b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"=""
     let allowed_main =
         |c: char| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~' | '+' | '/');
 

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -90,7 +90,7 @@ impl Cookie {
 
     /// Simple domain-match check following RFC 6265 §5.1.3.  Only the host
     /// portion of the request URI should be supplied (no port).
-    // cite(RFC 6265 § 5.1.3): "A string domain-matches a given domain string if at least one of the following conditions hold"
+    // cite(RFC 6265 § 5.1.3, label: cookie domain-match): "A string domain-matches a given domain string if at least one of the following conditions hold"
     pub fn domain_matches(&self, request_host: &str) -> bool {
         let req = request_host.to_ascii_lowercase();
         let dom = self.domain.as_str();
@@ -103,7 +103,7 @@ impl Cookie {
 
     /// Path-match per RFC 6265 §5.1.4.  `request_path` should be the path
     /// component extracted from the request-target (leading '/' or "/").
-    // cite(RFC 6265 § 5.1.4): "A request-path path-matches a given cookie-path if at least one of the following conditions holds"
+    // cite(RFC 6265 § 5.1.4, label: cookie path-match): "A request-path path-matches a given cookie-path if at least one of the following conditions holds"
     pub fn path_matches(&self, request_path: &str) -> bool {
         let cookie_path = self.path.as_str();
         // RFC 6265 §5.1.4:
@@ -171,7 +171,7 @@ pub fn parse_set_cookie(
                     // The user agent ignores such an attribute and uses the
                     // default-path instead.  We mirror that by only assigning
                     // when the value is syntactically valid.
-                    // cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+                    // cite(RFC 6265 § 5.2.4, label: cookie Path attribute): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
                     if v.starts_with('/') {
                         path_attr = Some(v.to_string());
                     }

--- a/lint-http-rules/src/helpers/domain.rs
+++ b/lint-http-rules/src/helpers/domain.rs
@@ -64,10 +64,7 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
         // reject — so the quote below is deliberately the clause about the *end* and
         // the interior, which is the part this branch actually enforces.
         // cite(RFC 1035 § 2.3.1): "end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
-        // (RFC 1123's § 2.1 heading is the old indented style with no trailing period,
-        // which the section resolver does not match, so this cite names the document
-        // and lets the sentence locate itself.)
-        // cite(RFC 1123): "the restriction on the first character is relaxed to allow either a letter or a digit."
+        // cite(RFC 1123 § 2.1): "the restriction on the first character is relaxed to allow either a letter or a digit."
         if first == '-' || last == '-' {
             return Err("domain label must not start or end with '-'".into());
         }

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -50,7 +50,7 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
         for t in parse_list_header(s) {
             saw_value = true;
 
-            // cite(RFC 9110 § 8.6): "Content-Length = 1*DIGIT"
+            // cite(RFC 9110 § 8.6, label: Content-Length grammar): "Content-Length = 1*DIGIT"
             if !t.chars().all(|c| c.is_ascii_digit()) {
                 return Err(ContentLengthError::InvalidCharacter(s.to_string()));
             }
@@ -143,7 +143,7 @@ pub fn get_all_header_values(headers: &HeaderMap, name: &str) -> Option<String> 
 pub fn inm_matches_known(inm: &str, known: &str) -> bool {
     fn normalize(s: &str) -> &str {
         let s = s.trim();
-        // cite(RFC 9110 § 13.1.2): "A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match"
+        // cite(RFC 9110 § 13.1.2, label: If-None-Match weak comparison): "A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match"
         if let Some(rest) = s.strip_prefix("W/") {
             rest.trim()
         } else {
@@ -323,7 +323,7 @@ pub fn get_cache_control_max_age(headers: &HeaderMap) -> Option<i64> {
 ///
 /// The resulting string is trimmed but otherwise returned verbatim.
 ///
-// cite(RFC 9110 § 8.8.3.2): "two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak"."
+// cite(RFC 9110 § 8.8.3.2): "two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak"."
 pub fn normalize_etag(s: &str) -> String {
     let trimmed = s.trim();
     if trimmed.len() >= 2 && (trimmed.starts_with("W/") || trimmed.starts_with("w/")) {
@@ -1003,7 +1003,7 @@ pub fn valid_qvalue(s: &str) -> bool {
     let s = s.trim();
     // The three-decimal cap and the "1 may only be followed by zeroes" asymmetry are
     // both in the production; neither is arbitrary.
-    // cite(RFC 9110 § 12.4.2): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"
+    // cite(RFC 9110 § 12.4.2, label: qvalue grammar): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"
     if s == "1" || s == "1.0" || s == "1.00" || s == "1.000" {
         return true;
     }
@@ -1278,7 +1278,7 @@ fn validate_domain(domain: &str) -> bool {
 /// Validate an entity-tag (ETag) value. Accepts '*' or an entity-tag
 /// which may be weak (prefix 'W/'). Returns Ok(()) on success or Err(msg) describing the problem.
 pub fn validate_entity_tag(val: &str) -> Result<(), String> {
-    // cite(RFC 9110 § 8.8.3): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
+    // cite(RFC 9110 § 8.8.3, label: entity-tag grammar): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
     let s = val.trim();
     if s == "*" {
         return Ok(());
@@ -1319,7 +1319,7 @@ pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
         .trim();
     let params = parts.next().map(|p| p.trim()).filter(|p| !p.is_empty());
 
-    // cite(RFC 9110 § 8.3.1): "media-type = type "/" subtype parameters"
+    // cite(RFC 9110 § 8.3.1, label: media-type grammar): "media-type = type "/" subtype parameters"
     if !media.contains('/') {
         return Err(format!(
             "Invalid media-type '{}': missing '/' between type and subtype",

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1161,7 +1161,11 @@ pub fn validate_mailbox_list(val: &str) -> Result<(), String> {
     }
 
     for p in parts {
-        // Validate each mailbox: either contains '<' '>' with addr-spec inside or is addr-spec directly
+        // Validate each mailbox: either contains '<' '>' with addr-spec inside or is
+        // addr-spec directly. The two branches are RFC 5322's two forms of a mailbox —
+        // the display-name in front of the angle-addr is why everything before '<' is
+        // skipped rather than rejected.
+        // cite(RFC 5322 § 3.4): "Normally, a mailbox is composed of two parts: (1) an optional display name that indicates the name of the recipient (which can be a person or a system) that could be displayed to the user of a mail application, and (2) an addr-spec address enclosed in angle brackets"
         if let Some(open) = p.find('<') {
             let close = p.rfind('>');
             let end = match close {
@@ -1174,6 +1178,7 @@ pub fn validate_mailbox_list(val: &str) -> Result<(), String> {
             }
         } else {
             // Bare addr-spec
+            // cite(RFC 5322 § 3.4): "There is an alternate simple form of a mailbox where the addr-spec address appears alone, without the recipient's name or the angle brackets."
             if let Err(e) = validate_addr_spec(p) {
                 return Err(format!("Invalid addr-spec '{}': {}", p, e));
             }
@@ -1188,6 +1193,13 @@ fn validate_addr_spec(addr: &str) -> Result<(), String> {
         return Err("empty addr-spec".into());
     }
 
+    // Both branches below enforce the same three-part shape — something local, one
+    // "@", something domain — with the local side deliberately held to RFC 5322's
+    // prose rather than its full grammar.
+    // cite(RFC 5322 § 3.4.1): "An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain."
+    // The leading-DQUOTE dispatch is the sentence's alternative made literal: a
+    // quoted-string can only begin with '"', and a dot-atom never can.
+    // cite(RFC 5322 § 3.4.1): "The locally interpreted string is either a quoted-string or a dot-atom."
     if addr.starts_with('"') {
         // quoted local-part style: "local"@domain
         if let Some(at_pos) = addr.rfind('@') {

--- a/lint-http-rules/src/helpers/status.rs
+++ b/lint-http-rules/src/helpers/status.rs
@@ -4,7 +4,7 @@
 
 /// Returns true if `status` is a redirection status (3xx).
 pub fn is_redirection_status(status: u16) -> bool {
-    // cite(RFC 9110 § 15.4): "The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request."
+    // cite(RFC 9110 § 15.4, label: 3xx redirection class): "The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request."
     (300..=399).contains(&status)
 }
 

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -140,7 +140,7 @@ pub fn validate_origin_value(s: &str) -> Option<String> {
 pub fn extract_authority_from_request_target(s: &str) -> Option<String> {
     let s_trim = s.trim();
 
-    // cite(RFC 9112 § 3.2): "request-target = origin-form / absolute-form / authority-form / asterisk-form"
+    // cite(RFC 9112 § 3.2, label: request-target forms): "request-target = origin-form / absolute-form / authority-form / asterisk-form"
     if s_trim.is_empty() || s_trim == "*" || s_trim.starts_with('/') {
         return None;
     }
@@ -203,7 +203,7 @@ pub fn extract_host_from_request_target(s: &str) -> Option<String> {
 pub fn extract_path_from_request_target(s: &str) -> Option<String> {
     let s_trim = s.trim();
 
-    // cite(RFC 9112 § 3.2): "request-target = origin-form / absolute-form / authority-form / asterisk-form"
+    // cite(RFC 9112 § 3.2, label: request-target forms): "request-target = origin-form / absolute-form / authority-form / asterisk-form"
     if s_trim == "*" {
         return None;
     }

--- a/lint-http-rules/src/helpers/websocket.rs
+++ b/lint-http-rules/src/helpers/websocket.rs
@@ -38,7 +38,7 @@ pub fn compute_accept(key: &str) -> Option<String> {
     // encoding is RFC 4648's instruction, and RFC 6455 does not state otherwise.
     // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
     match base64::engine::general_purpose::STANDARD.decode(key_trim) {
-        // cite(RFC 6455 § 4.1): "The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded"
+        // cite(RFC 6455 § 4.1, label: Sec-WebSocket-Key nonce): "The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded"
         Ok(bytes) if bytes.len() == 16 => {
             let mut hasher = sha1::Sha1::new();
             // The decode above is a length check and nothing more. What gets hashed is

--- a/lint-http-rules/src/helpers/websocket.rs
+++ b/lint-http-rules/src/helpers/websocket.rs
@@ -34,7 +34,9 @@ const WS_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 /// string** concatenated with the well-known GUID — not of the bytes it decodes to.
 pub fn compute_accept(key: &str) -> Option<String> {
     let key_trim = key.trim();
-    // decode key to ensure it is 16 bytes long
+    // decode key to ensure it is 16 bytes long. Returning None on a malformed
+    // encoding is RFC 4648's instruction, and RFC 6455 does not state otherwise.
+    // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
     match base64::engine::general_purpose::STANDARD.decode(key_trim) {
         // cite(RFC 6455 § 4.1): "The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded"
         Ok(bytes) if bytes.len() == 16 => {

--- a/lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
+++ b/lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -101,7 +101,9 @@ impl Rule for ClientSecWebsocketHeadersConsistency {
         if let Some(hv) =
             crate::helpers::headers::get_header_str(&tx.request.headers, "sec-websocket-key")
         {
-            // Validate base64
+            // Validate base64. Reporting a malformed encoding is RFC 4648's own
+            // instruction, and RFC 6455 does not state otherwise.
+            // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
             match base64::engine::general_purpose::STANDARD.decode(hv.trim()) {
                 Ok(bytes) => {
                     if bytes.len() != 16 {

--- a/lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
+++ b/lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
@@ -23,8 +23,8 @@ impl Rule for MessageHttp3HostAuthorityConsistency {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        // Only applies to HTTP/3 transactions.
-        // cite(RFC 9114 § 4.3): "Pseudo-header fields are not HTTP fields."
+        // Only applies to HTTP/3 transactions. This gate is scoping, not a normative
+        // check, so it carries no citation; the two comparisons below carry theirs.
         if tx.request.version != "HTTP/3" {
             return None;
         }
@@ -49,7 +49,8 @@ impl Rule for MessageHttp3HostAuthorityConsistency {
 
         let host_trimmed = host_str.trim();
 
-        // Both must not be empty when both are present (RFC 9114 §4.3.1).
+        // Both must not be empty when both are present.
+        // cite(RFC 9114 § 4.3.1): "If these fields are present, they MUST NOT be empty."
         if host_trimmed.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
@@ -60,8 +61,10 @@ impl Rule for MessageHttp3HostAuthorityConsistency {
             });
         }
 
-        // The values MUST contain the same value (RFC 9114 §4.3.1).
-        // Hostnames are case-insensitive (RFC 3986 §3.2.2).
+        // The two must carry the same value, compared case-insensitively because the
+        // host component is.
+        // cite(RFC 9114 § 4.3.1): "If both fields are present, they MUST contain the same value."
+        // cite(RFC 3986 § 3.2.2): "Although host is case-insensitive, producers and normalizers should use lowercase for registered names and hexadecimal addresses for the sake of uniformity"
         if !authority.eq_ignore_ascii_case(host_trimmed) {
             return Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+++ b/lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
@@ -23,13 +23,17 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        // Only applies to HTTP/3 transactions.
-        // cite(RFC 9114 § 4.3): "Pseudo-header fields are not HTTP fields."
+        // Only applies to HTTP/3 transactions. The version gate is scoping, not a
+        // normative check, so it carries no cite; each requirement below cites the
+        // sentence it enforces.
         if tx.request.version != "HTTP/3" {
             return None;
         }
 
-        // :method pseudo-header is required (RFC 9114 §4.3).
+        // :method is required. (The :scheme half of the same sentence is not
+        // checked — the canonical model does not retain scheme for origin-form
+        // requests, as the description says.)
+        // cite(RFC 9114 § 4.3.1): "All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4."
         let method = tx.request.method.trim();
         if method.is_empty() {
             return Some(Violation {
@@ -42,10 +46,10 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         let is_connect = method.eq_ignore_ascii_case("CONNECT");
 
         if is_connect {
-            // CONNECT requests require an authority (RFC 9114 §4.4).
-            // In the canonical model, the authority comes from the request-target
-            // (authority-form) or, for extended CONNECT using origin-form, from
-            // the Host header.
+            // CONNECT requires an authority; in the canonical model it comes from the
+            // request-target (authority-form) or, for extended CONNECT using
+            // origin-form, from the Host header.
+            // cite(RFC 9114 § 4.4): "The :authority pseudo-header field contains the host and port to connect to"
             let uri_trimmed = tx.request.uri.trim();
             if uri_trimmed.is_empty() {
                 return Some(Violation {
@@ -81,8 +85,11 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
                 });
             }
         } else {
-            // Non-CONNECT: :path pseudo-header is required (RFC 9114 §4.3).
-            // Asterisk-form ("*") is only valid for OPTIONS (RFC 9110 §7.1).
+            // Non-CONNECT: the request-target is either the asterisk-form (OPTIONS
+            // only) or a path. RFC 9110 § 7.1 permits "*" for OPTIONS and forbids it
+            // for every other method.
+            // cite(RFC 9110 § 7.1): "For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*")."
+            // cite(RFC 9110 § 7.1): "These forms MUST NOT be used with other methods."
             let uri_trimmed = tx.request.uri.trim();
             if uri_trimmed == "*" {
                 if !method.eq_ignore_ascii_case("OPTIONS") {
@@ -95,6 +102,7 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
                     });
                 }
             } else {
+                // cite(RFC 9114 § 4.3.1): "This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f)."
                 let has_path =
                     crate::helpers::uri::extract_path_from_request_target(uri_trimmed).is_some();
                 if !has_path {
@@ -106,10 +114,10 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
                 }
             }
 
-            // For schemes with a mandatory authority component (http, https),
-            // the request MUST contain either :authority or Host (RFC 9114 §4.3.1).
             // HTTP/3 always runs over QUIC/TLS, so the scheme is always http or
-            // https — the authority requirement applies to all non-CONNECT requests.
+            // https, both of which have a mandatory authority component — the
+            // requirement applies to every non-CONNECT request.
+            // cite(RFC 9114 § 4.3.1): "If the :scheme pseudo-header field identifies a scheme that has a mandatory authority component (including "http" and "https"), the request MUST contain either an :authority pseudo-header field or a Host header field."
             let has_authority =
                 crate::helpers::uri::extract_authority_from_request_target(&tx.request.uri)
                     .is_some();
@@ -125,7 +133,10 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
             }
         }
 
-        // Response: :status pseudo-header must be valid (RFC 9114 §4.3).
+        // Response: :status must be a three-digit code. Its presence is required by
+        // RFC 9114 § 4.3.2; the 100–599 range it must fall in is defined by RFC 9110
+        // § 15, which is the constraint this branch actually enforces.
+        // cite(RFC 9110 § 15): "All valid status codes are within the range of 100 to 599, inclusive."
         if let Some(resp) = &tx.response {
             if resp.version == "HTTP/3" && !(100..=599).contains(&resp.status) {
                 return Some(Violation {
@@ -179,7 +190,13 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
                 spec: "RFC 9110",
                 section: Some("7.1"),
                 url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
-                note: "Determining the Target Resource",
+                note: "Determining the Target Resource (asterisk-form request target)",
+            },
+            crate::rules::SpecRef {
+                spec: "RFC 9110",
+                section: Some("15"),
+                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
+                note: "Status Codes: valid codes are in the range 100-599",
             },
         ]
     }

--- a/lint-http-rules/src/rules/server_http3_status_code_validity.rs
+++ b/lint-http-rules/src/rules/server_http3_status_code_validity.rs
@@ -23,8 +23,7 @@ impl Rule for ServerHttp3StatusCodeValidity {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        // Only applies to HTTP/3 connections.
-        // cite(RFC 9114 § 4.3): "Pseudo-header fields are not HTTP fields."
+        // Only applies to HTTP/3 connections. Scoping, not a normative check — no cite.
         if tx.request.version != "HTTP/3" {
             return None;
         }
@@ -49,10 +48,11 @@ impl Rule for ServerHttp3StatusCodeValidity {
             });
         }
 
-        // RFC 9110 §15.2, RFC 9114 §4.1: Informational (1xx) responses
-        // consist of only a HEADERS frame — no content, no trailers.
+        // Informational (1xx) responses consist of only a HEADERS frame — no content,
+        // no trailers. One sentence governs all three checks in this block.
+        // cite(RFC 9110 § 15.2): "A 1xx response is terminated by the end of the header section; it cannot contain content or trailers."
         if (100..200).contains(&resp.status) {
-            // Content-Length MUST NOT appear on 1xx responses (RFC 9110 §15.2).
+            // Content-Length MUST NOT appear on a 1xx response — it announces content.
             if resp.headers.contains_key("content-length") {
                 return Some(Violation {
                     rule: self.id().into(),

--- a/lint-http-rules/src/rules/server_retry_after_status_validity.rs
+++ b/lint-http-rules/src/rules/server_retry_after_status_validity.rs
@@ -28,6 +28,12 @@ impl Rule for ServerRetryAfterStatusValidity {
         resp.headers.get_all("retry-after").iter().next()?;
 
         let status = resp.status;
+        // Each arm of the allowed set is one sentence: RFC 9110 names 503 and the 3xx
+        // class; RFC 6585 is where 429 gets its Retry-After, since RFC 9110 never
+        // mentions that status.
+        // cite(RFC 9110 § 10.2.3): "When sent with a 503 (Service Unavailable) response, Retry-After indicates how long the service is expected to be unavailable to the client."
+        // cite(RFC 9110 § 10.2.3): "When sent with any 3xx (Redirection) response, Retry-After indicates the minimum time that the user agent is asked to wait before issuing the redirected request."
+        // cite(RFC 6585 § 4): "The response representations SHOULD include details explaining the condition, and MAY include a Retry-After header indicating how long to wait before making a new request."
         let allowed =
             status == 503 || status == 429 || crate::helpers::status::is_redirection_status(status);
         if allowed {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -312,7 +312,7 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc4648.txt
   type: text/plain
   fragments:
-  - label: lint-http-rules/src/helpers/auth.rs
+  - label: base64 rejects non-alphabet
     section: § 3.3
     snippet: Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.
     cited_by:
@@ -400,7 +400,7 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc6265.txt
   type: text/plain
   fragments:
-  - label: lint-http-rules/src/helpers/cookie.rs
+  - label: cookie domain-match
     section: § 5.1.3
     snippet: A string domain-matches a given domain string if at least one of the following conditions hold
     cited_by:
@@ -408,7 +408,7 @@ sources:
       line: 93
     - file: lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
       line: 96
-  - label: lint-http-rules/src/helpers/cookie.rs (2)
+  - label: cookie path-match
     section: § 5.1.4
     snippet: A request-path path-matches a given cookie-path if at least one of the following conditions holds
     cited_by:
@@ -416,31 +416,31 @@ sources:
       line: 106
     - file: lint-http-rules/src/rules/stateful_cookie_domain_matching.rs
       line: 108
-  - label: lint-http-rules/src/helpers/cookie.rs (3)
+  - label: lint-http-rules/src/helpers/cookie.rs
     section: § 5.1.4
     snippet: If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 240
-  - label: lint-http-rules/src/helpers/cookie.rs (4)
+  - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 5.1.4
     snippet: Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 245
-  - label: lint-http-rules/src/helpers/cookie.rs (5)
+  - label: lint-http-rules/src/helpers/cookie.rs (3)
     section: § 5.1.4
     snippet: 'The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 230
-  - label: lint-http-rules/src/helpers/cookie.rs (6)
+  - label: lint-http-rules/src/helpers/cookie.rs (4)
     section: § 5.1.4
     snippet: output %x2F ("/") and skip the remaining steps.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 236
-  - label: lint-http-rules/src/helpers/cookie.rs (7)
+  - label: cookie Path attribute
     section: § 5.2.4
     snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
     cited_by:
@@ -556,7 +556,7 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 48
-  - label: lint-http-rules/src/helpers/websocket.rs (2)
+  - label: Sec-WebSocket-Key nonce
     section: § 4.1
     snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded
     cited_by:
@@ -564,13 +564,13 @@ sources:
       line: 41
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
       line: 28
-  - label: lint-http-rules/src/helpers/websocket.rs (3)
+  - label: lint-http-rules/src/helpers/websocket.rs (2)
     section: § 4.2.2
     snippet: server would append the string "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" to form the string
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 24
-  - label: lint-http-rules/src/helpers/websocket.rs (4)
+  - label: lint-http-rules/src/helpers/websocket.rs (3)
     section: § 4.2.2
     snippet: taking the SHA-1 hash of this concatenated value to obtain a 20-byte value
     cited_by:
@@ -618,7 +618,7 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc6750.txt
   type: text/plain
   fragments:
-  - label: lint-http-rules/src/helpers/auth.rs
+  - label: bearer b64token grammar
     section: § 2.1
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
     cited_by:
@@ -734,7 +734,7 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 260
-  - label: lint-http-rules/src/helpers/auth.rs (2)
+  - label: basic-credentials base64
     section: § 2
     snippet: and obtains the basic-credentials by encoding this octet sequence using Base64
     cited_by:
@@ -742,7 +742,7 @@ sources:
       line: 239
     - file: lint-http-rules/src/rules/message_basic_auth_base64_validity.rs
       line: 40
-  - label: lint-http-rules/src/helpers/auth.rs (3)
+  - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 2
     snippet: constructs the user-pass by concatenating the user-id, a single colon (":") character, and the password
     cited_by:
@@ -881,22 +881,23 @@ sources:
   type: text/plain
   fragments:
   - label: lint-http-proxy/src/h3_instrument.rs
-    snippet: For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025).
-    cited_by:
-    - file: lint-http-proxy/src/h3_instrument.rs
-      line: 492
-  - label: lint-http-proxy/src/h3_instrument.rs (2)
     section: § 16
     snippet: The QUIC variable-length integer encoding reserves the two most significant bits of the first byte to encode the base-2 logarithm of the integer encoding length in bytes.  The integer value is encoded on the remaining bits, in network byte order.
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 40
-  - label: lint-http-proxy/src/h3_instrument.rs (3)
+  - label: lint-http-proxy/src/h3_instrument.rs (2)
     section: § 16
     snippet: This means that integers are encoded on 1, 2, 4, or 8 bytes and can encode 6-, 14-, 30-, or 62-bit values, respectively.
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 41
+  - label: lint-http-proxy/src/h3_instrument.rs (3)
+    section: § A.1
+    snippet: For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025).
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 490
   - label: server_quic_transport_parameters
     section: § 18
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
@@ -1125,7 +1126,7 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 76
-  - label: lint-http-rules/src/helpers/headers.rs
+  - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
@@ -1135,7 +1136,7 @@ sources:
       line: 78
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 65
-  - label: lint-http-rules/src/helpers/headers.rs (2)
+  - label: If-None-Match weak comparison
     section: § 13.1.2
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
@@ -1143,73 +1144,73 @@ sources:
       line: 146
     - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
       line: 44
-  - label: lint-http-rules/src/helpers/headers.rs (3)
+  - label: lint-http-rules/src/helpers/headers.rs
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 122
-  - label: lint-http-rules/src/helpers/headers.rs (4)
+  - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 123
-  - label: lint-http-rules/src/helpers/headers.rs (5)
+  - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 242
-  - label: lint-http-rules/src/helpers/headers.rs (6)
+  - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5.6.1.2
     snippet: Empty elements do not contribute to the count of elements present.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 241
-  - label: lint-http-rules/src/helpers/headers.rs (7)
+  - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 971
-  - label: lint-http-rules/src/helpers/headers.rs (8)
+  - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 902
-  - label: lint-http-rules/src/helpers/headers.rs (9)
+  - label: lint-http-rules/src/helpers/headers.rs (7)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 919
-  - label: lint-http-rules/src/helpers/headers.rs (10)
+  - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 901
-  - label: lint-http-rules/src/helpers/headers.rs (11)
+  - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.6.5
     snippet: comment        = "(" *( ctext / quoted-pair / comment ) ")"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 748
-  - label: lint-http-rules/src/helpers/headers.rs (12)
+  - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.6.5
     snippet: ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 749
-  - label: lint-http-rules/src/helpers/headers.rs (13)
+  - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 632
-  - label: lint-http-rules/src/helpers/headers.rs (14)
+  - label: media-type grammar
     section: § 8.3.1
     snippet: media-type = type "/" subtype parameters
     cited_by:
@@ -1217,7 +1218,7 @@ sources:
       line: 1322
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
-  - label: lint-http-rules/src/helpers/headers.rs (15)
+  - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
@@ -1225,7 +1226,7 @@ sources:
       line: 53
     - file: lint-http-rules/src/rules/message_content_length.rs
       line: 27
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: entity-tag grammar
     section: § 8.8.3
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
@@ -1233,13 +1234,13 @@ sources:
       line: 1281
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+  - label: lint-http-rules/src/helpers/headers.rs (12)
     section: § 8.8.3.2
-    snippet: two entity tags are equivalent if their opaque- tags match character-by-character, regardless of either or both being tagged as "weak".
+    snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 326
-  - label: lint-http-rules/src/helpers/status.rs
+  - label: 3xx redirection class
     section: § 15.4
     snippet: The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
     cited_by:
@@ -1771,7 +1772,7 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 48
-  - label: lint-http-rules/src/helpers/uri.rs
+  - label: request-target forms
     section: § 3.2
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -302,6 +302,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 78
+  - label: message_http3_host_authority_consistency
+    section: § 3.2.2
+    snippet: Although host is case-insensitive, producers and normalizers should use lowercase for registered names and hexadecimal addresses for the sake of uniformity
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
+      line: 67
 - label: RFC 4648
   url: https://www.rfc-editor.org/rfc/rfc4648.txt
   type: text/plain
@@ -1055,6 +1061,8 @@ sources:
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket.rs
       line: 144
+    - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
+      line: 53
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 11.1
     snippet: It uses a case-insensitive token to identify the authentication scheme
@@ -1373,6 +1381,24 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
       line: 29
+  - label: message_http3_pseudo_headers_validity
+    section: § 15
+    snippet: All valid status codes are within the range of 100 to 599, inclusive.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 139
+  - label: message_http3_pseudo_headers_validity (2)
+    section: § 7.1
+    snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 91
+  - label: message_http3_pseudo_headers_validity (3)
+    section: § 7.1
+    snippet: These forms MUST NOT be used with other methods.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 92
   - label: message_if_match_etag_syntax
     section: § 13.1.1
     snippet: An origin server MUST use the strong comparison function when comparing entity tags for If-Match
@@ -1830,27 +1856,53 @@ sources:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
       line: 40
   - label: message_http3_host_authority_consistency
-    section: § 4.3
-    snippet: Pseudo-header fields are not HTTP fields.
+    section: § 4.3.1
+    snippet: If both fields are present, they MUST contain the same value.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
-      line: 27
-    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 27
-    - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
-      line: 27
+      line: 66
+  - label: message_http3_host_authority_consistency (2)
+    section: § 4.3.1
+    snippet: If these fields are present, they MUST NOT be empty.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
+      line: 53
   - label: message_http3_no_connection_header
     section: § 4.2
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP]
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
       line: 36
+  - label: message_http3_pseudo_headers_validity
+    section: § 4.3.1
+    snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 36
+  - label: message_http3_pseudo_headers_validity (2)
+    section: § 4.3.1
+    snippet: If the :scheme pseudo-header field identifies a scheme that has a mandatory authority component (including "http" and "https"), the request MUST contain either an :authority pseudo-header field or a Host header field.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 120
+  - label: message_http3_pseudo_headers_validity (3)
+    section: § 4.3.1
+    snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 105
+  - label: message_http3_pseudo_headers_validity (4)
+    section: § 4.4
+    snippet: The :authority pseudo-header field contains the host and port to connect to
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+      line: 52
   - label: server_http3_status_code_validity
     section: § 4.5
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
-      line: 41
+      line: 40
   - label: stateful_http3_goaway_semantics
     section: § 7.2.6
     snippet: The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -240,10 +240,11 @@ sources:
   type: text/plain
   fragments:
   - label: lint-http-rules/src/helpers/domain.rs
+    section: § 2.1
     snippet: the restriction on the first character is relaxed to allow either a letter or a digit.
     cited_by:
     - file: lint-http-rules/src/helpers/domain.rs
-      line: 70
+      line: 67
 - label: RFC 2045
   url: https://www.rfc-editor.org/rfc/rfc2045.txt
   type: text/plain

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -302,6 +302,48 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 78
+- label: RFC 4648
+  url: https://www.rfc-editor.org/rfc/rfc4648.txt
+  type: text/plain
+  fragments:
+  - label: lint-http-rules/src/helpers/auth.rs
+    section: § 3.3
+    snippet: Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.
+    cited_by:
+    - file: lint-http-rules/src/helpers/auth.rs
+      line: 242
+    - file: lint-http-rules/src/helpers/websocket.rs
+      line: 39
+    - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
+      line: 106
+- label: RFC 5322
+  url: https://www.rfc-editor.org/rfc/rfc5322.txt
+  type: text/plain
+  fragments:
+  - label: lint-http-rules/src/helpers/headers.rs
+    section: § 3.4
+    snippet: 'Normally, a mailbox is composed of two parts: (1) an optional display name that indicates the name of the recipient (which can be a person or a system) that could be displayed to the user of a mail application, and (2) an addr-spec address enclosed in angle brackets'
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1168
+  - label: lint-http-rules/src/helpers/headers.rs (2)
+    section: § 3.4
+    snippet: There is an alternate simple form of a mailbox where the addr-spec address appears alone, without the recipient's name or the angle brackets.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1181
+  - label: lint-http-rules/src/helpers/headers.rs (3)
+    section: § 3.4.1
+    snippet: An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1199
+  - label: lint-http-rules/src/helpers/headers.rs (4)
+    section: § 3.4.1
+    snippet: The locally interpreted string is either a quoted-string or a dot-atom.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1202
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.txt
   type: text/plain
@@ -507,13 +549,13 @@ sources:
     snippet: (as a string, not base64-decoded) with the string
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
-      line: 46
+      line: 48
   - label: lint-http-rules/src/helpers/websocket.rs (2)
     section: § 4.1
     snippet: The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
-      line: 39
+      line: 41
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
       line: 28
   - label: lint-http-rules/src/helpers/websocket.rs (3)
@@ -527,7 +569,7 @@ sources:
     snippet: taking the SHA-1 hash of this concatenated value to obtain a 20-byte value
     cited_by:
     - file: lint-http-rules/src/helpers/websocket.rs
-      line: 49
+      line: 51
   - label: stateful_websocket_frame_opcode_sequence
     section: § 11.8
     snippet: The opcode denotes the frame type of the WebSocket frame,
@@ -546,6 +588,16 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/stateful_websocket_handshake_validity.rs
       line: 43
+- label: RFC 6585
+  url: https://www.rfc-editor.org/rfc/rfc6585.txt
+  type: text/plain
+  fragments:
+  - label: server_retry_after_status_validity
+    section: § 4
+    snippet: The response representations SHOULD include details explaining the condition, and MAY include a Retry-After header indicating how long to wait before making a new request.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_retry_after_status_validity.rs
+      line: 36
 - label: RFC 6749
   url: https://www.rfc-editor.org/rfc/rfc6749.txt
   type: text/plain
@@ -565,7 +617,7 @@ sources:
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 295
+      line: 298
     - file: lint-http-rules/src/rules/message_bearer_token_format_validity.rs
       line: 51
 - label: RFC 6797
@@ -647,7 +699,7 @@ sources:
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 356
+      line: 359
   - label: message_digest_auth_validity
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque.'
@@ -675,7 +727,7 @@ sources:
     snippet: The user-id and password MUST NOT contain any control characters
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 257
+      line: 260
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 2
     snippet: and obtains the basic-credentials by encoding this octet sequence using Base64
@@ -689,7 +741,7 @@ sources:
     snippet: constructs the user-pass by concatenating the user-id, a single colon (":") character, and the password
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 247
+      line: 250
 - label: RFC 7807
   url: https://www.rfc-editor.org/rfc/rfc7807.txt
   type: text/plain
@@ -1154,7 +1206,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1310
+      line: 1322
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 90
   - label: lint-http-rules/src/helpers/headers.rs (15)
@@ -1170,7 +1222,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1269
+      line: 1281
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 58
   - label: lint-http-rules/src/helpers/headers.rs (17)
@@ -1501,10 +1553,22 @@ sources:
       line: 27
   - label: server_retry_after_status_validity
     section: § 10.2.3
+    snippet: When sent with a 503 (Service Unavailable) response, Retry-After indicates how long the service is expected to be unavailable to the client.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_retry_after_status_validity.rs
+      line: 34
+  - label: server_retry_after_status_validity (2)
+    section: § 10.2.3
+    snippet: When sent with any 3xx (Redirection) response, Retry-After indicates the minimum time that the user agent is asked to wait before issuing the redirected request.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_retry_after_status_validity.rs
+      line: 35
+  - label: server_retry_after_status_validity (3)
+    section: § 10.2.3
     snippet: the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request.
     cited_by:
     - file: lint-http-rules/src/rules/server_retry_after_status_validity.rs
-      line: 40
+      line: 46
   - label: server_status_code_valid_range
     section: § 15
     snippet: The status code of a response is a three-digit integer code that describes the result of the request


### PR DESCRIPTION
Widen the citation ratchet crate-wide, adopt apysource 0.5.1 / apycite 0.2.0, make RFC 1123 resolvable, quote the three docs the rules only pointed at, cite the H3 pseudo-header rules.

