### PR TITLE
HTTP/3 rule cites

### DIFF
--- a/docs/rules/server_alt_svc_h3_advertisement_valid.md
+++ b/docs/rules/server_alt_svc_h3_advertisement_valid.md
@@ -14,7 +14,7 @@ This rule complements `server_alt_svc_header_syntax` (general syntax) and `serve
 
 ## Specifications
 
-- [RFC 9114 §3.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1): HTTP/3 alternative service discovery
+- [RFC 9114 §3.1.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1.1): HTTP Alternative Services — advertising HTTP/3 via Alt-Svc using the "h3" ALPN token
 - [RFC 7838 §3](https://www.rfc-editor.org/rfc/rfc7838.html#section-3): Alt-Svc header field syntax and `ma` parameter semantics
 
 ## Configuration

--- a/docs/rules/server_quic_transport_parameters.md
+++ b/docs/rules/server_quic_transport_parameters.md
@@ -10,15 +10,16 @@ SPDX-License-Identifier: ISC
 
 Validates that the QUIC transport parameters advertised for HTTP/3 are reasonable. The proxy emits a `QuicTransportParams` event for the parameters **it advertises on its own client-facing HTTP/3 endpoint**, and this rule checks those. It does **not** validate a remote origin's parameters on the upstream leg: the QUIC stack exposes no way to read a peer's transport parameters, so an origin's are not observable and go unchecked here. The checks:
 
-* **Bidirectional streams allowed** — `initial_max_streams_bidi` must be non-zero so that at least one HTTP/3 request stream can be opened.
-* **Connection flow control** — `initial_max_data` must be non-zero so that data can actually be transferred.
-* **Stream flow control** — `initial_max_stream_data_bidi_local`, `initial_max_stream_data_bidi_remote`, and `initial_max_stream_data_uni` must be non-zero for their respective stream types to carry data.
-* **Idle timeout** — `max_idle_timeout_ms` should be set (non-zero) to prevent idle connections from consuming server resources indefinitely, and should not be excessively large (>10 minutes).
+* **Bidirectional streams allowed** — `initial_max_streams_bidi` should be non-zero (RFC 9114 §6.1) so that at least one HTTP/3 request stream can be opened; only an explicit 0 is flagged, not an absent value or a value below the §6.1 floor of 100.
+* **Connection flow control** — `initial_max_data` should be non-zero so that data can actually be transferred (a reasonableness check; RFC 9000 §18.2 permits 0, raisable via MAX_DATA).
+* **Stream flow control** — the per-stream windows should be non-zero so streams can carry data: `initial_max_stream_data_bidi_remote` for the client's request streams (RFC 9114 §6.1) and `initial_max_stream_data_uni` for the control/QPACK streams (RFC 9114 §6.2). `initial_max_stream_data_bidi_local` governs server-initiated bidirectional streams, which HTTP/3 does not use, so its non-zero check is a reasonableness heuristic.
+* **Idle timeout** — `max_idle_timeout_ms` should be set (non-zero) to prevent idle connections from consuming server resources indefinitely, and should not be excessively large (>10 minutes); both are reasonableness heuristics, since 0/absent legally disables the timeout (RFC 9000 §18.2).
 
 ## Specifications
 
 - [RFC 9000 §18.2](https://www.rfc-editor.org/rfc/rfc9000.html#section-18.2): Transport Parameter Definitions
-- [RFC 9114 §3.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1): Discovering an HTTP/3 Endpoint
+- [RFC 9114 §6.1](https://www.rfc-editor.org/rfc/rfc9114.html#section-6.1): Bidirectional Streams — servers SHOULD grant non-zero stream and flow-control limits
+- [RFC 9114 §6.2](https://www.rfc-editor.org/rfc/rfc9114.html#section-6.2): Unidirectional Streams — restricting their flow-control window blocks control/QPACK
 
 ## Configuration
 

--- a/docs/rules/stateful_101_switching_protocols.md
+++ b/docs/rules/stateful_101_switching_protocols.md
@@ -19,8 +19,8 @@ Validates that `101 Switching Protocols` responses follow correct HTTP upgrade s
 
 - [RFC 9110 §15.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2): 101 Switching Protocols
 - [RFC 9110 §7.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8): Upgrade
-- [RFC 9113 §8.6](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6): The CONNECT Method (HTTP/2 forbids 101)
-- [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade (HTTP/3 forbids 101). This said §4.1, whose subject is HTTP Message Framing, under a note naming a section title RFC 9114 does not have
+- [RFC 9113 §8.6](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6): The Upgrade Header Field (HTTP/2 forbids 101)
+- [RFC 9114 §4.5](https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5): HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/message_http3_no_connection_header.rs
+++ b/lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -6,6 +6,14 @@ use crate::lint::Violation;
 use crate::rules::Rule;
 
 /// Connection-specific headers that MUST NOT appear in HTTP/3 messages.
+///
+/// RFC 9114 §4.2 forbids "connection-specific header fields as discussed in
+/// Section 7.6.1 of [HTTP]"; §7.6.1 is what enumerates them. Its bullet list
+/// names Keep-Alive, Proxy-Connection, Transfer-Encoding, and Upgrade (TE is
+/// there too, but HTTP/3 keeps it as the exception below, so it is not here);
+/// `connection` is the Connection header field §7.6.1 defines and §4.2 says
+/// HTTP/3 does not use.
+/// cite(RFC 9110 § 7.6.1): "Furthermore, intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics."
 const FORBIDDEN_HEADERS: &[&str] = &[
     "connection",
     "keep-alive",
@@ -32,8 +40,12 @@ impl Rule for MessageHttp3NoConnectionHeader {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        // Only applies to HTTP/3 transactions.
-        // cite(RFC 9114 § 4.2): "An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP]"
+        // Only applies to HTTP/3 transactions. Scoping cite: HTTP/3's field model
+        // is why this rule exists. (The previous cite here — the *intermediary*
+        // MUST-remove sentence — did not govern this request version gate; it is
+        // re-homed to the reverse-proxy response gate below, and the enforcing
+        // "MUST NOT generate … MUST be treated as malformed" now sits on the check.)
+        // cite(RFC 9114 § 4.2): "HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means."
         if tx.request.version != "HTTP/3" {
             return None;
         }
@@ -56,10 +68,13 @@ impl Rule for MessageHttp3NoConnectionHeader {
             });
         }
 
-        // Check response headers only when the response itself is HTTP/3.
-        // In a reverse-proxy setup the upstream response may be HTTP/1.1 or
-        // HTTP/2 and legitimately carry Connection/Transfer-Encoding headers
-        // that are later stripped before forwarding over HTTP/3.
+        // Check response headers only when the response itself is HTTP/3. In a
+        // reverse-proxy setup the upstream response may be HTTP/1.1 or HTTP/2 and
+        // legitimately carry Connection/Transfer-Encoding headers; the transforming
+        // intermediary must strip them, and it is that post-transformation HTTP/3
+        // message this gate scopes to — the sentence that governs the reverse-proxy
+        // case the previous version-gate cite was mis-anchored on.
+        // cite(RFC 9114 § 4.2): "An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed."
         if let Some(resp) = &tx.response {
             if resp.version == "HTTP/3" {
                 if let Some(msg) = check_forbidden_headers(&resp.headers) {
@@ -70,8 +85,13 @@ impl Rule for MessageHttp3NoConnectionHeader {
                     });
                 }
 
-                // TE is a request-only header (RFC 9110 §10.1.4); any
-                // presence in an HTTP/3 response is invalid.
+                // TE is connection-specific (RFC 9110 §7.6.1) and thus forbidden in
+                // HTTP/3 — the §4.2 exception restores it only "in an HTTP/3 request
+                // header", so a response gets no exception and any TE there is an
+                // unexcepted connection-specific field. The request-scope of the
+                // same exception sentence is what governs here (TE is registered as
+                // a Request Context Field, RFC 9110 §10.1.4).
+                // cite(RFC 9114 § 4.2): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
                 if resp.headers.contains_key("te") {
                     return Some(Violation {
                         rule: self.id().into(),
@@ -151,6 +171,10 @@ impl Rule for MessageHttp3NoConnectionHeader {
 }
 
 /// Check for the presence of any forbidden connection-specific header.
+///
+/// Enforces the HTTP/3 prohibition for both request and response call sites
+/// (this helper owns the quote; §7.6.1 defines the set, in the const above).
+/// cite(RFC 9114 § 4.2): "An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed."
 fn check_forbidden_headers(headers: &hyper::HeaderMap) -> Option<String> {
     for &name in FORBIDDEN_HEADERS {
         if headers.contains_key(name) {
@@ -164,6 +188,11 @@ fn check_forbidden_headers(headers: &hyper::HeaderMap) -> Option<String> {
 }
 
 /// Check that the TE header, if present, contains only "trailers".
+///
+/// TE is the one connection-specific field HTTP/3 permits in a request, and only
+/// with the value "trailers" (matched case-insensitively — transfer-coding names
+/// are case-insensitive tokens).
+/// cite(RFC 9114 § 4.2): "The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers"."
 fn check_te_header(headers: &hyper::HeaderMap) -> Option<String> {
     if let Some(val) = headers.get("te") {
         if let Ok(s) = val.to_str() {
@@ -175,6 +204,9 @@ fn check_te_header(headers: &hyper::HeaderMap) -> Option<String> {
                 );
             }
         } else {
+            // Defensive guard: a value that is not valid UTF-8 cannot be a
+            // "trailers" token. No specific sentence governs this; §4.2's
+            // malformed-field rule is about field *names*, not values.
             return Some("HTTP/3 TE header contains non-UTF-8 value".into());
         }
     }

--- a/lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
@@ -6,10 +6,12 @@ use crate::lint::Violation;
 use crate::rules::Rule;
 
 /// Alt-Svc advertising `h3` must use the final protocol ID (not draft versions),
-/// with a reasonable `ma` (max-age) value (RFC 9114 §3.1, RFC 7838).
+/// with a reasonable `ma` (max-age) value (RFC 9114 §3.1.1, RFC 7838).
 pub struct ServerAltSvcH3AdvertisementValid;
 
-/// Maximum reasonable max-age: 1 year in seconds.
+/// Maximum reasonable max-age: 1 year in seconds. RFC 7838 sets **no** upper
+/// bound on `ma`; this is a linter heuristic to flag likely misconfiguration,
+/// not a spec limit — hence uncited (recorded in the audit ledger, §4.1).
 const MAX_REASONABLE_MA: u64 = 365 * 24 * 3600;
 
 impl Rule for ServerAltSvcH3AdvertisementValid {
@@ -30,7 +32,10 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
-        // cite(RFC 7838 § 1): "This specification defines a new concept in HTTP, "Alternative Services", that allows an origin server to nominate additional means of interacting with it"
+        // Server-scoped: this rule reads Alt-Svc from responses. §3 defines the
+        // header field itself (§1's cite was the broader "Alternative Services"
+        // concept — re-anchored to the sentence about the response header field).
+        // cite(RFC 7838 § 3): "An HTTP(S) origin server can advertise the availability of alternative services to clients by adding an Alt-Svc header field to responses."
         for hv in resp.headers.get_all("alt-svc").iter() {
             let s = match hv.to_str() {
                 Ok(s) => s,
@@ -47,7 +52,13 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
                     continue; // syntax rule handles this
                 }
 
-                // "clear" is a valid Alt-Svc directive (RFC 7838 §3)
+                // "clear" is a directive to invalidate cached alternatives, not an
+                // h3 advertisement, so there is nothing for this rule to validate.
+                // (The grammar makes "clear" case-sensitive — `%s"clear"`; matching
+                // it case-insensitively here is inert, as any non-lowercase form has
+                // no '=' and is skipped anyway. Case-sensitivity is the syntax rule's
+                // concern; see §4.1.)
+                // cite(RFC 7838 § 3): "A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated"
                 if proto_auth.eq_ignore_ascii_case("clear") {
                     continue;
                 }
@@ -62,16 +73,25 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
                     continue;
                 }
 
+                // RFC 7838 §3 says protocol-ids are matched by "simple string
+                // comparison" (case-sensitive); this rule folds to lowercase — a
+                // deliberate, more-permissive choice so case-variant draft tokens
+                // (e.g. "H3-29") are still flagged. Not cited: the spec sentence
+                // mandates case-sensitive comparison, which is not what this does
+                // (the #10 shape — permissive code, no honest quote; §4.1).
                 let proto_lower = protocol.to_ascii_lowercase();
 
-                // Draft h3 protocol IDs (h3-29, h3-Q050, etc.)
+                // Draft h3 protocol IDs (h3-29, h3-Q050, etc.): the final ALPN token
+                // advertised for HTTP/3 is "h3", so any "h3-*" draft token is not a
+                // valid advertisement of the shipped protocol.
+                // cite(RFC 9114 § 3.1.1): "An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token."
                 if proto_lower.starts_with("h3-") {
                     return Some(Violation {
                         rule: self.id().into(),
                         severity: config.severity,
                         message: format!(
                             "Alt-Svc uses draft HTTP/3 protocol identifier '{}'; \
-                             use the final 'h3' token instead (RFC 9114 §3.1)",
+                             use the final 'h3' token instead (RFC 9114 §3.1.1)",
                             protocol
                         ),
                     });
@@ -104,9 +124,9 @@ impl Rule for ServerAltSvcH3AdvertisementValid {
         &[
             crate::rules::SpecRef {
                 spec: "RFC 9114",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1",
-                note: "HTTP/3 alternative service discovery",
+                section: Some("3.1.1"),
+                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1.1",
+                note: "HTTP Alternative Services — advertising HTTP/3 via Alt-Svc using the \"h3\" ALPN token",
             },
             crate::rules::SpecRef {
                 spec: "RFC 7838",
@@ -152,6 +172,11 @@ fn check_h3_ma_param(
             continue;
         }
 
+        // `ma` carries a delta-seconds count — how long the advertisement stays
+        // fresh. This governs all three checks below: an absent value and a
+        // non-numeric value fail to express delta-seconds, and ma=0 means fresh
+        // for zero seconds (immediately stale).
+        // cite(RFC 7838 § 3.1): "The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh."
         if raw_val.is_empty() {
             return Some(Violation {
                 rule: rule_id.into(),
@@ -173,10 +198,12 @@ fn check_h3_ma_param(
                     rule: rule_id.into(),
                     severity: config.severity,
                     message: "Alt-Svc h3 entry has 'ma=0' which immediately invalidates \
-                         the advertisement (RFC 7838 §3)"
+                         the advertisement (RFC 7838 §3.1)"
                         .into(),
                 });
             }
+            // Heuristic ceiling, not spec-derived: RFC 7838 places no upper bound
+            // on `ma` (see MAX_REASONABLE_MA). Flags likely misconfiguration only.
             Ok(n) if n > MAX_REASONABLE_MA => {
                 return Some(Violation {
                     rule: rule_id.into(),

--- a/lint-http-rules/src/rules/server_quic_transport_parameters.rs
+++ b/lint-http-rules/src/rules/server_quic_transport_parameters.rs
@@ -5,13 +5,21 @@
 //! QUIC transport parameter validation for HTTP/3 (RFC 9000 §18.2).
 //!
 //! Checks that the QUIC transport parameters carried by a `QuicTransportParams`
-//! event are reasonable for HTTP/3 usage:
-//! - `initial_max_streams_bidi` must be non-zero so that at least one
-//!   request stream can be opened.
-//! - `initial_max_data` (connection-level flow control) must be non-zero.
-//! - `max_idle_timeout_ms` should be set (non-zero) and not excessively large.
-//! - Per-stream flow-control windows (`initial_max_stream_data_*`) must be
-//!   non-zero.
+//! event are reasonable for HTTP/3 usage. Each check flags only an outright 0;
+//! its spec grounding differs by parameter:
+//! - `initial_max_streams_bidi` (request-stream count) and
+//!   `initial_max_stream_data_bidi_remote` (the window for those peer-initiated
+//!   request streams) — RFC 9114 §6.1's SHOULD.
+//! - `initial_max_stream_data_uni` (control/QPACK windows) — RFC 9114 §6.2.
+//! - `initial_max_stream_data_bidi_local` — server-initiated bidi, which HTTP/3
+//!   does not use (§6.1), so this is a reasonableness heuristic.
+//! - `initial_max_data` (connection flow control) and `max_idle_timeout_ms` —
+//!   reasonableness heuristics; RFC 9000 §18.2 permits 0/absent (raisable via
+//!   MAX_DATA, and a 0 idle timeout legally disables the timeout).
+//!
+//! Everything here is SHOULD-level or softer: the rule flags an explicit 0 — the
+//! functional breaker — not an absent (`None`) value, and not the §6.1 floor of
+//! 100 request streams. These tolerances are deliberate.
 //!
 //! Scope: the only `QuicTransportParams` event the proxy currently produces
 //! carries the parameters **it advertises** on its own client-facing HTTP/3 leg
@@ -45,25 +53,35 @@ impl ProtocolRule for ServerQuicTransportParameters {
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
+        // The event carries the contents of the quic_transport_parameters TLS
+        // extension (this cite was re-homed here from the bidi check below, where
+        // it did not belong — it describes the extension, not a stream rule).
+        // cite(RFC 9000 § 18): "The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters"
         let params = match &event.kind {
             ProtocolEventKind::QuicTransportParams { params, .. } => params,
             _ => return None,
         };
 
-        // RFC 9000 §18.2 / RFC 9114 §3.1: HTTP/3 requires at least one
-        // bidirectional stream for request/response exchange.
-        // cite(RFC 9000 § 18): "The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters"
+        // "number of permitted streams" half of §6.1's SHOULD. §18.2: a 0 (or
+        // absent) grant only defers stream opening until a MAX_STREAMS frame, so
+        // this is a SHOULD-level reasonableness check, not a hard requirement; it
+        // flags an explicit 0 only (not None, and not the §6.1 floor of 100).
+        // cite(RFC 9114 § 6.1): "In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window."
         if params.initial_max_streams_bidi == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
                 message: "QUIC initial_max_streams_bidi is 0; HTTP/3 requires at least one \
-                     bidirectional stream for request/response exchange (RFC 9000 §18.2)"
+                     bidirectional stream for request/response exchange (RFC 9114 §6.1)"
                     .into(),
             });
         }
 
-        // Connection-level flow control window must allow data transfer.
+        // Connection-level flow control. Unlike the per-stream windows below, this
+        // is *not* covered by §6.1's SHOULD (which is about stream windows), so the
+        // non-zero check here is a reasonableness heuristic: §18.2 permits 0, with
+        // the limit raisable via MAX_DATA. The cite is the definition, not a MUST.
+        // cite(RFC 9000 § 18.2): "the initial value for the maximum amount of data that can be sent on the connection"
         if params.initial_max_data == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
@@ -74,7 +92,12 @@ impl ProtocolRule for ServerQuicTransportParameters {
             });
         }
 
-        // Per-stream flow control: bidirectional local.
+        // 0x05 is *locally* initiated bidi — i.e. server-initiated, which HTTP/3
+        // does not use, so §6.1's request-stream SHOULD does not reach this window.
+        // The non-zero check here is a reasonableness heuristic on a window HTTP/3
+        // rarely exercises; the cite is the §18.2 definition, not a requirement.
+        // cite(RFC 9000 § 18.2): "the initial flow control limit for locally initiated bidirectional streams"
+        // cite(RFC 9114 § 6.1): "HTTP/3 does not use server-initiated bidirectional streams"
         if params.initial_max_stream_data_bidi_local == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
@@ -85,30 +108,37 @@ impl ProtocolRule for ServerQuicTransportParameters {
             });
         }
 
-        // Per-stream flow control: bidirectional remote.
+        // 0x06 is *peer*-initiated bidi — from the server that is the client's
+        // request streams, so THIS is the "initial stream flow-control window" of
+        // §6.1's SHOULD (the honest request-stream window; the count is above).
+        // cite(RFC 9114 § 6.1): "In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window."
         if params.initial_max_stream_data_bidi_remote == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
-                message: "QUIC initial_max_stream_data_bidi_remote is 0; bidirectional streams \
-                     cannot carry data (RFC 9000 §18.2)"
+                message: "QUIC initial_max_stream_data_bidi_remote is 0; request streams \
+                     cannot carry data (RFC 9114 §6.1)"
                     .into(),
             });
         }
 
-        // Per-stream flow control: unidirectional (control stream, QPACK, etc.).
+        // Unidirectional (0x07) windows are §6.2's domain (control, QPACK streams),
+        // not §6.1's bidirectional SHOULD; a 0 window here starves those streams.
+        // cite(RFC 9114 § 6.2): "Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked."
         if params.initial_max_stream_data_uni == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
                 message: "QUIC initial_max_stream_data_uni is 0; HTTP/3 unidirectional streams \
-                     (control, QPACK) cannot carry data (RFC 9000 §18.2)"
+                     (control, QPACK) cannot carry data (RFC 9114 §6.2)"
                     .into(),
             });
         }
 
-        // Idle timeout: absent (None or Some(0)) means no timeout — warn
-        // because idle connections consume resources indefinitely.
+        // Idle timeout: 0/absent legally *disables* the timeout (§18.2), so both
+        // this warning and the >10-minute ceiling (see the const) are reasonableness
+        // heuristics, not spec requirements — flagging resource waste, not a MUST.
+        // cite(RFC 9000 § 18.2): "Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0."
         match params.max_idle_timeout_ms {
             Some(0) | None => {
                 return Some(Violation {
@@ -141,7 +171,7 @@ impl ProtocolRule for ServerQuicTransportParameters {
     }
 
     fn description(&self) -> &'static str {
-        "Validates that the QUIC transport parameters advertised for HTTP/3 are reasonable. The proxy emits a `QuicTransportParams` event for the parameters **it advertises on its own client-facing HTTP/3 endpoint**, and this rule checks those. It does **not** validate a remote origin's parameters on the upstream leg: the QUIC stack exposes no way to read a peer's transport parameters, so an origin's are not observable and go unchecked here. The checks:\n\n* **Bidirectional streams allowed** — `initial_max_streams_bidi` must be non-zero so that at least one HTTP/3 request stream can be opened.\n* **Connection flow control** — `initial_max_data` must be non-zero so that data can actually be transferred.\n* **Stream flow control** — `initial_max_stream_data_bidi_local`, `initial_max_stream_data_bidi_remote`, and `initial_max_stream_data_uni` must be non-zero for their respective stream types to carry data.\n* **Idle timeout** — `max_idle_timeout_ms` should be set (non-zero) to prevent idle connections from consuming server resources indefinitely, and should not be excessively large (>10 minutes)."
+        "Validates that the QUIC transport parameters advertised for HTTP/3 are reasonable. The proxy emits a `QuicTransportParams` event for the parameters **it advertises on its own client-facing HTTP/3 endpoint**, and this rule checks those. It does **not** validate a remote origin's parameters on the upstream leg: the QUIC stack exposes no way to read a peer's transport parameters, so an origin's are not observable and go unchecked here. The checks:\n\n* **Bidirectional streams allowed** — `initial_max_streams_bidi` should be non-zero (RFC 9114 §6.1) so that at least one HTTP/3 request stream can be opened; only an explicit 0 is flagged, not an absent value or a value below the §6.1 floor of 100.\n* **Connection flow control** — `initial_max_data` should be non-zero so that data can actually be transferred (a reasonableness check; RFC 9000 §18.2 permits 0, raisable via MAX_DATA).\n* **Stream flow control** — the per-stream windows should be non-zero so streams can carry data: `initial_max_stream_data_bidi_remote` for the client's request streams (RFC 9114 §6.1) and `initial_max_stream_data_uni` for the control/QPACK streams (RFC 9114 §6.2). `initial_max_stream_data_bidi_local` governs server-initiated bidirectional streams, which HTTP/3 does not use, so its non-zero check is a reasonableness heuristic.\n* **Idle timeout** — `max_idle_timeout_ms` should be set (non-zero) to prevent idle connections from consuming server resources indefinitely, and should not be excessively large (>10 minutes); both are reasonableness heuristics, since 0/absent legally disables the timeout (RFC 9000 §18.2)."
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
@@ -154,9 +184,15 @@ impl ProtocolRule for ServerQuicTransportParameters {
             },
             crate::rules::SpecRef {
                 spec: "RFC 9114",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1",
-                note: "Discovering an HTTP/3 Endpoint",
+                section: Some("6.1"),
+                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-6.1",
+                note: "Bidirectional Streams — servers SHOULD grant non-zero stream and flow-control limits",
+            },
+            crate::rules::SpecRef {
+                spec: "RFC 9114",
+                section: Some("6.2"),
+                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-6.2",
+                note: "Unidirectional Streams — restricting their flow-control window blocks control/QPACK",
             },
         ]
     }

--- a/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
@@ -39,7 +39,13 @@ impl Rule for Stateful101SwitchingProtocols {
         let resp = tx.response.as_ref()?;
 
         // ── Check: HTTP traffic after a prior 101 on the same connection ──
-        // cite(RFC 9110 § 15.2.2): "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field"
+        // The operative clause is "for a change in the application protocol being
+        // used on this connection": a 101 switches the connection's protocol, so a
+        // later HTTP transaction on it means the hand-off did not take. There is no
+        // hard "MUST NOT send HTTP after 101"; this is derived from that switch, and
+        // it is why the earlier cite quoted the wrong (introductory) half of the
+        // sentence — the connection-change clause is what governs here.
+        // cite(RFC 9110 § 15.2.2): "The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection."
         if tx.connection_id.is_some() {
             for prev in history.iter() {
                 if let Some(prev_resp) = &prev.response {
@@ -63,6 +69,13 @@ impl Rule for Stateful101SwitchingProtocols {
         }
 
         // ── Check: 101 on HTTP/1.0 ──
+        // A 101 is the server acting on the client's Upgrade request; in HTTP/1.0 it
+        // must ignore Upgrade, so it can never legitimately send a 101. This branch
+        // fires on any 101 over HTTP/1.0; the cited sentence literally covers the
+        // Upgrade-present case (the RFC's only "HTTP/1.0 doesn't do Upgrade" statement),
+        // and a bare 101 with no Upgrade at all is illegitimate a fortiori — a 101
+        // presupposes an Upgrade exchange HTTP/1.0 cannot have had.
+        // cite(RFC 9110 § 7.8): "A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field."
         if tx.request.version == "HTTP/1.0" {
             return Some(Violation {
                 rule: self.id().into(),
@@ -75,6 +88,7 @@ impl Rule for Stateful101SwitchingProtocols {
         }
 
         // ── Check: 101 on HTTP/2 ──
+        // cite(RFC 9113 § 8.6): "HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
         if tx.request.version == "HTTP/2" || tx.request.version == "HTTP/2.0" {
             return Some(Violation {
                 rule: self.id().into(),
@@ -85,32 +99,43 @@ impl Rule for Stateful101SwitchingProtocols {
         }
 
         // ── Check: 101 on HTTP/3 ──
+        // §4.5 is the only place RFC 9114 mentions 101 at all (the message said §4.1,
+        // whose subject is HTTP Message Framing). Also enforced by
+        // `server_http3_status_code_validity`; checked here for completeness.
+        // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
         if tx.request.version == "HTTP/3" {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
-                message: "101 Switching Protocols must not be sent over HTTP/3 (RFC 9114 §4.1)"
+                message: "101 Switching Protocols must not be sent over HTTP/3 (RFC 9114 §4.5)"
                     .into(),
             });
         }
 
         // ── Check: unsolicited 101 (no Upgrade in request) ──
-        // Use get_all_header_values to combine multiple Upgrade header fields
-        // into a single comma-separated list (RFC 9110 §5.3).
+        // get_all_header_values combines multiple Upgrade field lines into one
+        // comma-separated list; the field-combining grammar (RFC 9110 §5.3) is cited
+        // on the helper it calls (helpers/headers.rs), which owns that quote.
         let req_upgrade_combined =
             crate::helpers::headers::get_all_header_values(&tx.request.headers, "upgrade");
+        // No request Upgrade at all: the client indicated no protocol, so the switch
+        // the 101 announces is one it never invited. Same governing sentence as the
+        // empty-token and protocol-mismatch checks below — the three faces of "not
+        // indicated by the client" (nothing / malformed / a different protocol).
+        // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
         if req_upgrade_combined.is_none() {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
                 message: "Server sent 101 Switching Protocols but the request did not include an \
-                     Upgrade header (RFC 9110 §15.2.2)"
+                     Upgrade header (RFC 9110 §7.8)"
                     .into(),
             });
         }
         let req_upgrade_val = req_upgrade_combined.unwrap();
 
         // ── Check: 101 response missing Upgrade header ──
+        // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
         let resp_upgrade_combined =
             crate::helpers::headers::get_all_header_values(&resp.headers, "upgrade");
         if resp_upgrade_combined.is_none() {
@@ -125,7 +150,9 @@ impl Rule for Stateful101SwitchingProtocols {
         let resp_upgrade_val = resp_upgrade_combined.unwrap();
 
         // ── Check: protocol mismatch ──
-        // Collect the protocols offered by the client (case-insensitive comparison).
+        // Protocol names carry a preferred case but are matched case-insensitively,
+        // so both lists are folded to lowercase before comparison.
+        // cite(RFC 9110 § 7.8): "Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols."
         let offered: Vec<String> = crate::helpers::headers::parse_list_header(&req_upgrade_val)
             .map(|t| t.trim().to_ascii_lowercase())
             .collect();
@@ -136,6 +163,8 @@ impl Rule for Stateful101SwitchingProtocols {
                 .map(|t| t.trim().to_ascii_lowercase())
                 .collect();
 
+        // Upgrade present but no valid tokens (e.g. " , , "): still nothing indicated.
+        // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
         if offered.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
@@ -146,6 +175,9 @@ impl Rule for Stateful101SwitchingProtocols {
             });
         }
 
+        // An empty chosen list is a response Upgrade that indicates no protocol —
+        // the same MUST-generate obligation as the missing-header check above.
+        // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
         if chosen_list.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
@@ -156,7 +188,10 @@ impl Rule for Stateful101SwitchingProtocols {
             });
         }
 
-        // The server may choose one or more of the offered protocols.
+        // The server may choose one or more of the offered protocols, but every
+        // chosen protocol must have been offered — `all` fails on the first that
+        // was not, which is exactly "switch to a protocol not indicated".
+        // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
         let all_matched = chosen_list.iter().all(|c| offered.contains(c));
 
         if !all_matched {
@@ -165,7 +200,7 @@ impl Rule for Stateful101SwitchingProtocols {
                 severity: config.severity,
                 message: format!(
                     "101 response Upgrade '{}' was not offered by the client's Upgrade '{}' \
-                     (RFC 9110 §15.2.2)",
+                     (RFC 9110 §7.8)",
                     resp_upgrade_val.trim(),
                     req_upgrade_val.trim()
                 ),
@@ -197,13 +232,13 @@ impl Rule for Stateful101SwitchingProtocols {
                 spec: "RFC 9113",
                 section: Some("8.6"),
                 url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6",
-                note: "The CONNECT Method (HTTP/2 forbids 101)",
+                note: "The Upgrade Header Field (HTTP/2 forbids 101)",
             },
             crate::rules::SpecRef {
                 spec: "RFC 9114",
                 section: Some("4.5"),
                 url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
-                note: "HTTP Upgrade (HTTP/3 forbids 101). This said §4.1, whose subject is HTTP Message Framing, under a note naming a section title RFC 9114 does not have",
+                note: "HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism",
             },
         ]
     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1063,6 +1063,8 @@ sources:
       line: 20
     - file: lint-http-rules/src/helpers/headers.rs
       line: 695
+    - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
+      line: 16
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (6)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
@@ -1935,10 +1937,30 @@ sources:
       line: 53
   - label: message_http3_no_connection_header
     section: § 4.2
-    snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP]
+    snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 36
+      line: 177
+  - label: message_http3_no_connection_header (2)
+    section: § 4.2
+    snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
+      line: 77
+  - label: message_http3_no_connection_header (3)
+    section: § 4.2
+    snippet: HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
+      line: 48
+  - label: message_http3_no_connection_header (4)
+    section: § 4.2
+    snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
+    cited_by:
+    - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
+      line: 94
+    - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
+      line: 195
   - label: message_http3_pseudo_headers_validity
     section: § 4.3.1
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -770,11 +770,27 @@ sources:
   type: text/plain
   fragments:
   - label: server_alt_svc_h3_advertisement_valid
+    section: § 3
+    snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated
+    cited_by:
+    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
+      line: 61
+  - label: server_alt_svc_h3_advertisement_valid (2)
+    section: § 3
+    snippet: An HTTP(S) origin server can advertise the availability of alternative services to clients by adding an Alt-Svc header field to responses.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
+      line: 38
+  - label: server_alt_svc_h3_advertisement_valid (3)
+    section: § 3.1
+    snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
+      line: 179
+  - label: server_alt_svc_header_syntax
     section: § 1
     snippet: This specification defines a new concept in HTTP, "Alternative Services", that allows an origin server to nominate additional means of interacting with it
     cited_by:
-    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
-      line: 33
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 30
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -1947,6 +1963,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
       line: 52
+  - label: server_alt_svc_h3_advertisement_valid
+    section: § 3.1.1
+    snippet: An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
+      line: 87
   - label: server_http3_status_code_validity
     section: § 4.5
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -920,7 +920,25 @@ sources:
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 55
+      line: 59
+  - label: server_quic_transport_parameters (2)
+    section: § 18.2
+    snippet: Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 141
+  - label: server_quic_transport_parameters (3)
+    section: § 18.2
+    snippet: the initial flow control limit for locally initiated bidirectional streams
+    cited_by:
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 99
+  - label: server_quic_transport_parameters (4)
+    section: § 18.2
+    snippet: the initial value for the maximum amount of data that can be sent on the connection
+    cited_by:
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 84
 - label: RFC 9110
   url: https://www.rfc-editor.org/rfc/rfc9110.txt
   type: text/plain
@@ -1999,6 +2017,26 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 105
+  - label: server_quic_transport_parameters
+    section: § 6.1
+    snippet: HTTP/3 does not use server-initiated bidirectional streams
+    cited_by:
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 100
+  - label: server_quic_transport_parameters (2)
+    section: § 6.1
+    snippet: In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 69
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 114
+  - label: server_quic_transport_parameters (3)
+    section: § 6.2
+    snippet: Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
+      line: 127
   - label: stateful_http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1015,8 +1015,6 @@ sources:
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
       line: 380
-    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 11.7.1
     snippet: Unlike WWW-Authenticate, the Proxy-Authenticate header field applies only to the next outbound client on the response chain.
@@ -1609,6 +1607,42 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 34
+  - label: stateful_101_switching_protocols
+    section: § 15.2.2
+    snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 48
+  - label: stateful_101_switching_protocols (2)
+    section: § 15.2.2
+    snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 138
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 180
+  - label: stateful_101_switching_protocols (3)
+    section: § 7.8
+    snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 125
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 167
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 194
+  - label: stateful_101_switching_protocols (4)
+    section: § 7.8
+    snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 78
+  - label: stateful_101_switching_protocols (5)
+    section: § 7.8
+    snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 155
   - label: stateful_authentication_failure_loop
     section: § 15.5.2
     snippet: If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.
@@ -1831,6 +1865,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 33
+  - label: stateful_101_switching_protocols
+    section: § 8.6
+    snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
+    cited_by:
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 91
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.txt
   type: text/plain
@@ -1913,6 +1953,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
       line: 40
+    - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+      line: 105
   - label: stateful_http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.


### PR DESCRIPTION
101-upgrade, Alt-Svc, no-connection-header, QUIC transport-parameters.

