### PR TITLE
A fixture builder for octets a field may carry was written a fourth time

### DIFF
--- a/lint-http-core/src/test_helpers.rs
+++ b/lint-http-core/src/test_helpers.rs
@@ -35,6 +35,26 @@ pub fn make_headers_from_pairs(pairs: &[(&str, &str)]) -> HeaderMap {
     hm
 }
 
+/// [`make_headers_from_pairs`] for field values that are not valid UTF-8.
+///
+/// `HeaderValue::from_str` cannot express an octet above %x7E, and several field
+/// grammars admit one — `qdtext` takes `obs-text`, and a rule measuring what a
+/// sender wrote has to be given what it wrote. Kept beside the `&str` form
+/// rather than replacing it: most fixtures read better with string literals,
+/// and only a test about the octets needs this.
+///
+/// Panics if any field name or value is one `hyper` will not hold.
+pub fn make_headers_from_octet_pairs(pairs: &[(&str, &[u8])]) -> HeaderMap {
+    let mut hm = HeaderMap::new();
+    for (name, value) in pairs {
+        hm.append(
+            name.parse::<HeaderName>().expect("a field name"),
+            HeaderValue::from_bytes(value).expect("a field value"),
+        );
+    }
+    hm
+}
+
 fn insert_rule_config(
     cfg: &mut crate::config::Config,
     rule: &str,

--- a/lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
+++ b/lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
@@ -234,7 +234,7 @@ static REGISTRATION: &dyn crate::rules::Rule = &ClientAcceptRangesOnPartialConte
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{HeaderName, HeaderValue};
+
     use rstest::rstest;
 
     fn config() -> crate::config::Config {
@@ -260,16 +260,7 @@ mod tests {
         AResponse(u16, Fields<'a>, Fields<'a>),
     }
 
-    fn section(pairs: Fields<'_>) -> hyper::HeaderMap {
-        let mut hm = hyper::HeaderMap::new();
-        for (name, value) in pairs {
-            hm.append(
-                name.parse::<HeaderName>().expect("a field name"),
-                HeaderValue::from_bytes(value).expect("a field value"),
-            );
-        }
-        hm
-    }
+    use crate::test_helpers::make_headers_from_octet_pairs as section;
 
     /// Every fixture is built here. The rule reads two field sections of the
     /// previous response and treats a field line it cannot decode differently

--- a/lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
+++ b/lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
@@ -309,22 +309,9 @@ static REGISTRATION: &dyn crate::rules::Rule = &ClientPreferHeaderAndPreferenceA
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{HeaderName, HeaderValue};
-    use hyper::HeaderMap;
     use rstest::rstest;
 
-    /// Build a header map from raw octets, so a value `to_str` would refuse can
-    /// be written into a test.
-    fn headers(pairs: &[(&str, &[u8])]) -> HeaderMap {
-        let mut hm = HeaderMap::new();
-        for (name, value) in pairs {
-            hm.append(
-                name.parse::<HeaderName>().unwrap(),
-                HeaderValue::from_bytes(value).unwrap(),
-            );
-        }
-        hm
-    }
+    use crate::test_helpers::make_headers_from_octet_pairs as headers;
 
     fn run(
         method: &str,

--- a/lint-http-rules/src/rules/message_accept_ranges_and_206_consistency.rs
+++ b/lint-http-rules/src/rules/message_accept_ranges_and_206_consistency.rs
@@ -195,7 +195,7 @@ static REGISTRATION: &dyn crate::rules::Rule = &MessageAcceptRangesAnd206Consist
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::header::{HeaderName, HeaderValue};
+
     use rstest::rstest;
 
     fn config() -> crate::config::Config {
@@ -213,16 +213,7 @@ mod tests {
         headers: &[(&str, &[u8])],
         trailers: &[(&str, &[u8])],
     ) -> crate::http_transaction::HttpTransaction {
-        fn section(pairs: &[(&str, &[u8])]) -> hyper::HeaderMap {
-            let mut hm = hyper::HeaderMap::new();
-            for (name, value) in pairs {
-                hm.append(
-                    name.parse::<HeaderName>().expect("a field name"),
-                    HeaderValue::from_bytes(value).expect("a field value"),
-                );
-            }
-            hm
-        }
+        use crate::test_helpers::make_headers_from_octet_pairs as section;
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
         tx.response = Some(crate::http_transaction::ResponseInfo {

--- a/lint-http-rules/src/rules/message_trailer_headers_valid.rs
+++ b/lint-http-rules/src/rules/message_trailer_headers_valid.rs
@@ -281,13 +281,7 @@ mod tests {
         section: Section,
         lines: &[(&str, &[u8])],
     ) -> crate::http_transaction::HttpTransaction {
-        let mut hm = hyper::HeaderMap::new();
-        for (name, value) in lines {
-            hm.append(
-                name.parse::<HeaderName>().expect("header name"),
-                HeaderValue::from_bytes(value).expect("header value"),
-            );
-        }
+        let hm = crate::test_helpers::make_headers_from_octet_pairs(lines);
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         match section {
             Section::Request => tx.request.headers = hm,


### PR DESCRIPTION
The rewritten Prefer rule's tests needed a header section built from raw octets, because a `qdtext` may hold `obs-text` and `HeaderValue::from_str` cannot express one — and writing that loop made it the fourth identical copy in the rule tree. `make_headers_from_pairs` has been the shared answer for field values that are US-ASCII since the beginning; this is its other half, and it now sits beside it rather than in four test modules.

The three earlier copies were each written for the same reason and say so in their own comments: two range rules that distinguish a field line they cannot decode from one that is absent, and the trailer rule. All three now alias the shared one, so a test about what a sender wrote is assembled the same way wherever it lives.
