### PR TITLE
HTTP/3 SETTINGS & MAX_PUSH_ID rules

### DIFF
--- a/docs/rules/stateful_http3_settings_frame.md
+++ b/docs/rules/stateful_http3_settings_frame.md
@@ -10,13 +10,16 @@ SPDX-License-Identifier: ISC
 
 Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:
 
-* **No duplicate SETTINGS** — an endpoint MUST NOT send a SETTINGS frame more than once over a connection (RFC 9114 §7.2.4).  A second `H3SettingsReceived` event on the same connection is a violation.
-* **No reserved HTTP/2 setting identifiers** — setting identifiers that were defined in HTTP/2 but have no corresponding HTTP/3 setting are reserved.  Their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00`, `0x02` (SETTINGS_ENABLE_PUSH), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).
+* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.
+* **No reserved setting identifiers** — the `Reserved` rows of the "HTTP/3 Settings" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).
+
+Identifiers outside that set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored.
 
 ## Specifications
 
 - [RFC 9114 §7.2.4](https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4): SETTINGS
 - [RFC 9114 §7.2.4.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4.1): Defined SETTINGS Parameters
+- [RFC 9114 §11.2.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-11.2.2): Settings Parameters (Table 3: the Reserved rows)
 
 ## Configuration
 

--- a/docs/rules/stateful_http3_settings_frame.md
+++ b/docs/rules/stateful_http3_settings_frame.md
@@ -13,7 +13,9 @@ Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule insp
 * **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.
 * **No reserved setting identifiers** — the `Reserved` rows of the "HTTP/3 Settings" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).
 
-Identifiers outside that set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored.
+* **No repeated setting identifier** — the same setting identifier MUST NOT occur more than once in the SETTINGS frame (RFC 9114 §7.2.4).  A receiver MAY treat duplicates as a connection error of type `H3_SETTINGS_ERROR`; the sender's obligation is unconditional, so a repeated identifier within one frame is a violation.
+
+Identifiers outside the reserved set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored.
 
 ## Specifications
 
@@ -54,4 +56,11 @@ severity = "warn"
 ```http
 # Control stream sends SETTINGS { 0x03 = 100 }
 # Violation: SETTINGS contains reserved HTTP/2 setting identifier 0x03 (RFC 9114 §7.2.4.1)
