### PR TITLE
Review round: the octets a value may legally carry were written into …

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1099,6 +1099,21 @@ pub fn unescape_quoted_string(val: &str) -> Result<String, String> {
     Ok(out)
 }
 
+/// Render a field value, or one member of it, into a finding.
+///
+/// A value read through [`combined_field_value_as_written`] carries one `char`
+/// per octet, so it can hold octets that would corrupt the message rather than
+/// appear in it -- an HTAB inside a `quoted-string` is legal and reachable, and
+/// a lone backslash reads as an escape to whoever sees the finding next.
+///
+/// It is not the answer for `obs-text`: `escape_debug` leaves a printable code
+/// point alone, so %xE9 arrives in the message as `é`. That is legible and
+/// deliberate -- naming the offending octet is [`describe_octet`]'s job, and the
+/// findings that turn on one call it.
+pub fn shown_in_finding(s: &str) -> String {
+    s.escape_debug().to_string()
+}
+
 /// One `token [ BWS "=" BWS word ]` pair, parsed.
 ///
 /// RFC 7240 writes that production three times — `preference`, `parameter` and

--- a/lint-http-rules/src/rules/client_expect_header_valid.rs
+++ b/lint-http-rules/src/rules/client_expect_header_valid.rs
@@ -85,7 +85,7 @@ impl Rule for ClientExpectHeaderValid {
         let Some(members) = members_of(&value) else {
             return report(format!(
                 "Expect has a quoted-string that is never terminated: '{}'",
-                shown(&value)
+                crate::helpers::headers::shown_in_finding(&value)
             ));
         };
 
@@ -98,7 +98,7 @@ impl Rule for ClientExpectHeaderValid {
                     "Expect writes an empty list element (member {} of {}): '{}'",
                     i + 1,
                     members.len(),
-                    shown(&value)
+                    crate::helpers::headers::shown_in_finding(&value)
                 ));
             }
             let e = match parse_expectation(member) {
@@ -172,7 +172,7 @@ impl Rule for ClientExpectHeaderValid {
                      specification defines no value or parameters for it, so a recipient matching \
                      the member against 100-continue sees a different expectation and may answer \
                      417 (Expectation Failed). This is advice: the grammar admits the argument",
-                    shown(e.member)
+                    crate::helpers::headers::shown_in_finding(e.member)
                 ));
             }
         }
@@ -294,22 +294,6 @@ fn members_of(value: &str) -> Option<Vec<&str>> {
     })
 }
 
-/// Render a field value, or one member of it, into a finding.
-///
-/// The value was read octet by octet, so it can carry octets that would corrupt
-/// the message rather than appear in it -- an HTAB inside a `quoted-string` is
-/// legal and reachable, and a lone backslash reads as an escape to whoever sees
-/// the finding next. The sibling rules that read values as written escape them
-/// the same way.
-///
-/// It is not the answer for `obs-text`: `escape_debug` leaves a printable code
-/// point alone, so %xE9 arrives in the message as `é`. That is legible and
-/// deliberate -- naming the offending octet is [`describe_octet`]'s job, and the
-/// findings that turn on one call it.
-fn shown(s: &str) -> String {
-    s.escape_debug().to_string()
-}
-
 /// Parse one OWS-trimmed, non-empty list member against `expectation`.
 ///
 /// The member arrives one `char` per octet, so every octet no production admits
@@ -332,7 +316,7 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, String>
     if name.is_empty() {
         return Err(format!(
             "Expect member '{}' does not begin with a token: found {}",
-            shown(member),
+            crate::helpers::headers::shown_in_finding(member),
             first_octet_of(member)
         ));
     }
@@ -346,7 +330,7 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, String>
             "Invalid octet {} after the Expect expectation name '{}': the production admits only \
              '=' there, and `parameters` are inside the group the '=' opens",
             describe_octet(stopper as u8),
