### PR TITLE
Two quoted-strings in one member were scanned by two copies of one loop

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -949,6 +949,46 @@ pub fn quoting_is_balanced(s: &str) -> bool {
     !in_quote
 }
 
+/// The index of the DQUOTE that closes the `quoted-string` starting at `s[0]`,
+/// or `None` when nothing closes it.
+///
+/// Grammars that put a `quoted-string` in the middle of a construct --
+/// `expectation`'s value with `parameters` behind it, `Warning`'s `warn-text`
+/// with a `warn-date` behind it -- have to know where the construct ends before
+/// they can look at what follows. [`validate_quoted_string`] judges a slice
+/// someone else has already cut, which is the question after this one.
+///
+/// The escape rule is the splitters' and [`quoting_is_balanced`]'s: a backslash
+/// inside the string suppresses the next octet. Both call sites had transcribed
+/// this loop by hand, identically, which is two copies of a decision that has to
+/// agree with three other functions in this file.
+///
+/// Returns `None` when `s` does not open with a DQUOTE either -- there is no
+/// `quoted-string` to find the end of.
+///
+/// cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
+/// cite(RFC 9110 § 5.6.4): "quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )"
+pub fn quoted_string_end(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'"') {
+        return None;
+    }
+    let mut i = 1usize;
+    let mut prev_backslash = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if prev_backslash {
+            prev_backslash = false;
+        } else if b == b'\\' {
+            prev_backslash = true;
+        } else if b == b'"' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Validate a quoted-string per HTTP rules: must start and end with DQUOTE, support backslash escapes,
 /// must not contain unescaped control characters (except HTAB). Returns Ok(()) on success, Err(msg)
 /// on failure.

--- a/lint-http-rules/src/helpers/token.rs
+++ b/lint-http-rules/src/helpers/token.rs
@@ -40,6 +40,22 @@ pub fn find_invalid_token_char(s: &str) -> Option<char> {
     s.chars().find(|&c| !is_tchar(c))
 }
 
