### PR TITLE
HTTP/3 upstream

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -54,9 +54,15 @@ captures_include_body = false
 # Extra CA PEM files to trust for origin H3 endpoint certificates (private CAs),
 # in addition to the platform trust store.
 # h3_upstream_extra_ca_certs = ["/etc/lint-http/origin-ca.pem"]
-# Timeout (ms) for the H3 upstream connect/handshake and response head before
-# falling back to H1/H2. Default: 5000.
+# Timeout (ms) for the H3 upstream connect/handshake before falling back to
+# H1/H2. Default: 5000.
 # h3_upstream_connect_timeout_ms = 5000
+# Timeout (ms) for the H3 upstream response head (first origin byte) once the
+# request is sent. Bounded separately from the connect timeout — this is origin
+# think-time, so it is set far more generously to avoid dropping a slow-but-
+# healthy origin. An idempotent bodyless request that hits it is retried on
+# H1/H2; anything else returns 502. Default: 30000.
+# h3_upstream_response_timeout_ms = 30000
 # Base backoff (seconds) for the H3 negative cache: after a connect/handshake
 # failure an origin is not retried over H3 until this window (doubling per
 # consecutive failure) passes. Default: 30.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,39 @@ suppress_headers = []             # Headers to suppress from server responses
 - **passthrough_domains**: A list of domains (e.g., `["bank.com"]`) that should not be intercepted. Traffic to these domains will be tunneled opaque.
 - **suppress_headers**: A list of response headers to remove before sending to the client (e.g., `["Strict-Transport-Security"]` to prevent HSTS issues during testing).
 
+### HTTP/3 Upstream (Optional)
+
+By default the proxy forwards to origins over HTTP/1.1 or HTTP/2 (the hyper client). It can additionally forward the *proxy → origin* leg over **HTTP/3 (QUIC)** so that leg is exercised and linted like any other traffic. Selection is **capability-driven**: HTTP/3 is used for an origin when it is on the allowlist or has been discovered via `Alt-Svc`, and the proxy transparently falls back to HTTP/1.1/HTTP/2 when HTTP/3 is unavailable. These live in the `[general]` section and are all optional (the feature is off unless `h3_upstream_enabled = true`).
+
+```toml
+[general]
+h3_upstream_enabled = false                       # Master switch. Default: false
+h3_upstream_authorities = ["origin.example:443"]  # Origins always tried over H3 (pre-seeds discovery)
+h3_upstream_denylist = ["legacy.example:443"]     # Origins that must never use H3
+h3_upstream_trust_alt_svc = true                  # Learn H3 endpoints from origin Alt-Svc headers. Default: true
+h3_upstream_bind = "0.0.0.0:0"                    # UDP bind address for the H3 client. Default: "0.0.0.0:0"
+h3_upstream_extra_ca_certs = []                   # Extra CA PEM files to trust for origin H3 endpoint certs
+h3_upstream_connect_timeout_ms = 5000             # Connect + QUIC handshake budget. Default: 5000
+h3_upstream_response_timeout_ms = 30000           # Response-head (first byte) budget. Default: 30000
+h3_upstream_negative_ttl_seconds = 30             # Base backoff after an H3 failure. Default: 30
+h3_upstream_pool_idle_ms = 25000                  # Idle time before a pooled H3 connection is evicted. Default: 25000
+h3_upstream_pool_max = 256                        # Max pooled H3 connections (one per origin). Default: 256
+```
+
+- **h3_upstream_enabled**: Master switch. When `false` (default), every origin uses the HTTP/1.1/HTTP/2 client and none of the settings below have any effect.
+- **h3_upstream_authorities**: Origin authorities (`host:port`) always attempted over HTTP/3. This pre-seeds selection — the *first* request to an origin cannot have learned `Alt-Svc` yet, so without an allowlist entry HTTP/3 is inherently second-connection-onward. The port is optional and defaults to `443`, and matching is case-insensitive, so `example.com` and `example.com:443` are equivalent.
+- **h3_upstream_denylist**: Origin authorities that must **never** use HTTP/3, overriding both the allowlist and `Alt-Svc` discovery. Same `host[:port]` normalization as the allowlist.
+- **h3_upstream_trust_alt_svc**: When `true` (default), an origin's `Alt-Svc: h3=...` response header adds an HTTP/3 route for that origin at runtime (honoring `ma`/`clear`). A discovered endpoint is only *used* once its certificate validates **for the origin authority** (RFC 7838 §2.1 / RFC 9114 §3.3) — a mismatched cert fails the handshake and the proxy falls back. Set `false` to route HTTP/3 solely from `h3_upstream_authorities`.
+- **h3_upstream_bind**: The local UDP socket the HTTP/3 client binds. Default `"0.0.0.0:0"` (any interface, ephemeral port).
+- **h3_upstream_extra_ca_certs**: Extra CA PEM files (private CAs) to trust when validating origin HTTP/3 endpoint certificates, layered on top of the system roots. Useful for an internal origin under test.
+- **h3_upstream_connect_timeout_ms**: How long to wait for the QUIC connect + handshake before treating the attempt as failed and falling back to HTTP/1.1/HTTP/2 (default: 5000).
+- **h3_upstream_response_timeout_ms**: How long to wait for the origin's **response head** (first byte) once the request has been sent (default: 30000). This is origin think-time, bounded separately from — and far more generously than — the connect timeout so a slow-but-healthy origin is not dropped. An idempotent, bodyless request that hits this timeout is retried on HTTP/1.1/HTTP/2 (RFC 9110 §9.2.2); anything else returns `502`.
+- **h3_upstream_negative_ttl_seconds**: After a connect/handshake failure, an origin is not retried over HTTP/3 for this window (doubling per consecutive failure, capped), so a non-HTTP/3 origin is not probed on every request (default: 30). A successful HTTP/3 exchange clears the entry immediately. A response-head timeout does **not** negative-cache — the origin is healthy, just slow.
+- **h3_upstream_pool_idle_ms**: How long a pooled HTTP/3 connection may sit idle before eviction (default: 25000). Kept below the QUIC idle timeout so only still-live connections are reused.
+- **h3_upstream_pool_max**: Maximum pooled HTTP/3 connections, one per origin authority; the least-recently-used is evicted past this (default: 256).
+
+Which leg served each request is recorded in the capture: `response.version` is `HTTP/3` when the origin leg used HTTP/3, or `HTTP/1.1`/`HTTP/2` when it fell back. Enable `debug`-level logging to see per-request selection (H3 chosen, negative-cache suppression, pool reuse vs. fresh connect, and fallbacks).
+
 ### Lint Rules Configuration
 
 The `[rules]` section allows you to enable, disable, or configure specific lint rules. If a rule is omitted, it defaults to `false` (disabled).

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -205,7 +205,7 @@ Generated index of every rule in the catalogue. Each entry links to the per-rule
 ## Protocol Rules
 
 - [server_quic_transport_parameters](rules/server_quic_transport_parameters.md) — Validates that QUIC transport parameters negotiated during the handshake are reasonable for HTTP/3 usage.  This rule inspects protocol-level `QuicTransportParams` events and checks:
-- [stateful_http3_goaway_semantics](rules/stateful_http3_goaway_semantics.md) — Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  This rule inspects protocol-level events and checks:
+- [stateful_http3_goaway_semantics](rules/stateful_http3_goaway_semantics.md) — Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  A GOAWAY's identifier depends on who sent it: a server sends a client-initiated request stream ID, a client sends a push ID (RFC 9114 §5.2), so the checks below are scoped by sender.  This rule inspects protocol-level events and checks:
 - [stateful_http3_max_push_id](rules/stateful_http3_max_push_id.md) — Validates HTTP/3 `MAX_PUSH_ID` frame semantics across the lifetime of a connection.  This rule inspects protocol-level events emitted by the HTTP/3 control-stream parser and checks:
 - [stateful_http3_settings_frame](rules/stateful_http3_settings_frame.md) — Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:
 - [stateful_websocket_frame_opcode_sequence](rules/stateful_websocket_frame_opcode_sequence.md) — Validates message-level opcode sequencing rules for WebSocket frames observed during relay.  This rule inspects each frame event and checks:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -204,7 +204,7 @@ Generated index of every rule in the catalogue. Each entry links to the per-rule
 
 ## Protocol Rules
 
-- [server_quic_transport_parameters](rules/server_quic_transport_parameters.md) — Validates that QUIC transport parameters negotiated during the handshake are reasonable for HTTP/3 usage.  This rule inspects protocol-level `QuicTransportParams` events and checks:
+- [server_quic_transport_parameters](rules/server_quic_transport_parameters.md) — Validates that the QUIC transport parameters advertised for HTTP/3 are reasonable. The proxy emits a `QuicTransportParams` event for the parameters **it advertises on its own client-facing HTTP/3 endpoint**, and this rule checks those. It does **not** validate a remote origin's parameters on the upstream leg: the QUIC stack exposes no way to read a peer's transport parameters, so an origin's are not observable and go unchecked here. The checks:
 - [stateful_http3_goaway_semantics](rules/stateful_http3_goaway_semantics.md) — Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  A GOAWAY's identifier depends on who sent it: a server sends a client-initiated request stream ID, a client sends a push ID (RFC 9114 §5.2), so the checks below are scoped by sender.  This rule inspects protocol-level events and checks:
 - [stateful_http3_max_push_id](rules/stateful_http3_max_push_id.md) — Validates HTTP/3 `MAX_PUSH_ID` frame semantics across the lifetime of a connection.  This rule inspects protocol-level events emitted by the HTTP/3 control-stream parser and checks:
 - [stateful_http3_settings_frame](rules/stateful_http3_settings_frame.md) — Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:

--- a/docs/rules/server_quic_transport_parameters.md
+++ b/docs/rules/server_quic_transport_parameters.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: ISC
 
 ## Description
 
-Validates that QUIC transport parameters negotiated during the handshake are reasonable for HTTP/3 usage.  This rule inspects protocol-level `QuicTransportParams` events and checks:
+Validates that the QUIC transport parameters advertised for HTTP/3 are reasonable. The proxy emits a `QuicTransportParams` event for the parameters **it advertises on its own client-facing HTTP/3 endpoint**, and this rule checks those. It does **not** validate a remote origin's parameters on the upstream leg: the QUIC stack exposes no way to read a peer's transport parameters, so an origin's are not observable and go unchecked here. The checks:
 
 * **Bidirectional streams allowed** — `initial_max_streams_bidi` must be non-zero so that at least one HTTP/3 request stream can be opened.
 * **Connection flow control** — `initial_max_data` must be non-zero so that data can actually be transferred.

--- a/docs/rules/stateful_http3_goaway_semantics.md
+++ b/docs/rules/stateful_http3_goaway_semantics.md
@@ -8,10 +8,10 @@ SPDX-License-Identifier: ISC
 
 ## Description
 
-Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  This rule inspects protocol-level events and checks:
+Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  A GOAWAY's identifier depends on who sent it: a server sends a client-initiated request stream ID, a client sends a push ID (RFC 9114 §5.2), so the checks below are scoped by sender.  This rule inspects protocol-level events and checks:
 
-* **GOAWAY stream ID must not increase** — when multiple GOAWAY frames are received on the same connection, the stream ID in each subsequent GOAWAY MUST NOT be greater than the previous one (RFC 9114 §5.2).
-* **No streams beyond GOAWAY limit** — after a GOAWAY frame is received, no new request streams should be opened with an ID greater than the indicated last stream ID (RFC 9114 §5.2).
+* **GOAWAY identifier must not increase** — when multiple GOAWAY frames are received from the same peer on a connection, the identifier in each subsequent GOAWAY MUST NOT be greater than the previous one (RFC 9114 §5.2).
+* **No request streams beyond a server GOAWAY limit** — after a *server* GOAWAY (whose identifier is a request stream ID), no new request stream should be opened with an ID greater than the indicated last stream ID (RFC 9114 §5.2).  A client GOAWAY carries a push ID and does not constrain request streams.
 
 ## Specifications
 

--- a/docs/rules/stateful_http3_max_push_id.md
+++ b/docs/rules/stateful_http3_max_push_id.md
@@ -10,6 +10,8 @@ SPDX-License-Identifier: ISC
 
 Validates HTTP/3 `MAX_PUSH_ID` frame semantics across the lifetime of a connection.  This rule inspects protocol-level events emitted by the HTTP/3 control-stream parser and checks:
 
+* **A server must not send `MAX_PUSH_ID`** — `MAX_PUSH_ID` is a client-only frame; a `MAX_PUSH_ID` observed from a server is a connection error of type `H3_FRAME_UNEXPECTED` (RFC 9114 §7.2.7), regardless of its value.
+
 * **MAX_PUSH_ID must not decrease** — when multiple `MAX_PUSH_ID` frames are received on the same connection, each successive value MUST be greater than or equal to the previous one.  Receipt of a smaller value is a connection error of type `H3_ID_ERROR` (RFC 9114 §7.2.7).
 
 The first `MAX_PUSH_ID` on a connection establishes the initial limit and is always accepted, regardless of value (zero is valid and means the server is not allowed to push).
@@ -44,4 +46,11 @@ severity = "warn"
 # Client sends MAX_PUSH_ID { push_id: 10 }
 # Client sends MAX_PUSH_ID { push_id: 4 }
 # Violation: MAX_PUSH_ID 4 decreased from previous 10 (RFC 9114 §7.2.7, H3_ID_ERROR)