-            shown(name)
+            crate::helpers::headers::shown_in_finding(name)
         ));
     }
     let rest = &tail[1..];
@@ -357,13 +341,13 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, String>
         let Some(end) = quoted_string_end(rest) else {
             return Err(format!(
                 "Expect member '{}' has a quoted-string that is never terminated",
-                shown(member)
+                crate::helpers::headers::shown_in_finding(member)
             ));
         };
         validate_quoted_string(&rest[..=end]).map_err(|e| {
             format!(
                 "Invalid quoted-string in Expect member '{}': {}",
-                shown(member),
+                crate::helpers::headers::shown_in_finding(member),
                 e
             )
         })?;
@@ -375,7 +359,7 @@ pub(crate) fn parse_expectation(member: &str) -> Result<Expectation<'_>, String>
         if end == 0 {
             return Err(format!(
                 "Expect member '{}' has '=' with no token or quoted-string after it: found {}",
-                shown(member),
+                crate::helpers::headers::shown_in_finding(member),
                 first_octet_of(rest)
             ));
         }
@@ -421,8 +405,8 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
     if !segments[0].is_empty() {
         return Err(format!(
             "Expect member '{}' has octets after its value that are not parameters: '{}'",
-            shown(member),
-            shown(segments[0])
+            crate::helpers::headers::shown_in_finding(member),
+            crate::helpers::headers::shown_in_finding(segments[0])
         ));
     }
 
@@ -440,8 +424,8 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
         let Some((pname, pvalue)) = seg.split_once('=') else {
             return Err(format!(
                 "Expect member '{}' has a parameter with no value: '{}'",
-                shown(member),
-                shown(seg)
+                crate::helpers::headers::shown_in_finding(member),
+                crate::helpers::headers::shown_in_finding(seg)
             ));
         };
         // No `OWS` is written around a parameter's `=`, and the section says so
@@ -453,15 +437,15 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
         if pname.is_empty() {
             return Err(format!(
                 "Expect member '{}' has a parameter with no name: '{}'",
-                shown(member),
-                shown(seg)
+                crate::helpers::headers::shown_in_finding(member),
+                crate::helpers::headers::shown_in_finding(seg)
             ));
         }
         if let Some(c) = find_invalid_token_char(pname) {
             return Err(format!(
                 "Invalid octet {} in Expect parameter name '{}'",
                 describe_octet(c as u8),
-                shown(pname)
+                crate::helpers::headers::shown_in_finding(pname)
             ));
         }
         if pvalue.starts_with('"') {
@@ -474,21 +458,21 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
             validate_quoted_string(pvalue).map_err(|e| {
                 format!(
                     "Invalid quoted-string in Expect parameter '{}': {}",
-                    shown(seg),
+                    crate::helpers::headers::shown_in_finding(seg),
                     e
                 )
             })?;
         } else if pvalue.is_empty() {
             return Err(format!(
                 "Expect member '{}' has a parameter with an empty value: '{}'",
-                shown(member),
-                shown(seg)
+                crate::helpers::headers::shown_in_finding(member),
+                crate::helpers::headers::shown_in_finding(seg)
             ));
         } else if let Some(c) = find_invalid_token_char(pvalue) {
             return Err(format!(
                 "Invalid octet {} in Expect parameter value '{}'",
                 describe_octet(c as u8),
-                shown(pvalue)
+                crate::helpers::headers::shown_in_finding(pvalue)
             ));
         }
     }

--- a/lint-http-rules/src/rules/message_preference_applied_header_valid.rs
+++ b/lint-http-rules/src/rules/message_preference_applied_header_valid.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: ISC
 
 use crate::helpers::headers::{
-    combined_field_value_as_written, parse_token_bws_word, quoting_is_balanced,
+    combined_field_value_as_written, parse_token_bws_word, quoting_is_balanced, shown_in_finding,
     split_commas_respecting_quotes, split_semicolons_respecting_quotes, trim_ows,
 };
 use crate::lint::Violation;