+```
+
+### ❌ Bad (repeated setting identifier)
+
+```http
+# Control stream sends SETTINGS { 0x06 = 8192, 0x06 = 4096 }
+# Violation: SETTINGS contains setting identifier 0x06 more than once (RFC 9114 §7.2.4)
 ```

--- a/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
@@ -28,16 +28,19 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
+
+        // The event this rule recognizes is the MAX_PUSH_ID frame itself; every
+        // other protocol event is out of scope.
+        // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
         let current = match &event.kind {
             ProtocolEventKind::H3MaxPushId { push_id } => *push_id,
             _ => return None,
         };
 
-        // RFC 9114 §7.2.7: "A MAX_PUSH_ID frame cannot reduce the maximum
-        // push ID; receipt of a MAX_PUSH_ID frame that contains a smaller
-        // value than previously received MUST be treated as a connection
-        // error of type H3_ID_ERROR."
-        // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
+        // A value strictly smaller than one already received is the violation;
+        // the comparison is `<`, not `<=`, because equal does not reduce the
+        // maximum and is a legitimate idempotent re-send.
+        // cite(RFC 9114 § 7.2.7): "A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR"
         for prev in history.iter() {
             if let ProtocolEventKind::H3MaxPushId { push_id: prev_id } = &prev.kind {
                 if current < *prev_id {
@@ -51,13 +54,21 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
                         ),
                     });
                 }
-                // Only compare against the most recent prior MAX_PUSH_ID;
-                // earlier ones are necessarily ≤ that one if the rule has
-                // been holding.
+                // Compare only against the most recent prior MAX_PUSH_ID. On any
+                // connection that has not already violated, the running maximum
+                // is the most recent value, so this is exact; the spec's
+                // "previously received" only diverges from "most recent" after
+                // an earlier decrease, which was itself flagged at that step.
+                // Not a spec-licensed construct — a deliberate choice to avoid a
+                // redundant second finding (RULECITES §4.1).
                 break;
             }
         }
 
+        // No prior MAX_PUSH_ID: the maximum is unset at connection creation, so
+        // the first frame establishes it at any value (zero included) and is
+        // always accepted.
+        // cite(RFC 9114 § 7.2.7): "The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame"
         None
     }
 

--- a/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
@@ -10,6 +10,8 @@
 //! - Reserved setting identifiers (0x00, 0x02–0x05 — the `Reserved` rows of
 //!   Table 3 in RFC 9114 §11.2.2) must not appear; their receipt is a
 //!   connection error of type H3_SETTINGS_ERROR (RFC 9114 §7.2.4.1).
+//! - No setting identifier appears more than once within one SETTINGS frame
+//!   (RFC 9114 §7.2.4).
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
@@ -87,6 +89,25 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
             }
         }
 
+        // A setting identifier repeated within the one frame is a violation the
+        // sender committed; the receiver MAY reject it, but the MUST NOT is on
+        // the sender, so we report it.  Checked after the per-identifier scan so
+        // a reserved identifier is named for what it is even when repeated.
+        // cite(RFC 9114 § 7.2.4): "The same setting identifier MUST NOT occur more than once in the SETTINGS frame"
+        for (i, &(id, _)) in settings.iter().enumerate() {
+            if settings[..i].iter().any(|&(prev_id, _)| prev_id == id) {
+                return Some(Violation {
+                    rule: self.id().into(),
+                    severity: config.severity,
+                    message: format!(
+                        "HTTP/3 SETTINGS contains setting identifier 0x{:02X} more \
+                         than once (RFC 9114 §7.2.4)",
+                        id
+                    ),
+                });
+            }
+        }
+
         // Identifiers outside the reserved set — including the 0x1f*N+0x21
         // greasing values and unregistered extensions — pass without comment.
         // cite(RFC 9114 § 7.2.4): "An implementation MUST ignore any parameter with an identifier it does not understand"
@@ -98,7 +119,7 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
     }
 
     fn description(&self) -> &'static str {
-        "Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:\n\n* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.\n* **No reserved setting identifiers** — the `Reserved` rows of the \"HTTP/3 Settings\" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).\n\nIdentifiers outside that set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored."
+        "Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:\n\n* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.\n* **No reserved setting identifiers** — the `Reserved` rows of the \"HTTP/3 Settings\" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).\n\n* **No repeated setting identifier** — the same setting identifier MUST NOT occur more than once in the SETTINGS frame (RFC 9114 §7.2.4).  A receiver MAY treat duplicates as a connection error of type `H3_SETTINGS_ERROR`; the sender's obligation is unconditional, so a repeated identifier within one frame is a violation.\n\nIdentifiers outside the reserved set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -141,6 +162,11 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
                 compliance: Compliance::NonCompliant,
                 label: Some("(reserved HTTP/2 setting identifier)"),
                 snippet: "# Control stream sends SETTINGS { 0x03 = 100 }\n# Violation: SETTINGS contains reserved HTTP/2 setting identifier 0x03 (RFC 9114 §7.2.4.1)",
+            },
+            Example {
+                compliance: Compliance::NonCompliant,
+                label: Some("(repeated setting identifier)"),
+                snippet: "# Control stream sends SETTINGS { 0x06 = 8192, 0x06 = 4096 }\n# Violation: SETTINGS contains setting identifier 0x06 more than once (RFC 9114 §7.2.4)",
             },
         ]
     }
@@ -363,6 +389,55 @@ mod tests {
         let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
+    }
+
+    // ── Repeated setting identifier within one frame ─────────────────
+
+    #[test]
+    fn repeated_identifier_fails() {
+        let rule = StatefulHttp3SettingsFrame;
+        let conn = Uuid::new_v4();
+        let evt = make_settings(conn, vec![(0x06, 8192), (0x06, 4096)]);
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        assert!(result.is_some());
+        let msg = result.unwrap().message;
+        assert!(msg.contains("more than once"));
+        assert!(msg.contains("0x06"));
+    }
+
+    #[test]
+    fn repeated_identifier_non_adjacent_fails() {
+        let rule = StatefulHttp3SettingsFrame;
+        let conn = Uuid::new_v4();
+        // Same identifier repeated with an unrelated one between.
+        let evt = make_settings(conn, vec![(0x01, 4096), (0x07, 100), (0x01, 2048)]);
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        assert!(result.is_some());
+        assert!(result.unwrap().message.contains("0x01"));
+    }
+
+    #[test]
+    fn distinct_identifiers_with_equal_values_pass() {
+        // Repeated *values* are fine; only repeated identifiers are a violation.
+        let rule = StatefulHttp3SettingsFrame;
+        let conn = Uuid::new_v4();
+        let evt = make_settings(conn, vec![(0x06, 100), (0x01, 100), (0x07, 100)]);
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn reserved_identifier_reported_before_repeat() {
+        // A repeated reserved identifier is named as reserved, not as a repeat:
+        // the reserved scan runs first so the more specific violation wins.
+        let rule = StatefulHttp3SettingsFrame;
+        let conn = Uuid::new_v4();
+        let evt = make_settings(conn, vec![(0x03, 1), (0x03, 2)]);
+        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        assert!(result.is_some());
+        let msg = result.unwrap().message;
+        assert!(msg.contains("reserved"));
+        assert!(msg.contains("0x03"));
     }
 
     // ── Setting ID boundaries ────────────────────────────────────────

--- a/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
@@ -5,10 +5,11 @@
 //! HTTP/3 SETTINGS frame validation (RFC 9114 §7.2.4).
 //!
 //! Checks:
-//! - SETTINGS must not be sent more than once per connection.
-//! - Setting identifiers reserved from HTTP/2 (0x00, 0x02–0x05) must not
-//!   appear; their receipt is a connection error of type H3_SETTINGS_ERROR
-//!   (RFC 9114 §7.2.4.1).
+//! - SETTINGS is the first frame on the control stream and is not sent
+//!   subsequently, so a second one on the connection is a violation.
+//! - Reserved setting identifiers (0x00, 0x02–0x05 — the `Reserved` rows of
+//!   Table 3 in RFC 9114 §11.2.2) must not appear; their receipt is a
+//!   connection error of type H3_SETTINGS_ERROR (RFC 9114 §7.2.4.1).
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
@@ -16,14 +17,17 @@ use crate::rules::ProtocolRule;
 
 pub struct StatefulHttp3SettingsFrame;
 
-/// Setting identifiers reserved from HTTP/2 that MUST NOT appear in HTTP/3
-/// SETTINGS frames (RFC 9114 §7.2.4.1).
+/// The `Reserved` rows of the "HTTP/3 Settings" registry, transcribed from
+/// RFC 9114 Table 3 (§11.2.2).  Table 3 — not §7.2.4.1's "defined in [HTTP/2]"
+/// sentence — is what this list transcribes: `0x00` is reserved by the registry
+/// but was never an HTTP/2 setting, so only the table covers all five values.
+// cite(RFC 9114 § 11.2.2): "The entries in Table 3 are registered by this document"
 const RESERVED_SETTING_IDS: &[u64] = &[
-    0x00, // reserved
-    0x02, // SETTINGS_ENABLE_PUSH (HTTP/2 only)
-    0x03, // SETTINGS_MAX_CONCURRENT_STREAMS (HTTP/2 only)
-    0x04, // SETTINGS_INITIAL_WINDOW_SIZE (HTTP/2 only)
-    0x05, // SETTINGS_MAX_FRAME_SIZE (HTTP/2 only)
+    0x00, // Reserved (no HTTP/2 counterpart)
+    0x02, // Reserved (SETTINGS_ENABLE_PUSH in HTTP/2)
+    0x03, // Reserved (SETTINGS_MAX_CONCURRENT_STREAMS in HTTP/2)
+    0x04, // Reserved (SETTINGS_INITIAL_WINDOW_SIZE in HTTP/2)
+    0x05, // Reserved (SETTINGS_MAX_FRAME_SIZE in HTTP/2)
 ];
 
 impl ProtocolRule for StatefulHttp3SettingsFrame {
@@ -38,14 +42,22 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
+
+        // The event this rule recognizes is the SETTINGS frame itself; every
+        // other protocol event is out of scope.
+        // cite(RFC 9114 § 7.2.4): "The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate"
         let settings = match &event.kind {
             ProtocolEventKind::H3SettingsReceived { settings } => settings,
             _ => return None,
         };
 
-        // RFC 9114 §7.2.4: "A SETTINGS frame MUST NOT be sent more than once
-        // over a connection."
-        // cite(RFC 9114 § 7.2.4): "The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate"
+        // Scanning the whole connection history — rather than a single stream —
+        // is what makes a second SETTINGS visible at all.
+        // cite(RFC 9114 § 7.2.4): "SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream"
+        //
+        // A prior SETTINGS on this connection means this one was sent
+        // subsequently, which is the violation.
+        // cite(RFC 9114 § 7.2.4): "A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently"
         for prev in history.iter() {
             if matches!(&prev.kind, ProtocolEventKind::H3SettingsReceived { .. }) {
                 return Some(Violation {
@@ -58,9 +70,9 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
             }
         }
 
-        // RFC 9114 §7.2.4.1: identifiers defined in HTTP/2 without a
-        // corresponding HTTP/3 setting are reserved — their receipt MUST
-        // be treated as H3_SETTINGS_ERROR.
+        // Receipt of any reserved identifier is the violation; the sender was
+        // forbidden from putting it on the wire.
+        // cite(RFC 9114 § 7.2.4.1): "These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR"
         for &(id, _) in settings {
             if RESERVED_SETTING_IDS.contains(&id) {
                 return Some(Violation {
@@ -75,6 +87,9 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
             }
         }
 
+        // Identifiers outside the reserved set — including the 0x1f*N+0x21
+        // greasing values and unregistered extensions — pass without comment.
+        // cite(RFC 9114 § 7.2.4): "An implementation MUST ignore any parameter with an identifier it does not understand"
         None
     }
 
@@ -83,7 +98,7 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
     }
 
     fn description(&self) -> &'static str {
-        "Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:\n\n* **No duplicate SETTINGS** — an endpoint MUST NOT send a SETTINGS frame more than once over a connection (RFC 9114 §7.2.4).  A second `H3SettingsReceived` event on the same connection is a violation.\n* **No reserved HTTP/2 setting identifiers** — setting identifiers that were defined in HTTP/2 but have no corresponding HTTP/3 setting are reserved.  Their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00`, `0x02` (SETTINGS_ENABLE_PUSH), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE)."
+        "Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:\n\n* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.\n* **No reserved setting identifiers** — the `Reserved` rows of the \"HTTP/3 Settings\" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).\n\nIdentifiers outside that set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -99,6 +114,12 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
                 section: Some("7.2.4.1"),
                 url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4.1",
                 note: "Defined SETTINGS Parameters",