+```
+
+### ❌ Bad (server-sent MAX_PUSH_ID)
+
+```http
+# Server sends MAX_PUSH_ID { push_id: 5 }
+# Violation: a server MUST NOT send MAX_PUSH_ID (RFC 9114 §7.2.7, H3_FRAME_UNEXPECTED)
 ```

--- a/docs/rules/stateful_http3_settings_frame.md
+++ b/docs/rules/stateful_http3_settings_frame.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: ISC
 
 Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:
 
-* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.
+* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event *from the same peer* on the connection is a violation.  Because the obligation is per peer, the other peer's SETTINGS (observable on the upstream leg) is its own legitimate first frame, not a duplicate.
 * **No reserved setting identifiers** — the `Reserved` rows of the "HTTP/3 Settings" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).
 
 * **No repeated setting identifier** — the same setting identifier MUST NOT occur more than once in the SETTINGS frame (RFC 9114 §7.2.4).  A receiver MAY treat duplicates as a connection error of type `H3_SETTINGS_ERROR`; the sender's obligation is unconditional, so a repeated identifier within one frame is a violation.

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -122,10 +122,20 @@ pub struct GeneralConfig {
     pub h3_upstream_extra_ca_certs: Vec<String>,
 
     /// How long (ms) to wait for the HTTP/3 upstream QUIC connect + handshake
-    /// (and the response head) before treating the attempt as failed and
-    /// falling back to H1/H2 (default: 5000).
+    /// before treating the attempt as failed and falling back to H1/H2
+    /// (default: 5000).
     #[serde(default = "default_h3_upstream_connect_timeout_ms")]
     pub h3_upstream_connect_timeout_ms: u64,
+
+    /// How long (ms) to wait for the HTTP/3 upstream *response head* (first byte
+    /// from the origin) once the request has been sent. This is application
+    /// think-time, not transport setup, so it is bounded separately from — and
+    /// far more generously than — the connect timeout: a slow-but-healthy origin
+    /// must not be dropped at the connect budget. An idempotent, bodyless request
+    /// that hits this timeout is retried on H1/H2 (RFC 9110 §9.2.2); anything
+    /// else surfaces a 502 (default: 30000).
+    #[serde(default = "default_h3_upstream_response_timeout_ms")]
+    pub h3_upstream_response_timeout_ms: u64,
 
     /// Base backoff (seconds) for the H3 upstream negative cache: after a
     /// connect/handshake failure an origin authority is not retried over H3
@@ -196,6 +206,10 @@ const fn default_h3_upstream_negative_ttl_seconds() -> u64 {
     30
 }
 
+const fn default_h3_upstream_response_timeout_ms() -> u64 {
+    30_000
+}
+
 const fn default_h3_upstream_trust_alt_svc() -> bool {
     true
 }
@@ -247,6 +261,7 @@ impl Default for GeneralConfig {
             h3_upstream_bind: None,
             h3_upstream_extra_ca_certs: Vec::new(),
             h3_upstream_connect_timeout_ms: default_h3_upstream_connect_timeout_ms(),
+            h3_upstream_response_timeout_ms: default_h3_upstream_response_timeout_ms(),
             h3_upstream_negative_ttl_seconds: default_h3_upstream_negative_ttl_seconds(),
             h3_upstream_pool_idle_ms: default_h3_upstream_pool_idle_ms(),
             h3_upstream_pool_max: default_h3_upstream_pool_max(),

--- a/lint-http-core/src/protocol_event.rs
+++ b/lint-http-core/src/protocol_event.rs
@@ -19,7 +19,13 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use uuid::Uuid;
 
-/// Direction of a WebSocket message relative to the proxy.
+/// Direction of a message relative to the proxy: which peer sent it. For a
+/// WebSocket frame this is the message direction; for an HTTP/3 or QUIC event it
+/// identifies the *sender's role on the observed connection* — `Client` for a
+/// frame the downstream client sent (or the proxy's own client-facing leg),
+/// `Server` for a frame an upstream origin server sent (the upstream leg). This
+/// is what lets a rule tell an origin-sent MAX_PUSH_ID (a violation, RFC 9114
+/// §7.2.7) from a client-sent one.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageDirection {
@@ -27,6 +33,13 @@ pub enum MessageDirection {
     Client,
     /// Server to client.
     Server,
+}
+
+/// Default direction for H3/QUIC events deserialized from records written
+/// before the field existed: the proxy only observed the client-facing leg
+/// then, so those events were client-sent.
+fn default_direction_client() -> MessageDirection {
+    MessageDirection::Client
 }
 
 /// A single protocol-level event observed on a connection.
@@ -68,6 +81,10 @@ pub enum ProtocolEventKind {
     H3GoawayReceived {
         /// Stream ID from the GOAWAY frame, if the h3 crate exposes it.
         stream_id: Option<u64>,
+        /// Which peer sent the GOAWAY (a server GOAWAY carries a request stream
+        /// ID; a client GOAWAY carries a push ID — RFC 9114 §5.2).
+        #[serde(default = "default_direction_client")]
+        direction: MessageDirection,
     },
 
     /// A new HTTP/3 request stream was accepted.
@@ -84,14 +101,30 @@ pub enum ProtocolEventKind {
     H3SettingsReceived {
         /// (setting_id, value) pairs.
         settings: Vec<(u64, u64)>,
+        /// Which peer sent the SETTINGS (each peer sends its own on its control
+        /// stream, so this scopes duplicate-frame checks per direction).
+        #[serde(default = "default_direction_client")]
+        direction: MessageDirection,
     },
 
     /// MAX_PUSH_ID frame received.
-    H3MaxPushId { push_id: u64 },
+    H3MaxPushId {
+        push_id: u64,
+        /// Which peer sent it — a server MUST NOT send MAX_PUSH_ID (RFC 9114
+        /// §7.2.7), so `Server` here is a violation.
+        #[serde(default = "default_direction_client")]
+        direction: MessageDirection,
+    },
 
     // ── QUIC transport-level ───────────────────────────────────────────
     /// Negotiated QUIC transport parameters after handshake.
-    QuicTransportParams { params: QuicTransportParameters },
+    QuicTransportParams {
+        params: QuicTransportParameters,
+        /// Whose parameters these are: `Client` for the proxy's own client-facing
+        /// advertisement, `Server` for an upstream origin's real parameters.
+        #[serde(default = "default_direction_client")]
+        direction: MessageDirection,
+    },
 
     /// QUIC flow-control window update.
     QuicFlowControlUpdate {
@@ -206,7 +239,10 @@ mod tests {
         let e1 = ProtocolEvent {
             timestamp: Utc::now() + chrono::Duration::seconds(1),
             connection_id: conn,
-            kind: ProtocolEventKind::H3GoawayReceived { stream_id: None },
+            kind: ProtocolEventKind::H3GoawayReceived {
+                stream_id: None,
+                direction: MessageDirection::Client,
+            },
         };
         let e2 = ProtocolEvent {
             timestamp: Utc::now(),
@@ -236,10 +272,13 @@ mod tests {
 
     #[test]
     fn serde_roundtrip_h3_goaway() {
-        let evt = make_event(ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) });
+        let evt = make_event(ProtocolEventKind::H3GoawayReceived {
+            stream_id: Some(4),
+            direction: MessageDirection::Client,
+        });
         let json = serde_json::to_string(&evt).unwrap();
         let deserialized: ProtocolEvent = serde_json::from_str(&json).unwrap();
-        if let ProtocolEventKind::H3GoawayReceived { stream_id } = deserialized.kind {
+        if let ProtocolEventKind::H3GoawayReceived { stream_id, .. } = deserialized.kind {
             assert_eq!(stream_id, Some(4));
         } else {
             panic!("unexpected variant");

--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -20,7 +20,7 @@ use std::task::{self, Poll};
 use bytes::{Buf, Bytes};
 use h3::quic;
 
-use crate::protocol_event::ProtocolEventKind;
+use crate::protocol_event::{MessageDirection, ProtocolEventKind};
 
 /// Callback type for emitting protocol events from within stream wrappers.
 pub type EventSink = Arc<dyn Fn(ProtocolEventKind) + Send + Sync>;
@@ -127,6 +127,9 @@ const H3_FRAME_SETTINGS: u64 = 0x04;
 /// HTTP/3 frame type: MAX_PUSH_ID.
 // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
 const H3_FRAME_MAX_PUSH_ID: u64 = 0x0D;
+/// HTTP/3 frame type: GOAWAY.
+// cite(RFC 9114 § 7.2.6): "The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint."
+const H3_FRAME_GOAWAY: u64 = 0x07;
 /// HTTP/3 unidirectional stream type for the control stream.
 // cite(RFC 9114 § 6.2.1): "A control stream is indicated by a stream type of 0x00."
 const H3_STREAM_TYPE_CONTROL: u64 = 0x00;
@@ -167,6 +170,9 @@ struct FrameObserver {
     frame_remaining: u64,
     payload_buf: Vec<u8>,
     sink: EventSink,
+    /// Which peer's control stream this observes — stamped on every event it
+    /// emits (`Client` for the downstream leg, `Server` for the upstream leg).
+    direction: MessageDirection,
 }
 
 impl std::fmt::Debug for FrameObserver {
@@ -180,7 +186,7 @@ impl std::fmt::Debug for FrameObserver {
 }
 
 impl FrameObserver {
-    fn new(sink: EventSink) -> Self {
+    fn new(sink: EventSink, direction: MessageDirection) -> Self {
         Self {
             state: ObserverState::ReadingStreamType,
             varint: VarIntReader::new(),
@@ -188,6 +194,7 @@ impl FrameObserver {
             frame_remaining: 0,
             payload_buf: Vec::new(),
             sink,
+            direction,
         }
     }
 
@@ -227,7 +234,8 @@ impl FrameObserver {
                         self.frame_remaining = length;
 
                         let dominated = self.frame_type == H3_FRAME_SETTINGS
-                            || self.frame_type == H3_FRAME_MAX_PUSH_ID;
+                            || self.frame_type == H3_FRAME_MAX_PUSH_ID
+                            || self.frame_type == H3_FRAME_GOAWAY;
 
                         if length == 0 && dominated {
                             self.payload_buf.clear();
@@ -270,16 +278,31 @@ impl FrameObserver {
         }
     }
 
-    /// Parse the buffered payload and emit the corresponding protocol event.
+    /// Parse the buffered payload and emit the corresponding protocol event,
+    /// stamped with the observed peer's direction.
     fn emit_frame(&mut self) {
+        let direction = self.direction;
         match self.frame_type {
             H3_FRAME_SETTINGS => {
                 let settings = self.parse_settings();
-                (self.sink)(ProtocolEventKind::H3SettingsReceived { settings });
+                (self.sink)(ProtocolEventKind::H3SettingsReceived {
+                    settings,
+                    direction,
+                });
             }
             H3_FRAME_MAX_PUSH_ID => {
                 if let Some(push_id) = parse_varint_at(&self.payload_buf, 0).map(|(v, _)| v) {
-                    (self.sink)(ProtocolEventKind::H3MaxPushId { push_id });
+                    (self.sink)(ProtocolEventKind::H3MaxPushId { push_id, direction });
+                }
+            }
+            H3_FRAME_GOAWAY => {
+                // GOAWAY carries a single varint id (request stream ID from a
+                // server, push ID from a client — RFC 9114 §7.2.6).
+                if let Some(id) = parse_varint_at(&self.payload_buf, 0).map(|(v, _)| v) {
+                    (self.sink)(ProtocolEventKind::H3GoawayReceived {
+                        stream_id: Some(id),
+                        direction,
+                    });
                 }
             }
             _ => {}
@@ -351,16 +374,24 @@ impl quic::RecvStream for InstrumentedRecvStream {
 pub struct InstrumentedConnection {
     inner: h3_quinn::Connection,
     sink: EventSink,
+    /// The peer role of this connection, stamped on every emitted event —
+    /// `Client` toward the downstream client, `Server` toward an upstream origin.
+    direction: MessageDirection,
 }
 
 impl InstrumentedConnection {
-    /// Wrap an existing [`h3_quinn::Connection`].
+    /// Wrap an existing [`h3_quinn::Connection`], observing the peer identified
+    /// by `direction`.
     ///
     /// Every unidirectional stream accepted via [`poll_accept_recv`] will be
     /// wrapped in an [`InstrumentedRecvStream`] whose frame observer emits
-    /// events through `sink`.
-    pub fn new(conn: h3_quinn::Connection, sink: EventSink) -> Self {
-        Self { inner: conn, sink }
+    /// events through `sink`, tagged with `direction`.
+    pub fn new(conn: h3_quinn::Connection, sink: EventSink, direction: MessageDirection) -> Self {
+        Self {
+            inner: conn,
+            sink,
+            direction,
+        }
     }
 }
 
@@ -398,7 +429,7 @@ impl<B: Buf> quic::Connection<B> for InstrumentedConnection {
         match <h3_quinn::Connection as quic::Connection<B>>::poll_accept_recv(&mut self.inner, cx) {
             Poll::Ready(Ok(stream)) => Poll::Ready(Ok(InstrumentedRecvStream {
                 inner: stream,
-                observer: FrameObserver::new(self.sink.clone()),
+                observer: FrameObserver::new(self.sink.clone(), self.direction),
             })),
             Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
             Poll::Pending => Poll::Pending,
@@ -561,7 +592,7 @@ mod tests {
     #[test]
     fn non_control_stream_passthrough() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
         // Stream type 0x02 (QPACK encoder) — not a control stream.
         obs.observe(&[0x02, 0xFF, 0xFF, 0xFF]);
         assert!(events.lock().unwrap().is_empty());
@@ -573,7 +604,7 @@ mod tests {
     #[test]
     fn settings_single_chunk() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Control stream type (0x00), then SETTINGS frame:
         // Frame type 0x04, length 4 (two setting pairs: id=0x06 val=0x10, id=0x01 val=0x00)
@@ -588,7 +619,7 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 1);
-        if let ProtocolEventKind::H3SettingsReceived { ref settings } = evts[0] {
+        if let ProtocolEventKind::H3SettingsReceived { ref settings, .. } = evts[0] {
             assert_eq!(settings, &[(0x06, 16), (0x01, 0)]);
         } else {
             panic!("expected H3SettingsReceived, got {:?}", evts[0]);
@@ -598,7 +629,7 @@ mod tests {
     #[test]
     fn settings_split_across_chunks() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Split the same SETTINGS frame across multiple observe() calls.
         obs.observe(&[0x00]); // stream type
@@ -609,7 +640,7 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 1);
-        if let ProtocolEventKind::H3SettingsReceived { ref settings } = evts[0] {
+        if let ProtocolEventKind::H3SettingsReceived { ref settings, .. } = evts[0] {
             assert_eq!(settings, &[(0x06, 16)]);
         } else {
             panic!("expected H3SettingsReceived");
@@ -619,14 +650,14 @@ mod tests {
     #[test]
     fn settings_empty_payload() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // SETTINGS with zero-length payload (no settings).
         obs.observe(&[0x00, 0x04, 0x00]);
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 1);
-        if let ProtocolEventKind::H3SettingsReceived { ref settings } = evts[0] {
+        if let ProtocolEventKind::H3SettingsReceived { ref settings, .. } = evts[0] {
             assert!(settings.is_empty());
         } else {
             panic!("expected H3SettingsReceived");
@@ -638,7 +669,7 @@ mod tests {
     #[test]
     fn max_push_id_frame() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Control stream, then a dummy SETTINGS (required first), then MAX_PUSH_ID.
         obs.observe(&[
@@ -651,7 +682,7 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 2); // SETTINGS + MAX_PUSH_ID
-        if let ProtocolEventKind::H3MaxPushId { push_id } = evts[1] {
+        if let ProtocolEventKind::H3MaxPushId { push_id, .. } = evts[1] {
             assert_eq!(push_id, 7);
         } else {
             panic!("expected H3MaxPushId, got {:?}", evts[1]);
@@ -663,7 +694,7 @@ mod tests {
     #[test]
     fn unknown_frame_skipped() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         obs.observe(&[
             0x00, // control stream
@@ -678,7 +709,7 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 2); // SETTINGS + MAX_PUSH_ID
-        if let ProtocolEventKind::H3MaxPushId { push_id } = evts[1] {
+        if let ProtocolEventKind::H3MaxPushId { push_id, .. } = evts[1] {
             assert_eq!(push_id, 2);
         } else {
             panic!("expected H3MaxPushId");
@@ -688,7 +719,7 @@ mod tests {
     #[test]
     fn unknown_frame_split_across_chunks() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Control stream + SETTINGS
         obs.observe(&[0x00, 0x04, 0x00]);
@@ -700,7 +731,7 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 2);
-        if let ProtocolEventKind::H3MaxPushId { push_id } = evts[1] {
+        if let ProtocolEventKind::H3MaxPushId { push_id, .. } = evts[1] {
             assert_eq!(push_id, 9);
         } else {
             panic!("expected H3MaxPushId");
@@ -712,7 +743,7 @@ mod tests {
     #[test]
     fn settings_with_2byte_varint_values() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // SETTINGS_MAX_FIELD_SECTION_SIZE (0x06) = 1000 (2-byte varint 0x43E8)
         // Payload: 0x06 (1) + 0x43,0xE8 (2) + 0x01 (1) + 0x00 (1) = 5 bytes
@@ -729,7 +760,7 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 1);
-        if let ProtocolEventKind::H3SettingsReceived { ref settings } = evts[0] {
+        if let ProtocolEventKind::H3SettingsReceived { ref settings, .. } = evts[0] {
             assert_eq!(settings, &[(0x06, 1000), (0x01, 0)]);
         } else {
             panic!("expected H3SettingsReceived");
@@ -741,7 +772,7 @@ mod tests {
     #[test]
     fn two_byte_stream_type_non_control() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Stream type 0x41 (2-byte varint for value 1 = push stream).
         obs.observe(&[0x40, 0x01, 0xFF, 0xFF]);
@@ -754,7 +785,7 @@ mod tests {
     #[test]
     fn zero_length_settings_after_nonempty_settings_emits_empty() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // First SETTINGS with one pair, then a zero-length SETTINGS.
         obs.observe(&[
@@ -767,7 +798,7 @@ mod tests {
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 2);
         // Second SETTINGS must have an empty settings vec, not stale data.
-        if let ProtocolEventKind::H3SettingsReceived { ref settings } = evts[1] {
+        if let ProtocolEventKind::H3SettingsReceived { ref settings, .. } = evts[1] {
             assert!(settings.is_empty());
         } else {
             panic!("expected H3SettingsReceived, got {:?}", evts[1]);
@@ -777,7 +808,7 @@ mod tests {
     #[test]
     fn zero_length_max_push_id_does_not_emit() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Control stream, SETTINGS (empty), then MAX_PUSH_ID with length=0.
         // A zero-length MAX_PUSH_ID has no varint to parse, so no event.
@@ -801,7 +832,7 @@ mod tests {
     #[test]
     fn oversized_settings_frame_is_skipped() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Control stream, then a SETTINGS frame claiming a payload larger
         // than MAX_BUFFERED_PAYLOAD.  The observer must skip it rather
@@ -826,7 +857,7 @@ mod tests {
     #[test]
     fn frame_after_oversized_frame_still_observed() {
         let (sink, events) = test_sink();
-        let mut obs = FrameObserver::new(sink);
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
 
         // Control stream, oversized SETTINGS (skipped), then normal MAX_PUSH_ID.
         obs.observe(&[0x00, 0x04, 0x67, 0x10]); // SETTINGS, length=10000
@@ -835,10 +866,76 @@ mod tests {
 
         let evts = events.lock().unwrap();
         assert_eq!(evts.len(), 1);
-        if let ProtocolEventKind::H3MaxPushId { push_id } = evts[0] {
+        if let ProtocolEventKind::H3MaxPushId { push_id, .. } = evts[0] {
             assert_eq!(push_id, 5);
         } else {
             panic!("expected H3MaxPushId");
+        }
+    }
+
+    // ── FrameObserver: direction tagging ─────────────────────────────
+
+    #[test]
+    fn observed_events_carry_the_configured_direction() {
+        // The same control-stream bytes tagged Server (an upstream leg) yield
+        // Server-directed events; Client yields Client-directed ones.
+        for dir in [MessageDirection::Client, MessageDirection::Server] {
+            let (sink, events) = test_sink();
+            let mut obs = FrameObserver::new(sink, dir);
+            // Control stream, SETTINGS (empty), then MAX_PUSH_ID push_id=3.
+            obs.observe(&[0x00, 0x04, 0x00, 0x0D, 0x01, 0x03]);
+            let evts = events.lock().unwrap();
+            assert_eq!(evts.len(), 2);
+            match evts[0] {
+                ProtocolEventKind::H3SettingsReceived { direction, .. } => {
+                    assert_eq!(direction, dir)
+                }
+                _ => panic!("expected SETTINGS"),
+            }
+            match evts[1] {
+                ProtocolEventKind::H3MaxPushId { direction, .. } => assert_eq!(direction, dir),
+                _ => panic!("expected MAX_PUSH_ID"),
+            }
+        }
+    }
+
+    // ── FrameObserver: GOAWAY ────────────────────────────────────────
+
+    #[test]
+    fn goaway_frame_is_parsed_with_id_and_direction() {
+        let (sink, events) = test_sink();
+        let mut obs = FrameObserver::new(sink, MessageDirection::Server);
+        // Control stream, SETTINGS (empty), then GOAWAY (type 0x07) length=1 id=8.
+        obs.observe(&[0x00, 0x04, 0x00, 0x07, 0x01, 0x08]);
+        let evts = events.lock().unwrap();
+        assert_eq!(evts.len(), 2);
+        match evts[1] {
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id,
+                direction,
+            } => {
+                assert_eq!(stream_id, Some(8));
+                assert_eq!(direction, MessageDirection::Server);
+            }
+            _ => panic!("expected a GOAWAY event, got {:?}", evts[1]),
+        }
+    }
+
+    #[test]
+    fn goaway_frame_split_across_observe_calls() {
+        let (sink, events) = test_sink();
+        let mut obs = FrameObserver::new(sink, MessageDirection::Client);
+        obs.observe(&[0x00, 0x04, 0x00]); // control stream + empty SETTINGS
+        obs.observe(&[0x07]); // GOAWAY frame type
+        obs.observe(&[0x02]); // length = 2
+        obs.observe(&[0x44, 0x00]); // 2-byte varint id = 0x0400 = 1024
+        let evts = events.lock().unwrap();
+        assert_eq!(evts.len(), 2);
+        match evts[1] {
+            ProtocolEventKind::H3GoawayReceived { stream_id, .. } => {
+                assert_eq!(stream_id, Some(1024))
+            }
+            _ => panic!("expected a GOAWAY event"),
         }
     }
 }

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -162,6 +162,17 @@ pub(super) async fn exchange(
                 // body cannot be replayed, so surface the failure as-is.
                 Err(format!("h3 upstream error: {error}"))
             }
+            Err(H3Failure::ResponseTimeout { error, replay }) => match replay {
+                // A slow (not unreachable) origin: the request was fully sent but
+                // no head came in time. Retry an idempotent bodyless request on
+                // H1/H2; do *not* negative-cache — the origin is healthy, just
+                // slow, and suppressing H3 would punish it. Anything else 502s.
+                Some(request) => {
+                    warn!(%authority, error = %error, "h3 upstream response-head timeout; retrying idempotent request via H1/H2");
+                    forward_via_hyper(shared, *request).await
+                }
+                None => Err(format!("h3 upstream response timed out: {error}")),
+            },
         }
     } else {
         forward_via_hyper(shared, upstream_req).await

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -130,7 +130,7 @@ pub(super) async fn exchange(
     let resp: Result<hyper::Response<ResponseBody>, String> = if let Some((h3, authority, route)) =
         h3_target
     {
-        match h3.forward(upstream_req, &route).await {
+        match h3.forward(upstream_req, &route, shared).await {
             Ok(r) => {
                 h3.record_success(&authority);
                 Ok(r)

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -19,7 +19,7 @@ use hyper::{HeaderMap, Method, Request, Uri};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio::time::Instant;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::state::ClientIdentifier;
@@ -122,14 +122,25 @@ pub(super) async fn exchange(
         let authority = a.as_str();
         let h3 = shared.upstream.h3.as_ref()?;
         if h3.is_suppressed(authority) {
+            debug!(%authority, "h3 upstream suppressed by negative cache; using H1/H2");
             return None;
         }
         h3.route_for(authority)
             .map(|route| (h3, authority.to_string(), route))
     });
+    if h3_target.is_none() {
+        if let Some(a) = uri.authority() {
+            // Only interesting when H3 is configured at all; otherwise this is
+            // the ordinary H1/H2 path and not worth a line per request.
+            if shared.upstream.h3.is_some() {
+                debug!(authority = %a, "no h3 route for origin; using H1/H2");
+            }
+        }
+    }
     let resp: Result<hyper::Response<ResponseBody>, String> = if let Some((h3, authority, route)) =
         h3_target
     {
+        debug!(%authority, "forwarding upstream over HTTP/3");
         match h3.forward(upstream_req, &route, shared).await {
             Ok(r) => {
                 h3.record_success(&authority);

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -177,16 +177,23 @@ async fn handle_h3_connection(
         })
     };
 
-    let instrumented =
-        crate::h3_instrument::InstrumentedConnection::new(h3_quinn::Connection::new(conn), sink);
+    // This connection faces the downstream client, so its observed control-stream
+    // frames are client-sent.
+    let instrumented = crate::h3_instrument::InstrumentedConnection::new(
+        h3_quinn::Connection::new(conn),
+        sink,
+        crate::protocol_event::MessageDirection::Client,
+    );
     let mut h3_conn = h3::server::Connection::new(instrumented).await?;
 
     // Emit the QUIC transport parameters that this server advertised
-    // during the handshake, so protocol-level rules can validate them.
+    // during the handshake, so protocol-level rules can validate them. These are
+    // the proxy's own client-facing parameters (Client leg).
     if let Some(ref params) = shared.quic_transport_params {
         emit_h3_protocol_event(
             crate::protocol_event::ProtocolEventKind::QuicTransportParams {
                 params: params.clone(),
+                direction: crate::protocol_event::MessageDirection::Client,
             },
             connection_id,
             &shared,
@@ -235,13 +242,10 @@ async fn handle_h3_connection(
                 });
             }
             Ok(None) => {
-                // Connection closed gracefully.  The h3 crate does not
-                // expose the GOAWAY stream ID, so we emit None.
-                emit_h3_protocol_event(
-                    crate::protocol_event::ProtocolEventKind::H3GoawayReceived { stream_id: None },
-                    connection_id,
-                    &shared,
-                );
+                // Connection closed gracefully. A real client GOAWAY (with its
+                // id and `Client` direction) is emitted by the frame observer on
+                // the control stream, so nothing is synthesized here — a plain
+                // close is not a GOAWAY.
                 break;
             }
             Err(e) => {

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -221,13 +221,21 @@ impl H3UpstreamClient {
         let mut endpoint = quinn::Endpoint::client(bind)?;
         endpoint.set_default_client_config(client_config);
 
+        // Canonicalize the configured authorities so an operator's intent matches
+        // a request authority whether or not either side spells out `:443`
+        // (unparseable entries are dropped).
         let authorities = cfg
             .general
             .h3_upstream_authorities
             .iter()
-            .cloned()
+            .filter_map(|a| normalize_authority(a))
             .collect();
-        let denylist = cfg.general.h3_upstream_denylist.iter().cloned().collect();
+        let denylist = cfg
+            .general
+            .h3_upstream_denylist
+            .iter()
+            .filter_map(|a| normalize_authority(a))
+            .collect();
 
         Ok(Some(Self {
             endpoint,
@@ -247,19 +255,25 @@ impl H3UpstreamClient {
     /// Whether `authority` is currently suppressed from H3 attempts by a live
     /// negative-cache backoff window.
     pub(super) fn is_suppressed(&self, authority: &str) -> bool {
+        let Some(key) = normalize_authority(authority) else {
+            return false;
+        };
         let map = self.negative.lock().unwrap();
-        map.get(authority).is_some_and(|e| e.until > Instant::now())
+        map.get(&key).is_some_and(|e| e.until > Instant::now())
     }
 
     /// Record a connect/handshake failure for `authority`, extending its
     /// backoff window (doubling per consecutive failure, capped).
     pub(super) fn record_failure(&self, authority: &str) {
+        let Some(key) = normalize_authority(authority) else {
+            return;
+        };
         let now = Instant::now();
         let mut map = self.negative.lock().unwrap();
         if map.len() >= NEGATIVE_CACHE_CAP {
             map.retain(|_, e| e.until > now);
         }
-        let entry = map.entry(authority.to_string()).or_insert(NegEntry {
+        let entry = map.entry(key).or_insert(NegEntry {
             until: now,
             failures: 0,
         });
@@ -277,7 +291,9 @@ impl H3UpstreamClient {
     /// Clear any negative-cache entry for `authority` after a successful H3
     /// exchange, so a recovered origin resumes H3 immediately.
     pub(super) fn record_success(&self, authority: &str) {
-        self.negative.lock().unwrap().remove(authority);
+        if let Some(key) = normalize_authority(authority) {
+            self.negative.lock().unwrap().remove(&key);
+        }
     }
 
     /// Resolve how to reach `authority` over HTTP/3, or `None` if it should not
@@ -286,24 +302,27 @@ impl H3UpstreamClient {
     /// the advertised endpoint. Either way the TLS name stays the origin host so
     /// the endpoint cert is validated for the origin (RFC 7838 §2.1).
     pub(super) fn route_for(&self, authority: &str) -> Option<H3Route> {
-        if self.denylist.contains(authority) {
+        // Match on the canonical key so allowlist/denylist/discovery/pool all
+        // agree regardless of whether `:443` is spelled out (host case-folded).
+        let key = normalize_authority(authority)?;
+        if self.denylist.contains(&key) {
             return None;
         }
-        let (host, port) = split_authority(authority)?;
-        if self.authorities.contains(authority) {
+        let (host, port) = split_authority(&key)?;
+        if self.authorities.contains(&key) {
             return Some(H3Route {
                 dial_host: host.clone(),
                 dial_port: port,
                 authority_host: host,
-                authority: authority.to_string(),
+                authority: key,
             });
         }
-        let (dial_host, dial_port) = self.discovered(authority)?;
+        let (dial_host, dial_port) = self.discovered(&key)?;
         Some(H3Route {
             dial_host,
             dial_port,
             authority_host: host,
-            authority: authority.to_string(),
+            authority: key,
         })
     }
 
@@ -325,6 +344,12 @@ impl H3UpstreamClient {
         if !self.trust_alt_svc {
             return;
         }
+        // Key discovery on the canonical authority so `route_for` finds it
+        // regardless of how the port was spelled on either side.
+        let Some(authority) = normalize_authority(authority) else {
+            return;
+        };
+        let authority = authority.as_str();
         let origin_host = origin_host.trim_start_matches('[').trim_end_matches(']');
         for hv in headers.get_all("alt-svc").iter() {
             let Ok(s) = hv.to_str() else { continue };
@@ -648,6 +673,24 @@ fn split_authority(authority: &str) -> Option<(String, u16)> {
         return None;
     }
     Some((host.to_string(), port))
+}
+
+/// Canonical authority key used for every H3 routing lookup: the port is
+/// defaulted to 443 (H3 is always TLS), the host is lower-cased (host
+/// comparison is case-insensitive, RFC 9110 §4.2.3), and an IPv6 literal is
+/// re-bracketed so the key round-trips through DNS/SNI unchanged. This collapses
+/// `example.com`, `example.com:443`, and `EXAMPLE.com:443` to one key so a
+/// config entry matches a request authority regardless of how the port was
+/// written. `None` when the authority cannot be parsed.
+fn normalize_authority(authority: &str) -> Option<String> {
+    let (host, port) = split_authority(authority)?;
+    let host = host.to_ascii_lowercase();
+    Some(if host.contains(':') {
+        // Bare IPv6 literal (split_authority stripped the brackets) — re-wrap it.
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    })
 }
 
 /// The routing-relevant content of an `Alt-Svc` header.
@@ -1077,6 +1120,97 @@ mod tests {
             split_authority("[::1]"),
             Some(("::1".to_string(), 443)),
             "bracketed IPv6 without a port defaults to 443, not a mis-split"
+        );
+    }
+
+    #[test]
+    fn normalize_authority_canonicalizes_port_case_and_ipv6() {
+        assert_eq!(
+            normalize_authority("example.com").as_deref(),
+            Some("example.com:443"),
+            "absent port defaults to 443"
+        );
+        assert_eq!(
+            normalize_authority("example.com:443").as_deref(),
+            Some("example.com:443"),
+            "explicit :443 is the same key as the bare host"
+        );
+        assert_eq!(
+            normalize_authority("EXAMPLE.com:8443").as_deref(),
+            Some("example.com:8443"),
+            "host is case-folded, non-443 port preserved"
+        );
+        assert_eq!(
+            normalize_authority("[::1]").as_deref(),
+            Some("[::1]:443"),
+            "IPv6 literal is re-bracketed with the default port"
+        );
+        assert_eq!(
+            normalize_authority("[::1]:8443").as_deref(),
+            Some("[::1]:8443")
+        );
+    }
+
+    #[tokio::test]
+    async fn allowlist_matches_regardless_of_port_spelling() {
+        // Configured without a port; requests may or may not carry `:443`.
+        let client = client_with(|g| {
+            g.h3_upstream_authorities = vec!["example.com".to_string()];
+        });
+        assert!(
+            client.route_for("example.com:443").is_some(),
+            "a `:443` request authority matches a no-port allowlist entry"
+        );
+        assert!(
+            client.route_for("example.com").is_some(),
+            "a no-port request authority also matches"
+        );
+        // Reciprocal: configured *with* a port, requested without.
+        let client = client_with(|g| {
+            g.h3_upstream_authorities = vec!["origin.example:443".to_string()];
+        });
+        assert!(client.route_for("origin.example").is_some());
+    }
+
+    #[tokio::test]
+    async fn denylist_matches_regardless_of_port_spelling() {
+        let client = client_with(|g| {
+            g.h3_upstream_authorities = vec!["deny.example:443".to_string()];
+            g.h3_upstream_denylist = vec!["deny.example".to_string()];
+        });
+        assert!(
+            client.route_for("deny.example:443").is_none(),
+            "a no-port denylist entry blocks a `:443` request authority"
+        );
+    }
+
+    #[tokio::test]
+    async fn discovery_matches_regardless_of_port_spelling() {
+        let client = client_with(|_| {});
+        // Advertisement recorded under the bare-host authority form.
+        client.record_alt_svc(
+            "origin.example",
+            "origin.example",
+            &alt_svc_headers(&["h3=\":8443\"; ma=3600"]),
+        );
+        let route = client
+            .route_for("origin.example:443")
+            .expect("discovery found via the `:443` form");
+        assert_eq!(route.dial_port, 8443);
+    }
+
+    #[tokio::test]
+    async fn negative_cache_normalizes_authority() {
+        let client = test_client(30);
+        client.record_failure("a.example");
+        assert!(
+            client.is_suppressed("a.example:443"),
+            "a failure recorded without a port suppresses the `:443` form"
+        );
+        client.record_success("a.example:443");
+        assert!(
+            !client.is_suppressed("a.example"),
+            "clearing the `:443` form clears the no-port form"
         );
     }
 

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -456,6 +456,7 @@ impl H3UpstreamClient {
                     && !conn.driver.is_finished();
                 if fresh {
                     *conn.last_used.lock().unwrap() = Instant::now();
+                    tracing::debug!(authority = %route.authority, "h3 upstream reusing pooled connection");
                     return Ok((conn.clone(), true));
                 }
                 pool.remove(&route.authority);
@@ -464,6 +465,7 @@ impl H3UpstreamClient {
 
         // Connect outside the lock (async); a rare concurrent race may open two
         // connections to the same origin — acceptable (§3.3 is SHOULD NOT).
+        tracing::debug!(authority = %route.authority, dial = %format!("{}:{}", route.dial_host, route.dial_port), "h3 upstream opening fresh connection");
         let conn = Arc::new(self.connect(route, shared).await?);
         let mut pool = self.pool.lock().unwrap();
         if pool.len() >= self.pool_max && !pool.contains_key(&route.authority) {

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -78,6 +78,16 @@ pub(super) enum H3Failure {
     /// The request body was already in flight; the streaming body cannot be
     /// replayed, so the caller must not retry (whatever the method).
     Consumed { error: anyhow::Error },
+    /// The request was fully sent but the origin did not produce a response head
+    /// within the response timeout. A timeout is not proof the origin didn't
+    /// process the request, so a fall-back is only safe when the request was
+    /// idempotent *and* bodyless (RFC 9110 §9.2.2) — the sole case the body can
+    /// be replayed and re-execution is harmless. `replay` carries a rebuilt
+    /// bodyless request then, else `None` (surface a 502).
+    ResponseTimeout {
+        error: anyhow::Error,
+        replay: Option<Box<Request<ClientBody>>>,
+    },
 }
 
 /// One negative-cache entry: the origin is not attempted over H3 until `until`,
@@ -153,8 +163,12 @@ pub(super) struct H3UpstreamClient {
     denylist: HashSet<String>,
     /// Whether an origin's Alt-Svc header may add an H3 route at runtime.
     trust_alt_svc: bool,
-    /// Bound on the connect + handshake (and the response head).
+    /// Bound on the connect + handshake.
     connect_timeout: Duration,
+    /// Bound on the response head (first origin byte) once the request is sent —
+    /// application think-time, kept separate from (and looser than) the connect
+    /// budget so a slow-but-healthy origin isn't dropped.
+    response_timeout: Duration,
     /// Base backoff window for the negative cache.
     negative_ttl: Duration,
     /// Authorities whose H3 connect/handshake recently failed, suppressed from
@@ -243,6 +257,7 @@ impl H3UpstreamClient {
             denylist,
             trust_alt_svc: cfg.general.h3_upstream_trust_alt_svc,
             connect_timeout: Duration::from_millis(cfg.general.h3_upstream_connect_timeout_ms),
+            response_timeout: Duration::from_millis(cfg.general.h3_upstream_response_timeout_ms),
             negative_ttl: Duration::from_secs(cfg.general.h3_upstream_negative_ttl_seconds),
             negative: Mutex::new(HashMap::new()),
             discovery: Mutex::new(HashMap::new()),
@@ -551,13 +566,23 @@ impl H3UpstreamClient {
         // replayed, so any failure is non-retryable. Mirror the response side of
         // the client-facing handler: data frames forward as QUIC DATA, a trailing
         // trailers frame as an H3 trailers section.
-        let (_, body) = req.into_parts();
+        let (parts, body) = req.into_parts();
+        let idempotent = parts.method.is_idempotent();
+        // Count the request-body bytes actually put on the wire. Because the body
+        // is fully sent before the response head is read (send-then-recv), a zero
+        // count at response time is a reliable "the request was bodyless" — a far
+        // sturdier signal than `Body::is_end_stream`, which hyper's streaming
+        // `Incoming` reports as `false` even for an empty body.
         let send_body = async {
             let mut body = body;
+            let mut sent: u64 = 0;
             while let Some(frame) = body.frame().await {
                 let frame = frame.map_err(|e| anyhow::anyhow!("h3 upstream request body: {e}"))?;
                 match frame.into_data() {
-                    Ok(data) => stream.send_data(data).await?,
+                    Ok(data) => {
+                        sent += data.len() as u64;
+                        stream.send_data(data).await?;
+                    }
                     Err(frame) => {
                         if let Ok(trailers) = frame.into_trailers() {
                             stream.send_trailers(trailers).await?;
@@ -566,14 +591,15 @@ impl H3UpstreamClient {
                 }
             }
             stream.finish().await?;
-            Ok::<_, anyhow::Error>(())
+            Ok::<_, anyhow::Error>(sent)
         };
-        if let Err(error) = send_body.await {
-            return Err(H3Failure::Consumed { error });
-        }
+        let sent = match send_body.await {
+            Ok(n) => n,
+            Err(error) => return Err(H3Failure::Consumed { error }),
+        };
 
         let resp_head =
-            match tokio::time::timeout(self.connect_timeout, stream.recv_response()).await {
+            match tokio::time::timeout(self.response_timeout, stream.recv_response()).await {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
                     return Err(H3Failure::Consumed {
@@ -581,8 +607,21 @@ impl H3UpstreamClient {
                     });
                 }
                 Err(_) => {
-                    return Err(H3Failure::Consumed {
+                    // The request was fully sent but the origin produced no
+                    // response head in time. This is not proof the origin didn't
+                    // process it, so retry on H1/H2 only when the request was
+                    // idempotent *and* bodyless (`sent == 0`) — the one case the
+                    // body can be replayed and re-execution is harmless
+                    // (RFC 9110 §9.2.2). Otherwise surface the failure as a 502.
+                    let replay = (idempotent && sent == 0).then(|| {
+                        let empty = http_body_util::Empty::<Bytes>::new()
+                            .map_err(|e| -> BoxError { match e {} })
+                            .boxed_unsync();
+                        Box::new(Request::from_parts(parts, empty))
+                    });
+                    return Err(H3Failure::ResponseTimeout {
                         error: anyhow::anyhow!("h3 upstream response timed out"),
+                        replay,
                     });
                 }
             };
@@ -1320,7 +1359,11 @@ mod tests {
 
         let resp = match h3.forward(req, &route, &shared).await {
             Ok(r) => r,
-            Err(H3Failure::Retryable { error, .. } | H3Failure::Consumed { error }) => {
+            Err(
+                H3Failure::Retryable { error, .. }
+                | H3Failure::Consumed { error }
+                | H3Failure::ResponseTimeout { error, .. },
+            ) => {
                 panic!("forward failed: {error}")
             }
         };

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -29,7 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::poll_fn;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
@@ -41,10 +41,14 @@ use hyper::http::uri::{PathAndQuery, Scheme};
 use hyper::{HeaderMap, Request, Response, Uri, Version};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::CertificateDer;
+use tracing::warn;
+use uuid::Uuid;
 
 use crate::config::Config;
+use crate::h3_instrument::InstrumentedConnection;
+use crate::protocol_event::{MessageDirection, ProtocolEvent, ProtocolEventKind};
 
-use super::{BoxError, ClientBody, ResponseBody};
+use super::{BoxError, ClientBody, ResponseBody, Shared};
 
 /// Upper bound on distinct authorities held in the negative cache; expired
 /// entries are pruned before this is exceeded so a churn of one-off origins
@@ -122,6 +126,13 @@ struct PooledConn {
     send: H3Send,
     driver: tokio::task::JoinHandle<()>,
     last_used: Mutex<Instant>,
+    /// This upstream connection's own id, distinct from any client connection.
+    /// Origin-sent control-frame events (SETTINGS/MAX_PUSH_ID/GOAWAY) are
+    /// recorded under it so they never conflate with a client leg's history.
+    /// The sink emits on a copy of this id; the field is read only by the
+    /// test-only [`Self::pooled_connection_id`] accessor.
+    #[cfg_attr(not(test), allow(dead_code))]
+    connection_id: Uuid,
 }
 
 impl Drop for PooledConn {
@@ -341,11 +352,35 @@ impl H3UpstreamClient {
 
     /// Open a fresh QUIC connection to the route's endpoint (validated for the
     /// origin authority) and spawn its driver, bounded by the connect timeout.
-    async fn connect(&self, route: &H3Route) -> anyhow::Result<PooledConn> {
+    /// The connection is instrumented so the origin's control-stream frames are
+    /// observed and emitted as `Server`-tagged events under a freshly-minted
+    /// upstream `connection_id`, routed through `shared`'s protocol-event
+    /// pipeline (via a weak ref, so the pool never keeps `Shared` alive).
+    ///
+    /// Observable set: the H3 control-stream frames (SETTINGS / MAX_PUSH_ID /
+    /// GOAWAY). The origin's *QUIC transport parameters* are **not** emitted —
+    /// quinn exposes no API to read a peer's transport parameters — so no
+    /// `Server`-tagged `QuicTransportParams` event exists on this leg. A future
+    /// `server_quic_transport_parameters` activation would need a different
+    /// source than this path.
+    async fn connect(&self, route: &H3Route, shared: &Arc<Shared>) -> anyhow::Result<PooledConn> {
         let addr = lookup_endpoint(&route.dial_host, route.dial_port).await?;
+        let connection_id = crate::connection::ConnectionMetadata::new_quic(addr).id;
+
+        let weak = Arc::downgrade(shared);
+        let sink: crate::h3_instrument::EventSink = Arc::new(move |kind| {
+            emit_upstream_h3_event(kind, connection_id, &weak);
+        });
+
         let handshake = async {
             let conn = self.endpoint.connect(addr, &route.authority_host)?.await?;
-            let pair = h3::client::new(h3_quinn::Connection::new(conn)).await?;
+            // Server leg: observed control-stream frames are origin-sent.
+            let instrumented = InstrumentedConnection::new(
+                h3_quinn::Connection::new(conn),
+                sink,
+                MessageDirection::Server,
+            );
+            let pair = h3::client::new(instrumented).await?;
             Ok::<_, anyhow::Error>(pair)
         };
         let (mut driver, send) = match tokio::time::timeout(self.connect_timeout, handshake).await {
@@ -360,6 +395,7 @@ impl H3UpstreamClient {
             send,
             driver,
             last_used: Mutex::new(Instant::now()),
+            connection_id,
         })
     }
 
@@ -371,6 +407,7 @@ impl H3UpstreamClient {
         &self,
         route: &H3Route,
         force_fresh: bool,
+        shared: &Arc<Shared>,
     ) -> anyhow::Result<(Arc<PooledConn>, bool)> {
         if !force_fresh {
             let mut pool = self.pool.lock().unwrap();
@@ -387,7 +424,7 @@ impl H3UpstreamClient {
 
         // Connect outside the lock (async); a rare concurrent race may open two
         // connections to the same origin — acceptable (§3.3 is SHOULD NOT).
-        let conn = Arc::new(self.connect(route).await?);
+        let conn = Arc::new(self.connect(route, shared).await?);
         let mut pool = self.pool.lock().unwrap();
         if pool.len() >= self.pool_max && !pool.contains_key(&route.authority) {
             if let Some(lru) = pool
@@ -412,6 +449,14 @@ impl H3UpstreamClient {
         }
     }
 
+    /// The upstream `connection_id` of the pooled connection for `authority`,
+    /// under which its origin-sent protocol events are recorded — used by tests
+    /// to assert where those events land.
+    #[cfg(test)]
+    pub(super) fn pooled_connection_id(&self, authority: &str) -> Option<Uuid> {
+        Some(self.pool.lock().unwrap().get(authority)?.connection_id)
+    }
+
     /// Evict pooled connections that are idle past `pool_idle` or whose driver
     /// has ended. Meant to be called periodically from the maintenance loop.
     pub(super) fn sweep_idle(&self) {
@@ -432,6 +477,7 @@ impl H3UpstreamClient {
         &self,
         req: Request<ClientBody>,
         route: &H3Route,
+        shared: &Arc<Shared>,
     ) -> Result<Response<ResponseBody>, H3Failure> {
         // Build the https target from the request URI *without consuming* `req`,
         // so it can be handed back for fall-back. The head keeps the origin
@@ -454,7 +500,7 @@ impl H3UpstreamClient {
                 Ok(h) => h,
                 Err(error) => return Err(pre_request(error, req)),
             };
-            let (conn, reused) = match self.get_or_connect(route, force_fresh).await {
+            let (conn, reused) = match self.get_or_connect(route, force_fresh, shared).await {
                 Ok(c) => c,
                 Err(error) => return Err(pre_request(error, req)),
             };
@@ -539,6 +585,30 @@ impl H3UpstreamClient {
         builder
             .body(resp_body)
             .map_err(|e| H3Failure::Consumed { error: e.into() })
+    }
+}
+
+/// Lint + record an origin-sent HTTP/3 protocol event on the upstream
+/// `connection_id`, routed through the proxy's protocol-event pipeline. Holds
+/// only a weak ref to `Shared` (captured by the connection's frame-observer
+/// sink), so a live pooled connection never keeps the whole proxy alive; if the
+/// proxy has shut down the event is simply dropped.
+fn emit_upstream_h3_event(kind: ProtocolEventKind, connection_id: Uuid, shared: &Weak<Shared>) {
+    let Some(shared) = shared.upgrade() else {
+        return;
+    };
+    let pe = ProtocolEvent {
+        timestamp: chrono::Utc::now(),
+        connection_id,
+        kind,
+    };
+    for v in shared.protocol_event_pipeline().commit(&pe) {
+        warn!(
+            rule = %v.rule,
+            severity = ?v.severity,
+            "H3 upstream protocol violation: {}",
+            v.message
+        );
     }
 }
 
@@ -1008,5 +1078,152 @@ mod tests {
             Some(("::1".to_string(), 443)),
             "bracketed IPv6 without a port defaults to 443, not a mis-split"
         );
+    }
+
+    /// Mint a CA + a leaf cert valid for 127.0.0.1, returning (ca_pem, leaf DER,
+    /// leaf key DER) for an in-process origin the proxy can trust.
+    fn test_certs() -> (
+        String,
+        rustls::pki_types::CertificateDer<'static>,
+        rustls::pki_types::PrivateKeyDer<'static>,
+    ) {
+        use rcgen::{
+            BasicConstraints, CertificateParams, IsCa, Issuer, KeyPair, SanType,
+            PKCS_ECDSA_P256_SHA256,
+        };
+        let mut ca_params = CertificateParams::new(Vec::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let ca_pem = ca_params.self_signed(&ca_key).unwrap().pem();
+
+        let mut leaf = CertificateParams::new(Vec::new()).unwrap();
+        leaf.subject_alt_names = vec![SanType::IpAddress(std::net::IpAddr::V4(
+            std::net::Ipv4Addr::new(127, 0, 0, 1),
+        ))];
+        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+        let issuer = Issuer::new(ca_params, ca_key);
+        let leaf_cert = leaf.signed_by(&leaf_key, &issuer).unwrap();
+        (
+            ca_pem,
+            leaf_cert.der().clone(),
+            rustls::pki_types::PrivatePkcs8KeyDer::from(leaf_key.serialize_der()).into(),
+        )
+    }
+
+    /// A minimal in-process HTTP/3 origin that answers 200 for one request. Its
+    /// h3 server sends SETTINGS on its control stream during the handshake — the
+    /// server-sent frame this test observes on the upstream leg.
+    fn spawn_h3_origin(
+        leaf: rustls::pki_types::CertificateDer<'static>,
+        key: rustls::pki_types::PrivateKeyDer<'static>,
+    ) -> SocketAddr {
+        let mut tls = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![leaf], key)
+            .unwrap();
+        tls.alpn_protocols = vec![b"h3".to_vec()];
+        let quic =
+            quinn::crypto::rustls::QuicServerConfig::try_from(tls).expect("quic server config");
+        let endpoint = quinn::Endpoint::server(
+            quinn::ServerConfig::with_crypto(Arc::new(quic)),
+            "127.0.0.1:0".parse().unwrap(),
+        )
+        .unwrap();
+        let addr = endpoint.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Some(incoming) = endpoint.accept().await {
+                tokio::spawn(async move {
+                    let Ok(conn) = incoming.await else { return };
+                    let Ok(mut h3) =
+                        h3::server::Connection::<_, Bytes>::new(h3_quinn::Connection::new(conn))
+                            .await
+                    else {
+                        return;
+                    };
+                    while let Ok(Some(resolver)) = h3.accept().await {
+                        tokio::spawn(async move {
+                            if let Ok((_req, mut stream)) = resolver.resolve_request().await {
+                                let resp = http::Response::builder().status(200).body(()).unwrap();
+                                let _ = stream.send_response(resp).await;
+                                let _ = stream.finish().await;
+                            }
+                        });
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn origin_settings_appear_as_server_events_on_the_upstream_connection() {
+        let (ca_pem, leaf, key) = test_certs();
+        let ca_path = std::env::temp_dir().join(format!("lint_p5_ca_{}.pem", uuid::Uuid::new_v4()));
+        tokio::fs::write(&ca_path, ca_pem.as_bytes()).await.unwrap();
+
+        let origin = spawn_h3_origin(leaf, key);
+        let authority = origin.to_string();
+
+        let mut cfg = Config::default();
+        cfg.general.h3_upstream_enabled = true;
+        cfg.general.h3_upstream_authorities = vec![authority.clone()];
+        cfg.general.h3_upstream_extra_ca_certs = vec![ca_path.to_string_lossy().to_string()];
+        let (shared, tmp, _cw) =
+            crate::proxy::test_support::make_shared_with_cfg(Arc::new(cfg), None)
+                .await
+                .unwrap();
+
+        let h3 = shared.upstream.h3.as_ref().expect("h3 client");
+        let route = h3.route_for(&authority).expect("allowlisted route");
+        let body = http_body_util::Empty::<Bytes>::new()
+            .map_err(|e| -> BoxError { match e {} })
+            .boxed_unsync();
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("http://{authority}/x"))
+            .body(body)
+            .unwrap();
+
+        let resp = match h3.forward(req, &route, &shared).await {
+            Ok(r) => r,
+            Err(H3Failure::Retryable { error, .. } | H3Failure::Consumed { error }) => {
+                panic!("forward failed: {error}")
+            }
+        };
+        assert_eq!(resp.status(), 200);
+        let _ = resp.into_body().collect().await;
+
+        let conn_id = h3
+            .pooled_connection_id(&authority)
+            .expect("origin connection pooled");
+
+        // The origin's SETTINGS arrive on its control stream and are recorded as
+        // a Server-tagged event under the upstream connection id.
+        let mut found = false;
+        for _ in 0..100 {
+            let events = shared
+                .protocol_event_store
+                .get_history_for_connection(conn_id);
+            if events.iter().any(|e| {
+                matches!(
+                    e.kind,
+                    ProtocolEventKind::H3SettingsReceived {
+                        direction: MessageDirection::Server,
+                        ..
+                    }
+                )
+            }) {
+                found = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            found,
+            "origin SETTINGS should be recorded as a Server event on the upstream connection_id"
+        );
+
+        let _ = tokio::fs::remove_file(&tmp).await;
+        let _ = tokio::fs::remove_file(&ca_path).await;
     }
 }

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -121,6 +121,10 @@ pub(super) struct H3Route {
     authority: String,
 }
 
+/// Handle to the spawned request-body pump: it returns the bytes actually sent
+/// and any (post-response-head-benign) send error, or a body-read error.
+type PumpHandle = tokio::task::JoinHandle<Result<(u64, Option<anyhow::Error>), anyhow::Error>>;
+
 /// The clonable request-sender handle for a pooled h3 connection. `SendRequest`
 /// is `Clone` (an internal refcount keeps the connection open while any clone
 /// lives), so one pooled connection multiplexes many concurrent request streams.
@@ -536,7 +540,7 @@ impl H3UpstreamClient {
         // method. A fresh connection that still can't open a stream is a genuine
         // pre-request failure (safe to fall back to H1/H2).
         let mut force_fresh = false;
-        let (mut stream, conn) = loop {
+        let (stream, conn) = loop {
             // `send_request` consumes the head, so rebuild it per attempt.
             let head = match build_h3_head(&req, https_uri.clone()) {
                 Ok(h) => h,
@@ -564,70 +568,109 @@ impl H3UpstreamClient {
             }
         };
 
-        // From here the request body streams to the origin and can no longer be
-        // replayed, so any failure is non-retryable. Mirror the response side of
-        // the client-facing handler: data frames forward as QUIC DATA, a trailing
-        // trailers frame as an H3 trailers section.
+        // From here the request body streams to the origin. Split the stream so
+        // the body is sent *concurrently* with awaiting the response head: an
+        // origin that answers early (e.g. 401/413 before draining a large upload)
+        // is seen immediately instead of only after the whole body is sent.
+        let (mut send, mut recv) = stream.split();
         let (parts, body) = req.into_parts();
         let idempotent = parts.method.is_idempotent();
-        // Count the request-body bytes actually put on the wire. Because the body
-        // is fully sent before the response head is read (send-then-recv), a zero
-        // count at response time is a reliable "the request was bodyless" — a far
-        // sturdier signal than `Body::is_end_stream`, which hyper's streaming
-        // `Incoming` reports as `false` even for an empty body.
-        let send_body = async {
+
+        // Pump the request body on its own task. It always drains the body to the
+        // end (the tee's `Drop` fires `body_done` regardless, so the capture
+        // commit never hangs) and keeps the full-body capture faithful; once the
+        // origin stops reading — `send_data` errors after an early response — it
+        // stops sending but keeps draining. It returns the bytes actually sent
+        // plus any send error, which is benign once a response head has arrived.
+        // Data frames forward as QUIC DATA, a trailing trailers frame as an H3
+        // trailers section (mirroring the client-facing handler).
+        let pump = tokio::spawn(async move {
             let mut body = body;
             let mut sent: u64 = 0;
+            let mut send_err: Option<anyhow::Error> = None;
             while let Some(frame) = body.frame().await {
-                let frame = frame.map_err(|e| anyhow::anyhow!("h3 upstream request body: {e}"))?;
+                let frame = match frame {
+                    Ok(f) => f,
+                    // A client-side body read error ends the upload; the tee's
+                    // `Drop` still fires `body_done`. Report it as the cause.
+                    Err(e) => return Err(anyhow::anyhow!("h3 upstream request body: {e}")),
+                };
+                if send_err.is_some() {
+                    // Origin stopped reading; keep draining so the capture is
+                    // complete, but do not touch the (reset) send half.
+                    continue;
+                }
                 match frame.into_data() {
                     Ok(data) => {
-                        sent += data.len() as u64;
-                        stream.send_data(data).await?;
+                        let n = data.len() as u64;
+                        match send.send_data(data).await {
+                            Ok(()) => sent += n,
+                            Err(e) => send_err = Some(e.into()),
+                        }
                     }
                     Err(frame) => {
                         if let Ok(trailers) = frame.into_trailers() {
-                            stream.send_trailers(trailers).await?;
+                            if let Err(e) = send.send_trailers(trailers).await {
+                                send_err = Some(e.into());
+                            }
                         }
                     }
                 }
             }
-            stream.finish().await?;
-            Ok::<_, anyhow::Error>(sent)
-        };
-        let sent = match send_body.await {
-            Ok(n) => n,
-            Err(error) => return Err(H3Failure::Consumed { error }),
-        };
+            if send_err.is_none() {
+                let _ = send.finish().await;
+            }
+            Ok::<(u64, Option<anyhow::Error>), anyhow::Error>((sent, send_err))
+        });
 
         let resp_head =
-            match tokio::time::timeout(self.response_timeout, stream.recv_response()).await {
+            match tokio::time::timeout(self.response_timeout, recv.recv_response()).await {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
+                    // No response head; the stream/connection failed. Abort the
+                    // pump so it drops the request body and fires `body_done`
+                    // (a pump parked on flow control would otherwise never run its
+                    // `Drop`), then surface the error. The body is (partly) in
+                    // flight, so this is not replayable.
+                    pump.abort();
                     return Err(H3Failure::Consumed {
                         error: anyhow::anyhow!("h3 upstream recv_response: {e}"),
                     });
                 }
                 Err(_) => {
-                    // The request was fully sent but the origin produced no
-                    // response head in time. This is not proof the origin didn't
-                    // process it, so retry on H1/H2 only when the request was
-                    // idempotent *and* bodyless (`sent == 0`) — the one case the
-                    // body can be replayed and re-execution is harmless
-                    // (RFC 9110 §9.2.2). Otherwise surface the failure as a 502.
-                    let replay = (idempotent && sent == 0).then(|| {
-                        let empty = http_body_util::Empty::<Bytes>::new()
-                            .map_err(|e| -> BoxError { match e {} })
-                            .boxed_unsync();
-                        Box::new(Request::from_parts(parts, empty))
-                    });
+                    // Response-head timeout. This is not proof the origin didn't
+                    // process the request, so retry on H1/H2 only when the request
+                    // was genuinely bodyless: the pump finished having produced no
+                    // data frames *and no send error* (`(0, None)`) — the one case
+                    // the body can be replayed as `Empty` and re-execution is
+                    // harmless for an idempotent method (RFC 9110 §9.2.2). A send
+                    // error also leaves `sent == 0`, so it must be excluded or a
+                    // body-bearing request would be replayed empty (dropping its
+                    // payload while keeping its Content-Length).
+                    let replay = if idempotent && pump.is_finished() {
+                        match pump.await {
+                            Ok(Ok((0, None))) => Some(Box::new(Request::from_parts(
+                                parts,
+                                http_body_util::Empty::<Bytes>::new()
+                                    .map_err(|e| -> BoxError { match e {} })
+                                    .boxed_unsync(),
+                            ))),
+                            _ => None,
+                        }
+                    } else {
+                        // Not replayable: cancel the pump so a body still in flight
+                        // is dropped and `body_done` fires (else the 502 path would
+                        // block awaiting a capture that never completes).
+                        pump.abort();
+                        None
+                    };
                     return Err(H3Failure::ResponseTimeout {
                         error: anyhow::anyhow!("h3 upstream response timed out"),
                         replay,
                     });
                 }
             };
-        let (_send_half, recv_half) = stream.split();
+        let recv_half = recv;
 
         // Record the origin leg's version as HTTP/3 (see the exchange core, which
         // reads `resp.version()` into `tx.response.version`).
@@ -641,10 +684,17 @@ impl H3UpstreamClient {
         // The response body keeps the pooled connection alive while it streams
         // (the pool holds another ref); it does not abort the driver — the
         // connection stays pooled for reuse and is torn down only on eviction.
+        // It also owns the body pump: for a normal request the pump has already
+        // finished (the origin read the body before responding); when it hasn't
+        // (an origin that responded early without draining the upload, so the
+        // pump may be parked on QUIC flow control), the response body's `Drop`
+        // aborts it, dropping the request body so `body_done` fires. This bounds
+        // the pump to the response's lifetime — it can never leak or park forever.
         let resp_body = H3ResponseBody {
             recv: recv_half,
             state: RespState::Data,
             _conn: conn,
+            pump: Some(pump),
         }
         .boxed_unsync();
 
@@ -864,6 +914,21 @@ struct H3ResponseBody<S> {
     recv: h3::client::RequestStream<S, Bytes>,
     state: RespState,
     _conn: Arc<PooledConn>,
+    /// The request-body pump task. Held so it is aborted when this response body
+    /// is dropped — see the construction site: this is what guarantees the
+    /// request tee is dropped (firing `body_done`) even if the pump was parked
+    /// on QUIC flow control after the origin responded without draining the body.
+    pump: Option<PumpHandle>,
+}
+
+impl<S> Drop for H3ResponseBody<S> {
+    fn drop(&mut self) {
+        if let Some(pump) = self.pump.take() {
+            // No-op if the pump already finished (normal request); otherwise
+            // cancels a still-running/parked pump so the request body is dropped.
+            pump.abort();
+        }
+    }
 }
 
 impl<S> Body for H3ResponseBody<S>

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -833,13 +833,23 @@ async fn upstream_h3_discovered_via_alt_svc_is_used_on_next_request() -> anyhow:
         "second request is served over H3 (discovered)"
     );
 
-    let caps = read_captures(&captures_path).await?;
-    let versions: Vec<&str> = caps
-        .iter()
-        .filter_map(|v| v["response"]["version"].as_str())
-        .collect();
+    // The capture is written asynchronously, so the H3 request's record may not
+    // be on disk the instant its response returns. Poll until it appears rather
+    // than reading once and racing the writer under a loaded CI CPU.
+    let deadline = std::time::Instant::now() + startup_timeout();
+    let versions = loop {
+        let caps = read_captures(&captures_path).await?;
+        let versions: Vec<String> = caps
+            .iter()
+            .filter_map(|v| v["response"]["version"].as_str().map(str::to_string))
+            .collect();
+        if versions.iter().any(|v| v == "HTTP/3") || std::time::Instant::now() > deadline {
+            break versions;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    };
     assert!(
-        versions.contains(&"HTTP/3"),
+        versions.iter().any(|v| v == "HTTP/3"),
         "a request should have been forwarded over H3 after discovery: {versions:?}"
     );
 

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -561,7 +561,10 @@ async fn upstream_h3_slow_origin_idempotent_get_falls_back_to_h1() -> anyhow::Re
     let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
 
     let (status, _headers, body) = proxy_get(proxy_addr, &authority, "/slow", &[]).await?;
-    assert_eq!(status, 200, "an idempotent GET should fall back to H1, not 502");
+    assert_eq!(
+        status, 200,
+        "an idempotent GET should fall back to H1, not 502"
+    );
     assert_eq!(body, b"fellback");
     assert!(
         h1_hits.load(Ordering::SeqCst) >= 1,
@@ -642,6 +645,132 @@ async fn upstream_h3_slow_origin_non_idempotent_post_502s() -> anyhow::Result<()
     proxy_handle.abort();
     h3_origin.abort();
     h1_origin.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+/// An H3 origin that answers `401` the instant it sees a request, **without
+/// reading the request body** — exercising the duplex path where the origin
+/// responds (and resets the request stream) before the upload is drained.
+fn start_h3_origin_early_response(
+    pki: &TestPki,
+    bind: SocketAddr,
+) -> anyhow::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+    let endpoint = h3_server_endpoint(pki, bind)?;
+    let addr = endpoint.local_addr()?;
+    let handle = tokio::spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            tokio::spawn(async move {
+                let Ok(conn) = incoming.await else { return };
+                let Ok(mut h3) =
+                    h3::server::Connection::<_, Bytes>::new(h3_quinn::Connection::new(conn)).await
+                else {
+                    return;
+                };
+                while let Ok(Some(resolver)) = h3.accept().await {
+                    tokio::spawn(async move {
+                        if let Ok((_req, mut stream)) = resolver.resolve_request().await {
+                            // Respond immediately, ignoring the request body.
+                            let resp = http::Response::builder().status(401).body(()).unwrap();
+                            let _ = stream.send_response(resp).await;
+                            let _ = stream.finish().await;
+                        }
+                    });
+                }
+            });
+        }
+    });
+    Ok((addr, handle))
+}
+
+#[tokio::test]
+async fn upstream_h3_origin_early_response_is_delivered_and_captured() -> anyhow::Result<()> {
+    // The H3 origin answers 401 without draining the (sizeable) POST body. With
+    // duplex send/recv the proxy observes that response concurrently with the
+    // upload, delivers it to the client, and still commits the transaction —
+    // proving the body pump handles an origin-reset stream without hanging the
+    // capture or mis-recording the leg.
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let (origin_addr, origin_handle) =
+        start_h3_origin_early_response(&pki, "127.0.0.1:0".parse()?)?;
+    let authority = origin_addr.to_string();
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let big = vec![b'x'; 256 * 1024];
+    let (status, _body) = proxy_post(proxy_addr, &authority, "/gate", &big).await?;
+    assert_eq!(status, 401, "the early origin response reaches the client");
+
+    let caps = read_captures(&captures_path).await?;
+    let v = &caps[0];
+    assert_eq!(v["response"]["status"].as_u64(), Some(401));
+    assert_eq!(
+        v["response"]["version"].as_str(),
+        Some("HTTP/3"),
+        "the leg is recorded as HTTP/3 even though the origin responded early"
+    );
+
+    proxy_handle.abort();
+    origin_handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_early_response_to_large_upload_commits_without_hanging() -> anyhow::Result<()>
+{
+    // Regression for the duplex body pump: the origin answers 401 without reading
+    // an upload *larger than the QUIC flow-control window*, so the pump parks in
+    // `send_data`. The response must still reach the client AND the transaction
+    // must still commit — proving the pump is aborted (dropping the request tee,
+    // firing `body_done`) when the response body drops, rather than parking
+    // forever and leaking the capture. A timeout guards against the regression
+    // hanging the whole suite.
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let (origin_addr, origin_handle) =
+        start_h3_origin_early_response(&pki, "127.0.0.1:0".parse()?)?;
+    let authority = origin_addr.to_string();
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // 16 MiB comfortably exceeds quinn's default per-stream receive window, so the
+    // pump parks once the origin (which never reads) stops accepting bytes.
+    let big = vec![b'x'; 16 * 1024 * 1024];
+    let (status, _body) = tokio::time::timeout(
+        Duration::from_secs(20),
+        proxy_post(proxy_addr, &authority, "/gate", &big),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("proxy_post hung — the parked pump was not aborted"))??;
+    assert_eq!(status, 401, "the early origin response reaches the client");
+
+    // The capture being written at all proves `body_done` fired despite the
+    // parked pump (read_captures has its own startup timeout).
+    let caps = read_captures(&captures_path).await?;
+    assert_eq!(caps[0]["response"]["status"].as_u64(), Some(401));
+
+    proxy_handle.abort();
+    origin_handle.abort();
     let _ = tokio::fs::remove_file(&captures_path).await;
     let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -482,6 +482,171 @@ async fn upstream_h3_non_idempotent_not_retried_after_midflight_failure() -> any
     Ok(())
 }
 
+/// An H3 origin that completes the handshake, reads one request, then holds the
+/// connection open **without ever responding** — so the proxy's response-head
+/// read hits its response timeout (as opposed to erroring on a dropped
+/// connection). Binds `bind` (UDP) and returns its accept-loop handle.
+fn start_h3_origin_silent(
+    pki: &TestPki,
+    bind: SocketAddr,
+) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+    let endpoint = h3_server_endpoint(pki, bind)?;
+    let handle = tokio::spawn(async move {
+        while let Some(incoming) = endpoint.accept().await {
+            tokio::spawn(async move {
+                let Ok(conn) = incoming.await else { return };
+                let Ok(mut h3) =
+                    h3::server::Connection::<_, Bytes>::new(h3_quinn::Connection::new(conn)).await
+                else {
+                    return;
+                };
+                // Read the request but never send a response; keep both the
+                // connection (`h3`) and the request stream alive by sleeping, so
+                // the client's `recv_response` blocks until its timeout fires.
+                if let Ok(Some(resolver)) = h3.accept().await {
+                    if let Ok((_req, _stream)) = resolver.resolve_request().await {
+                        tokio::time::sleep(Duration::from_secs(60)).await;
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            });
+        }
+    });
+    Ok(handle)
+}
+
+#[tokio::test]
+async fn upstream_h3_slow_origin_idempotent_get_falls_back_to_h1() -> anyhow::Result<()> {
+    // The H3 origin handshakes and reads the GET but never answers, so the proxy
+    // hits its (short) response-head timeout. A GET is idempotent and bodyless,
+    // so the request is replayable: the proxy falls back to an H1 origin on the
+    // same authority's TCP port and the client gets a 200 — a slow-but-healthy
+    // origin must not surface as a 502.
+    use tokio::io::AsyncWriteExt;
+
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let port = reserve_udp_port()?;
+    let authority = format!("127.0.0.1:{port}");
+    let bind: SocketAddr = authority.parse()?;
+
+    let h3_origin = start_h3_origin_silent(&pki, bind)?;
+
+    // H1 origin on the same TCP port: proves the fall-back landed.
+    let h1_hits = Arc::new(AtomicUsize::new(0));
+    let h1_hits_srv = h1_hits.clone();
+    let tcp = tokio::net::TcpListener::bind(bind).await?;
+    let h1_origin = tokio::spawn(async move {
+        while let Ok((mut sock, _)) = tcp.accept().await {
+            h1_hits_srv.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nfellback")
+                    .await;
+            });
+        }
+    });
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    // Handshake budget generous; response budget tiny so the timeout is prompt.
+    cfg.general.h3_upstream_connect_timeout_ms = 3000;
+    cfg.general.h3_upstream_response_timeout_ms = 300;
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let (status, _headers, body) = proxy_get(proxy_addr, &authority, "/slow", &[]).await?;
+    assert_eq!(status, 200, "an idempotent GET should fall back to H1, not 502");
+    assert_eq!(body, b"fellback");
+    assert!(
+        h1_hits.load(Ordering::SeqCst) >= 1,
+        "the fall-back should have reached the H1 origin"
+    );
+
+    let caps = read_captures(&captures_path).await?;
+    let v = &caps[0];
+    assert_eq!(
+        v["response"]["version"].as_str(),
+        Some("HTTP/1.1"),
+        "a response-timeout fall-back records the leg actually used (H1)"
+    );
+
+    proxy_handle.abort();
+    h3_origin.abort();
+    h1_origin.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_slow_origin_non_idempotent_post_502s() -> anyhow::Result<()> {
+    // Same silent H3 origin, but a POST carrying a body. The body is already in
+    // flight (sent > 0) and the method is non-idempotent, so a response-timeout
+    // is NOT replayable: the proxy must 502 rather than re-send to H1 (RFC 9110
+    // §9.2.2). An H1 origin on the same port proves it is never hit.
+    use tokio::io::AsyncWriteExt;
+
+    let pki = gen_test_pki()?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let port = reserve_udp_port()?;
+    let authority = format!("127.0.0.1:{port}");
+    let bind: SocketAddr = authority.parse()?;
+
+    let h3_origin = start_h3_origin_silent(&pki, bind)?;
+
+    let h1_hits = Arc::new(AtomicUsize::new(0));
+    let h1_hits_srv = h1_hits.clone();
+    let tcp = tokio::net::TcpListener::bind(bind).await?;
+    let h1_origin = tokio::spawn(async move {
+        while let Ok((mut sock, _)) = tcp.accept().await {
+            h1_hits_srv.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nh1")
+                    .await;
+            });
+        }
+    });
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    cfg.general.h3_upstream_connect_timeout_ms = 3000;
+    cfg.general.h3_upstream_response_timeout_ms = 300;
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let (status, _body) = proxy_post(proxy_addr, &authority, "/x", b"payload").await?;
+    assert_eq!(
+        status, 502,
+        "a non-idempotent POST that times out mid-response is not replayable"
+    );
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        h1_hits.load(Ordering::SeqCst),
+        0,
+        "a POST with a body must not be retried on H1 after a response timeout"
+    );
+
+    proxy_handle.abort();
+    h3_origin.abort();
+    h1_origin.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
+    Ok(())
+}
+
 /// Reserve an ephemeral UDP port, then release it so a caller can bind it.
 fn reserve_udp_port() -> anyhow::Result<u16> {
     let s = std::net::UdpSocket::bind("127.0.0.1:0")?;

--- a/lint-http-rules/src/lint_protocol.rs
+++ b/lint-http-rules/src/lint_protocol.rs
@@ -65,7 +65,10 @@ mod tests {
         let event = ProtocolEvent {
             timestamp: Utc::now(),
             connection_id: Uuid::new_v4(),
-            kind: crate::protocol_event::ProtocolEventKind::H3GoawayReceived { stream_id: None },
+            kind: crate::protocol_event::ProtocolEventKind::H3GoawayReceived {
+                stream_id: None,
+                direction: crate::protocol_event::MessageDirection::Client,
+            },
         };
 
         let violations = lint_protocol_event(&event, &cfg, &store);

--- a/lint-http-rules/src/rules/server_quic_transport_parameters.rs
+++ b/lint-http-rules/src/rules/server_quic_transport_parameters.rs
@@ -4,14 +4,23 @@
 
 //! QUIC transport parameter validation for HTTP/3 (RFC 9000 §18.2).
 //!
-//! Checks that the negotiated QUIC transport parameters are reasonable for
-//! HTTP/3 usage:
+//! Checks that the QUIC transport parameters carried by a `QuicTransportParams`
+//! event are reasonable for HTTP/3 usage:
 //! - `initial_max_streams_bidi` must be non-zero so that at least one
 //!   request stream can be opened.
 //! - `initial_max_data` (connection-level flow control) must be non-zero.
 //! - `max_idle_timeout_ms` should be set (non-zero) and not excessively large.
 //! - Per-stream flow-control windows (`initial_max_stream_data_*`) must be
 //!   non-zero.
+//!
+//! Scope: the only `QuicTransportParams` event the proxy currently produces
+//! carries the parameters **it advertises** on its own client-facing HTTP/3 leg
+//! (tagged `MessageDirection::Client`). The QUIC library (quinn) exposes no
+//! API to read a *peer's* transport parameters, so an origin's parameters on the
+//! upstream leg are not observable and are therefore not validated here — this
+//! rule lints the proxy's own advertised parameters, not a remote endpoint's.
+//! Reviving origin-side validation needs a QUIC stack that surfaces the peer's
+//! transport parameters.
 
 use crate::lint::Violation;
 use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
@@ -132,7 +141,7 @@ impl ProtocolRule for ServerQuicTransportParameters {
     }
 
     fn description(&self) -> &'static str {
-        "Validates that QUIC transport parameters negotiated during the handshake are reasonable for HTTP/3 usage.  This rule inspects protocol-level `QuicTransportParams` events and checks:\n\n* **Bidirectional streams allowed** — `initial_max_streams_bidi` must be non-zero so that at least one HTTP/3 request stream can be opened.\n* **Connection flow control** — `initial_max_data` must be non-zero so that data can actually be transferred.\n* **Stream flow control** — `initial_max_stream_data_bidi_local`, `initial_max_stream_data_bidi_remote`, and `initial_max_stream_data_uni` must be non-zero for their respective stream types to carry data.\n* **Idle timeout** — `max_idle_timeout_ms` should be set (non-zero) to prevent idle connections from consuming server resources indefinitely, and should not be excessively large (>10 minutes)."
+        "Validates that the QUIC transport parameters advertised for HTTP/3 are reasonable. The proxy emits a `QuicTransportParams` event for the parameters **it advertises on its own client-facing HTTP/3 endpoint**, and this rule checks those. It does **not** validate a remote origin's parameters on the upstream leg: the QUIC stack exposes no way to read a peer's transport parameters, so an origin's are not observable and go unchecked here. The checks:\n\n* **Bidirectional streams allowed** — `initial_max_streams_bidi` must be non-zero so that at least one HTTP/3 request stream can be opened.\n* **Connection flow control** — `initial_max_data` must be non-zero so that data can actually be transferred.\n* **Stream flow control** — `initial_max_stream_data_bidi_local`, `initial_max_stream_data_bidi_remote`, and `initial_max_stream_data_uni` must be non-zero for their respective stream types to carry data.\n* **Idle timeout** — `max_idle_timeout_ms` should be set (non-zero) to prevent idle connections from consuming server resources indefinitely, and should not be excessively large (>10 minutes)."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {

--- a/lint-http-rules/src/rules/server_quic_transport_parameters.rs
+++ b/lint-http-rules/src/rules/server_quic_transport_parameters.rs
@@ -37,7 +37,7 @@ impl ProtocolRule for ServerQuicTransportParameters {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let params = match &event.kind {
-            ProtocolEventKind::QuicTransportParams { params } => params,
+            ProtocolEventKind::QuicTransportParams { params, .. } => params,
             _ => return None,
         };
 
@@ -187,7 +187,8 @@ static REGISTRATION: &dyn crate::rules::ProtocolRule = &ServerQuicTransportParam
 mod tests {
     use super::*;
     use crate::protocol_event::{
-        ProtocolEvent, ProtocolEventHistory, ProtocolEventKind, QuicTransportParameters,
+        MessageDirection, ProtocolEvent, ProtocolEventHistory, ProtocolEventKind,
+        QuicTransportParameters,
     };
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
@@ -208,7 +209,10 @@ mod tests {
         ProtocolEvent {
             timestamp: base_ts(),
             connection_id: Uuid::new_v4(),
-            kind: ProtocolEventKind::QuicTransportParams { params },
+            kind: ProtocolEventKind::QuicTransportParams {
+                params,
+                direction: MessageDirection::Client,
+            },
         }
     }
 

--- a/lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+++ b/lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
@@ -11,7 +11,9 @@
 //!   indicated last stream ID should be initiated.
 
 use crate::lint::Violation;
-use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
+use crate::protocol_event::{
+    MessageDirection, ProtocolEvent, ProtocolEventHistory, ProtocolEventKind,
+};
 use crate::rules::ProtocolRule;
 
 pub struct StatefulHttp3GoawaySemantics;
@@ -34,55 +36,78 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
             // increase beyond the value sent in a previous GOAWAY.
             ProtocolEventKind::H3GoawayReceived {
                 stream_id: current_id,
-                ..
+                direction: current_dir,
             } => {
                 for prev in history.iter() {
                     if let ProtocolEventKind::H3GoawayReceived {
-                        stream_id: prev_id, ..
+                        stream_id: prev_id,
+                        direction: prev_dir,
                     } = &prev.kind
                     {
+                        // Compare only same-sender GOAWAYs: a server's identifier
+                        // is a request stream ID, a client's is a push ID — two
+                        // different id spaces, so monotonicity holds within each.
+                        // cite(RFC 9114 § 5.2): "The server sends a client-initiated bidirectional stream ID; the client sends a push ID."
+                        if current_dir != prev_dir {
+                            continue;
+                        }
+                        // A later identifier above an earlier one is the error;
+                        // `>` (not `>=`) because re-sending the same value is
+                        // allowed.
+                        // cite(RFC 9114 § 5.2): "Receiving a GOAWAY containing a larger identifier than previously received MUST be treated as a connection error of type H3_ID_ERROR."
                         if let (Some(curr), Some(prev)) = (current_id, prev_id) {
                             if curr > prev {
                                 return Some(Violation {
                                     rule: self.id().into(),
                                     severity: config.severity,
                                     message: format!(
-                                        "HTTP/3 GOAWAY stream ID {} increased from previous {} \
+                                        "HTTP/3 GOAWAY identifier {} increased from previous {} \
                                          (RFC 9114 §5.2)",
                                         curr, prev
                                     ),
                                 });
                             }
                         }
-                        break; // Only check the most recent prior GOAWAY
+                        break; // Only check the most recent prior same-sender GOAWAY
                     }
                 }
                 None
             }
 
-            // After a GOAWAY with a known stream ID, no streams beyond that
-            // ID should open.  When the GOAWAY stream ID is unknown (None)
-            // we cannot determine the limit, so we skip the check to avoid
-            // false positives.
+            // After a *server* GOAWAY with a known stream ID, no request streams
+            // beyond that ID should open. Only a server GOAWAY carries a request
+            // stream ID comparable to an opened stream; a client GOAWAY's push ID
+            // is a different space, so scoping to server GOAWAYs is what makes
+            // this check valid. A `None` id or a non-server GOAWAY is skipped.
             ProtocolEventKind::H3StreamOpened { stream_id } => {
                 for prev in history.iter() {
                     if let ProtocolEventKind::H3GoawayReceived {
-                        stream_id: Some(goaway_id),
-                        ..
+                        stream_id: goaway_id,
+                        direction,
                     } = &prev.kind
                     {
-                        if stream_id > goaway_id {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "HTTP/3 stream {} opened after GOAWAY with last \
-                                     stream ID {} (RFC 9114 §5.2)",
-                                    stream_id, goaway_id
-                                ),
-                            });
+                        // cite(RFC 9114 § 5.2): "The server sends a client-initiated bidirectional stream ID; the client sends a push ID."
+                        if *direction != MessageDirection::Server {
+                            continue;
                         }
-                        break; // Only check the most recent GOAWAY
+                        // Opening a request stream at or beyond the server's
+                        // last-processed stream ID is initiating a new request
+                        // after the GOAWAY, which the endpoint must not do.
+                        // cite(RFC 9114 § 5.2): "Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer."
+                        if let Some(goaway_id) = goaway_id {
+                            if stream_id > goaway_id {
+                                return Some(Violation {
+                                    rule: self.id().into(),
+                                    severity: config.severity,
+                                    message: format!(
+                                        "HTTP/3 stream {} opened after server GOAWAY with last \
+                                         stream ID {} (RFC 9114 §5.2)",
+                                        stream_id, goaway_id
+                                    ),
+                                });
+                            }
+                        }
+                        break; // Only the most recent server GOAWAY sets the limit
                     }
                 }
                 None
@@ -97,7 +122,7 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
     }
 
     fn description(&self) -> &'static str {
-        "Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  This rule inspects protocol-level events and checks:\n\n* **GOAWAY stream ID must not increase** — when multiple GOAWAY frames are received on the same connection, the stream ID in each subsequent GOAWAY MUST NOT be greater than the previous one (RFC 9114 §5.2).\n* **No streams beyond GOAWAY limit** — after a GOAWAY frame is received, no new request streams should be opened with an ID greater than the indicated last stream ID (RFC 9114 §5.2)."
+        "Validates HTTP/3 GOAWAY frame semantics during connection lifecycle.  A GOAWAY's identifier depends on who sent it: a server sends a client-initiated request stream ID, a client sends a push ID (RFC 9114 §5.2), so the checks below are scoped by sender.  This rule inspects protocol-level events and checks:\n\n* **GOAWAY identifier must not increase** — when multiple GOAWAY frames are received from the same peer on a connection, the identifier in each subsequent GOAWAY MUST NOT be greater than the previous one (RFC 9114 §5.2).\n* **No request streams beyond a server GOAWAY limit** — after a *server* GOAWAY (whose identifier is a request stream ID), no new request stream should be opened with an ID greater than the indicated last stream ID (RFC 9114 §5.2).  A client GOAWAY carries a push ID and does not constrain request streams."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -174,6 +199,18 @@ mod tests {
             ProtocolEventKind::H3GoawayReceived {
                 stream_id,
                 direction: MessageDirection::Client,
+            },
+        )
+    }
+
+    /// A server GOAWAY, whose identifier is a request stream ID — the only kind
+    /// that limits how far client request streams may open.
+    fn make_server_goaway(conn: Uuid, stream_id: Option<u64>) -> ProtocolEvent {
+        make_event(
+            conn,
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id,
+                direction: MessageDirection::Server,
             },
         )
     }
@@ -291,7 +328,7 @@ mod tests {
     fn stream_opened_beyond_goaway_limit_fails() {
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
-        let goaway = make_goaway(conn, Some(4));
+        let goaway = make_server_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 5);
         let result = rule.check_event(&evt, &history, &make_config());
@@ -299,6 +336,19 @@ mod tests {
         let msg = result.unwrap().message;
         assert!(msg.contains("stream 5"));
         assert!(msg.contains("last stream ID 4"));
+    }
+
+    #[test]
+    fn stream_opened_after_client_goaway_is_not_a_stream_violation() {
+        // A client GOAWAY carries a *push ID*, not a request stream ID, so it
+        // must not constrain how far request streams may open (the false
+        // positive this scoping prevents).
+        let rule = StatefulHttp3GoawaySemantics;
+        let conn = Uuid::new_v4();
+        let goaway = make_goaway(conn, Some(4)); // client GOAWAY (push id 4)
+        let history = ProtocolEventHistory::new(vec![goaway]);
+        let evt = make_stream_opened(conn, 5);
+        assert!(rule.check_event(&evt, &history, &make_config()).is_none());
     }
 
     #[test]
@@ -395,7 +445,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3GoawayReceived {
                 stream_id: Some(2),
-                direction: MessageDirection::Client,
+                direction: MessageDirection::Server,
             },
             t,
         );
@@ -465,7 +515,7 @@ mod tests {
         // GOAWAY with stream_id=0 means only stream 0 allowed; stream 1 is beyond.
         let rule = StatefulHttp3GoawaySemantics;
         let conn = Uuid::new_v4();
-        let goaway = make_goaway(conn, Some(0));
+        let goaway = make_server_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 1);
         let result = rule.check_event(&evt, &history, &make_config());

--- a/lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+++ b/lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
@@ -34,9 +34,13 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
             // increase beyond the value sent in a previous GOAWAY.
             ProtocolEventKind::H3GoawayReceived {
                 stream_id: current_id,
+                ..
             } => {
                 for prev in history.iter() {
-                    if let ProtocolEventKind::H3GoawayReceived { stream_id: prev_id } = &prev.kind {
+                    if let ProtocolEventKind::H3GoawayReceived {
+                        stream_id: prev_id, ..
+                    } = &prev.kind
+                    {
                         if let (Some(curr), Some(prev)) = (current_id, prev_id) {
                             if curr > prev {
                                 return Some(Violation {
@@ -64,6 +68,7 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
                 for prev in history.iter() {
                     if let ProtocolEventKind::H3GoawayReceived {
                         stream_id: Some(goaway_id),
+                        ..
                     } = &prev.kind
                     {
                         if stream_id > goaway_id {
@@ -133,6 +138,7 @@ static REGISTRATION: &dyn crate::rules::ProtocolRule = &StatefulHttp3GoawaySeman
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol_event::MessageDirection;
     use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
@@ -163,7 +169,13 @@ mod tests {
     }
 
     fn make_goaway(conn: Uuid, stream_id: Option<u64>) -> ProtocolEvent {
-        make_event(conn, ProtocolEventKind::H3GoawayReceived { stream_id })
+        make_event(
+            conn,
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id,
+                direction: MessageDirection::Client,
+            },
+        )
     }
 
     fn make_stream_opened(conn: Uuid, stream_id: u64) -> ProtocolEvent {
@@ -356,6 +368,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3GoawayReceived {
                 stream_id: Some(10),
+                direction: MessageDirection::Client,
             },
             t + chrono::Duration::seconds(1),
         );
@@ -380,7 +393,10 @@ mod tests {
         );
         let goaway = make_event_at(
             conn,
-            ProtocolEventKind::H3GoawayReceived { stream_id: Some(2) },
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id: Some(2),
+                direction: MessageDirection::Client,
+            },
             t,
         );
         let history = ProtocolEventHistory::new(vec![closed, goaway]);
@@ -399,13 +415,17 @@ mod tests {
         // History (newest first): goaway(6) at t+1, goaway(10) at t
         let g1 = make_event_at(
             conn,
-            ProtocolEventKind::H3GoawayReceived { stream_id: Some(6) },
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id: Some(6),
+                direction: MessageDirection::Client,
+            },
             t + chrono::Duration::seconds(1),
         );
         let g2 = make_event_at(
             conn,
             ProtocolEventKind::H3GoawayReceived {
                 stream_id: Some(10),
+                direction: MessageDirection::Client,
             },
             t,
         );

--- a/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
@@ -11,7 +11,9 @@
 //!   type H3_ID_ERROR.
 
 use crate::lint::Violation;
-use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
+use crate::protocol_event::{
+    MessageDirection, ProtocolEvent, ProtocolEventHistory, ProtocolEventKind,
+};
 use crate::rules::ProtocolRule;
 
 pub struct StatefulHttp3MaxPushId;
@@ -32,10 +34,27 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
         // The event this rule recognizes is the MAX_PUSH_ID frame itself; every
         // other protocol event is out of scope.
         // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
-        let current = match &event.kind {
-            ProtocolEventKind::H3MaxPushId { push_id, .. } => *push_id,
+        let (current, direction) = match &event.kind {
+            ProtocolEventKind::H3MaxPushId { push_id, direction } => (*push_id, *direction),
             _ => return None,
         };
+
+        // MAX_PUSH_ID is a client-only frame: a server sending one at all is the
+        // violation, whatever its value. This became checkable once the upstream
+        // leg is observed with a sender direction — a `Server` MAX_PUSH_ID is one
+        // the origin sent to this proxy, which as the receiving client must reject.
+        // cite(RFC 9114 § 7.2.7): "A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED."
+        if direction == MessageDirection::Server {
+            return Some(Violation {
+                rule: self.id().into(),
+                severity: config.severity,
+                message: format!(
+                    "HTTP/3 MAX_PUSH_ID (push_id {}) sent by a server; a server MUST NOT \
+                     send MAX_PUSH_ID (RFC 9114 §7.2.7, H3_FRAME_UNEXPECTED)",
+                    current
+                ),
+            });
+        }
 
         // A value strictly smaller than one already received is the violation;
         // the comparison is `<`, not `<=`, because equal does not reduce the
@@ -80,7 +99,7 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
     }
 
     fn description(&self) -> &'static str {
-        "Validates HTTP/3 `MAX_PUSH_ID` frame semantics across the lifetime of a connection.  This rule inspects protocol-level events emitted by the HTTP/3 control-stream parser and checks:\n\n* **MAX_PUSH_ID must not decrease** — when multiple `MAX_PUSH_ID` frames are received on the same connection, each successive value MUST be greater than or equal to the previous one.  Receipt of a smaller value is a connection error of type `H3_ID_ERROR` (RFC 9114 §7.2.7).\n\nThe first `MAX_PUSH_ID` on a connection establishes the initial limit and is always accepted, regardless of value (zero is valid and means the server is not allowed to push)."
+        "Validates HTTP/3 `MAX_PUSH_ID` frame semantics across the lifetime of a connection.  This rule inspects protocol-level events emitted by the HTTP/3 control-stream parser and checks:\n\n* **A server must not send `MAX_PUSH_ID`** — `MAX_PUSH_ID` is a client-only frame; a `MAX_PUSH_ID` observed from a server is a connection error of type `H3_FRAME_UNEXPECTED` (RFC 9114 §7.2.7), regardless of its value.\n\n* **MAX_PUSH_ID must not decrease** — when multiple `MAX_PUSH_ID` frames are received on the same connection, each successive value MUST be greater than or equal to the previous one.  Receipt of a smaller value is a connection error of type `H3_ID_ERROR` (RFC 9114 §7.2.7).\n\nThe first `MAX_PUSH_ID` on a connection establishes the initial limit and is always accepted, regardless of value (zero is valid and means the server is not allowed to push)."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -112,6 +131,11 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
                 compliance: Compliance::NonCompliant,
                 label: Some("(decreasing MAX_PUSH_ID)"),
                 snippet: "# Client sends MAX_PUSH_ID { push_id: 10 }\n# Client sends MAX_PUSH_ID { push_id: 4 }\n# Violation: MAX_PUSH_ID 4 decreased from previous 10 (RFC 9114 §7.2.7, H3_ID_ERROR)",
+            },
+            Example {
+                compliance: Compliance::NonCompliant,
+                label: Some("(server-sent MAX_PUSH_ID)"),
+                snippet: "# Server sends MAX_PUSH_ID { push_id: 5 }\n# Violation: a server MUST NOT send MAX_PUSH_ID (RFC 9114 §7.2.7, H3_FRAME_UNEXPECTED)",
             },
         ]
     }
@@ -159,6 +183,37 @@ mod tests {
                 direction: MessageDirection::Client,
             },
         )
+    }
+
+    // ── A server MUST NOT send MAX_PUSH_ID (RFC 9114 §7.2.7) ──────────────
+
+    #[test]
+    fn server_sent_max_push_id_is_a_violation() {
+        let rule = StatefulHttp3MaxPushId;
+        let conn = Uuid::new_v4();
+        let evt = make_event(
+            conn,
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 5,
+                direction: MessageDirection::Server,
+            },
+        );
+        let v = rule
+            .check_event(&evt, &ProtocolEventHistory::empty(), &make_config())
+            .expect("a server-sent MAX_PUSH_ID must be flagged");
+        assert!(v.message.contains("server"));
+        assert!(v.message.contains("H3_FRAME_UNEXPECTED"));
+    }
+
+    #[test]
+    fn client_sent_max_push_id_is_not_flagged_by_the_server_check() {
+        // The server-only check must not fire for a normal client MAX_PUSH_ID.
+        let rule = StatefulHttp3MaxPushId;
+        let conn = Uuid::new_v4();
+        let evt = make_max_push_id(conn, 5);
+        assert!(rule
+            .check_event(&evt, &ProtocolEventHistory::empty(), &make_config())
+            .is_none());
     }
 
     // ── First MAX_PUSH_ID on a connection: any value is valid ────────────

--- a/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
@@ -33,7 +33,7 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
         // other protocol event is out of scope.
         // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
         let current = match &event.kind {
-            ProtocolEventKind::H3MaxPushId { push_id } => *push_id,
+            ProtocolEventKind::H3MaxPushId { push_id, .. } => *push_id,
             _ => return None,
         };
 
@@ -42,7 +42,10 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
         // maximum and is a legitimate idempotent re-send.
         // cite(RFC 9114 § 7.2.7): "A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR"
         for prev in history.iter() {
-            if let ProtocolEventKind::H3MaxPushId { push_id: prev_id } = &prev.kind {
+            if let ProtocolEventKind::H3MaxPushId {
+                push_id: prev_id, ..
+            } = &prev.kind
+            {
                 if current < *prev_id {
                     return Some(Violation {
                         rule: self.id().into(),
@@ -121,6 +124,7 @@ static REGISTRATION: &dyn crate::rules::ProtocolRule = &StatefulHttp3MaxPushId;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol_event::MessageDirection;
     use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
@@ -148,7 +152,13 @@ mod tests {
     }
 
     fn make_max_push_id(conn: Uuid, push_id: u64) -> ProtocolEvent {
-        make_event(conn, ProtocolEventKind::H3MaxPushId { push_id })
+        make_event(
+            conn,
+            ProtocolEventKind::H3MaxPushId {
+                push_id,
+                direction: MessageDirection::Client,
+            },
+        )
     }
 
     // ── First MAX_PUSH_ID on a connection: any value is valid ────────────
@@ -257,15 +267,28 @@ mod tests {
         // History (newest first): 20, 10, 5
         let g1 = make_event_at(
             conn,
-            ProtocolEventKind::H3MaxPushId { push_id: 20 },
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 20,
+                direction: MessageDirection::Client,
+            },
             t + chrono::Duration::seconds(2),
         );
         let g2 = make_event_at(
             conn,
-            ProtocolEventKind::H3MaxPushId { push_id: 10 },
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 10,
+                direction: MessageDirection::Client,
+            },
             t + chrono::Duration::seconds(1),
         );
-        let g3 = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 5 }, t);
+        let g3 = make_event_at(
+            conn,
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 5,
+                direction: MessageDirection::Client,
+            },
+            t,
+        );
         let history = ProtocolEventHistory::new(vec![g1, g2, g3]);
         // 20 (most recent) == 20 -> OK
         let evt = make_max_push_id(conn, 20);
@@ -285,10 +308,20 @@ mod tests {
         let t = base_ts();
         let newer = make_event_at(
             conn,
-            ProtocolEventKind::H3MaxPushId { push_id: 5 },
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 5,
+                direction: MessageDirection::Client,
+            },
             t + chrono::Duration::seconds(1),
         );
-        let older = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 50 }, t);
+        let older = make_event_at(
+            conn,
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 50,
+                direction: MessageDirection::Client,
+            },
+            t,
+        );
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 8);
         let result = rule.check_event(&evt, &history, &make_config());
@@ -303,10 +336,20 @@ mod tests {
         let t = base_ts();
         let newer = make_event_at(
             conn,
-            ProtocolEventKind::H3MaxPushId { push_id: 20 },
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 20,
+                direction: MessageDirection::Client,
+            },
             t + chrono::Duration::seconds(1),
         );
-        let older = make_event_at(conn, ProtocolEventKind::H3MaxPushId { push_id: 5 }, t);
+        let older = make_event_at(
+            conn,
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 5,
+                direction: MessageDirection::Client,
+            },
+            t,
+        );
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 10);
         let result = rule.check_event(&evt, &history, &make_config());
@@ -327,12 +370,16 @@ mod tests {
             conn,
             ProtocolEventKind::H3SettingsReceived {
                 settings: vec![(0x06, 8192)],
+                direction: MessageDirection::Client,
             },
             t + chrono::Duration::seconds(2),
         );
         let prev = make_event_at(
             conn,
-            ProtocolEventKind::H3MaxPushId { push_id: 10 },
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 10,
+                direction: MessageDirection::Client,
+            },
             t + chrono::Duration::seconds(1),
         );
         let stream = make_event_at(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 }, t);
@@ -353,6 +400,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3SettingsReceived {
                 settings: vec![(0x06, 8192)],
+                direction: MessageDirection::Client,
             },
             t + chrono::Duration::seconds(1),
         );
@@ -374,6 +422,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3SettingsReceived {
                 settings: vec![(0x06, 4096)],
+                direction: MessageDirection::Client,
             },
         );
         let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
@@ -386,7 +435,10 @@ mod tests {
         let conn = Uuid::new_v4();
         let evt = make_event(
             conn,
-            ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) },
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id: Some(4),
+                direction: MessageDirection::Client,
+            },
         );
         let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
@@ -459,7 +511,10 @@ mod tests {
         for i in 0..10 {
             history_vec.push(make_event_at(
                 conn,
-                ProtocolEventKind::H3MaxPushId { push_id: 7 },
+                ProtocolEventKind::H3MaxPushId {
+                    push_id: 7,
+                    direction: MessageDirection::Client,
+                },
                 t + chrono::Duration::seconds(10 - i),
             ));
         }
@@ -483,6 +538,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3SettingsReceived {
                 settings: vec![(0x06, 8192)],
+                direction: MessageDirection::Client,
             },
             t + chrono::Duration::seconds(100),
         )];
@@ -500,7 +556,10 @@ mod tests {
         }
         history_vec.push(make_event_at(
             conn,
-            ProtocolEventKind::H3MaxPushId { push_id: 15 },
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 15,
+                direction: MessageDirection::Client,
+            },
             t,
         ));
         let history = ProtocolEventHistory::new(history_vec);

--- a/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
@@ -49,7 +49,7 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
         // other protocol event is out of scope.
         // cite(RFC 9114 § 7.2.4): "The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate"
         let settings = match &event.kind {
-            ProtocolEventKind::H3SettingsReceived { settings } => settings,
+            ProtocolEventKind::H3SettingsReceived { settings, .. } => settings,
             _ => return None,
         };
 
@@ -179,6 +179,7 @@ static REGISTRATION: &dyn crate::rules::ProtocolRule = &StatefulHttp3SettingsFra
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol_event::MessageDirection;
     use crate::protocol_event::{ProtocolEvent, ProtocolEventHistory, ProtocolEventKind};
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
@@ -206,7 +207,13 @@ mod tests {
     }
 
     fn make_settings(conn: Uuid, settings: Vec<(u64, u64)>) -> ProtocolEvent {
-        make_event(conn, ProtocolEventKind::H3SettingsReceived { settings })
+        make_event(
+            conn,
+            ProtocolEventKind::H3SettingsReceived {
+                settings,
+                direction: MessageDirection::Client,
+            },
+        )
     }
 
     // ── First SETTINGS on a connection: valid cases ──────────────────
@@ -305,6 +312,7 @@ mod tests {
             conn,
             ProtocolEventKind::H3SettingsReceived {
                 settings: vec![(0x06, 4096)],
+                direction: MessageDirection::Client,
             },
             t + chrono::Duration::seconds(1),
         );
@@ -319,6 +327,7 @@ mod tests {
                     initial_max_stream_data_bidi_remote: None,
                     initial_max_stream_data_uni: None,
                 },
+                direction: MessageDirection::Client,
             },
             t,
         );
@@ -507,7 +516,10 @@ mod tests {
         let conn = Uuid::new_v4();
         let evt = make_event(
             conn,
-            ProtocolEventKind::H3GoawayReceived { stream_id: Some(4) },
+            ProtocolEventKind::H3GoawayReceived {
+                stream_id: Some(4),
+                direction: MessageDirection::Client,
+            },
         );
         let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
@@ -517,7 +529,13 @@ mod tests {
     fn max_push_id_event_ignored() {
         let rule = StatefulHttp3SettingsFrame;
         let conn = Uuid::new_v4();
-        let evt = make_event(conn, ProtocolEventKind::H3MaxPushId { push_id: 10 });
+        let evt = make_event(
+            conn,
+            ProtocolEventKind::H3MaxPushId {
+                push_id: 10,
+                direction: MessageDirection::Client,
+            },
+        );
         let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());
     }

--- a/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
@@ -6,7 +6,8 @@
 //!
 //! Checks:
 //! - SETTINGS is the first frame on the control stream and is not sent
-//!   subsequently, so a second one on the connection is a violation.
+//!   subsequently *by that peer*, so a second one from the same peer on the
+//!   connection is a violation (the other peer's SETTINGS is its own first frame).
 //! - Reserved setting identifiers (0x00, 0x02–0x05 — the `Reserved` rows of
 //!   Table 3 in RFC 9114 §11.2.2) must not appear; their receipt is a
 //!   connection error of type H3_SETTINGS_ERROR (RFC 9114 §7.2.4.1).
@@ -48,8 +49,11 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
         // The event this rule recognizes is the SETTINGS frame itself; every
         // other protocol event is out of scope.
         // cite(RFC 9114 § 7.2.4): "The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate"
-        let settings = match &event.kind {
-            ProtocolEventKind::H3SettingsReceived { settings, .. } => settings,
+        let (settings, direction) = match &event.kind {
+            ProtocolEventKind::H3SettingsReceived {
+                settings,
+                direction,
+            } => (settings, *direction),
             _ => return None,
         };
 
@@ -57,16 +61,26 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
         // is what makes a second SETTINGS visible at all.
         // cite(RFC 9114 § 7.2.4): "SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream"
         //
-        // A prior SETTINGS on this connection means this one was sent
-        // subsequently, which is the violation.
+        // A prior SETTINGS *from the same peer* means this one was sent
+        // subsequently, which is the violation. The rule is per peer ("by each
+        // peer"), so the other peer's SETTINGS — now observable on the upstream
+        // leg — is its own legitimate first frame, not a duplicate of this one.
         // cite(RFC 9114 § 7.2.4): "A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently"
         for prev in history.iter() {
-            if matches!(&prev.kind, ProtocolEventKind::H3SettingsReceived { .. }) {
+            if let ProtocolEventKind::H3SettingsReceived {
+                direction: prev_dir,
+                ..
+            } = &prev.kind
+            {
+                if *prev_dir != direction {
+                    continue;
+                }
                 return Some(Violation {
                     rule: self.id().into(),
                     severity: config.severity,
                     message:
-                        "HTTP/3 duplicate SETTINGS frame on the same connection (RFC 9114 §7.2.4)"
+                        "HTTP/3 duplicate SETTINGS frame from the same peer on one connection \
+                         (RFC 9114 §7.2.4)"
                             .into(),
                 });
             }
@@ -119,7 +133,7 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
     }
 
     fn description(&self) -> &'static str {
-        "Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:\n\n* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event on the same connection is a violation.\n* **No reserved setting identifiers** — the `Reserved` rows of the \"HTTP/3 Settings\" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).\n\n* **No repeated setting identifier** — the same setting identifier MUST NOT occur more than once in the SETTINGS frame (RFC 9114 §7.2.4).  A receiver MAY treat duplicates as a connection error of type `H3_SETTINGS_ERROR`; the sender's obligation is unconditional, so a repeated identifier within one frame is a violation.\n\nIdentifiers outside the reserved set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored."
+        "Validates HTTP/3 SETTINGS frame semantics on the control stream.  This rule inspects protocol-level events emitted by the QUIC stream wrapper and checks:\n\n* **No duplicate SETTINGS** — a SETTINGS frame MUST be sent as the first frame of each control stream by each peer, and it MUST NOT be sent subsequently (RFC 9114 §7.2.4).  SETTINGS applies to the entire connection, never a single stream, so a second `H3SettingsReceived` event *from the same peer* on the connection is a violation.  Because the obligation is per peer, the other peer's SETTINGS (observable on the upstream leg) is its own legitimate first frame, not a duplicate.\n* **No reserved setting identifiers** — the `Reserved` rows of the \"HTTP/3 Settings\" registry (RFC 9114 Table 3, §11.2.2) MUST NOT be sent, and their receipt MUST be treated as a connection error of type `H3_SETTINGS_ERROR` (RFC 9114 §7.2.4.1).  The reserved identifiers are `0x00` (no HTTP/2 counterpart), `0x02` (SETTINGS_ENABLE_PUSH in HTTP/2), `0x03` (SETTINGS_MAX_CONCURRENT_STREAMS), `0x04` (SETTINGS_INITIAL_WINDOW_SIZE), and `0x05` (SETTINGS_MAX_FRAME_SIZE).\n\n* **No repeated setting identifier** — the same setting identifier MUST NOT occur more than once in the SETTINGS frame (RFC 9114 §7.2.4).  A receiver MAY treat duplicates as a connection error of type `H3_SETTINGS_ERROR`; the sender's obligation is unconditional, so a repeated identifier within one frame is a violation.\n\nIdentifiers outside the reserved set — including the `0x1f * N + 0x21` greasing values and unregistered extensions — are ignored, per RFC 9114 §7.2.4's requirement that unknown parameters be ignored."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -214,6 +228,29 @@ mod tests {
                 direction: MessageDirection::Client,
             },
         )
+    }
+
+    fn make_server_settings(conn: Uuid, settings: Vec<(u64, u64)>) -> ProtocolEvent {
+        make_event(
+            conn,
+            ProtocolEventKind::H3SettingsReceived {
+                settings,
+                direction: MessageDirection::Server,
+            },
+        )
+    }
+
+    #[test]
+    fn other_peers_settings_is_not_a_duplicate() {
+        // The SETTINGS rule is per peer: a server SETTINGS following a client
+        // SETTINGS on one connection is the server's own first frame, not a
+        // duplicate of the client's.
+        let rule = StatefulHttp3SettingsFrame;
+        let conn = Uuid::new_v4();
+        let prior_client = make_settings(conn, vec![(0x06, 4096)]);
+        let history = ProtocolEventHistory::new(vec![prior_client]);
+        let evt = make_server_settings(conn, vec![(0x06, 8192)]);
+        assert!(rule.check_event(&evt, &history, &make_config()).is_none());
     }
 
     // ── First SETTINGS on a connection: valid cases ──────────────────

--- a/lint-http-rules/src/rules/stateful_websocket_frame_opcode_sequence.rs
+++ b/lint-http-rules/src/rules/stateful_websocket_frame_opcode_sequence.rs
@@ -302,7 +302,10 @@ mod tests {
         let evt = ProtocolEvent {
             timestamp: Utc::now(),
             connection_id: Uuid::new_v4(),
-            kind: ProtocolEventKind::H3GoawayReceived { stream_id: None },
+            kind: ProtocolEventKind::H3GoawayReceived {
+                stream_id: None,
+                direction: MessageDirection::Client,
+            },
         };
         let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
         assert!(result.is_none());

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1848,7 +1848,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 125
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 50
+      line: 51
   - label: lint-http-proxy/src/h3_instrument.rs (3)
     section: § 7.2.6
     snippet: The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint.
@@ -1856,7 +1856,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 131
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 31
+      line: 33
   - label: lint-http-proxy/src/h3_instrument.rs (4)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
@@ -1864,7 +1864,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 128
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 34
+      line: 36
   - label: message_http3_host_authority_consistency
     section: § 4.3.1
     snippet: If both fields are present, they MUST contain the same value.
@@ -1913,54 +1913,80 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
       line: 40
+  - label: stateful_http3_goaway_semantics
+    section: § 5.2
+    snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+      line: 96
+  - label: stateful_http3_goaway_semantics (2)
+    section: § 5.2
+    snippet: Receiving a GOAWAY containing a larger identifier than previously received MUST be treated as a connection error of type H3_ID_ERROR.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+      line: 57
+  - label: stateful_http3_goaway_semantics (3)
+    section: § 5.2
+    snippet: The server sends a client-initiated bidirectional stream ID; the client sends a push ID.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+      line: 50
+    - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+      line: 89
   - label: stateful_http3_max_push_id
     section: § 7.2.7
     snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 43
+      line: 62
   - label: stateful_http3_max_push_id (2)
+    section: § 7.2.7
+    snippet: A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+      line: 46
+  - label: stateful_http3_max_push_id (3)
     section: § 7.2.7
     snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 74
+      line: 93
   - label: stateful_http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 26
+      line: 27
   - label: stateful_http3_settings_frame (2)
     section: § 7.2.4
     snippet: A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 62
+      line: 68
   - label: stateful_http3_settings_frame (3)
     section: § 7.2.4
     snippet: An implementation MUST ignore any parameter with an identifier it does not understand
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 113
+      line: 127
   - label: stateful_http3_settings_frame (4)
     section: § 7.2.4
     snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 58
+      line: 62
   - label: stateful_http3_settings_frame (5)
     section: § 7.2.4
     snippet: The same setting identifier MUST NOT occur more than once in the SETTINGS frame
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 96
+      line: 110
   - label: stateful_http3_settings_frame (6)
     section: § 7.2.4.1
     snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 77
+      line: 91
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.txt
   type: text/plain

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1014,7 +1014,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 358
+      line: 369
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -904,7 +904,7 @@ sources:
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 46
+      line: 55
 - label: RFC 9110
   url: https://www.rfc-editor.org/rfc/rfc9110.txt
   type: text/plain
@@ -1014,7 +1014,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 369
+      line: 380
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -898,7 +898,7 @@ sources:
     snippet: For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025).
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 490
+      line: 521
   - label: server_quic_transport_parameters
     section: § 18
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
@@ -1840,7 +1840,7 @@ sources:
     snippet: A control stream is indicated by a stream type of 0x00.
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 131
+      line: 134
   - label: lint-http-proxy/src/h3_instrument.rs (2)
     section: § 7.2.4
     snippet: The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate
@@ -1850,6 +1850,14 @@ sources:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
       line: 50
   - label: lint-http-proxy/src/h3_instrument.rs (3)
+    section: § 7.2.6
+    snippet: The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint.
+    cited_by:
+    - file: lint-http-proxy/src/h3_instrument.rs
+      line: 131
+    - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+      line: 31
+  - label: lint-http-proxy/src/h3_instrument.rs (4)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
     cited_by:
@@ -1905,12 +1913,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
       line: 40
-  - label: stateful_http3_goaway_semantics
-    section: § 7.2.6
-    snippet: The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint.
-    cited_by:
-    - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 31
   - label: stateful_http3_max_push_id
     section: § 7.2.7
     snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
@@ -1922,7 +1924,7 @@ sources:
     snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 71
+      line: 74
   - label: stateful_http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document


### PR DESCRIPTION
Observe and flag server-sent H3 control frames, port-agnostic origin matching, response-head bounding, QUIC-params scope fix, concurrent body streaming.