@@ -172,7 +172,7 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
         if members.iter().any(|m| m.is_empty()) {
             return violation(format!(
                 "Preference-Applied header contains an empty list element: '{}'",
-                applied
+                shown_in_finding(&applied)
             ));
         }
 
@@ -189,7 +189,7 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
             if split_semicolons_respecting_quotes(member).len() > 1 {
                 return violation(format!(
                     "Preference-Applied member '{}' carries parameters, which its grammar does not include",
-                    member
+                    shown_in_finding(member)
                 ));
             }
 
@@ -199,7 +199,8 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
                 Err(e) => {
                     return violation(format!(
                         "Preference-Applied member '{}' does not match applied-pref: {}",
-                        member, e
+                        shown_in_finding(member),
+                        e
                     ))
                 }
             };
@@ -214,7 +215,7 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
             if parsed.bws {
                 return violation(format!(
                     "Preference-Applied member '{}' has whitespace around its '='; the grammar admits BWS there only for historical reasons",
-                    member
+                    shown_in_finding(member)
                 ));
             }
 
@@ -240,6 +241,11 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
             // server cannot have honored a preference that was not asked for.
             //
             // cite(RFC 7240 § 3): "The Preference-Applied response header MAY be included within a response message as an indication as to which Prefer tokens were honored by the server and applied to the processing of a request."