+            },
+            crate::rules::SpecRef {
+                spec: "RFC 9114",
+                section: Some("11.2.2"),
+                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-11.2.2",
+                note: "Settings Parameters (Table 3: the Reserved rows)",
             },
         ]
     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1856,7 +1856,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 128
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 40
+      line: 34
   - label: message_http3_host_authority_consistency
     section: § 4.3.1
     snippet: If both fields are present, they MUST contain the same value.
@@ -1911,6 +1911,18 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
       line: 31
+  - label: stateful_http3_max_push_id
+    section: § 7.2.7
+    snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+      line: 43
+  - label: stateful_http3_max_push_id (2)
+    section: § 7.2.7
+    snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+      line: 71
   - label: stateful_http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1848,7 +1848,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 125
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 48
+      line: 50
   - label: lint-http-proxy/src/h3_instrument.rs (3)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
@@ -1916,31 +1916,37 @@ sources:
     snippet: The entries in Table 3 are registered by this document
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 24
+      line: 26
   - label: stateful_http3_settings_frame (2)
     section: § 7.2.4
     snippet: A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 60
+      line: 62
   - label: stateful_http3_settings_frame (3)
     section: § 7.2.4
     snippet: An implementation MUST ignore any parameter with an identifier it does not understand
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 92
+      line: 113
   - label: stateful_http3_settings_frame (4)
     section: § 7.2.4
     snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 56
+      line: 58
   - label: stateful_http3_settings_frame (5)
+    section: § 7.2.4
+    snippet: The same setting identifier MUST NOT occur more than once in the SETTINGS frame
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 96
+  - label: stateful_http3_settings_frame (6)
     section: § 7.2.4.1
     snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 75
+      line: 77
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.txt
   type: text/plain

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1911,6 +1911,36 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
       line: 31
+  - label: stateful_http3_settings_frame
+    section: § 11.2.2
+    snippet: The entries in Table 3 are registered by this document
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 24
+  - label: stateful_http3_settings_frame (2)
+    section: § 7.2.4
+    snippet: A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 60
+  - label: stateful_http3_settings_frame (3)
+    section: § 7.2.4
+    snippet: An implementation MUST ignore any parameter with an identifier it does not understand
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 92
+  - label: stateful_http3_settings_frame (4)
+    section: § 7.2.4
+    snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 56
+  - label: stateful_http3_settings_frame (5)
+    section: § 7.2.4.1
+    snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+      line: 75
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.txt
   type: text/plain


### PR DESCRIPTION
Cite the SETTINGS and MAX_PUSH_ID rules at their enforcing constructs. Fix: report a setting identifier repeated within one SETTINGS frame.

