### PR TITLE
HTTP/3 origin forwarding 

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -35,6 +35,17 @@ captures_include_body = false
 # Server name (SNI) for the HTTP/3 TLS certificate. Clients must connect
 # using this name. Defaults to "localhost" when omitted.
 # h3_server_name = "proxy.example.com"
+# Forward to origins over HTTP/3 (QUIC) when they are known to speak it. This is
+# the outbound (proxy->origin) leg, independent of h3_listen above. Only origins
+# whose authority is in h3_upstream_authorities are attempted over H3; all others
+# use the H1/H2 client. Default: false.
+# h3_upstream_enabled = false
+# h3_upstream_authorities = ["origin.example.com:443"]
+# UDP bind address for the H3 upstream client. Default: "0.0.0.0:0".
+# h3_upstream_bind = "0.0.0.0:0"
+# Extra CA PEM files to trust for origin H3 endpoint certificates (private CAs),
+# in addition to the platform trust store.
+# h3_upstream_extra_ca_certs = ["/etc/lint-http/origin-ca.pem"]
 # Serve the live capture stream at GET /_lint_http/stream (Server-Sent Events,
 # one event per transaction as it commits). Exposes all proxied traffic to
 # anyone who can reach the proxy port, so it is opt-in. Default: false.

--- a/config_example.toml
+++ b/config_example.toml
@@ -61,6 +61,12 @@ captures_include_body = false
 # failure an origin is not retried over H3 until this window (doubling per
 # consecutive failure) passes. Default: 30.
 # h3_upstream_negative_ttl_seconds = 30
+# Idle time (ms) after which a pooled H3 connection is evicted; kept under the
+# QUIC idle timeout so only live connections are reused. Default: 25000.
+# h3_upstream_pool_idle_ms = 25000
+# Maximum pooled H3 connections (one per origin); LRU-evicted past this.
+# Default: 256.
+# h3_upstream_pool_max = 256
 # Serve the live capture stream at GET /_lint_http/stream (Server-Sent Events,
 # one event per transaction as it commits). Exposes all proxied traffic to
 # anyone who can reach the proxy port, so it is opt-in. Default: false.

--- a/config_example.toml
+++ b/config_example.toml
@@ -40,7 +40,15 @@ captures_include_body = false
 # whose authority is in h3_upstream_authorities are attempted over H3; all others
 # use the H1/H2 client. Default: false.
 # h3_upstream_enabled = false
+# Origins always tried over H3 (pre-seeds discovery; the first request to an
+# origin can't have learned Alt-Svc yet).
 # h3_upstream_authorities = ["origin.example.com:443"]
+# Origins that must never use H3, even if Alt-Svc advertises it.
+# h3_upstream_denylist = ["legacy.example.com:443"]
+# Trust an origin's Alt-Svc header to discover an H3 endpoint at runtime. A
+# discovered endpoint is still only used once its cert validates for the origin
+# authority. Set false to route H3 solely from h3_upstream_authorities. Default: true.
+# h3_upstream_trust_alt_svc = true
 # UDP bind address for the H3 upstream client. Default: "0.0.0.0:0".
 # h3_upstream_bind = "0.0.0.0:0"
 # Extra CA PEM files to trust for origin H3 endpoint certificates (private CAs),

--- a/config_example.toml
+++ b/config_example.toml
@@ -46,6 +46,13 @@ captures_include_body = false
 # Extra CA PEM files to trust for origin H3 endpoint certificates (private CAs),
 # in addition to the platform trust store.
 # h3_upstream_extra_ca_certs = ["/etc/lint-http/origin-ca.pem"]