+/// The byte index at which the leading `token` in `s` ends -- `s.len()` when the
+/// whole string is one.
+///
+/// A grammar that writes `token` followed by a delimiter (`expectation`'s `"="`,
+/// a media type's `"/"`) has to cut the token off before it can judge either
+/// half, and the cut and the character class have to be the same decision.
+/// Asking [`find_invalid_token_char`] instead answers a different question: it
+/// says the string is not *entirely* a token, which is the wrong verdict when
+/// the grammar expects it not to be.
+///
+/// Every `tchar` is one octet, so the index is a `char` boundary and safe to
+/// slice on.
+pub fn token_run_end(s: &str) -> usize {
+    s.find(|c| !is_tchar(c)).unwrap_or(s.len())
+}
+
 /// Return the first ASCII lowercase alphabetic character in `s` if any.
 pub fn find_first_lowercase(s: &str) -> Option<char> {
     s.chars()
@@ -69,6 +85,20 @@ mod tests {
     #[case("G@T", Some('@'))]
     fn test_find_invalid_token_char(#[case] s: &str, #[case] expected: Option<char>) {
         assert_eq!(find_invalid_token_char(s), expected);
+    }
+
+    #[rstest]
+    #[case("100-continue", 12)]
+    #[case("a=b", 1)]
+    #[case("=b", 0)]
+    #[case("", 0)]
+    #[case("wait;level", 4)]
+    // `obs-text` is not a `tchar`, and the index is still a `char` boundary to
+    // slice on because everything before it was one octet each.
+    #[case("caf\u{E9}", 3)]
+    fn test_token_run_end(#[case] s: &str, #[case] expected: usize) {
+        assert_eq!(token_run_end(s), expected);
+        assert!(s.is_char_boundary(token_run_end(s)));
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/message_warning_header_syntax.rs
+++ b/lint-http-rules/src/rules/message_warning_header_syntax.rs
@@ -90,26 +90,10 @@ fn check_warning_value_str(val: &str) -> Option<String> {
         }
 
         // find end of quoted-string (respecting backslash escapes)
-        let bytes = s.as_bytes();
-        let mut i = idx + 1;
-        let mut prev_backslash = false;
-        let mut found_end = None;
-        while i < bytes.len() {
-            let b = bytes[i];
-            if prev_backslash {
-                prev_backslash = false;
-            } else if b == b'\\' {
-                prev_backslash = true;
-            } else if b == b'"' {
-                found_end = Some(i);
-                break;
-            }
-            i += 1;
-        }
-        if found_end.is_none() {
+        let Some(rel_end) = crate::helpers::headers::quoted_string_end(&s[idx..]) else {
             return Some("Warning warn-text quoted-string not terminated".into());
-        }
-        let qend = found_end.unwrap();
+        };
+        let qend = idx + rel_end;
         let qstr = &s[idx..=qend];
         if let Err(e) = crate::helpers::headers::validate_quoted_string(qstr) {
             return Some(format!("Invalid quoted-string in warn-text: {}", e));
@@ -127,25 +111,10 @@ fn check_warning_value_str(val: &str) -> Option<String> {
                 return Some("Warning warn-date must be a quoted-string if present".into());
             }
             // find end of date quoted-string
-            let mut k = j + 1;
-            let mut prev_bs = false;
-            let mut end_date = None;
-            while k < s.len() {
-                let b = s.as_bytes()[k];
-                if prev_bs {
-                    prev_bs = false;
-                } else if b == b'\\' {
-                    prev_bs = true;
-                } else if b == b'"' {
-                    end_date = Some(k);
-                    break;
-                }
-                k += 1;
-            }
-            if end_date.is_none() {
+            let Some(rel_date_end) = crate::helpers::headers::quoted_string_end(&s[j..]) else {
                 return Some("Warning warn-date quoted-string not terminated".into());
-            }
-            let date_q = &s[j..=end_date.unwrap()];
+            };
+            let date_q = &s[j..=j + rel_date_end];
             match crate::helpers::headers::unescape_quoted_string(date_q) {
                 Ok(inner) => {
                     if !crate::http_date::is_valid_http_date(&inner) {
@@ -156,7 +125,7 @@ fn check_warning_value_str(val: &str) -> Option<String> {
             }
 
             // ensure nothing else after date except whitespace
-            let mut rem_idx = end_date.unwrap() + 1;
+            let mut rem_idx = j + rel_date_end + 1;
             while rem_idx < s.len() {
                 if !(s.as_bytes()[rem_idx] as char).is_ascii_whitespace() {
                     return Some("Extra characters after warn-date".into());

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1496
+      line: 1536
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1491
+      line: 1531
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1490
+      line: 1530
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -977,25 +977,25 @@ sources:
     snippet: 'Normally, a mailbox is composed of two parts: (1) an optional display name that indicates the name of the recipient (which can be a person or a system) that could be displayed to the user of a mail application, and (2) an addr-spec address enclosed in angle brackets'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1240
+      line: 1280
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.4
     snippet: There is an alternate simple form of a mailbox where the addr-spec address appears alone, without the recipient's name or the angle brackets.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1253
+      line: 1293
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.4.1
     snippet: An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1271
+      line: 1311
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.4.1
     snippet: The locally interpreted string is either a quoted-string or a dot-atom.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1274
+      line: 1314
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.txt
   type: text/plain
@@ -1317,7 +1317,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1492
+      line: 1532
     - file: lint-http-rules/src/helpers/uri.rs
       line: 177
   - label: lint-http-rules/src/helpers/uri.rs
@@ -1916,25 +1916,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1170
+      line: 1210
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1111
+      line: 1151
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1149
+      line: 1189
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1142
+      line: 1182
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -3036,7 +3036,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1079
+      line: 1119
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -3142,13 +3142,13 @@ sources:
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1032
+      line: 1072
   - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 963
+      line: 1003
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -3160,7 +3160,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 942
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 980
+      line: 970
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1020
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 422
   - label: lint-http-rules/src/helpers/headers.rs (13)
@@ -3168,7 +3170,9 @@ sources:
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 962
+      line: 969
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1002
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 313
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -3182,7 +3186,7 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1445
+      line: 1485
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -3194,7 +3198,7 @@ sources:
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1435
+      line: 1475
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 296
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -3246,7 +3250,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1394
+      line: 1434
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
@@ -3264,7 +3268,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1353
+      line: 1393
   - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
@@ -5758,7 +5762,7 @@ sources:
     snippet: The "Warning" header field was used to carry additional information about the status or transformation of a message
     cited_by:
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
-      line: 194
+      line: 163
   - label: semantic_cache_coherence
     section: § 4.2.4
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server


### PR DESCRIPTION
Finding where a quoted-string closes is a question any grammar that embeds one has to answer before it can look at what follows, and three functions had written the walk out by hand: the Warning rule's warn-text and its warn-date, twenty lines apart in the same function, and the Expect rule's expectation value. The escape rule they were each transcribing has to agree with the two splitters and the parity check next door, so a fourth copy is a fourth chance to disagree.

The second Warning copy is the reason this is worth a commit of its own. It survived the grep that found the first, because its locals are spelled prev_bs and end_date rather than prev_backslash and found_end — a duplicate transcription outlives a rename, so counting occurrences of the first copy's variable names is exactly the search that misses the second.

token_run_end comes along for the same reason: "split the leading token off before the delimiter" is a question about tchar, and token.rs is where the next reader will look for it. Asking find_invalid_token_char instead answers a different one — that the string is not *entirely* a token, which is the wrong verdict when the grammar expects it not to be.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