+            // `parsed.name` needs no escaping where the values around it do: the
+            // parse returns a name only after finding every octet in it to be a
+            // `tchar`, which is visible US-ASCII. A `word`'s content has no such
+            // guarantee — `qdtext` admits HTAB and `obs-text` — so the two
+            // values below go through [`shown_in_finding`] and the name does not.
             let Some(requested) = prefer.prefs.get(&name) else {
                 return violation(format!(
                     "Preference-Applied names '{}', which the request's Prefer header did not ask for",
@@ -256,7 +262,9 @@ impl Rule for MessagePreferenceAppliedHeaderValid {
                 if applied_value != requested_value {
                     return violation(format!(
                         "Preference-Applied reports '{}' applied with value '{}', where the request asked for '{}'",
-                        parsed.name, applied_value, requested_value
+                        parsed.name,
+                        shown_in_finding(applied_value),
+                        shown_in_finding(requested_value)
                     ));
                 }
             }
@@ -517,6 +525,19 @@ mod tests {
         ))
         .expect("finding");
         assert!(v.message.contains("BWS"), "{}", v.message);
+    }
+
+    /// `qdtext` admits HTAB, so a conforming value can carry an octet that would
+    /// break the line of a finding rather than appear in it. The message is
+    /// derived data and gets its own test.
+    #[test]
+    fn a_value_reaching_a_finding_is_escaped_into_it() {
+        let v = check(&tx_with(&[b"foo=bar"], &[b"foo=\"a\tb\""])).expect("finding");
+        assert!(
+            v.message.contains("a\\tb") && !v.message.contains('\t'),
+            "{}",
+            v.message
+        );
     }
 
     /// The neighbour named in `description()` is the one that judges what the

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1630
+      line: 1645
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1625
+      line: 1640
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1624
+      line: 1639
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -977,25 +977,25 @@ sources:
     snippet: 'Normally, a mailbox is composed of two parts: (1) an optional display name that indicates the name of the recipient (which can be a person or a system) that could be displayed to the user of a mail application, and (2) an addr-spec address enclosed in angle brackets'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1374
+      line: 1389
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.4
     snippet: There is an alternate simple form of a mailbox where the addr-spec address appears alone, without the recipient's name or the angle brackets.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1387
+      line: 1402
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.4.1
     snippet: An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1405
+      line: 1420
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.4.1
     snippet: The locally interpreted string is either a quoted-string or a dot-atom.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1408
+      line: 1423
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.txt
   type: text/plain
@@ -1317,7 +1317,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1626
+      line: 1641
     - file: lint-http-rules/src/helpers/uri.rs
       line: 177
   - label: lint-http-rules/src/helpers/uri.rs
@@ -1782,13 +1782,13 @@ sources:
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
       line: 22
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
-      line: 229
+      line: 230
   - label: message_preference_applied_header_valid (3)
     section: § 2
     snippet: For both preference token names and parameter names, comparison is case insensitive while values are case sensitive regardless of whether token or quoted-string values are used.
     cited_by:
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
-      line: 224
+      line: 225
   - label: message_preference_applied_header_valid (4)
     section: § 2
     snippet: If any preference is specified more than once, only the first instance is to be considered.
@@ -1814,7 +1814,7 @@ sources:
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
       line: 113
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
-      line: 242
+      line: 243
   - label: message_preference_applied_header_valid (8)
     section: § 3
     snippet: The syntax of the Preference-Applied header differs from that of the Prefer header in that parameters are not included.
@@ -1972,25 +1972,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1304
+      line: 1319
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1245
+      line: 1260
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1283
+      line: 1298
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1276
+      line: 1291
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -2450,7 +2450,7 @@ sources:
     snippet: expectation = token [ "=" ( token / quoted-string ) parameters ]
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 325
+      line: 309
   - label: client_expect_header_valid (10)
     section: § 15.5.18
     snippet: The 417 (Expectation Failed) status code indicates that the expectation given in the request's Expect header field (Section 10.1.1) could not be met by at least one of the inbound servers.
@@ -2462,7 +2462,7 @@ sources:
     snippet: A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules.
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 326
+      line: 310
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
       line: 73
     - file: lint-http-rules/src/rules/server_status_code_valid_range.rs
@@ -2506,7 +2506,7 @@ sources:
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 401
+      line: 385
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
       line: 209
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
@@ -2518,7 +2518,7 @@ sources:
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 402
+      line: 386
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
       line: 231
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
@@ -2528,7 +2528,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 403
+      line: 387
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -2544,7 +2544,7 @@ sources:
     snippet: '|  *Note:* Parameters do not allow whitespace (not even "bad" |  whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 452
+      line: 436
   - label: client_expect_header_valid (16)
     section: § A
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
@@ -2562,7 +2562,7 @@ sources:
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 436
+      line: 420
   - label: client_host_header
     section: § 7.2
     snippet: A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.
@@ -3214,7 +3214,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1213
+      line: 1228
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -3314,7 +3314,7 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1145
+      line: 1160
   - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
@@ -3358,7 +3358,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1002
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1144
+      line: 1159
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 313
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -3372,7 +3372,7 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1579
+      line: 1594
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -3384,9 +3384,9 @@ sources:
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1569
+      line: 1584
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 400
+      line: 384
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 296
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -3438,7 +3438,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1528
+      line: 1543
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
@@ -3456,7 +3456,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1487
+      line: 1502
   - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
@@ -4420,13 +4420,13 @@ sources:
     snippet: A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
-      line: 213
+      line: 214
   - label: message_preference_applied_header_valid (3)
     section: § 5.6.3
     snippet: A sender MUST NOT generate BWS in messages.
     cited_by:
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
-      line: 212
+      line: 213
   - label: message_problem_details_structure
     section: § 6.4
     snippet: This abstract definition of content reflects the data after it has been extracted from the message framing.


### PR DESCRIPTION
…the finding

Every message here interpolated a member, or the whole field value, exactly as read — and the read is one `char` per octet, so an HTAB inside a `quoted-string` (`qdtext` admits it) or a lone backslash arrives in the finding as itself rather than as a description of itself. The previous iteration settled this and left the answer private to the rule that found it, which is the second copy this would have been; it moves to the shared header helpers instead, with the reason it is not the `obs-text` answer intact. The preference token beside those values is deliberately not escaped: the parse only returns a name after finding every octet in it to be a `tchar`, and the comment says so, so nobody harmonises it later.