+# Timeout (ms) for the H3 upstream connect/handshake and response head before
+# falling back to H1/H2. Default: 5000.
+# h3_upstream_connect_timeout_ms = 5000
+# Base backoff (seconds) for the H3 negative cache: after a connect/handshake
+# failure an origin is not retried over H3 until this window (doubling per
+# consecutive failure) passes. Default: 30.
+# h3_upstream_negative_ttl_seconds = 30
 # Serve the live capture stream at GET /_lint_http/stream (Server-Sent Events,
 # one event per transaction as it commits). Exposes all proxied traffic to
 # anyone who can reach the proxy port, so it is opt-in. Default: false.

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -106,6 +106,19 @@ pub struct GeneralConfig {
     #[serde(default)]
     pub h3_upstream_extra_ca_certs: Vec<String>,
 
+    /// How long (ms) to wait for the HTTP/3 upstream QUIC connect + handshake
+    /// (and the response head) before treating the attempt as failed and
+    /// falling back to H1/H2 (default: 5000).
+    #[serde(default = "default_h3_upstream_connect_timeout_ms")]
+    pub h3_upstream_connect_timeout_ms: u64,
+
+    /// Base backoff (seconds) for the H3 upstream negative cache: after a
+    /// connect/handshake failure an origin authority is not retried over H3
+    /// until this window (doubling per consecutive failure) elapses, so a
+    /// non-H3 origin isn't probed on every request (default: 30).
+    #[serde(default = "default_h3_upstream_negative_ttl_seconds")]
+    pub h3_upstream_negative_ttl_seconds: u64,
+
     /// Whether the live capture stream endpoint (`GET /_lint_http/stream`, an
     /// SSE feed of each transaction as it commits) is served. It exposes every
     /// proxied transaction (and body prefixes when `captures_include_body` is
@@ -147,6 +160,14 @@ const fn default_shutdown_timeout_seconds() -> u64 {
     30
 }
 
+const fn default_h3_upstream_connect_timeout_ms() -> u64 {
+    5000
+}
+
+const fn default_h3_upstream_negative_ttl_seconds() -> u64 {
+    30
+}
+
 fn default_listen() -> String {
     "127.0.0.1:3000".to_string()
 }
@@ -183,6 +204,8 @@ impl Default for GeneralConfig {
             h3_upstream_authorities: Vec::new(),
             h3_upstream_bind: None,
             h3_upstream_extra_ca_certs: Vec::new(),
+            h3_upstream_connect_timeout_ms: default_h3_upstream_connect_timeout_ms(),
+            h3_upstream_negative_ttl_seconds: default_h3_upstream_negative_ttl_seconds(),
             live_stream_enabled: default_live_stream_enabled(),
         }
     }

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -88,11 +88,26 @@ pub struct GeneralConfig {
     #[serde(default)]
     pub h3_upstream_enabled: bool,
 
-    /// Origin authorities (`host:port`) to forward over HTTP/3 when
-    /// `h3_upstream_enabled` is set. Until Alt-Svc discovery lands, this
-    /// allowlist is the only capability signal that an origin speaks H3.
+    /// Origin authorities (`host:port`) to always forward over HTTP/3 when
+    /// `h3_upstream_enabled` is set. This pre-seeds H3 (the first request to an
+    /// origin can't have learned Alt-Svc yet); origins discovered via Alt-Svc
+    /// are added on top at runtime.
     #[serde(default)]
     pub h3_upstream_authorities: Vec<String>,
+
+    /// Origin authorities (`host:port`) that must never be forwarded over HTTP/3,
+    /// even when Alt-Svc advertises it. Layered on top of the allowlist and
+    /// discovery cache. Empty by default.
+    #[serde(default)]
+    pub h3_upstream_denylist: Vec<String>,
+
+    /// Whether to trust an origin's `Alt-Svc` advertisement to discover an H3
+    /// endpoint at runtime. When false, only `h3_upstream_authorities` selects
+    /// H3 (Alt-Svc is ignored for routing). Default: true. Note that syntactic
+    /// trust is not sufficient — a discovered endpoint is used only once its
+    /// certificate validates for the origin authority (RFC 7838 §2.1).
+    #[serde(default = "default_h3_upstream_trust_alt_svc")]
+    pub h3_upstream_trust_alt_svc: bool,
 
     /// UDP socket address the HTTP/3 upstream client binds for its QUIC
     /// endpoint. Defaults to "0.0.0.0:0" (ephemeral) when omitted.
@@ -168,6 +183,10 @@ const fn default_h3_upstream_negative_ttl_seconds() -> u64 {
     30
 }
 
+const fn default_h3_upstream_trust_alt_svc() -> bool {
+    true
+}
+
 fn default_listen() -> String {
     "127.0.0.1:3000".to_string()
 }
@@ -202,6 +221,8 @@ impl Default for GeneralConfig {
             h3_server_name: None,
             h3_upstream_enabled: false,
             h3_upstream_authorities: Vec::new(),
+            h3_upstream_denylist: Vec::new(),
+            h3_upstream_trust_alt_svc: default_h3_upstream_trust_alt_svc(),
             h3_upstream_bind: None,
             h3_upstream_extra_ca_certs: Vec::new(),
             h3_upstream_connect_timeout_ms: default_h3_upstream_connect_timeout_ms(),

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -134,6 +134,19 @@ pub struct GeneralConfig {
     #[serde(default = "default_h3_upstream_negative_ttl_seconds")]
     pub h3_upstream_negative_ttl_seconds: u64,
 
+    /// How long (ms) a pooled H3 upstream connection may sit idle before it is
+    /// evicted and a fresh connection is opened on the next request. Kept below
+    /// the QUIC idle timeout so the pool reuses only still-live connections
+    /// (default: 25000).
+    #[serde(default = "default_h3_upstream_pool_idle_ms")]
+    pub h3_upstream_pool_idle_ms: u64,
+
+    /// Maximum number of pooled H3 upstream connections (one per origin
+    /// authority). When exceeded, the least-recently-used connection is evicted
+    /// (default: 256).
+    #[serde(default = "default_h3_upstream_pool_max")]
+    pub h3_upstream_pool_max: usize,
+
     /// Whether the live capture stream endpoint (`GET /_lint_http/stream`, an
     /// SSE feed of each transaction as it commits) is served. It exposes every
     /// proxied transaction (and body prefixes when `captures_include_body` is
@@ -187,6 +200,14 @@ const fn default_h3_upstream_trust_alt_svc() -> bool {
     true
 }
 
+const fn default_h3_upstream_pool_idle_ms() -> u64 {
+    25_000
+}
+
+const fn default_h3_upstream_pool_max() -> usize {
+    256
+}
+
 fn default_listen() -> String {
     "127.0.0.1:3000".to_string()
 }
@@ -227,6 +248,8 @@ impl Default for GeneralConfig {
             h3_upstream_extra_ca_certs: Vec::new(),
             h3_upstream_connect_timeout_ms: default_h3_upstream_connect_timeout_ms(),
             h3_upstream_negative_ttl_seconds: default_h3_upstream_negative_ttl_seconds(),
+            h3_upstream_pool_idle_ms: default_h3_upstream_pool_idle_ms(),
+            h3_upstream_pool_max: default_h3_upstream_pool_max(),
             live_stream_enabled: default_live_stream_enabled(),
         }
     }

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -81,6 +81,31 @@ pub struct GeneralConfig {
     #[serde(default)]
     pub h3_server_name: Option<String>,
 
+    /// Enable the HTTP/3 (QUIC) *upstream* leg: when set, requests whose origin
+    /// authority is listed in `h3_upstream_authorities` are forwarded to the
+    /// origin over HTTP/3 instead of the hyper H1/H2 client (default: false).
+    /// Independent of `h3_listen` (that is the client-facing H3 *server*).
+    #[serde(default)]
+    pub h3_upstream_enabled: bool,
+
+    /// Origin authorities (`host:port`) to forward over HTTP/3 when
+    /// `h3_upstream_enabled` is set. Until Alt-Svc discovery lands, this
+    /// allowlist is the only capability signal that an origin speaks H3.
+    #[serde(default)]
+    pub h3_upstream_authorities: Vec<String>,
+
+    /// UDP socket address the HTTP/3 upstream client binds for its QUIC
+    /// endpoint. Defaults to "0.0.0.0:0" (ephemeral) when omitted.
+    #[serde(default)]
+    pub h3_upstream_bind: Option<String>,
+
+    /// Extra CA certificate PEM files to trust when validating an origin's
+    /// HTTP/3 endpoint certificate, in addition to the platform trust store.
+    /// For origins fronted by a private CA (and for driving an in-process H3
+    /// origin under test). Empty by default.
+    #[serde(default)]
+    pub h3_upstream_extra_ca_certs: Vec<String>,
+
     /// Whether the live capture stream endpoint (`GET /_lint_http/stream`, an
     /// SSE feed of each transaction as it commits) is served. It exposes every
     /// proxied transaction (and body prefixes when `captures_include_body` is
@@ -154,6 +179,10 @@ impl Default for GeneralConfig {
             shutdown_timeout_seconds: default_shutdown_timeout_seconds(),
             h3_listen: None,
             h3_server_name: None,
+            h3_upstream_enabled: false,
+            h3_upstream_authorities: Vec::new(),
+            h3_upstream_bind: None,
+            h3_upstream_extra_ca_certs: Vec::new(),
             live_stream_enabled: default_live_stream_enabled(),
         }
     }

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -26,6 +26,7 @@ use crate::state::ClientIdentifier;
 
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
 use super::tee_body::{self, CapturedBody};
+use super::upstream_h3::H3Failure;
 use super::{boxed_full, BoxError, ClientBody, ResponseBody, Shared};
 
 /// The post-front-half request inputs both transports compute, ready for the
@@ -112,27 +113,58 @@ pub(super) async fn exchange(
     };
 
     // Choose the upstream transport at this single seam: HTTP/3 when the origin
-    // authority is on the H3 allowlist (capability-driven, opt-in), else the
-    // hyper H1/H2 client. Both branches yield a `Response<ResponseBody>` so the
-    // tee/commit machinery below is identical; the H3 branch stamps the response
-    // version as HTTP/3, which is what lands in `tx.response.version`.
-    let h3_client = uri.authority().and_then(|a| {
+    // authority is on the H3 allowlist (capability-driven, opt-in) and not
+    // currently negative-cached, else the hyper H1/H2 client. Both branches
+    // yield a `Response<ResponseBody>` so the tee/commit machinery below is
+    // identical; the H3 branch stamps the response version as HTTP/3, which is
+    // what lands in `tx.response.version` (a fall-back records its real version).
+    let h3_target = uri.authority().and_then(|a| {
+        let authority = a.as_str();
         shared
             .upstream
             .h3
             .as_ref()
-            .filter(|h3| h3.handles(a.as_str()))
+            .filter(|h3| h3.handles(authority) && !h3.is_suppressed(authority))
+            .map(|h3| (h3, authority.to_string()))
     });
-    let resp: Result<hyper::Response<ResponseBody>, String> = if let Some(h3) = h3_client {
-        h3.forward(upstream_req).await.map_err(|e| e.to_string())
+    let resp: Result<hyper::Response<ResponseBody>, String> = if let Some((h3, authority)) =
+        h3_target
+    {
+        match h3.forward(upstream_req).await {
+            Ok(r) => {
+                h3.record_success(&authority);
+                Ok(r)
+            }
+            Err(H3Failure::Retryable {
+                error,
+                request,
+                pre_request,
+            }) => {
+                // A connect/handshake failure marks the origin as not currently
+                // reachable over H3. Fall back to H1/H2 when it is safe: always
+                // for a pre-request failure (nothing reached the origin), else
+                // only for an idempotent method (RFC 9110 §9.2.2) — a header-sent
+                // failure of a non-idempotent method must not be blindly retried.
+                if pre_request {
+                    h3.record_failure(&authority);
+                }
+                if pre_request || method.is_idempotent() {
+                    warn!(%authority, error = %error, "h3 upstream unavailable; falling back to H1/H2");
+                    forward_via_hyper(shared, *request).await
+                } else {
+                    Err(format!(
+                        "h3 upstream error (non-idempotent, not retried): {error}"
+                    ))
+                }
+            }
+            Err(H3Failure::Consumed { error }) => {
+                // Request bytes were in flight with no response; the streaming
+                // body cannot be replayed, so surface the failure as-is.
+                Err(format!("h3 upstream error: {error}"))
+            }
+        }
     } else {
-        shared
-            .upstream
-            .client
-            .request(upstream_req)
-            .await
-            .map(|r| r.map(|b| b.map_err(|e| -> BoxError { e.into() }).boxed_unsync()))
-            .map_err(|e| e.to_string())
+        forward_via_hyper(shared, upstream_req).await
     };
     let resp = match resp {
         Ok(r) => r,
@@ -233,6 +265,22 @@ pub(super) async fn exchange(
         headers: out_headers,
         body: resp_body,
     }
+}
+
+/// Send `req` through the hyper H1/H2 client, boxing its response body into the
+/// shared [`ResponseBody`] shape. Used both for non-H3 origins and as the H3
+/// fall-back path, so the two produce an identical result type.
+async fn forward_via_hyper(
+    shared: &Arc<Shared>,
+    req: Request<ClientBody>,
+) -> Result<hyper::Response<ResponseBody>, String> {
+    shared
+        .upstream
+        .client
+        .request(req)
+        .await
+        .map(|r| r.map(|b| b.map_err(|e| -> BoxError { e.into() }).boxed_unsync()))
+        .map_err(|e| e.to_string())
 }
 
 /// Build the upstream request line + headers (method, URI, client headers minus

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -120,17 +120,17 @@ pub(super) async fn exchange(
     // what lands in `tx.response.version` (a fall-back records its real version).
     let h3_target = uri.authority().and_then(|a| {
         let authority = a.as_str();
-        shared
-            .upstream
-            .h3
-            .as_ref()
-            .filter(|h3| h3.handles(authority) && !h3.is_suppressed(authority))
-            .map(|h3| (h3, authority.to_string()))
+        let h3 = shared.upstream.h3.as_ref()?;
+        if h3.is_suppressed(authority) {
+            return None;
+        }
+        h3.route_for(authority)
+            .map(|route| (h3, authority.to_string(), route))
     });
-    let resp: Result<hyper::Response<ResponseBody>, String> = if let Some((h3, authority)) =
+    let resp: Result<hyper::Response<ResponseBody>, String> = if let Some((h3, authority, route)) =
         h3_target
     {
-        match h3.forward(upstream_req).await {
+        match h3.forward(upstream_req, &route).await {
             Ok(r) => {
                 h3.record_success(&authority);
                 Ok(r)
@@ -192,6 +192,15 @@ pub(super) async fn exchange(
     let status = resp.status().as_u16();
     let upstream_headers = resp.headers().clone();
     let resp_ver = format_http_version(resp.version());
+
+    // Feed any `Alt-Svc` advertisement (seen on whichever leg served this
+    // response) into the H3 discovery cache, so a later request to this origin
+    // can opportunistically use H3 (RFC 7838 / RFC 9114 §3.1.1).
+    if let Some(h3) = shared.upstream.h3.as_ref() {
+        if let Some(a) = uri.authority() {
+            h3.record_alt_svc(a.as_str(), a.host(), &upstream_headers);
+        }
+    }
 
     // Status, headers, and upgrade info are known immediately. The body streams
     // to the client unbuffered while `TeeBody` copies a bounded prefix and sums

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -111,7 +111,30 @@ pub(super) async fn exchange(
         }
     };
 
-    let resp = match shared.upstream.client.request(upstream_req).await {
+    // Choose the upstream transport at this single seam: HTTP/3 when the origin
+    // authority is on the H3 allowlist (capability-driven, opt-in), else the
+    // hyper H1/H2 client. Both branches yield a `Response<ResponseBody>` so the
+    // tee/commit machinery below is identical; the H3 branch stamps the response
+    // version as HTTP/3, which is what lands in `tx.response.version`.
+    let h3_client = uri.authority().and_then(|a| {
+        shared
+            .upstream
+            .h3
+            .as_ref()
+            .filter(|h3| h3.handles(a.as_str()))
+    });
+    let resp: Result<hyper::Response<ResponseBody>, String> = if let Some(h3) = h3_client {
+        h3.forward(upstream_req).await.map_err(|e| e.to_string())
+    } else {
+        shared
+            .upstream
+            .client
+            .request(upstream_req)
+            .await
+            .map(|r| r.map(|b| b.map_err(|e| -> BoxError { e.into() }).boxed_unsync()))
+            .map_err(|e| e.to_string())
+    };
+    let resp = match resp {
         Ok(r) => r,
         Err(e) => {
             let duration = started.elapsed().as_millis() as u64;
@@ -153,10 +176,8 @@ pub(super) async fn exchange(
     };
 
     let prefix_cap = shared.cfg.general.captures_max_body_bytes;
-    let inner = resp
-        .into_body()
-        .map_err(|e| -> BoxError { e.into() })
-        .boxed_unsync();
+    // Already a `ResponseBody` from both upstream branches above.
+    let inner = resp.into_body();
     let (resp_body, done_rx) = tee_body::tee(inner, prefix_cap);
 
     // Commit once both body halves have finished streaming — the request body

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -17,6 +17,7 @@ mod tee_body;
 #[cfg(test)]
 mod test_support;
 mod upstream;
+mod upstream_h3;
 mod websocket;
 
 use bytes::Bytes;
@@ -152,7 +153,7 @@ async fn run_proxy_inner(
 ) -> anyhow::Result<()> {
     // Load the platform trust store once; the forwarding client and the
     // WebSocket-upgrade path share it.
-    let upstream = upstream::Upstream::new()?;
+    let upstream = upstream::Upstream::new(&cfg)?;
 
     let ca = if cfg.tls.enabled {
         let cert_path = cfg.tls.ca_cert_path.as_deref().unwrap_or("ca.crt");

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -238,6 +238,26 @@ async fn run_proxy_inner(
         shutdown: shutdown.clone(),
     });
 
+    // Periodically evict idle pooled H3 *upstream* connections. Only spawned when
+    // the H3 upstream client exists; cancelled on shutdown.
+    let pool_sweep_handle = shared.upstream.h3.is_some().then(|| {
+        let shared_sweep = shared.clone();
+        let sweep_shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        if let Some(h3) = shared_sweep.upstream.h3.as_ref() {
+                            h3.sweep_idle();
+                        }
+                    }
+                    _ = sweep_shutdown.cancelled() => break,
+                }
+            }
+        })
+    });
+
     // Start HTTP/3 (QUIC) accept loop if an endpoint was created. It shares the
     // same connection semaphore as TCP, so `max_connections` bounds both
     // transports and the drain barrier below waits for live H3 connections too.
@@ -311,6 +331,9 @@ async fn run_proxy_inner(
 
     let _ = cleanup_handle.await;
     if let Some(handle) = h3_handle {
+        let _ = handle.await;
+    }
+    if let Some(handle) = pool_sweep_handle {
         let _ = handle.await;
     }
 

--- a/lint-http-proxy/src/proxy/test_support.rs
+++ b/lint-http-proxy/src/proxy/test_support.rs
@@ -31,7 +31,7 @@ pub(super) async fn make_shared_with_cfg(
         .to_string();
     let cw = CaptureWriter::new(p.clone(), false).await?;
 
-    let upstream = super::upstream::Upstream::new()?;
+    let upstream = super::upstream::Upstream::new(&cfg)?;
     let state = StdArc::new(crate::state::StateStore::new(300, 10));
     let protocol_event_store = StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
         300, 100,

--- a/lint-http-proxy/src/proxy/upstream.rs
+++ b/lint-http-proxy/src/proxy/upstream.rs
@@ -19,6 +19,9 @@ use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
 use tracing::warn;
 
+use crate::config::Config;
+
+use super::upstream_h3::H3UpstreamClient;
 use super::ClientBody;
 
 /// Outbound connection resources, constructed once from a single trust-store
@@ -33,11 +36,18 @@ pub(crate) struct Upstream {
     /// client adds ALPN on top; the WebSocket upgrade path uses it bare. Shared
     /// so the trust store is loaded a single time.
     pub(super) tls_config: Arc<rustls::ClientConfig>,
+    /// HTTP/3 (QUIC) upstream client, present only when `h3_upstream_enabled`.
+    /// Built from the *same* native roots as the H1/H2 path (plus any configured
+    /// private CAs) so the trust store loads once. `None` when H3 forwarding is
+    /// off, in which case every request takes the hyper client above.
+    pub(super) h3: Option<H3UpstreamClient>,
 }
 
 impl Upstream {
-    /// Load the platform trust store once and build both outbound shapes from it.
-    pub(super) fn new() -> anyhow::Result<Self> {
+    /// Load the platform trust store once and build every outbound shape from it:
+    /// the H1/H2 forwarding client, the bare WebSocket-upgrade config, and — when
+    /// `h3_upstream_enabled` — the QUIC H3 upstream client.
+    pub(super) fn new(cfg: &Config) -> anyhow::Result<Self> {
         let loaded = rustls_native_certs::load_native_certs();
         if !loaded.errors.is_empty() {
             warn!(errors = ?loaded.errors, "errors loading platform certificates");
@@ -49,6 +59,11 @@ impl Upstream {
         if roots.is_empty() {
             anyhow::bail!("no native root certificates could be loaded");
         }
+
+        // Build the H3 upstream client before the base config consumes `roots`:
+        // it needs the same native roots plus any configured private CAs, and
+        // rustls bakes the roots into an immutable verifier at build time.
+        let h3 = H3UpstreamClient::build(cfg, &roots)?;
 
         // Base config carries no ALPN: `with_tls_config` asserts that, and the
         // WebSocket path needs it bare. The forwarding client adds h1/h2 below.
@@ -65,6 +80,10 @@ impl Upstream {
             .build();
         let client = LegacyClient::builder(TokioExecutor::new()).build(https);
 
-        Ok(Self { client, tls_config })
+        Ok(Self {
+            client,
+            tls_config,
+            h3,
+        })
     }
 }

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The HTTP/3 (QUIC) *upstream* leg: forwarding a proxied request to an origin
+//! over HTTP/3 instead of the hyper H1/H2 client.
+//!
+//! This is the outbound mirror of the client-facing H3 server in
+//! [`super::http3`]. A single shared quinn client [`Endpoint`] (one UDP bind,
+//! ALPN `h3`, the same native roots as the H1/H2 path) opens a fresh QUIC
+//! connection per request — no pool yet — sends the request with the
+//! hop-by-hop-stripped header section [`super::exchange`] already built, and
+//! adapts the h3 response stream back into a [`ResponseBody`] so the shared
+//! tee/commit machinery downstream is reused unchanged.
+//!
+//! # Field discipline (RFC 9114 §4.2)
+//! An intermediary transforming a message to HTTP/3 MUST remove
+//! connection-specific fields (Connection, Keep-Alive, Upgrade,
+//! Transfer-Encoding, Proxy-*); a field section that carries one is *malformed*.
+//! This path does not build its own header map — it forwards the request
+//! [`super::exchange::build_upstream_request`] already stripped via the shared
+//! hop-by-hop set (which covers exactly those fields), so the H3 request section
+//! is well-formed by construction. Pseudo-headers (`:method`/`:scheme`/
+//! `:path`/`:authority`) are derived by the h3 crate from the request's method
+//! and absolute URI; the URI's scheme is forced to `https` here because there is
+//! no plaintext HTTP/3.
+
+use std::collections::HashSet;
+use std::future::poll_fn;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, Bytes};
+use h3::quic::RecvStream;
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame};
+use hyper::http::uri::{PathAndQuery, Scheme};
+use hyper::{Request, Response, Uri, Version};
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::CertificateDer;
+
+use crate::config::Config;
+
+use super::{BoxError, ClientBody, ResponseBody};
+
+/// Shared HTTP/3 upstream client: one quinn client endpoint plus the set of
+/// origin authorities eligible for H3 forwarding.
+pub(super) struct H3UpstreamClient {
+    endpoint: quinn::Endpoint,
+    /// Origin authorities (`host:port`) the operator opted into forwarding over
+    /// H3. Until Alt-Svc discovery lands this allowlist is the sole capability
+    /// signal.
+    authorities: HashSet<String>,
+}
+
+impl H3UpstreamClient {
+    /// Build the client when `h3_upstream_enabled`, else return `None`. Uses the
+    /// caller's native `roots` (so the trust store loads once) augmented with any
+    /// `h3_upstream_extra_ca_certs` private CAs, and binds a single UDP endpoint.
+    pub(super) fn build(
+        cfg: &Config,
+        roots: &rustls::RootCertStore,
+    ) -> anyhow::Result<Option<Self>> {
+        if !cfg.general.h3_upstream_enabled {
+            return Ok(None);
+        }
+
+        // Clone the shared native roots and layer any configured private CAs on
+        // top; rustls freezes the root set into the verifier at build time.
+        let mut roots = roots.clone();
+        for path in &cfg.general.h3_upstream_extra_ca_certs {
+            let certs: Vec<CertificateDer> = CertificateDer::pem_file_iter(path)
+                .map_err(|e| anyhow::anyhow!("h3_upstream_extra_ca_certs {path}: {e}"))?
+                .collect::<Result<_, _>>()
+                .map_err(|e| anyhow::anyhow!("h3_upstream_extra_ca_certs {path}: {e}"))?;
+            for cert in certs {
+                roots.add(cert).ok();
+            }
+        }
+
+        let mut tls = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        tls.alpn_protocols = vec![b"h3".to_vec()];
+
+        let quic_client = quinn::crypto::rustls::QuicClientConfig::try_from(tls)
+            .map_err(|e| anyhow::anyhow!("h3 upstream QUIC client config: {e}"))?;
+        let client_config = quinn::ClientConfig::new(Arc::new(quic_client));
+
+        let bind: SocketAddr = cfg
+            .general
+            .h3_upstream_bind
+            .as_deref()
+            .unwrap_or("0.0.0.0:0")
+            .parse()
+            .map_err(|e| anyhow::anyhow!("h3_upstream_bind: {e}"))?;
+        let mut endpoint = quinn::Endpoint::client(bind)?;
+        endpoint.set_default_client_config(client_config);
+
+        let authorities = cfg
+            .general
+            .h3_upstream_authorities
+            .iter()
+            .cloned()
+            .collect();
+
+        Ok(Some(Self {
+            endpoint,
+            authorities,
+        }))
+    }
+
+    /// Whether requests to `authority` should be forwarded over HTTP/3.
+    pub(super) fn handles(&self, authority: &str) -> bool {
+        self.authorities.contains(authority)
+    }
+
+    /// Forward `req` (already hop-by-hop stripped) to its origin over HTTP/3 and
+    /// return a `hyper::Response` whose body streams the origin's response.
+    /// Opens a fresh QUIC connection each call (P1: no pool).
+    pub(super) async fn forward(
+        &self,
+        req: Request<ClientBody>,
+    ) -> anyhow::Result<Response<ResponseBody>> {
+        let (mut parts, body) = req.into_parts();
+
+        // HTTP/3 is always over TLS: force the origin request's :scheme to https.
+        let uri = force_https(&parts.uri)?;
+        let authority = uri
+            .authority()
+            .ok_or_else(|| anyhow::anyhow!("h3 upstream: request URI has no authority"))?
+            .clone();
+        // `Authority::host()` keeps the brackets on an IPv6 literal (`[::1]`),
+        // which neither `lookup_host` nor a rustls `ServerName` accepts — strip
+        // them so both the DNS/socket lookup and the TLS name are well-formed.
+        let host = authority
+            .host()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .to_string();
+        let port = authority.port_u16().unwrap_or(443);
+        let addr = tokio::net::lookup_host((host.as_str(), port))
+            .await?
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("h3 upstream: could not resolve {authority}"))?;
+        parts.uri = uri;
+        let head = Request::from_parts(parts, ());
+
+        let conn = self.endpoint.connect(addr, &host)?.await?;
+        let (mut driver, mut send_request) =
+            h3::client::new(h3_quinn::Connection::new(conn)).await?;
+        // Drive the connection in the background so request/response frames make
+        // progress; aborted when the response body is dropped (see `ConnGuard`).
+        let driver = tokio::spawn(async move {
+            let _ = poll_fn(|cx| driver.poll_close(cx)).await;
+        });
+
+        let mut stream = send_request.send_request(head).await?;
+
+        // Stream the request body to the origin, mirroring the response side of
+        // the client-facing handler: data frames forward as QUIC DATA, a trailing
+        // trailers frame as an H3 trailers section.
+        let mut body = body;
+        while let Some(frame) = body.frame().await {
+            let frame = frame.map_err(|e| anyhow::anyhow!("h3 upstream request body: {e}"))?;
+            match frame.into_data() {
+                Ok(data) => stream.send_data(data).await?,
+                Err(frame) => {
+                    if let Ok(trailers) = frame.into_trailers() {
+                        stream.send_trailers(trailers).await?;
+                    }
+                }
+            }
+        }
+        stream.finish().await?;
+
+        let resp_head = stream.recv_response().await?;
+        let (send_half, recv_half) = stream.split();
+
+        // Record the origin leg's version as HTTP/3 (see the exchange core, which
+        // reads `resp.version()` into `tx.response.version`).
+        let mut builder = Response::builder()
+            .status(resp_head.status())
+            .version(Version::HTTP_3);
+        for (name, value) in resp_head.headers() {
+            builder = builder.header(name, value);
+        }
+
+        let guard = ConnGuard {
+            _send_request: Box::new(send_request),
+            _send_half: Box::new(send_half),
+            driver,
+        };
+        let resp_body = H3ResponseBody {
+            recv: recv_half,
+            state: RespState::Data,
+            _guard: guard,
+        }
+        .boxed_unsync();
+
+        Ok(builder.body(resp_body)?)
+    }
+}
+
+/// Rebuild `uri` with an `https` scheme (and a `/` path if none), so the H3
+/// request carries a valid `:scheme`/`:path` even when the client reached the
+/// proxy with an `http://` origin-form target.
+fn force_https(uri: &Uri) -> anyhow::Result<Uri> {
+    let mut parts = uri.clone().into_parts();
+    parts.scheme = Some(Scheme::HTTPS);
+    if parts.path_and_query.is_none() {
+        parts.path_and_query = Some(PathAndQuery::from_static("/"));
+    }
+    Ok(Uri::from_parts(parts)?)
+}
+
+/// Keeps the QUIC connection alive for as long as the response body streams.
+///
+/// Dropping the last `SendRequest` triggers a client-initiated connection close
+/// in the h3 crate, and the connection only advances while its driver task runs;
+/// so both are held here until the body is fully read (or dropped), at which
+/// point the driver is aborted and the connection winds down.
+struct ConnGuard {
+    _send_request: Box<dyn Send>,
+    _send_half: Box<dyn Send>,
+    driver: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.driver.abort();
+    }
+}
+
+/// Whether the next poll reads response data, then trailers, then ends — the
+/// receive-side mirror of [`super::http3_body`]'s request-body adapter.
+enum RespState {
+    Data,
+    Trailers,
+    Done,
+}
+
+/// Streams the origin's HTTP/3 response body out of the recv half of the client
+/// request stream, yielding a trailers frame after the data if the origin sent
+/// any. Owns a [`ConnGuard`] so the connection outlives the stream.
+struct H3ResponseBody<S> {
+    recv: h3::client::RequestStream<S, Bytes>,
+    state: RespState,
+    _guard: ConnGuard,
+}
+
+impl<S> Body for H3ResponseBody<S>
+where
+    S: RecvStream,
+{
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, BoxError>>> {
+        // `RequestStream` is `Unpin`, so poll the recv half without structural
+        // pinning (the same pattern the request-body adapter uses).
+        let this = self.get_mut();
+        loop {
+            match this.state {
+                RespState::Data => match this.recv.poll_recv_data(cx) {
+                    Poll::Ready(Ok(Some(mut buf))) => {
+                        let bytes = buf.copy_to_bytes(buf.remaining());
+                        return Poll::Ready(Some(Ok(Frame::data(bytes))));
+                    }
+                    Poll::Ready(Ok(None)) => this.state = RespState::Trailers,
+                    Poll::Ready(Err(e)) => {
+                        this.state = RespState::Done;
+                        return Poll::Ready(Some(Err(Box::new(e) as BoxError)));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                RespState::Trailers => match this.recv.poll_recv_trailers(cx) {
+                    Poll::Ready(Ok(Some(trailers))) => {
+                        this.state = RespState::Done;
+                        return Poll::Ready(Some(Ok(Frame::trailers(trailers))));
+                    }
+                    Poll::Ready(Ok(None)) => {
+                        this.state = RespState::Done;
+                        return Poll::Ready(None);
+                    }
+                    Poll::Ready(Err(e)) => {
+                        this.state = RespState::Done;
+                        return Poll::Ready(Some(Err(Box::new(e) as BoxError)));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                RespState::Done => return Poll::Ready(None),
+            }
+        }
+    }
+}

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -99,11 +99,35 @@ struct DiscoveryEntry {
 /// endpoint to dial (the origin itself, or an Alt-Svc alternative) and the TLS
 /// server name — always the **origin** authority host, so the endpoint's
 /// certificate must validate *for the origin* (RFC 7838 §2.1 / RFC 9114 §3.3),
-/// not merely for the alternative's own name.
+/// not merely for the alternative's own name. `authority` is the pool key.
 pub(super) struct H3Route {
     dial_host: String,
     dial_port: u16,
     authority_host: String,
+    authority: String,
+}
+
+/// The clonable request-sender handle for a pooled h3 connection. `SendRequest`
+/// is `Clone` (an internal refcount keeps the connection open while any clone
+/// lives), so one pooled connection multiplexes many concurrent request streams.
+type H3Send = h3::client::SendRequest<h3_quinn::OpenStreams, Bytes>;
+
+/// A live, pooled HTTP/3 connection to one origin, reused across requests
+/// (RFC 9114 §3.3: SHOULD NOT open more than one connection to a given endpoint).
+/// Held behind an `Arc`: the pool keeps one strong ref, and each in-flight
+/// response body keeps another, so eviction never tears down a connection whose
+/// response is still streaming — the driver is aborted only when the last ref
+/// drops.
+struct PooledConn {
+    send: H3Send,
+    driver: tokio::task::JoinHandle<()>,
+    last_used: Mutex<Instant>,
+}
+
+impl Drop for PooledConn {
+    fn drop(&mut self) {
+        self.driver.abort();
+    }
 }
 
 /// Shared HTTP/3 upstream client: one quinn client endpoint plus the set of
@@ -127,6 +151,12 @@ pub(super) struct H3UpstreamClient {
     negative: Mutex<HashMap<String, NegEntry>>,
     /// Alt-Svc discovery cache: origin authority → advertised H3 endpoints.
     discovery: Mutex<HashMap<String, DiscoveryEntry>>,
+    /// Connection pool: origin authority → live reusable connection.
+    pool: Mutex<HashMap<String, Arc<PooledConn>>>,
+    /// Idle window after which a pooled connection is evicted.
+    pool_idle: Duration,
+    /// Maximum pooled connections; LRU-evicted past this.
+    pool_max: usize,
 }
 
 impl H3UpstreamClient {
@@ -197,6 +227,9 @@ impl H3UpstreamClient {
             negative_ttl: Duration::from_secs(cfg.general.h3_upstream_negative_ttl_seconds),
             negative: Mutex::new(HashMap::new()),
             discovery: Mutex::new(HashMap::new()),
+            pool: Mutex::new(HashMap::new()),
+            pool_idle: Duration::from_millis(cfg.general.h3_upstream_pool_idle_ms),
+            pool_max: cfg.general.h3_upstream_pool_max.max(1),
         }))
     }
 
@@ -251,6 +284,7 @@ impl H3UpstreamClient {
                 dial_host: host.clone(),
                 dial_port: port,
                 authority_host: host,
+                authority: authority.to_string(),
             });
         }
         let (dial_host, dial_port) = self.discovered(authority)?;
@@ -258,6 +292,7 @@ impl H3UpstreamClient {
             dial_host,
             dial_port,
             authority_host: host,
+            authority: authority.to_string(),
         })
     }
 
@@ -304,72 +339,140 @@ impl H3UpstreamClient {
         }
     }
 
+    /// Open a fresh QUIC connection to the route's endpoint (validated for the
+    /// origin authority) and spawn its driver, bounded by the connect timeout.
+    async fn connect(&self, route: &H3Route) -> anyhow::Result<PooledConn> {
+        let addr = lookup_endpoint(&route.dial_host, route.dial_port).await?;
+        let handshake = async {
+            let conn = self.endpoint.connect(addr, &route.authority_host)?.await?;
+            let pair = h3::client::new(h3_quinn::Connection::new(conn)).await?;
+            Ok::<_, anyhow::Error>(pair)
+        };
+        let (mut driver, send) = match tokio::time::timeout(self.connect_timeout, handshake).await {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => return Err(anyhow::anyhow!("h3 upstream connect timed out")),
+        };
+        let driver = tokio::spawn(async move {
+            let _ = poll_fn(|cx| driver.poll_close(cx)).await;
+        });
+        Ok(PooledConn {
+            send,
+            driver,
+            last_used: Mutex::new(Instant::now()),
+        })
+    }
+
+    /// Return a pooled connection for the route's authority — reusing a live,
+    /// non-idle one when possible (`reused = true`), otherwise connecting a fresh
+    /// one and inserting it (evicting the LRU past `pool_max`). `force_fresh`
+    /// skips reuse (used to retry after a pooled connection refused a stream).
+    async fn get_or_connect(
+        &self,
+        route: &H3Route,
+        force_fresh: bool,
+    ) -> anyhow::Result<(Arc<PooledConn>, bool)> {
+        if !force_fresh {
+            let mut pool = self.pool.lock().unwrap();
+            if let Some(conn) = pool.get(&route.authority) {
+                let fresh = conn.last_used.lock().unwrap().elapsed() < self.pool_idle
+                    && !conn.driver.is_finished();
+                if fresh {
+                    *conn.last_used.lock().unwrap() = Instant::now();
+                    return Ok((conn.clone(), true));
+                }
+                pool.remove(&route.authority);
+            }
+        }
+
+        // Connect outside the lock (async); a rare concurrent race may open two
+        // connections to the same origin — acceptable (§3.3 is SHOULD NOT).
+        let conn = Arc::new(self.connect(route).await?);
+        let mut pool = self.pool.lock().unwrap();
+        if pool.len() >= self.pool_max && !pool.contains_key(&route.authority) {
+            if let Some(lru) = pool
+                .iter()
+                .min_by_key(|(_, c)| *c.last_used.lock().unwrap())
+                .map(|(k, _)| k.clone())
+            {
+                pool.remove(&lru);
+            }
+        }
+        pool.insert(route.authority.clone(), conn.clone());
+        Ok((conn, false))
+    }
+
+    /// Drop `conn` from the pool if it is still the mapped connection for
+    /// `authority` (a newer replacement is left untouched). In-flight response
+    /// bodies holding a clone keep it alive until they finish.
+    fn invalidate(&self, authority: &str, conn: &Arc<PooledConn>) {
+        let mut pool = self.pool.lock().unwrap();
+        if pool.get(authority).is_some_and(|c| Arc::ptr_eq(c, conn)) {
+            pool.remove(authority);
+        }
+    }
+
+    /// Evict pooled connections that are idle past `pool_idle` or whose driver
+    /// has ended. Meant to be called periodically from the maintenance loop.
+    pub(super) fn sweep_idle(&self) {
+        let mut pool = self.pool.lock().unwrap();
+        pool.retain(|_, c| {
+            c.last_used.lock().unwrap().elapsed() < self.pool_idle && !c.driver.is_finished()
+        });
+    }
+
     /// Forward `req` (already hop-by-hop stripped) to its origin over HTTP/3 and
     /// return a `hyper::Response` whose body streams the origin's response.
-    /// Opens a fresh QUIC connection each call (P1: no pool). On failure the
-    /// [`H3Failure`] tells the caller whether the request is safe to fall back
-    /// to H1/H2.
+    /// Reuses a pooled connection when possible; on a refused stream (origin
+    /// GOAWAY or a dead idle connection — RFC 9114 §5.2, retry-safe for any
+    /// method) it invalidates that connection and retries once on a fresh one.
+    /// On failure the [`H3Failure`] tells the caller whether the request is safe
+    /// to fall back to H1/H2.
     pub(super) async fn forward(
         &self,
         req: Request<ClientBody>,
         route: &H3Route,
     ) -> Result<Response<ResponseBody>, H3Failure> {
-        // Build the https target + H3 head from the request URI *without
-        // consuming* `req`, so it can be handed back for fall-back. The head
-        // keeps the origin authority (`:authority`); only the dialed socket comes
-        // from the route (an Alt-Svc alternative may differ from the origin).
+        // Build the https target from the request URI *without consuming* `req`,
+        // so it can be handed back for fall-back. The head keeps the origin
+        // authority (`:authority`); only the dialed socket comes from the route.
         let https_uri = match force_https(req.uri()) {
             Ok(u) => u,
             Err(error) => return Err(pre_request(error, req)),
         };
-        let head = match build_h3_head(&req, https_uri) {
-            Ok(h) => h,
-            Err(error) => return Err(pre_request(error, req)),
-        };
-        let addr = match lookup_endpoint(&route.dial_host, route.dial_port).await {
-            Ok(a) => a,
-            Err(error) => return Err(pre_request(error, req)),
-        };
 
-        // Connect + handshake, bounded by the configured timeout. Nothing has
-        // reached the origin yet, so any failure here is safe to retry for any
-        // method and triggers the negative cache. The TLS name is the *origin*
-        // authority host, so a discovered endpoint's cert is validated for the
-        // origin (RFC 7838 §2.1); a mismatch fails here and falls back.
-        let connect = async {
-            let conn = self.endpoint.connect(addr, &route.authority_host)?.await?;
-            let pair = h3::client::new(h3_quinn::Connection::new(conn)).await?;
-            Ok::<_, anyhow::Error>(pair)
-        };
-        let (mut driver, mut send_request) =
-            match tokio::time::timeout(self.connect_timeout, connect).await {
-                Ok(Ok(pair)) => pair,
-                Ok(Err(error)) => return Err(pre_request(error, req)),
-                Err(_) => {
-                    return Err(pre_request(
-                        anyhow::anyhow!("h3 upstream connect timed out"),
-                        req,
-                    ))
-                }
+        // Acquire a stream, reusing a pooled connection when possible. A reused
+        // connection may refuse the stream (origin GOAWAY, or a connection that
+        // died while idle) — those refusals are pre-processing, so per RFC 9114
+        // §5.2 the request is retried once on a fresh connection, safe for any
+        // method. A fresh connection that still can't open a stream is a genuine
+        // pre-request failure (safe to fall back to H1/H2).
+        let mut force_fresh = false;
+        let (mut stream, conn) = loop {
+            // `send_request` consumes the head, so rebuild it per attempt.
+            let head = match build_h3_head(&req, https_uri.clone()) {
+                Ok(h) => h,
+                Err(error) => return Err(pre_request(error, req)),
             };
-        // Drive the connection in the background so request/response frames make
-        // progress; aborted when the response body is dropped (see `ConnGuard`).
-        let driver = tokio::spawn(async move {
-            let _ = poll_fn(|cx| driver.poll_close(cx)).await;
-        });
-
-        // Open the request stream and send the header section. The origin may
-        // have seen the header bytes, but the body is still intact, so fall-back
-        // is safe only for an idempotent method (`pre_request = false`).
-        let mut stream = match send_request.send_request(head).await {
-            Ok(s) => s,
-            Err(e) => {
-                driver.abort();
-                return Err(H3Failure::Retryable {
-                    error: anyhow::anyhow!("h3 upstream send_request: {e}"),
-                    request: Box::new(req),
-                    pre_request: false,
-                });
+            let (conn, reused) = match self.get_or_connect(route, force_fresh).await {
+                Ok(c) => c,
+                Err(error) => return Err(pre_request(error, req)),
+            };
+            match conn.send.clone().send_request(head).await {
+                Ok(stream) => break (stream, conn),
+                Err(e) => {
+                    self.invalidate(&route.authority, &conn);
+                    if reused {
+                        // The pooled connection refused the stream; retry fresh.
+                        force_fresh = true;
+                        continue;
+                    }
+                    return Err(H3Failure::Retryable {
+                        error: anyhow::anyhow!("h3 upstream send_request: {e}"),
+                        request: Box::new(req),
+                        pre_request: true,
+                    });
+                }
             }
         };
 
@@ -395,7 +498,6 @@ impl H3UpstreamClient {
             Ok::<_, anyhow::Error>(())
         };
         if let Err(error) = send_body.await {
-            driver.abort();
             return Err(H3Failure::Consumed { error });
         }
 
@@ -403,19 +505,17 @@ impl H3UpstreamClient {
             match tokio::time::timeout(self.connect_timeout, stream.recv_response()).await {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
-                    driver.abort();
                     return Err(H3Failure::Consumed {
                         error: anyhow::anyhow!("h3 upstream recv_response: {e}"),
                     });
                 }
                 Err(_) => {
-                    driver.abort();
                     return Err(H3Failure::Consumed {
                         error: anyhow::anyhow!("h3 upstream response timed out"),
                     });
                 }
             };
-        let (send_half, recv_half) = stream.split();
+        let (_send_half, recv_half) = stream.split();
 
         // Record the origin leg's version as HTTP/3 (see the exchange core, which
         // reads `resp.version()` into `tx.response.version`).
@@ -426,15 +526,13 @@ impl H3UpstreamClient {
             builder = builder.header(name, value);
         }
 
-        let guard = ConnGuard {
-            _send_request: Box::new(send_request),
-            _send_half: Box::new(send_half),
-            driver,
-        };
+        // The response body keeps the pooled connection alive while it streams
+        // (the pool holds another ref); it does not abort the driver — the
+        // connection stays pooled for reuse and is torn down only on eviction.
         let resp_body = H3ResponseBody {
             recv: recv_half,
             state: RespState::Data,
-            _guard: guard,
+            _conn: conn,
         }
         .boxed_unsync();
 
@@ -596,24 +694,6 @@ fn force_https(uri: &Uri) -> anyhow::Result<Uri> {
     Ok(Uri::from_parts(parts)?)
 }
 
-/// Keeps the QUIC connection alive for as long as the response body streams.
-///
-/// Dropping the last `SendRequest` triggers a client-initiated connection close
-/// in the h3 crate, and the connection only advances while its driver task runs;
-/// so both are held here until the body is fully read (or dropped), at which
-/// point the driver is aborted and the connection winds down.
-struct ConnGuard {
-    _send_request: Box<dyn Send>,
-    _send_half: Box<dyn Send>,
-    driver: tokio::task::JoinHandle<()>,
-}
-
-impl Drop for ConnGuard {
-    fn drop(&mut self) {
-        self.driver.abort();
-    }
-}
-
 /// Whether the next poll reads response data, then trailers, then ends — the
 /// receive-side mirror of [`super::http3_body`]'s request-body adapter.
 enum RespState {
@@ -624,11 +704,12 @@ enum RespState {
 
 /// Streams the origin's HTTP/3 response body out of the recv half of the client
 /// request stream, yielding a trailers frame after the data if the origin sent
-/// any. Owns a [`ConnGuard`] so the connection outlives the stream.
+/// any. Holds an `Arc` to the pooled connection so it outlives the stream even
+/// if the pool evicts the connection mid-response.
 struct H3ResponseBody<S> {
     recv: h3::client::RequestStream<S, Bytes>,
     state: RespState,
-    _guard: ConnGuard,
+    _conn: Arc<PooledConn>,
 }
 
 impl<S> Body for H3ResponseBody<S>

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -38,7 +38,7 @@ use h3::quic::RecvStream;
 use http_body_util::BodyExt;
 use hyper::body::{Body, Frame};
 use hyper::http::uri::{PathAndQuery, Scheme};
-use hyper::{Request, Response, Uri, Version};
+use hyper::{HeaderMap, Request, Response, Uri, Version};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::CertificateDer;
 
@@ -50,6 +50,10 @@ use super::{BoxError, ClientBody, ResponseBody};
 /// entries are pruned before this is exceeded so a churn of one-off origins
 /// can't grow the map without bound.
 const NEGATIVE_CACHE_CAP: usize = 1024;
+
+/// Same bound for the Alt-Svc discovery cache — a proxy that sees many distinct
+/// origins advertising H3 must not accumulate mappings without limit.
+const DISCOVERY_CACHE_CAP: usize = 1024;
 
 /// Why an HTTP/3 upstream attempt failed, carrying enough context for the
 /// caller to decide whether a fall-back to H1/H2 is safe (RFC 9110 §9.2.2).
@@ -79,14 +83,41 @@ struct NegEntry {
     failures: u32,
 }
 
+/// Default freshness for a discovered Alt-Svc mapping when it carries no `ma`
+/// (RFC 7838 §3.1 leaves the default to the client; 24h is the common choice,
+/// matching the alt-svc rule's documented assumption).
+const DEFAULT_ALT_SVC_MA_SECS: u64 = 24 * 60 * 60;
+
+/// A discovered Alt-Svc mapping: the advertised H3 endpoints and when the
+/// mapping stops being fresh (`ma`).
+struct DiscoveryEntry {
+    endpoints: Vec<(String, u16)>,
+    expiry: Instant,
+}
+
+/// Where and how to open an H3 connection for an origin authority: the QUIC
+/// endpoint to dial (the origin itself, or an Alt-Svc alternative) and the TLS
+/// server name — always the **origin** authority host, so the endpoint's
+/// certificate must validate *for the origin* (RFC 7838 §2.1 / RFC 9114 §3.3),
+/// not merely for the alternative's own name.
+pub(super) struct H3Route {
+    dial_host: String,
+    dial_port: u16,
+    authority_host: String,
+}
+
 /// Shared HTTP/3 upstream client: one quinn client endpoint plus the set of
 /// origin authorities eligible for H3 forwarding.
 pub(super) struct H3UpstreamClient {
     endpoint: quinn::Endpoint,
-    /// Origin authorities (`host:port`) the operator opted into forwarding over
-    /// H3. Until Alt-Svc discovery lands this allowlist is the sole capability
-    /// signal.
+    /// Origin authorities (`host:port`) the operator opted into always
+    /// forwarding over H3, pre-seeding discovery.
     authorities: HashSet<String>,
+    /// Origin authorities that must never use H3, overriding both the allowlist
+    /// and Alt-Svc discovery.
+    denylist: HashSet<String>,
+    /// Whether an origin's Alt-Svc header may add an H3 route at runtime.
+    trust_alt_svc: bool,
     /// Bound on the connect + handshake (and the response head).
     connect_timeout: Duration,
     /// Base backoff window for the negative cache.
@@ -94,6 +125,8 @@ pub(super) struct H3UpstreamClient {
     /// Authorities whose H3 connect/handshake recently failed, suppressed from
     /// H3 attempts until their backoff window elapses.
     negative: Mutex<HashMap<String, NegEntry>>,
+    /// Alt-Svc discovery cache: origin authority → advertised H3 endpoints.
+    discovery: Mutex<HashMap<String, DiscoveryEntry>>,
 }
 
 impl H3UpstreamClient {
@@ -153,13 +186,17 @@ impl H3UpstreamClient {
             .iter()
             .cloned()
             .collect();
+        let denylist = cfg.general.h3_upstream_denylist.iter().cloned().collect();
 
         Ok(Some(Self {
             endpoint,
             authorities,
+            denylist,
+            trust_alt_svc: cfg.general.h3_upstream_trust_alt_svc,
             connect_timeout: Duration::from_millis(cfg.general.h3_upstream_connect_timeout_ms),
             negative_ttl: Duration::from_secs(cfg.general.h3_upstream_negative_ttl_seconds),
             negative: Mutex::new(HashMap::new()),
+            discovery: Mutex::new(HashMap::new()),
         }))
     }
 
@@ -199,9 +236,72 @@ impl H3UpstreamClient {
         self.negative.lock().unwrap().remove(authority);
     }
 
-    /// Whether requests to `authority` should be forwarded over HTTP/3.
-    pub(super) fn handles(&self, authority: &str) -> bool {
-        self.authorities.contains(authority)
+    /// Resolve how to reach `authority` over HTTP/3, or `None` if it should not
+    /// be attempted. The denylist wins over everything; otherwise the configured
+    /// allowlist dials the origin directly, and a fresh Alt-Svc discovery dials
+    /// the advertised endpoint. Either way the TLS name stays the origin host so
+    /// the endpoint cert is validated for the origin (RFC 7838 §2.1).
+    pub(super) fn route_for(&self, authority: &str) -> Option<H3Route> {
+        if self.denylist.contains(authority) {
+            return None;
+        }
+        let (host, port) = split_authority(authority)?;
+        if self.authorities.contains(authority) {
+            return Some(H3Route {
+                dial_host: host.clone(),
+                dial_port: port,
+                authority_host: host,
+            });
+        }
+        let (dial_host, dial_port) = self.discovered(authority)?;
+        Some(H3Route {
+            dial_host,
+            dial_port,
+            authority_host: host,
+        })
+    }
+
+    /// Return a fresh discovered H3 endpoint for `authority`, if any.
+    fn discovered(&self, authority: &str) -> Option<(String, u16)> {
+        let map = self.discovery.lock().unwrap();
+        let entry = map.get(authority)?;
+        if entry.expiry <= Instant::now() {
+            return None;
+        }
+        entry.endpoints.first().cloned()
+    }
+
+    /// Fold an origin's `Alt-Svc` response header(s) into the discovery cache:
+    /// `clear` drops the mapping, an `h3` advertisement (re)populates it with the
+    /// advertised endpoints and an `ma`-derived expiry. No-op when Alt-Svc trust
+    /// is disabled. `origin_host` resolves the `":port"` (same-host) form.
+    pub(super) fn record_alt_svc(&self, authority: &str, origin_host: &str, headers: &HeaderMap) {
+        if !self.trust_alt_svc {
+            return;
+        }
+        let origin_host = origin_host.trim_start_matches('[').trim_end_matches(']');
+        for hv in headers.get_all("alt-svc").iter() {
+            let Ok(s) = hv.to_str() else { continue };
+            match parse_alt_svc(s, origin_host) {
+                Some(AltSvc::Clear) => {
+                    self.discovery.lock().unwrap().remove(authority);
+                }
+                Some(AltSvc::Advertise { endpoints, ma }) => {
+                    let now = Instant::now();
+                    let expiry = now
+                        .checked_add(Duration::from_secs(ma))
+                        .unwrap_or_else(|| now + Duration::from_secs(DEFAULT_ALT_SVC_MA_SECS));
+                    let mut map = self.discovery.lock().unwrap();
+                    // Bound the map: drop stale mappings before admitting a new
+                    // authority (refreshing an existing key never grows it).
+                    if map.len() >= DISCOVERY_CACHE_CAP && !map.contains_key(authority) {
+                        map.retain(|_, e| e.expiry > now);
+                    }
+                    map.insert(authority.to_string(), DiscoveryEntry { endpoints, expiry });
+                }
+                None => {}
+            }
+        }
     }
 
     /// Forward `req` (already hop-by-hop stripped) to its origin over HTTP/3 and
@@ -212,23 +312,32 @@ impl H3UpstreamClient {
     pub(super) async fn forward(
         &self,
         req: Request<ClientBody>,
+        route: &H3Route,
     ) -> Result<Response<ResponseBody>, H3Failure> {
-        // Resolve the origin address / TLS name / https target from the request
-        // URI *without consuming* `req`, so it can be handed back for fall-back.
-        let (addr, host, https_uri) = match resolve_target(req.uri()).await {
-            Ok(t) => t,
+        // Build the https target + H3 head from the request URI *without
+        // consuming* `req`, so it can be handed back for fall-back. The head
+        // keeps the origin authority (`:authority`); only the dialed socket comes
+        // from the route (an Alt-Svc alternative may differ from the origin).
+        let https_uri = match force_https(req.uri()) {
+            Ok(u) => u,
             Err(error) => return Err(pre_request(error, req)),
         };
         let head = match build_h3_head(&req, https_uri) {
             Ok(h) => h,
             Err(error) => return Err(pre_request(error, req)),
         };
+        let addr = match lookup_endpoint(&route.dial_host, route.dial_port).await {
+            Ok(a) => a,
+            Err(error) => return Err(pre_request(error, req)),
+        };
 
         // Connect + handshake, bounded by the configured timeout. Nothing has
         // reached the origin yet, so any failure here is safe to retry for any
-        // method and triggers the negative cache.
+        // method and triggers the negative cache. The TLS name is the *origin*
+        // authority host, so a discovered endpoint's cert is validated for the
+        // origin (RFC 7838 §2.1); a mismatch fails here and falls back.
         let connect = async {
-            let conn = self.endpoint.connect(addr, &host)?.await?;
+            let conn = self.endpoint.connect(addr, &route.authority_host)?.await?;
             let pair = h3::client::new(h3_quinn::Connection::new(conn)).await?;
             Ok::<_, anyhow::Error>(pair)
         };
@@ -345,27 +454,121 @@ fn pre_request(error: anyhow::Error, request: Request<ClientBody>) -> H3Failure 
     }
 }
 
-/// Resolve the origin socket address, TLS server name, and https target URI
-/// from a request URI, without consuming anything.
-async fn resolve_target(uri: &Uri) -> anyhow::Result<(SocketAddr, String, Uri)> {
-    let https_uri = force_https(uri)?;
-    let authority = https_uri
-        .authority()
-        .ok_or_else(|| anyhow::anyhow!("h3 upstream: request URI has no authority"))?;
-    // `Authority::host()` keeps the brackets on an IPv6 literal (`[::1]`), which
-    // neither `lookup_host` nor a rustls `ServerName` accepts — strip them so
-    // both the DNS/socket lookup and the TLS name are well-formed.
-    let host = authority
-        .host()
-        .trim_start_matches('[')
-        .trim_end_matches(']')
-        .to_string();
-    let port = authority.port_u16().unwrap_or(443);
-    let addr = tokio::net::lookup_host((host.as_str(), port))
+/// Resolve `host:port` to a socket address for dialing the QUIC endpoint.
+async fn lookup_endpoint(host: &str, port: u16) -> anyhow::Result<SocketAddr> {
+    tokio::net::lookup_host((host, port))
         .await?
         .next()
-        .ok_or_else(|| anyhow::anyhow!("h3 upstream: could not resolve {authority}"))?;
-    Ok((addr, host, https_uri))
+        .ok_or_else(|| anyhow::anyhow!("h3 upstream: could not resolve {host}:{port}"))
+}
+
+/// Split an `host[:port]` authority into its bracket-stripped host and port,
+/// defaulting the port to 443 when absent (H3 is always TLS — this mirrors the
+/// original `port_u16().unwrap_or(443)` so a no-port allowlist entry still
+/// routes over H3). `Authority::host()` keeps the brackets on an IPv6 literal
+/// (`[::1]`), which neither `lookup_host` nor a rustls `ServerName` accepts.
+fn split_authority(authority: &str) -> Option<(String, u16)> {
+    let (host_part, port) = match authority.rfind(':') {
+        // A ':' inside a bracketed IPv6 literal (before the closing ']') is not
+        // a port separator, e.g. bare "[::1]".
+        Some(i) if authority[i..].contains(']') => (authority, 443),
+        Some(i) => (&authority[..i], authority[i + 1..].parse().ok()?),
+        None => (authority, 443),
+    };
+    let host = host_part.trim_start_matches('[').trim_end_matches(']');
+    if host.is_empty() {
+        return None;
+    }
+    Some((host.to_string(), port))
+}
+
+/// The routing-relevant content of an `Alt-Svc` header.
+enum AltSvc {
+    /// `Alt-Svc: clear` — drop any cached mapping for the origin.
+    Clear,
+    /// One or more `h3=` advertisements plus the smallest `ma` seen.
+    Advertise {
+        endpoints: Vec<(String, u16)>,
+        ma: u64,
+    },
+}
+
+/// Parse an `Alt-Svc` header value for HTTP/3 routing. Reuses the alt-svc rules'
+/// list/param splitting (`crate::helpers::headers`) and their acceptance
+/// criteria — only the final `h3` token (draft `h3-NN` is rejected, as
+/// `server_alt_svc_h3_advertisement_valid` flags). `origin_host` resolves the
+/// `":port"` (same-host) advertisement form. Returns `None` when the header
+/// carries no usable h3 route and no `clear`.
+fn parse_alt_svc(header: &str, origin_host: &str) -> Option<AltSvc> {
+    use crate::helpers::headers::{parse_list_header, split_semicolons_respecting_quotes};
+
+    let mut endpoints = Vec::new();
+    let mut ma = DEFAULT_ALT_SVC_MA_SECS;
+    for entry in parse_list_header(header) {
+        let mut parts = entry.splitn(2, ';');
+        let proto_auth = parts.next().unwrap_or("").trim();
+        let params = parts.next().unwrap_or("");
+
+        if proto_auth.eq_ignore_ascii_case("clear") {
+            return Some(AltSvc::Clear);
+        }
+        let Some(eq) = proto_auth.find('=') else {
+            continue;
+        };
+        // Only the final `h3` ALPN token routes; draft `h3-NN` is not usable
+        // (mirrors `server_alt_svc_h3_advertisement_valid`).
+        if !proto_auth[..eq].trim().eq_ignore_ascii_case("h3") {
+            continue;
+        }
+        let auth = proto_auth[eq + 1..].trim().trim_matches('"');
+        let Some(endpoint) = parse_alt_authority(auth, origin_host) else {
+            continue;
+        };
+
+        // An `ma=0` invalidates the advertisement; otherwise track the smallest
+        // freshness across the h3 entries as the mapping's expiry.
+        if let Some(entry_ma) = alt_svc_ma(&split_semicolons_respecting_quotes(params)) {
+            if entry_ma == 0 {
+                continue;
+            }
+            ma = ma.min(entry_ma);
+        }
+        endpoints.push(endpoint);
+    }
+
+    (!endpoints.is_empty()).then_some(AltSvc::Advertise { endpoints, ma })
+}
+
+/// Parse an Alt-Svc `alt-authority` (`[uri-host] ":" port`) into a dialable
+/// `(host, port)`; an empty host means "same host as the origin".
+fn parse_alt_authority(auth: &str, origin_host: &str) -> Option<(String, u16)> {
+    let colon = auth.rfind(':')?;
+    let port: u16 = auth[colon + 1..].parse().ok()?;
+    let host = auth[..colon].trim_start_matches('[').trim_end_matches(']');
+    let host = if host.is_empty() {
+        origin_host.to_string()
+    } else {
+        host.to_string()
+    };
+    Some((host, port))
+}
+
+/// Extract the `ma` (max-age) parameter value from split Alt-Svc params, if any.
+fn alt_svc_ma(params: &[&str]) -> Option<u64> {
+    for param in params {
+        let mut kv = param.splitn(2, '=');
+        let key = kv.next().unwrap_or("").trim();
+        if !key.eq_ignore_ascii_case("ma") {
+            continue;
+        }
+        let raw = kv.next().unwrap_or("").trim();
+        let val = raw
+            .strip_prefix('"')
+            .and_then(|v| v.strip_suffix('"'))
+            .unwrap_or(raw);
+        return val.parse::<u64>().ok();
+    }
+    None
 }
 
 /// Build the HTTP/3 request head (method, https target, headers) from the
@@ -541,6 +744,188 @@ mod tests {
         assert!(
             !client.is_suppressed("b.example:443"),
             "suppression is per authority"
+        );
+    }
+
+    fn client_with(mutate: impl FnOnce(&mut crate::config::GeneralConfig)) -> H3UpstreamClient {
+        let mut cfg = Config::default();
+        cfg.general.h3_upstream_enabled = true;
+        mutate(&mut cfg.general);
+        let roots = rustls::RootCertStore::empty();
+        H3UpstreamClient::build(&cfg, &roots)
+            .expect("build h3 client")
+            .expect("h3 client is Some when enabled")
+    }
+
+    fn alt_svc_headers(values: &[&str]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for v in values {
+            h.append("alt-svc", v.parse().unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn parse_alt_svc_same_host_and_explicit_host() {
+        match parse_alt_svc("h3=\":443\"; ma=3600", "example.com") {
+            Some(AltSvc::Advertise { endpoints, ma }) => {
+                assert_eq!(endpoints, vec![("example.com".to_string(), 443)]);
+                assert_eq!(ma, 3600);
+            }
+            _ => panic!("expected an h3 advertisement"),
+        }
+        match parse_alt_svc("h3=\"alt.example.com:8443\"", "example.com") {
+            Some(AltSvc::Advertise { endpoints, ma }) => {
+                assert_eq!(endpoints, vec![("alt.example.com".to_string(), 8443)]);
+                assert_eq!(ma, DEFAULT_ALT_SVC_MA_SECS, "absent ma defaults");
+            }
+            _ => panic!("expected advertise"),
+        }
+    }
+
+    #[test]
+    fn parse_alt_svc_rejects_draft_and_non_h3_and_clear() {
+        assert!(
+            parse_alt_svc("h3-29=\":443\"", "example.com").is_none(),
+            "draft h3-NN is not a usable route"
+        );
+        assert!(
+            parse_alt_svc("h2=\":443\"", "example.com").is_none(),
+            "non-h3 protocols do not route H3"
+        );
+        assert!(matches!(
+            parse_alt_svc("clear", "example.com"),
+            Some(AltSvc::Clear)
+        ));
+        // ma=0 invalidates the h3 entry.
+        assert!(parse_alt_svc("h3=\":443\"; ma=0", "example.com").is_none());
+    }
+
+    #[tokio::test]
+    async fn discovery_populates_consults_and_clears() {
+        let client = client_with(|_| {});
+        let auth = "origin.example:443";
+
+        assert!(client.route_for(auth).is_none(), "nothing discovered yet");
+
+        client.record_alt_svc(
+            auth,
+            "origin.example",
+            &alt_svc_headers(&["h3=\":8443\"; ma=3600"]),
+        );
+        let route = client.route_for(auth).expect("discovered route");
+        assert_eq!(route.dial_host, "origin.example");
+        assert_eq!(route.dial_port, 8443);
+        assert_eq!(
+            route.authority_host, "origin.example",
+            "TLS name stays the origin authority (cert-for-origin)"
+        );
+
+        client.record_alt_svc(auth, "origin.example", &alt_svc_headers(&["clear"]));
+        assert!(
+            client.route_for(auth).is_none(),
+            "Alt-Svc: clear drops the mapping"
+        );
+    }
+
+    #[tokio::test]
+    async fn discovery_honours_ma_expiry() {
+        let client = client_with(|_| {});
+        let auth = "origin.example:443";
+        // A fresh mapping is consulted.
+        client.record_alt_svc(
+            auth,
+            "origin.example",
+            &alt_svc_headers(&["h3=\":8443\"; ma=3600"]),
+        );
+        assert!(
+            client.route_for(auth).is_some(),
+            "fresh mapping is consulted"
+        );
+
+        // Force the entry's expiry into the past: it must no longer be consulted.
+        {
+            let mut map = client.discovery.lock().unwrap();
+            let entry = map.get_mut(auth).unwrap();
+            entry.expiry = Instant::now() - Duration::from_secs(1);
+        }
+        assert!(
+            client.route_for(auth).is_none(),
+            "an expired mapping (ma elapsed) is not consulted"
+        );
+    }
+
+    #[tokio::test]
+    async fn discovery_ignored_when_trust_disabled() {
+        let client = client_with(|g| g.h3_upstream_trust_alt_svc = false);
+        let auth = "origin.example:443";
+        client.record_alt_svc(
+            auth,
+            "origin.example",
+            &alt_svc_headers(&["h3=\":8443\"; ma=3600"]),
+        );
+        assert!(
+            client.route_for(auth).is_none(),
+            "Alt-Svc discovery is off, so no route"
+        );
+    }
+
+    #[tokio::test]
+    async fn route_allowlist_and_denylist() {
+        let client = client_with(|g| {
+            g.h3_upstream_authorities = vec!["allow.example:443".to_string()];
+            g.h3_upstream_denylist = vec!["deny.example:443".to_string()];
+        });
+        let route = client.route_for("allow.example:443").expect("allowlisted");
+        assert_eq!(route.dial_host, "allow.example");
+        assert_eq!(route.dial_port, 443);
+        assert!(
+            client.route_for("other.example:443").is_none(),
+            "not allowlisted, not discovered"
+        );
+
+        // Denylist wins even over a discovered mapping.
+        client.record_alt_svc(
+            "deny.example:443",
+            "deny.example",
+            &alt_svc_headers(&["h3=\":8443\"; ma=3600"]),
+        );
+        assert!(
+            client.route_for("deny.example:443").is_none(),
+            "denylist overrides discovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn route_defaults_missing_port_to_443() {
+        // A no-port allowlist entry still routes over H3 (H3 is always TLS), as
+        // it did before Alt-Svc routing landed.
+        let client = client_with(|g| {
+            g.h3_upstream_authorities = vec!["example.com".to_string()];
+        });
+        let route = client
+            .route_for("example.com")
+            .expect("no-port entry routes");
+        assert_eq!(route.dial_host, "example.com");
+        assert_eq!(route.dial_port, 443);
+    }
+
+    #[test]
+    fn split_authority_forms() {
+        assert_eq!(
+            split_authority("example.com:8443"),
+            Some(("example.com".to_string(), 8443))
+        );
+        assert_eq!(
+            split_authority("example.com"),
+            Some(("example.com".to_string(), 443)),
+            "absent port defaults to 443"
+        );
+        assert_eq!(split_authority("[::1]:443"), Some(("::1".to_string(), 443)));
+        assert_eq!(
+            split_authority("[::1]"),
+            Some(("::1".to_string(), 443)),
+            "bracketed IPv6 without a port defaults to 443, not a mis-split"
         );
     }
 }

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -25,12 +25,13 @@
 //! and absolute URI; the URI's scheme is forced to `https` here because there is
 //! no plaintext HTTP/3.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::poll_fn;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
 use bytes::{Buf, Bytes};
 use h3::quic::RecvStream;
@@ -45,6 +46,39 @@ use crate::config::Config;
 
 use super::{BoxError, ClientBody, ResponseBody};
 
+/// Upper bound on distinct authorities held in the negative cache; expired
+/// entries are pruned before this is exceeded so a churn of one-off origins
+/// can't grow the map without bound.
+const NEGATIVE_CACHE_CAP: usize = 1024;
+
+/// Why an HTTP/3 upstream attempt failed, carrying enough context for the
+/// caller to decide whether a fall-back to H1/H2 is safe (RFC 9110 §9.2.2).
+pub(super) enum H3Failure {
+    /// The failure left the request replayable — either nothing reached the
+    /// origin (`pre_request`) or only the header section did with the body
+    /// still intact. `request` is the original, un-consumed request. A
+    /// `pre_request` failure is safe to fall back for **any** method and marks
+    /// the origin in the negative cache; a header-sent failure is safe only for
+    /// an idempotent method.
+    Retryable {
+        error: anyhow::Error,
+        /// Boxed to keep this variant near the size of `Consumed` — a bare
+        /// `Request<ClientBody>` would make the whole `H3Failure` large.
+        request: Box<Request<ClientBody>>,
+        pre_request: bool,
+    },
+    /// The request body was already in flight; the streaming body cannot be
+    /// replayed, so the caller must not retry (whatever the method).
+    Consumed { error: anyhow::Error },
+}
+
+/// One negative-cache entry: the origin is not attempted over H3 until `until`,
+/// and `failures` drives the exponential backoff of that window.
+struct NegEntry {
+    until: Instant,
+    failures: u32,
+}
+
 /// Shared HTTP/3 upstream client: one quinn client endpoint plus the set of
 /// origin authorities eligible for H3 forwarding.
 pub(super) struct H3UpstreamClient {
@@ -53,6 +87,13 @@ pub(super) struct H3UpstreamClient {
     /// H3. Until Alt-Svc discovery lands this allowlist is the sole capability
     /// signal.
     authorities: HashSet<String>,
+    /// Bound on the connect + handshake (and the response head).
+    connect_timeout: Duration,
+    /// Base backoff window for the negative cache.
+    negative_ttl: Duration,
+    /// Authorities whose H3 connect/handshake recently failed, suppressed from
+    /// H3 attempts until their backoff window elapses.
+    negative: Mutex<HashMap<String, NegEntry>>,
 }
 
 impl H3UpstreamClient {
@@ -87,7 +128,14 @@ impl H3UpstreamClient {
 
         let quic_client = quinn::crypto::rustls::QuicClientConfig::try_from(tls)
             .map_err(|e| anyhow::anyhow!("h3 upstream QUIC client config: {e}"))?;
-        let client_config = quinn::ClientConfig::new(Arc::new(quic_client));
+        let mut client_config = quinn::ClientConfig::new(Arc::new(quic_client));
+        // Bound idle QUIC connections (P1 opens one per request; P4 pools them)
+        // so a stranded connection winds down instead of lingering.
+        let mut transport = quinn::TransportConfig::default();
+        transport.max_idle_timeout(Some(
+            quinn::IdleTimeout::try_from(Duration::from_secs(30)).expect("30s idle timeout fits"),
+        ));
+        client_config.transport_config(Arc::new(transport));
 
         let bind: SocketAddr = cfg
             .general
@@ -109,7 +157,46 @@ impl H3UpstreamClient {
         Ok(Some(Self {
             endpoint,
             authorities,
+            connect_timeout: Duration::from_millis(cfg.general.h3_upstream_connect_timeout_ms),
+            negative_ttl: Duration::from_secs(cfg.general.h3_upstream_negative_ttl_seconds),
+            negative: Mutex::new(HashMap::new()),
         }))
+    }
+
+    /// Whether `authority` is currently suppressed from H3 attempts by a live
+    /// negative-cache backoff window.
+    pub(super) fn is_suppressed(&self, authority: &str) -> bool {
+        let map = self.negative.lock().unwrap();
+        map.get(authority).is_some_and(|e| e.until > Instant::now())
+    }
+
+    /// Record a connect/handshake failure for `authority`, extending its
+    /// backoff window (doubling per consecutive failure, capped).
+    pub(super) fn record_failure(&self, authority: &str) {
+        let now = Instant::now();
+        let mut map = self.negative.lock().unwrap();
+        if map.len() >= NEGATIVE_CACHE_CAP {
+            map.retain(|_, e| e.until > now);
+        }
+        let entry = map.entry(authority.to_string()).or_insert(NegEntry {
+            until: now,
+            failures: 0,
+        });
+        entry.failures = entry.failures.saturating_add(1);
+        // ttl * 2^(failures-1), shift capped at 6 (×64) to bound the window.
+        // `checked_add` guards against an absurdly large configured ttl whose
+        // saturated Duration would overflow `Instant` and panic this request task.
+        let shift = (entry.failures - 1).min(6);
+        let backoff = self.negative_ttl.saturating_mul(1u32 << shift);
+        entry.until = now
+            .checked_add(backoff)
+            .unwrap_or_else(|| now + Duration::from_secs(24 * 60 * 60));
+    }
+
+    /// Clear any negative-cache entry for `authority` after a successful H3
+    /// exchange, so a recovered origin resumes H3 immediately.
+    pub(super) fn record_success(&self, authority: &str) {
+        self.negative.lock().unwrap().remove(authority);
     }
 
     /// Whether requests to `authority` should be forwarded over HTTP/3.
@@ -119,64 +206,106 @@ impl H3UpstreamClient {
 
     /// Forward `req` (already hop-by-hop stripped) to its origin over HTTP/3 and
     /// return a `hyper::Response` whose body streams the origin's response.
-    /// Opens a fresh QUIC connection each call (P1: no pool).
+    /// Opens a fresh QUIC connection each call (P1: no pool). On failure the
+    /// [`H3Failure`] tells the caller whether the request is safe to fall back
+    /// to H1/H2.
     pub(super) async fn forward(
         &self,
         req: Request<ClientBody>,
-    ) -> anyhow::Result<Response<ResponseBody>> {
-        let (mut parts, body) = req.into_parts();
+    ) -> Result<Response<ResponseBody>, H3Failure> {
+        // Resolve the origin address / TLS name / https target from the request
+        // URI *without consuming* `req`, so it can be handed back for fall-back.
+        let (addr, host, https_uri) = match resolve_target(req.uri()).await {
+            Ok(t) => t,
+            Err(error) => return Err(pre_request(error, req)),
+        };
+        let head = match build_h3_head(&req, https_uri) {
+            Ok(h) => h,
+            Err(error) => return Err(pre_request(error, req)),
+        };
 
-        // HTTP/3 is always over TLS: force the origin request's :scheme to https.
-        let uri = force_https(&parts.uri)?;
-        let authority = uri
-            .authority()
-            .ok_or_else(|| anyhow::anyhow!("h3 upstream: request URI has no authority"))?
-            .clone();
-        // `Authority::host()` keeps the brackets on an IPv6 literal (`[::1]`),
-        // which neither `lookup_host` nor a rustls `ServerName` accepts — strip
-        // them so both the DNS/socket lookup and the TLS name are well-formed.
-        let host = authority
-            .host()
-            .trim_start_matches('[')
-            .trim_end_matches(']')
-            .to_string();
-        let port = authority.port_u16().unwrap_or(443);
-        let addr = tokio::net::lookup_host((host.as_str(), port))
-            .await?
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("h3 upstream: could not resolve {authority}"))?;
-        parts.uri = uri;
-        let head = Request::from_parts(parts, ());
-
-        let conn = self.endpoint.connect(addr, &host)?.await?;
+        // Connect + handshake, bounded by the configured timeout. Nothing has
+        // reached the origin yet, so any failure here is safe to retry for any
+        // method and triggers the negative cache.
+        let connect = async {
+            let conn = self.endpoint.connect(addr, &host)?.await?;
+            let pair = h3::client::new(h3_quinn::Connection::new(conn)).await?;
+            Ok::<_, anyhow::Error>(pair)
+        };
         let (mut driver, mut send_request) =
-            h3::client::new(h3_quinn::Connection::new(conn)).await?;
+            match tokio::time::timeout(self.connect_timeout, connect).await {
+                Ok(Ok(pair)) => pair,
+                Ok(Err(error)) => return Err(pre_request(error, req)),
+                Err(_) => {
+                    return Err(pre_request(
+                        anyhow::anyhow!("h3 upstream connect timed out"),
+                        req,
+                    ))
+                }
+            };
         // Drive the connection in the background so request/response frames make
         // progress; aborted when the response body is dropped (see `ConnGuard`).
         let driver = tokio::spawn(async move {
             let _ = poll_fn(|cx| driver.poll_close(cx)).await;
         });
 
-        let mut stream = send_request.send_request(head).await?;
+        // Open the request stream and send the header section. The origin may
+        // have seen the header bytes, but the body is still intact, so fall-back
+        // is safe only for an idempotent method (`pre_request = false`).
+        let mut stream = match send_request.send_request(head).await {
+            Ok(s) => s,
+            Err(e) => {
+                driver.abort();
+                return Err(H3Failure::Retryable {
+                    error: anyhow::anyhow!("h3 upstream send_request: {e}"),
+                    request: Box::new(req),
+                    pre_request: false,
+                });
+            }
+        };
 
-        // Stream the request body to the origin, mirroring the response side of
+        // From here the request body streams to the origin and can no longer be
+        // replayed, so any failure is non-retryable. Mirror the response side of
         // the client-facing handler: data frames forward as QUIC DATA, a trailing
         // trailers frame as an H3 trailers section.
-        let mut body = body;
-        while let Some(frame) = body.frame().await {
-            let frame = frame.map_err(|e| anyhow::anyhow!("h3 upstream request body: {e}"))?;
-            match frame.into_data() {
-                Ok(data) => stream.send_data(data).await?,
-                Err(frame) => {
-                    if let Ok(trailers) = frame.into_trailers() {
-                        stream.send_trailers(trailers).await?;
+        let (_, body) = req.into_parts();
+        let send_body = async {
+            let mut body = body;
+            while let Some(frame) = body.frame().await {
+                let frame = frame.map_err(|e| anyhow::anyhow!("h3 upstream request body: {e}"))?;
+                match frame.into_data() {
+                    Ok(data) => stream.send_data(data).await?,
+                    Err(frame) => {
+                        if let Ok(trailers) = frame.into_trailers() {
+                            stream.send_trailers(trailers).await?;
+                        }
                     }
                 }
             }
+            stream.finish().await?;
+            Ok::<_, anyhow::Error>(())
+        };
+        if let Err(error) = send_body.await {
+            driver.abort();
+            return Err(H3Failure::Consumed { error });
         }
-        stream.finish().await?;
 
-        let resp_head = stream.recv_response().await?;
+        let resp_head =
+            match tokio::time::timeout(self.connect_timeout, stream.recv_response()).await {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => {
+                    driver.abort();
+                    return Err(H3Failure::Consumed {
+                        error: anyhow::anyhow!("h3 upstream recv_response: {e}"),
+                    });
+                }
+                Err(_) => {
+                    driver.abort();
+                    return Err(H3Failure::Consumed {
+                        error: anyhow::anyhow!("h3 upstream response timed out"),
+                    });
+                }
+            };
         let (send_half, recv_half) = stream.split();
 
         // Record the origin leg's version as HTTP/3 (see the exchange core, which
@@ -200,8 +329,56 @@ impl H3UpstreamClient {
         }
         .boxed_unsync();
 
-        Ok(builder.body(resp_body)?)
+        builder
+            .body(resp_body)
+            .map_err(|e| H3Failure::Consumed { error: e.into() })
     }
+}
+
+/// A pre-request failure: nothing reached the origin, so the request is
+/// replayable for any method and the origin should be negative-cached.
+fn pre_request(error: anyhow::Error, request: Request<ClientBody>) -> H3Failure {
+    H3Failure::Retryable {
+        error,
+        request: Box::new(request),
+        pre_request: true,
+    }
+}
+
+/// Resolve the origin socket address, TLS server name, and https target URI
+/// from a request URI, without consuming anything.
+async fn resolve_target(uri: &Uri) -> anyhow::Result<(SocketAddr, String, Uri)> {
+    let https_uri = force_https(uri)?;
+    let authority = https_uri
+        .authority()
+        .ok_or_else(|| anyhow::anyhow!("h3 upstream: request URI has no authority"))?;
+    // `Authority::host()` keeps the brackets on an IPv6 literal (`[::1]`), which
+    // neither `lookup_host` nor a rustls `ServerName` accepts — strip them so
+    // both the DNS/socket lookup and the TLS name are well-formed.
+    let host = authority
+        .host()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_string();
+    let port = authority.port_u16().unwrap_or(443);
+    let addr = tokio::net::lookup_host((host.as_str(), port))
+        .await?
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("h3 upstream: could not resolve {authority}"))?;
+    Ok((addr, host, https_uri))
+}
+
+/// Build the HTTP/3 request head (method, https target, headers) from the
+/// original request without consuming it, so a fall-back can reuse `req`.
+fn build_h3_head(req: &Request<ClientBody>, https_uri: Uri) -> anyhow::Result<Request<()>> {
+    let mut builder = Request::builder()
+        .method(req.method().clone())
+        .uri(https_uri)
+        .version(req.version());
+    for (name, value) in req.headers() {
+        builder = builder.header(name, value);
+    }
+    Ok(builder.body(())?)
 }
 
 /// Rebuild `uri` with an `https` scheme (and a `/` path if none), so the H3
@@ -297,5 +474,73 @@ where
                 RespState::Done => return Poll::Ready(None),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_client(negative_ttl_seconds: u64) -> H3UpstreamClient {
+        let mut cfg = Config::default();
+        cfg.general.h3_upstream_enabled = true;
+        cfg.general.h3_upstream_negative_ttl_seconds = negative_ttl_seconds;
+        // An empty root store is fine: these tests never open a connection, they
+        // only exercise the in-memory negative cache.
+        let roots = rustls::RootCertStore::empty();
+        H3UpstreamClient::build(&cfg, &roots)
+            .expect("build h3 client")
+            .expect("h3 client is Some when enabled")
+    }
+
+    #[tokio::test]
+    async fn negative_cache_suppresses_then_clears_on_success() {
+        let client = test_client(30);
+        let auth = "origin.example:443";
+
+        assert!(
+            !client.is_suppressed(auth),
+            "fresh authority is not suppressed"
+        );
+
+        client.record_failure(auth);
+        assert!(
+            client.is_suppressed(auth),
+            "a connect failure suppresses H3 for the backoff window"
+        );
+
+        // A second failure keeps it suppressed (window doubles).
+        client.record_failure(auth);
+        assert!(client.is_suppressed(auth));
+
+        client.record_success(auth);
+        assert!(
+            !client.is_suppressed(auth),
+            "a success clears the negative-cache entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn negative_cache_window_expires() {
+        // A zero-second base TTL means the window is already elapsed on insert,
+        // so the authority is not suppressed.
+        let client = test_client(0);
+        let auth = "origin.example:443";
+        client.record_failure(auth);
+        assert!(
+            !client.is_suppressed(auth),
+            "an elapsed window no longer suppresses"
+        );
+    }
+
+    #[tokio::test]
+    async fn negative_cache_only_covers_the_failing_authority() {
+        let client = test_client(30);
+        client.record_failure("a.example:443");
+        assert!(client.is_suppressed("a.example:443"));
+        assert!(
+            !client.is_suppressed("b.example:443"),
+            "suppression is per authority"
+        );
     }
 }

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Integration test for the HTTP/3 (QUIC) *upstream* leg (proxy -> origin).
+//!
+//! A client speaks plain HTTP/1.1 to the proxy; the proxy forwards to an
+//! in-process HTTP/3 origin because that origin's authority is on the
+//! `h3_upstream_authorities` allowlist. This exercises the P1 seam end to end:
+//! the QUIC client endpoint, the request/response adaptation, capture parity
+//! (the transaction records the origin leg as HTTP/3), and the RFC 9114 §4.2
+//! field discipline (a connection-specific field is stripped before it reaches
+//! the origin).
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Empty};
+use hyper_util::rt::TokioIo;
+
+use lint_http::config::Config;
+
+mod common;
+use common::{start_run_proxy_and_wait, startup_timeout};
+
+/// A self-signed test CA and a leaf certificate (IP SAN 127.0.0.1) signed by it.
+struct TestPki {
+    ca_pem: String,
+    leaf_cert: rustls::pki_types::CertificateDer<'static>,
+    leaf_key: rustls::pki_types::PrivateKeyDer<'static>,
+}
+
+/// Generate a throwaway CA and a leaf cert valid for 127.0.0.1, so the proxy's
+/// H3 upstream client (configured to trust the CA) validates the origin's
+/// endpoint certificate for its authority.
+fn gen_test_pki() -> anyhow::Result<TestPki> {
+    use rcgen::{
+        BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, SanType,
+        PKCS_ECDSA_P256_SHA256,
+    };
+
+    let mut ca_params = CertificateParams::new(Vec::new())?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "lint-http upstream-h3 test CA");
+    let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
+    let ca_cert = ca_params.self_signed(&ca_key)?;
+    let ca_pem = ca_cert.pem();
+
+    let mut leaf_params = CertificateParams::new(Vec::new())?;
+    leaf_params.subject_alt_names =
+        vec![SanType::IpAddress(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))];
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, "127.0.0.1");
+    let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
+
+    let issuer = Issuer::new(ca_params, ca_key);
+    let leaf_cert = leaf_params.signed_by(&leaf_key, &issuer)?;
+
+    let leaf_cert_der = leaf_cert.der().clone();
+    let leaf_key_der = rustls::pki_types::PrivatePkcs8KeyDer::from(leaf_key.serialize_der()).into();
+
+    Ok(TestPki {
+        ca_pem,
+        leaf_cert: leaf_cert_der,
+        leaf_key: leaf_key_der,
+    })
+}
+
+/// Captured request headers the origin saw, for the field-discipline assertions.
+type CapturedHeaders = Arc<Mutex<Option<Vec<(String, String)>>>>;
+
+/// Start an in-process HTTP/3 origin that replies `200` `"world"` with an
+/// `x-origin: h3` header and records the request headers it received. Returns
+/// its UDP address, the captured-headers handle, and the accept-loop task.
+fn start_h3_origin(
+    pki: &TestPki,
+) -> anyhow::Result<(SocketAddr, CapturedHeaders, tokio::task::JoinHandle<()>)> {
+    let mut tls = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![pki.leaf_cert.clone()], pki.leaf_key.clone_key())?;
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+
+    let quic = quinn::crypto::rustls::QuicServerConfig::try_from(tls)
+        .map_err(|e| anyhow::anyhow!("origin QUIC server config: {e}"))?;
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic));
+    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse()?)?;
+    let addr = endpoint.local_addr()?;
+
+    let captured: CapturedHeaders = Arc::new(Mutex::new(None));
+    let captured_loop = captured.clone();
+    let handle = tokio::spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            let captured = captured_loop.clone();
+            tokio::spawn(async move {
+                let conn = match incoming.await {
+                    Ok(c) => c,
+                    Err(_) => return,
+                };
+                let mut h3 =
+                    match h3::server::Connection::new(h3_quinn::Connection::new(conn)).await {
+                        Ok(c) => c,
+                        Err(_) => return,
+                    };
+                while let Ok(Some(resolver)) = h3.accept().await {
+                    let captured = captured.clone();
+                    tokio::spawn(async move {
+                        if let Ok((req, mut stream)) = resolver.resolve_request().await {
+                            let hs = req
+                                .headers()
+                                .iter()
+                                .map(|(k, v)| {
+                                    (k.as_str().to_string(), v.to_str().unwrap_or("").to_string())
+                                })
+                                .collect();
+                            *captured.lock().unwrap() = Some(hs);
+
+                            let resp = http::Response::builder()
+                                .status(200)
+                                .header("x-origin", "h3")
+                                .body(())
+                                .unwrap();
+                            let _ = stream.send_response(resp).await;
+                            let _ = stream.send_data(Bytes::from_static(b"world")).await;
+                            let _ = stream.finish().await;
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+    Ok((addr, captured, handle))
+}
+
+/// Send one HTTP/1.1 request to the proxy (absolute origin authority via Host),
+/// returning status, response headers, and body.
+async fn proxy_get(
+    proxy_addr: SocketAddr,
+    origin_authority: &str,
+    path: &str,
+    extra_headers: &[(&str, &str)],
+) -> anyhow::Result<(u16, Vec<(String, String)>, Vec<u8>)> {
+    let stream = tokio::net::TcpStream::connect(proxy_addr).await?;
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream)).await?;
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let mut builder = hyper::Request::builder()
+        .method("GET")
+        .uri(format!("http://{origin_authority}{path}"))
+        .header("host", origin_authority);
+    for (k, v) in extra_headers {
+        builder = builder.header(*k, *v);
+    }
+    let req = builder.body(Empty::<Bytes>::new())?;
+
+    let resp = sender.send_request(req).await?;
+    let status = resp.status().as_u16();
+    let headers = resp
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body = resp.into_body().collect().await?.to_bytes().to_vec();
+    Ok((status, headers, body))
+}
+
+async fn read_captures(path: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+    let deadline = std::time::Instant::now() + startup_timeout();
+    loop {
+        if let Ok(content) = tokio::fs::read_to_string(path).await {
+            let lines: Vec<serde_json::Value> = content
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .filter_map(|l| serde_json::from_str(l).ok())
+                .collect();
+            if !lines.is_empty() {
+                return Ok(lines);
+            }
+        }
+        if std::time::Instant::now() > deadline {
+            anyhow::bail!("capture not written within timeout");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn upstream_h3_forwards_with_capture_parity_and_strips_connection_field() -> anyhow::Result<()>
+{
+    let pki = gen_test_pki()?;
+
+    // Persist the CA PEM so the proxy can load it as an extra trust root.
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let (origin_addr, captured, origin_handle) = start_h3_origin(&pki)?;
+    let origin_authority = origin_addr.to_string();
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![origin_authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // `keep-alive` is a connection-specific field (RFC 9114 §4.2) that must be
+    // stripped before the H3 request; `x-forward-me` is an ordinary field that
+    // must survive, proving parity with the H1/H2 forward.
+    let (status, headers, body) = proxy_get(
+        proxy_addr,
+        &origin_authority,
+        "/hello",
+        &[("keep-alive", "timeout=5"), ("x-forward-me", "yes")],
+    )
+    .await?;
+
+    assert_eq!(status, 200, "proxy should relay the origin's 200");
+    assert_eq!(body, b"world");
+    assert!(
+        headers.iter().any(|(k, v)| k == "x-origin" && v == "h3"),
+        "origin's x-origin header should reach the client: {headers:?}"
+    );
+
+    // The origin received the forwarded request: ordinary field kept, the
+    // connection-specific field stripped.
+    let origin_headers = captured
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("origin should have recorded the forwarded request headers");
+    assert!(
+        origin_headers
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case("x-forward-me") && v == "yes"),
+        "x-forward-me should be forwarded to the H3 origin: {origin_headers:?}"
+    );
+    assert!(
+        !origin_headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("keep-alive")),
+        "keep-alive (connection-specific, RFC 9114 §4.2) must be stripped: {origin_headers:?}"
+    );
+
+    // Capture parity: the transaction records the origin leg as HTTP/3 while the
+    // client leg stays HTTP/1.1 (each hop's version recorded independently).
+    let caps = read_captures(&captures_path).await?;
+    let v = &caps[0];
+    assert_eq!(v["response"]["status"].as_u64(), Some(200));
+    assert_eq!(
+        v["response"]["version"].as_str(),
+        Some("HTTP/3"),
+        "upstream (origin) leg should be recorded as HTTP/3"
+    );
+    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/1.1"));
+
+    // Cleanup
+    proxy_handle.abort();
+    origin_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_disabled_authority_uses_h1_path() -> anyhow::Result<()> {
+    // An origin *not* on the allowlist takes the ordinary H1/H2 client. Use an
+    // H1 wiremock origin and assert the recorded upstream version is HTTP/1.1,
+    // confirming the H3 branch is gated by the allowlist.
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plain"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("h1"))
+        .mount(&mock)
+        .await;
+
+    let mut cfg = Config::default();
+    // H3 upstream is enabled but the mock's authority is not on the allowlist.
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec!["somewhere-else.example:443".to_string()];
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let mock_authority = format!("127.0.0.1:{}", mock.address().port());
+    let (status, _headers, body) = proxy_get(proxy_addr, &mock_authority, "/plain", &[]).await?;
+    assert_eq!(status, 200);
+    assert_eq!(body, b"h1");
+
+    let caps = read_captures(&captures_path).await?;
+    let v = &caps[0];
+    assert_eq!(
+        v["response"]["version"].as_str(),
+        Some("HTTP/1.1"),
+        "non-allowlisted authority should use the H1/H2 client, not H3"
+    );
+
+    proxy_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    Ok(())
+}

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -81,6 +81,19 @@ fn gen_test_pki_san(san: rcgen::SanType) -> anyhow::Result<TestPki> {
 /// Captured request headers the origin saw, for the field-discipline assertions.
 type CapturedHeaders = Arc<Mutex<Option<Vec<(String, String)>>>>;
 
+/// Build a QUIC server endpoint for the in-process H3 origin, using `pki`'s leaf
+/// cert and ALPN `h3`.
+fn h3_server_endpoint(pki: &TestPki, bind: SocketAddr) -> anyhow::Result<quinn::Endpoint> {
+    let mut tls = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![pki.leaf_cert.clone()], pki.leaf_key.clone_key())?;
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+    let quic = quinn::crypto::rustls::QuicServerConfig::try_from(tls)
+        .map_err(|e| anyhow::anyhow!("origin QUIC server config: {e}"))?;
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic));
+    Ok(quinn::Endpoint::server(server_config, bind)?)
+}
+
 /// Start an in-process HTTP/3 origin that replies `200` `"world"` with an
 /// `x-origin: h3` header and records the request headers it received. Returns
 /// its UDP address, the captured-headers handle, and the accept-loop task.
@@ -88,15 +101,7 @@ fn start_h3_origin(
     pki: &TestPki,
     bind: SocketAddr,
 ) -> anyhow::Result<(SocketAddr, CapturedHeaders, tokio::task::JoinHandle<()>)> {
-    let mut tls = rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(vec![pki.leaf_cert.clone()], pki.leaf_key.clone_key())?;
-    tls.alpn_protocols = vec![b"h3".to_vec()];
-
-    let quic = quinn::crypto::rustls::QuicServerConfig::try_from(tls)
-        .map_err(|e| anyhow::anyhow!("origin QUIC server config: {e}"))?;
-    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic));
-    let endpoint = quinn::Endpoint::server(server_config, bind)?;
+    let endpoint = h3_server_endpoint(pki, bind)?;
     let addr = endpoint.local_addr()?;
 
     let captured: CapturedHeaders = Arc::new(Mutex::new(None));
@@ -609,6 +614,168 @@ async fn upstream_h3_discovered_endpoint_with_wrong_cert_is_not_used() -> anyhow
 
     proxy_handle.abort();
     e_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+/// An H3 origin that counts accepted QUIC connections and serves `200`/"world"
+/// for every request stream (multiplexed), so a test can assert that pooling
+/// reuses one connection across requests.
+fn start_h3_origin_counting(
+    pki: &TestPki,
+    bind: SocketAddr,
+) -> anyhow::Result<(SocketAddr, Arc<AtomicUsize>, tokio::task::JoinHandle<()>)> {
+    let endpoint = h3_server_endpoint(pki, bind)?;
+    let addr = endpoint.local_addr()?;
+    let conns = Arc::new(AtomicUsize::new(0));
+    let conns_loop = conns.clone();
+    let handle = tokio::spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            conns_loop.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let Ok(conn) = incoming.await else { return };
+                let Ok(mut h3) =
+                    h3::server::Connection::<_, Bytes>::new(h3_quinn::Connection::new(conn)).await
+                else {
+                    return;
+                };
+                while let Ok(Some(resolver)) = h3.accept().await {
+                    tokio::spawn(async move {
+                        if let Ok((_req, mut stream)) = resolver.resolve_request().await {
+                            let resp = http::Response::builder().status(200).body(()).unwrap();
+                            let _ = stream.send_response(resp).await;
+                            let _ = stream.send_data(Bytes::from_static(b"world")).await;
+                            let _ = stream.finish().await;
+                        }
+                    });
+                }
+            });
+        }
+    });
+    Ok((addr, conns, handle))
+}
+
+/// An H3 origin that counts accepted connections, serves exactly one request per
+/// connection, then sends GOAWAY (via `shutdown`) refusing further streams — so
+/// a reused pooled connection is refused and the proxy must retry on a fresh one.
+fn start_h3_origin_goaway(
+    pki: &TestPki,
+    bind: SocketAddr,
+) -> anyhow::Result<(SocketAddr, Arc<AtomicUsize>, tokio::task::JoinHandle<()>)> {
+    let endpoint = h3_server_endpoint(pki, bind)?;
+    let addr = endpoint.local_addr()?;
+    let conns = Arc::new(AtomicUsize::new(0));
+    let conns_loop = conns.clone();
+    let handle = tokio::spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            conns_loop.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let Ok(conn) = incoming.await else { return };
+                let Ok(mut h3) =
+                    h3::server::Connection::<_, Bytes>::new(h3_quinn::Connection::new(conn)).await
+                else {
+                    return;
+                };
+                if let Ok(Some(resolver)) = h3.accept().await {
+                    if let Ok((_req, mut stream)) = resolver.resolve_request().await {
+                        let resp = http::Response::builder().status(200).body(()).unwrap();
+                        let _ = stream.send_response(resp).await;
+                        let _ = stream.send_data(Bytes::from_static(b"world")).await;
+                        let _ = stream.finish().await;
+                    }
+                }
+                // GOAWAY allowing the request just served (grace = 1) but refusing
+                // any further stream; keep the connection alive briefly so it is
+                // the GOAWAY — not a connection close — that refuses the retry.
+                let _ = h3.shutdown(1).await;
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            });
+        }
+    });
+    Ok((addr, conns, handle))
+}
+
+#[tokio::test]
+async fn upstream_h3_pool_reuses_one_connection_across_requests() -> anyhow::Result<()> {
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_pool_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let (origin_addr, conns, origin_handle) =
+        start_h3_origin_counting(&pki, "127.0.0.1:0".parse()?)?;
+    let authority = origin_addr.to_string();
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // Three sequential requests to the same origin should share one pooled
+    // QUIC connection.
+    for _ in 0..3 {
+        let (status, _h, body) = proxy_get(proxy_addr, &authority, "/p", &[]).await?;
+        assert_eq!(status, 200);
+        assert_eq!(body, b"world");
+    }
+
+    assert_eq!(
+        conns.load(Ordering::SeqCst),
+        1,
+        "three requests should reuse a single pooled H3 connection"
+    );
+
+    proxy_handle.abort();
+    origin_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_goaway_refused_request_is_retried_on_fresh_connection() -> anyhow::Result<()> {
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_goaway_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let (origin_addr, conns, origin_handle) = start_h3_origin_goaway(&pki, "127.0.0.1:0".parse()?)?;
+    let authority = origin_addr.to_string();
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // First request opens and pools a connection; the origin GOAWAYs it after
+    // serving. The second request reuses the pooled connection, is refused, and
+    // must be retried on a fresh connection — so both succeed and the origin
+    // accepts a second connection.
+    let (s1, _h1, b1) = proxy_get(proxy_addr, &authority, "/g", &[]).await?;
+    assert_eq!(s1, 200);
+    assert_eq!(b1, b"world");
+
+    // Let the origin's GOAWAY reach the pooled connection before reusing it.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (s2, _h2, b2) = proxy_get(proxy_addr, &authority, "/g", &[]).await?;
+    assert_eq!(
+        s2, 200,
+        "the GOAWAY-refused request is retried on a fresh connection"
+    );
+    assert_eq!(b2, b"world");
+
+    assert!(
+        conns.load(Ordering::SeqCst) >= 2,
+        "a second connection is opened to retry the refused request, got {}",
+        conns.load(Ordering::SeqCst)
+    );
+
+    proxy_handle.abort();
+    origin_handle.abort();
     let _ = tokio::fs::remove_file(&captures_path).await;
     let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -38,9 +38,15 @@ struct TestPki {
 /// H3 upstream client (configured to trust the CA) validates the origin's
 /// endpoint certificate for its authority.
 fn gen_test_pki() -> anyhow::Result<TestPki> {
+    use rcgen::SanType;
+    gen_test_pki_san(SanType::IpAddress(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))))
+}
+
+/// Like [`gen_test_pki`] but with a caller-chosen SAN, so a test can mint a leaf
+/// that is *not* valid for 127.0.0.1 (to exercise the cert-for-origin gate).
+fn gen_test_pki_san(san: rcgen::SanType) -> anyhow::Result<TestPki> {
     use rcgen::{
-        BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, SanType,
-        PKCS_ECDSA_P256_SHA256,
+        BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, PKCS_ECDSA_P256_SHA256,
     };
 
     let mut ca_params = CertificateParams::new(Vec::new())?;
@@ -53,11 +59,10 @@ fn gen_test_pki() -> anyhow::Result<TestPki> {
     let ca_pem = ca_cert.pem();
 
     let mut leaf_params = CertificateParams::new(Vec::new())?;
-    leaf_params.subject_alt_names =
-        vec![SanType::IpAddress(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))];
+    leaf_params.subject_alt_names = vec![san];
     leaf_params
         .distinguished_name
-        .push(DnType::CommonName, "127.0.0.1");
+        .push(DnType::CommonName, "lint-http upstream-h3 test leaf");
     let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
 
     let issuer = Issuer::new(ca_params, ca_key);
@@ -81,6 +86,7 @@ type CapturedHeaders = Arc<Mutex<Option<Vec<(String, String)>>>>;
 /// its UDP address, the captured-headers handle, and the accept-loop task.
 fn start_h3_origin(
     pki: &TestPki,
+    bind: SocketAddr,
 ) -> anyhow::Result<(SocketAddr, CapturedHeaders, tokio::task::JoinHandle<()>)> {
     let mut tls = rustls::ServerConfig::builder()
         .with_no_client_auth()
@@ -90,7 +96,7 @@ fn start_h3_origin(
     let quic = quinn::crypto::rustls::QuicServerConfig::try_from(tls)
         .map_err(|e| anyhow::anyhow!("origin QUIC server config: {e}"))?;
     let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic));
-    let endpoint = quinn::Endpoint::server(server_config, "127.0.0.1:0".parse()?)?;
+    let endpoint = quinn::Endpoint::server(server_config, bind)?;
     let addr = endpoint.local_addr()?;
 
     let captured: CapturedHeaders = Arc::new(Mutex::new(None));
@@ -203,7 +209,7 @@ async fn upstream_h3_forwards_with_capture_parity_and_strips_connection_field() 
         std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
-    let (origin_addr, captured, origin_handle) = start_h3_origin(&pki)?;
+    let (origin_addr, captured, origin_handle) = start_h3_origin(&pki, "127.0.0.1:0".parse()?)?;
     let origin_authority = origin_addr.to_string();
 
     let mut cfg = Config::default();
@@ -466,6 +472,143 @@ async fn upstream_h3_non_idempotent_not_retried_after_midflight_failure() -> any
     proxy_handle.abort();
     h3_origin.abort();
     h1_origin.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+/// Reserve an ephemeral UDP port, then release it so a caller can bind it.
+fn reserve_udp_port() -> anyhow::Result<u16> {
+    let s = std::net::UdpSocket::bind("127.0.0.1:0")?;
+    let port = s.local_addr()?.port();
+    drop(s);
+    Ok(port)
+}
+
+#[tokio::test]
+async fn upstream_h3_discovered_via_alt_svc_is_used_on_next_request() -> anyhow::Result<()> {
+    // An H1 origin advertises H3 via Alt-Svc. The first request goes H1 (nothing
+    // discovered yet) and populates the discovery cache; the second request is
+    // routed over H3 to the advertised endpoint.
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_disc_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    // The advertised H3 endpoint (serves "world" over H3), bound to a known port.
+    let port_e = reserve_udp_port()?;
+    let (_e_addr, _captured, e_handle) =
+        start_h3_origin(&pki, format!("127.0.0.1:{port_e}").parse()?)?;
+
+    // The H1 origin advertises `h3=":port_e"` (same host, the H3 port).
+    let mock = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/d"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("h1")
+                .insert_header("alt-svc", format!("h3=\":{port_e}\"; ma=3600").as_str()),
+        )
+        .mount(&mock)
+        .await;
+    let authority = format!("127.0.0.1:{}", mock.address().port());
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    // No allowlist: H3 is reached purely through Alt-Svc discovery.
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // First request: H1 (wiremock), which advertises Alt-Svc.
+    let (s1, _h1, b1) = proxy_get(proxy_addr, &authority, "/d", &[]).await?;
+    assert_eq!(s1, 200);
+    assert_eq!(b1, b"h1", "first request is served by the H1 origin");
+
+    // Second request: discovered → H3 endpoint, which answers "world".
+    let (s2, _h2, b2) = proxy_get(proxy_addr, &authority, "/d", &[]).await?;
+    assert_eq!(s2, 200);
+    assert_eq!(
+        b2, b"world",
+        "second request is served over H3 (discovered)"
+    );
+
+    let caps = read_captures(&captures_path).await?;
+    let versions: Vec<&str> = caps
+        .iter()
+        .filter_map(|v| v["response"]["version"].as_str())
+        .collect();
+    assert!(
+        versions.contains(&"HTTP/3"),
+        "a request should have been forwarded over H3 after discovery: {versions:?}"
+    );
+
+    proxy_handle.abort();
+    e_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_discovered_endpoint_with_wrong_cert_is_not_used() -> anyhow::Result<()> {
+    // The discovered H3 endpoint presents a (trusted-CA) certificate that is
+    // valid for "wrong.example", NOT for the origin's 127.0.0.1 authority. Per
+    // RFC 7838 §2.1 the mapping must not be used: the H3 handshake fails the
+    // name check and the proxy falls back to H1, leaving the H3 endpoint unused.
+    use rcgen::SanType;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Leaf valid for "wrong.example" only.
+    let pki = gen_test_pki_san(SanType::DnsName("wrong.example".try_into()?))?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_disc_badca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let port_e = reserve_udp_port()?;
+    let (_e_addr, e_captured, e_handle) =
+        start_h3_origin(&pki, format!("127.0.0.1:{port_e}").parse()?)?;
+
+    let mock = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/w"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("h1-origin")
+                .insert_header("alt-svc", format!("h3=\":{port_e}\"; ma=3600").as_str()),
+        )
+        .mount(&mock)
+        .await;
+    let authority = format!("127.0.0.1:{}", mock.address().port());
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    cfg.general.h3_upstream_connect_timeout_ms = 2000;
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // First request populates discovery; second would use H3 but the cert is
+    // not valid for the origin, so it falls back to H1.
+    let (s1, _h1, _b1) = proxy_get(proxy_addr, &authority, "/w", &[]).await?;
+    assert_eq!(s1, 200);
+    let (s2, _h2, b2) = proxy_get(proxy_addr, &authority, "/w", &[]).await?;
+    assert_eq!(s2, 200, "the request still succeeds by falling back to H1");
+    assert_eq!(
+        b2, b"h1-origin",
+        "served by the H1 origin, not the H3 endpoint"
+    );
+
+    // The H3 endpoint never served a request: its cert failed the origin-name
+    // check during the handshake, before any request was sent.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(
+        e_captured.lock().unwrap().is_none(),
+        "an endpoint whose cert is not valid for the origin must not be used"
+    );
+
+    proxy_handle.abort();
+    e_handle.abort();
     let _ = tokio::fs::remove_file(&captures_path).await;
     let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -16,8 +16,10 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use bytes::Bytes;
-use http_body_util::{BodyExt, Empty};
+use http_body_util::{BodyExt, Empty, Full};
 use hyper_util::rt::TokioIo;
 
 use lint_http::config::Config;
@@ -305,5 +307,166 @@ async fn upstream_h3_disabled_authority_uses_h1_path() -> anyhow::Result<()> {
 
     proxy_handle.abort();
     let _ = tokio::fs::remove_file(&captures_path).await;
+    Ok(())
+}
+
+/// Send one HTTP/1.1 POST to the proxy, returning status and response body.
+async fn proxy_post(
+    proxy_addr: SocketAddr,
+    origin_authority: &str,
+    path: &str,
+    body: &[u8],
+) -> anyhow::Result<(u16, Vec<u8>)> {
+    let stream = tokio::net::TcpStream::connect(proxy_addr).await?;
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream)).await?;
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let req = hyper::Request::builder()
+        .method("POST")
+        .uri(format!("http://{origin_authority}{path}"))
+        .header("host", origin_authority)
+        .body(Full::new(Bytes::copy_from_slice(body)))?;
+    let resp = sender.send_request(req).await?;
+    let status = resp.status().as_u16();
+    let body = resp.into_body().collect().await?.to_bytes().to_vec();
+    Ok((status, body))
+}
+
+#[tokio::test]
+async fn upstream_h3_connect_failure_falls_back_to_h1() -> anyhow::Result<()> {
+    // The allowlisted authority has an H1 origin (wiremock, TCP) but *no* H3
+    // endpoint on the matching UDP port. The H3 attempt fails at connect
+    // (pre-request), so the proxy falls back to H1/H2 and the request succeeds —
+    // and the capture records the leg actually used as HTTP/1.1.
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/fb"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("fell-back"))
+        .mount(&mock)
+        .await;
+
+    let authority = format!("127.0.0.1:{}", mock.address().port());
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    // Keep the failed-connect wait short so the fall-back is prompt.
+    cfg.general.h3_upstream_connect_timeout_ms = 1500;
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let (status, _headers, body) = proxy_get(proxy_addr, &authority, "/fb", &[]).await?;
+    assert_eq!(status, 200, "the H1 fall-back should succeed");
+    assert_eq!(body, b"fell-back");
+
+    let caps = read_captures(&captures_path).await?;
+    let v = &caps[0];
+    assert_eq!(
+        v["response"]["version"].as_str(),
+        Some("HTTP/1.1"),
+        "a fall-back records the leg actually used (H1), not H3"
+    );
+
+    proxy_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_non_idempotent_not_retried_after_midflight_failure() -> anyhow::Result<()> {
+    // A POST (non-idempotent) whose H3 attempt fails *after* the handshake — the
+    // origin accepts the connection and reads the request, then drops without
+    // responding — must NOT be retried on H1/H2 (RFC 9110 §9.2.2). We prove it
+    // by running a working H1 origin on the same authority's TCP port and
+    // asserting it is never hit while the client gets a 502.
+    use tokio::io::AsyncWriteExt;
+
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    // Reserve a port that both the UDP (H3) origin and the TCP (H1) origin bind.
+    let reserved = std::net::UdpSocket::bind("127.0.0.1:0")?;
+    let port = reserved.local_addr()?.port();
+    drop(reserved);
+    let authority = format!("127.0.0.1:{port}");
+    let bind: SocketAddr = authority.parse()?;
+
+    // H3 origin: completes the handshake, reads one request, then drops the
+    // connection without responding — a mid-flight failure for the proxy.
+    let mut tls = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![pki.leaf_cert.clone()], pki.leaf_key.clone_key())?;
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+    let quic = quinn::crypto::rustls::QuicServerConfig::try_from(tls)
+        .map_err(|e| anyhow::anyhow!("origin QUIC server config: {e}"))?;
+    let server_config = quinn::ServerConfig::with_crypto(Arc::new(quic));
+    let h3_endpoint = quinn::Endpoint::server(server_config, bind)?;
+    let h3_origin = tokio::spawn(async move {
+        while let Some(incoming) = h3_endpoint.accept().await {
+            tokio::spawn(async move {
+                let Ok(conn) = incoming.await else { return };
+                let Ok(mut h3) =
+                    h3::server::Connection::<_, Bytes>::new(h3_quinn::Connection::new(conn)).await
+                else {
+                    return;
+                };
+                // Read one request, then return — dropping `h3` closes the
+                // connection so the proxy's response read fails mid-flight.
+                if let Ok(Some(resolver)) = h3.accept().await {
+                    let _ = resolver.resolve_request().await;
+                }
+            });
+        }
+    });
+
+    // H1 origin on the same TCP port: records every hit; would return 200 if the
+    // proxy (incorrectly) fell back.
+    let h1_hits = Arc::new(AtomicUsize::new(0));
+    let h1_hits_srv = h1_hits.clone();
+    let tcp = tokio::net::TcpListener::bind(bind).await?;
+    let h1_origin = tokio::spawn(async move {
+        while let Ok((mut sock, _)) = tcp.accept().await {
+            h1_hits_srv.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nh1")
+                    .await;
+            });
+        }
+    });
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    cfg.general.h3_upstream_connect_timeout_ms = 3000;
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let (status, _body) = proxy_post(proxy_addr, &authority, "/x", b"payload").await?;
+    assert_eq!(
+        status, 502,
+        "a mid-flight H3 failure of a non-idempotent method surfaces as 502"
+    );
+
+    // Give any (erroneous) fall-back a chance to land before asserting it didn't.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        h1_hits.load(Ordering::SeqCst),
+        0,
+        "a non-idempotent POST must not be retried on H1 after a mid-flight H3 failure"
+    );
+
+    proxy_handle.abort();
+    h3_origin.abort();
+    h1_origin.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1014,7 +1014,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 308
+      line: 349
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1014,7 +1014,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 280
+      line: 308
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1014,7 +1014,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 349
+      line: 358
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs


### PR DESCRIPTION
Forward to origins over H3, fall back to H1/H2 with a negative cache, discover H3 origins from Alt-Svc (cert-gated), pool/reuse upstream connections.

