### PR TITLE
The version number two documents state in words was written a digit s…

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -41,7 +41,7 @@ pub(super) struct ProxiedRequest {
     /// Original client request headers; suppression is applied only when
     /// building the upstream request.
     pub headers: HeaderMap,
-    /// Request version string ("HTTP/1.1", "HTTP/3", …).
+    /// Request version string ("HTTP/1.1", "HTTP/3.0", …).
     pub version: String,
     /// The request body, already wrapped so it streams to the upstream while a
     /// bounded prefix is teed for capture (H3 wraps a buffered body).

--- a/lint-http-proxy/src/proxy/hop_by_hop.rs
+++ b/lint-http-proxy/src/proxy/hop_by_hop.rs
@@ -43,14 +43,37 @@ pub(super) static HOP_BY_HOP_HEADERS: &[&str] = &[
     "proxy-authorization",
 ];
 
-/// Convert hyper::Version into the textual HTTP-version token used in start/status lines.
+/// Render the version a message arrived under as the `HTTP-version` token a
+/// capture records.
+///
+/// Only the HTTP/1.x arms are transcribing something the message carried: that
+/// is the one wire format with a start-line to put a version field in. The
+/// other two arms are writing down a number their own specifications state in
+/// words, precisely because those wire formats have nowhere to carry one — and
+/// both are stated with the minor digit present, which is the general rule for
+/// a major version that defines no minor versions.
+// cite(RFC 9112 § 2.3): "The version of an HTTP/1.x message is indicated by an HTTP-version field in the start-line."
+// cite(RFC 9112 § 2.3, label: HTTP-version): "HTTP-version  = HTTP-name "/" DIGIT "." DIGIT"
+// cite(RFC 9110 § 2.5): "When a major version of HTTP does not define any minor versions, the minor version "0" is implied."
+// cite(RFC 9110 § 2.5): "The "0" is used when referring to that protocol within elements that require a minor version identifier."
 pub(super) fn format_http_version(v: hyper::Version) -> String {
     match v {
         hyper::Version::HTTP_09 => "HTTP/0.9".to_string(),
         hyper::Version::HTTP_10 => "HTTP/1.0".to_string(),
         hyper::Version::HTTP_11 => "HTTP/1.1".to_string(),
+        // cite(RFC 9113 § 8.3.1): "Individual HTTP/2 requests do not carry an explicit indicator of protocol version."
+        // cite(RFC 9113 § 8.3.1): "All HTTP/2 requests implicitly have a protocol version of "2.0""
+        // cite(RFC 9113 § 8.3.2): "HTTP/2 responses implicitly have a protocol version of "2.0"."
         hyper::Version::HTTP_2 => "HTTP/2.0".to_string(),
-        hyper::Version::HTTP_3 => "HTTP/3".to_string(),
+        // The same two sentences for HTTP/3, and they name the same spelling:
+        // a minor digit of zero, not an absent minor digit. This arm wrote
+        // `HTTP/3` until 2026-08-03, which no version production generates and
+        // which six rules were matching against as a literal.
+        // cite(RFC 9114 § 4.3.1): "HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line."
+        // cite(RFC 9114 § 4.3.1): "HTTP/3 requests implicitly have a protocol version of "3.0"."
+        // cite(RFC 9114 § 4.3.2): "HTTP/3 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line."
+        // cite(RFC 9114 § 4.3.2): "HTTP/3 responses implicitly have a protocol version of "3.0"."
+        hyper::Version::HTTP_3 => "HTTP/3.0".to_string(),
         _ => "HTTP/1.1".to_string(),
     }
 }
@@ -97,7 +120,7 @@ mod tests {
     #[case(Version::HTTP_10, "HTTP/1.0")]
     #[case(Version::HTTP_11, "HTTP/1.1")]
     #[case(Version::HTTP_2, "HTTP/2.0")]
-    #[case(Version::HTTP_3, "HTTP/3")]
+    #[case(Version::HTTP_3, "HTTP/3.0")]
     fn format_http_version_cases(#[case] ver: Version, #[case] expected: &str) {
         assert_eq!(format_http_version(ver), expected.to_string());
     }

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -375,7 +375,12 @@ async fn handle_h3_request(
         uri,
         uri_str,
         headers: req_headers,
-        version: "HTTP/3".to_string(),
+        // The version number RFC 9114 § 4.3.1 states for a request that has
+        // nowhere to carry one, written the way § 2.5 of [HTTP] writes a major
+        // version with no minor versions of its own. `format_http_version`
+        // renders the same string from `hyper::Version::HTTP_3`.
+        // cite(RFC 9114 § 4.3.1): "HTTP/3 requests implicitly have a protocol version of "3.0"."
+        version: "HTTP/3.0".to_string(),
         body,
         body_done: body_done_rx,
         client_id,

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -297,7 +297,7 @@ async fn h3_happy_path_forwards_request_and_captures() -> anyhow::Result<()> {
 
     let v: serde_json::Value = serde_json::from_str(lines[0])?;
     assert_eq!(v["response"]["status"].as_u64(), Some(200));
-    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3"));
+    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3.0"));
     // connection_id and sequence_number should be set
     assert!(v["connection_id"].as_str().is_some());
     assert_eq!(v["sequence_number"].as_u64(), Some(0));
@@ -339,7 +339,7 @@ async fn h3_upstream_error_returns_502_and_records_transaction() -> anyhow::Resu
 
     let v: serde_json::Value = serde_json::from_str(lines[0])?;
     assert_eq!(v["response"]["status"].as_u64(), Some(502));
-    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3"));
+    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3.0"));
     assert!(v["connection_id"].as_str().is_some());
 
     // Cleanup
@@ -560,7 +560,7 @@ async fn h3_large_request_body_streams_and_truncates_capture() -> anyhow::Result
 
     let v: serde_json::Value = serde_json::from_str(lines[0])?;
     assert_eq!(v["response"]["status"].as_u64(), Some(200));
-    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3"));
+    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3.0"));
     assert_eq!(v["request_body_over_limit"].as_bool(), Some(true));
     assert_eq!(v["request"]["body_length"].as_u64(), Some(64));
 
@@ -663,7 +663,7 @@ async fn h3_request_with_host_header_fallback() -> anyhow::Result<()> {
 
     // The captured URI should contain the host from the Host header
     let v: serde_json::Value = serde_json::from_str(lines.last().unwrap())?;
-    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3"));
+    assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3.0"));
     // The host header value was used to build the upstream URI
     let captured_uri = v["request"]["uri"].as_str().unwrap_or("");
     assert!(

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -296,7 +296,7 @@ async fn upstream_h3_forwards_with_capture_parity_and_strips_connection_field() 
     assert_eq!(v["response"]["status"].as_u64(), Some(200));
     assert_eq!(
         v["response"]["version"].as_str(),
-        Some("HTTP/3"),
+        Some("HTTP/3.0"),
         "upstream (origin) leg should be recorded as HTTP/3"
     );
     assert_eq!(v["request"]["version"].as_str(), Some("HTTP/1.1"));
@@ -746,7 +746,7 @@ async fn upstream_h3_origin_early_response_is_delivered_and_captured() -> anyhow
     assert_eq!(v["response"]["status"].as_u64(), Some(401));
     assert_eq!(
         v["response"]["version"].as_str(),
-        Some("HTTP/3"),
+        Some("HTTP/3.0"),
         "the leg is recorded as HTTP/3 even though the origin responded early"
     );
 
@@ -892,13 +892,13 @@ async fn upstream_h3_discovered_via_alt_svc_is_used_on_next_request() -> anyhow:
             .iter()
             .filter_map(|v| v["response"]["version"].as_str().map(str::to_string))
             .collect();
-        if versions.iter().any(|v| v == "HTTP/3") || std::time::Instant::now() > deadline {
+        if versions.iter().any(|v| v == "HTTP/3.0") || std::time::Instant::now() > deadline {
             break versions;
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     };
     assert!(
-        versions.iter().any(|v| v == "HTTP/3"),
+        versions.iter().any(|v| v == "HTTP/3.0"),
         "a request should have been forwarded over H3 after discovery: {versions:?}"
     );
 

--- a/lint-http-rules/src/helpers/mod.rs
+++ b/lint-http-rules/src/helpers/mod.rs
@@ -21,4 +21,5 @@ pub mod status;
 pub mod structured_fields;
 pub mod token;
 pub mod uri;
+pub mod version;
 pub mod websocket;

--- a/lint-http-rules/src/helpers/version.rs
+++ b/lint-http-rules/src/helpers/version.rs
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The `HTTP-version` production, and the one question every version gate asks
+//! of it.
+//!
+//! Two things live here because they are one thing. The production is what an
+//! HTTP/1.x start-line carries and what `message_http_version_syntax_valid`
+//! reports against; the *major digit* is what a dozen rules actually want when
+//! they ask "is this an HTTP/3 message" — and asking that by comparing the
+//! whole string against a literal makes every one of those rules depend on the
+//! exact spelling some other part of this workspace happened to choose.
+//!
+//! Only HTTP/1.x messages carry the field. What a capture records for the other
+//! two versions is a version number their own specifications state in words,
+//! because neither wire format has anywhere to put one.
+// cite(RFC 9112 § 2.3): "The version of an HTTP/1.x message is indicated by an HTTP-version field in the start-line."
+// cite(RFC 9113 § 8.3.1): "Individual HTTP/2 requests do not carry an explicit indicator of protocol version."
+// cite(RFC 9114 § 4.3.1): "HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line."
+
+/// The two decimal digits of an HTTP version number, in the order they are
+/// written.
+///
+/// Kept as digits rather than as a `(u8, u8)` pair because the two are not
+/// interchangeable: the first names the wire format, the second is a
+/// capability advertisement about the sender.
+// cite(RFC 9110 § 2.5): "HTTP's version number consists of two decimal digits separated by a "." (period or decimal point)."
+// cite(RFC 9110 § 2.5): "The first digit (major version) indicates the messaging syntax, whereas the second digit (minor version) indicates the highest minor version within that major version to which the sender is conformant (able to understand for future communication)."
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct HttpVersion {
+    /// The first digit: which messaging syntax carried the message.
+    pub major: u8,
+    /// The second digit: the highest minor version the sender is conformant
+    /// with.
+    pub minor: u8,
+}
+
+/// Which of the production's three terminals a value failed to match.
+///
+/// One variant per terminal rather than one "malformed" verdict, because the
+/// three are different mistakes: a name in the wrong case, a number that is not
+/// two digits around a period, and a character that is not a digit at all.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum HttpVersionError {
+    /// `HTTP-name "/"` — the value does not begin with the name, written
+    /// exactly that way, followed by a solidus.
+    Name,
+    /// `DIGIT "." DIGIT` — what follows the solidus is not one character, a
+    /// period, and one character.
+    Shape,
+    /// The right shape, but one of the two characters is not a `DIGIT`.
+    Digit,
+}
+
+impl std::fmt::Display for HttpVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The name is a case-sensitive string, which the notation writes as
+        // `%s` and the section says again in prose beside the grammar -- so
+        // `http/1.1` fails this terminal, and saying which terminal is what
+        // separates it from `HTTP/11`.
+        // cite(RFC 9112 § 2.3): "HTTP-version is case-sensitive."
+        match self {
+            Self::Name => f.write_str(
+                "it does not begin with the name 'HTTP' -- spelled in exactly that case -- \
+                 followed by a '/'",
+            ),
+            Self::Shape => f.write_str(
+                "what follows 'HTTP/' is not one character, a '.', and one character: the \
+                 version number is a major digit and a minor digit, and each is a single digit",
+            ),
+            Self::Digit => f.write_str(
+                "the major and minor positions each hold one character, but a character in \
+                 one of them is not a decimal digit",
+            ),
+        }
+    }
+}
+
+/// Read a value as the `HTTP-version` production.
+///
+/// The whole production is nine octets and every one of them is fixed: the
+/// four of the name, the solidus, a digit, the period, a digit. Reading it
+/// byte-wise is the transcription, and it is also what keeps a multi-byte
+/// character out of the "single DIGIT" comparison -- `HTTP/é.1` is one
+/// character in the major position and two bytes, and a length test that
+/// counted bytes would report the wrong terminal.
+// cite(RFC 9112 § 2.3, label: HTTP-version): "HTTP-version  = HTTP-name "/" DIGIT "." DIGIT"
+// cite(RFC 9112 § A, label: HTTP-name): "HTTP-name = %x48.54.54.50 ; HTTP"
+// The core rule stands alone in its section at fifteen characters, under the
+// extractor's floor; the comment beside it is part of the same definition and
+// carries it over.
+// cite(RFC 5234 § B.1, label: DIGIT): "DIGIT          =  %x30-39 ; 0-9"
+pub fn parse(value: &str) -> Result<HttpVersion, HttpVersionError> {
+    let rest = value.strip_prefix("HTTP/").ok_or(HttpVersionError::Name)?;
+
+    // Three characters, not three bytes: the shape question is about how many
+    // characters sit around the period, and the digit question is asked next.
+    let mut chars = rest.chars();
+    let (Some(major), Some(dot), Some(minor), None) =
+        (chars.next(), chars.next(), chars.next(), chars.next())
+    else {
+        return Err(HttpVersionError::Shape);
+    };
+    if dot != '.' {
+        return Err(HttpVersionError::Shape);
+    }
+    if !major.is_ascii_digit() || !minor.is_ascii_digit() {
+        return Err(HttpVersionError::Digit);
+    }
+
+    Ok(HttpVersion {
+        major: major as u8 - b'0',
+        minor: minor as u8 - b'0',
+    })
+}
+
+/// Is this the major version `major` -- i.e. is this message's wire format the
+/// one that digit names?
+///
+/// This is the question a version gate is asking, and it is deliberately not a
+/// string comparison. A gate written as `version == "HTTP/3"` is a claim about
+/// how one particular writer spells the number, so it goes silent the moment
+/// the spelling changes and says nothing while it does; reading the digit the
+/// specification names leaves nothing to spell.
+// cite(RFC 9110 § 2.5): "The first digit (major version) indicates the messaging syntax"
+// cite(RFC 9114 § 4.3.1): "HTTP/3 requests implicitly have a protocol version of "3.0"."
+// cite(RFC 9113 § 8.3.1): "All HTTP/2 requests implicitly have a protocol version of "2.0""
+pub fn is_major(value: &str, major: u8) -> bool {
+    matches!(parse(value), Ok(v) if v.major == major)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("HTTP/1.1", 1, 1)]
+    #[case("HTTP/1.0", 1, 0)]
+    #[case("HTTP/0.9", 0, 9)]
+    #[case("HTTP/2.0", 2, 0)]
+    #[case("HTTP/3.0", 3, 0)]
+    #[case("HTTP/9.9", 9, 9)]
+    fn the_production_generates_these(#[case] value: &str, #[case] major: u8, #[case] minor: u8) {
+        assert_eq!(parse(value), Ok(HttpVersion { major, minor }));
+    }
+
+    #[rstest]
+    // The name is case-sensitive, so the whole terminal fails on one letter.
+    #[case("http/1.1", HttpVersionError::Name)]
+    #[case("Http/1.1", HttpVersionError::Name)]
+    #[case("1.1", HttpVersionError::Name)]
+    #[case("", HttpVersionError::Name)]
+    #[case("HTTP1.1", HttpVersionError::Name)]
+    // Two digits around one period, and neither more nor fewer.
+    #[case("HTTP/1", HttpVersionError::Shape)]
+    #[case("HTTP/1.", HttpVersionError::Shape)]
+    #[case("HTTP/11.0", HttpVersionError::Shape)]
+    #[case("HTTP/1.10", HttpVersionError::Shape)]
+    #[case("HTTP/1.1.1", HttpVersionError::Shape)]
+    #[case("HTTP/1,1", HttpVersionError::Shape)]
+    // A minor version this proxy once wrote and no production generates.
+    #[case("HTTP/3", HttpVersionError::Shape)]
+    // The right shape; the wrong alphabet.
+    #[case("HTTP/1.x", HttpVersionError::Digit)]
+    #[case("HTTP/x.1", HttpVersionError::Digit)]
+    fn the_production_generates_none_of_these(
+        #[case] value: &str,
+        #[case] expected: HttpVersionError,
+    ) {
+        assert_eq!(parse(value), Err(expected));
+    }
+
+    /// A character in the major position that is one character and two bytes.
+    /// A byte-length test would call this the wrong terminal.
+    #[test]
+    fn a_multibyte_character_is_one_character_in_the_major_position() {
+        assert_eq!(parse("HTTP/é.1"), Err(HttpVersionError::Digit));
+    }
+
+    #[rstest]
+    #[case("HTTP/3.0", 3, true)]
+    #[case("HTTP/2.0", 2, true)]
+    #[case("HTTP/1.1", 1, true)]
+    #[case("HTTP/1.0", 1, true)]
+    #[case("HTTP/2.0", 3, false)]
+    #[case("HTTP/1.1", 3, false)]
+    // Nothing that fails the production names a major version, including the
+    // spelling that omitted the minor digit.
+    #[case("HTTP/3", 3, false)]
+    #[case("http/3.0", 3, false)]
+    fn is_major_reads_the_digit(#[case] value: &str, #[case] major: u8, #[case] expected: bool) {
+        assert_eq!(is_major(value, major), expected);
+    }
+
+    /// The three errors print as three different sentences, because they are
+    /// three different mistakes.
+    #[test]
+    fn each_terminal_names_itself() {
+        assert!(HttpVersionError::Name
+            .to_string()
+            .contains("exactly that case"));
+        assert!(HttpVersionError::Shape.to_string().contains("single digit"));
+        assert!(HttpVersionError::Digit
+            .to_string()
+            .contains("decimal digit"));
+    }
+}

--- a/lint-http-rules/src/rules/client_host_header.rs
+++ b/lint-http-rules/src/rules/client_host_header.rs
@@ -452,7 +452,7 @@ mod tests {
     /// sent its authority as control data was reported before this gate existed.
     #[rstest]
     #[case("HTTP/2.0", "https://example.com/path", None)]
-    #[case("HTTP/3", "https://example.com/path", None)]
+    #[case("HTTP/3.0", "https://example.com/path", None)]
     #[case(
         "HTTP/2.0",
         "/path",

--- a/lint-http-rules/src/rules/client_request_target_form_checks.rs
+++ b/lint-http-rules/src/rules/client_request_target_form_checks.rs
@@ -535,10 +535,10 @@ mod tests {
     // the reassembly: `https://example.com*` is neither an authority-form nor an
     // asterisk-form, and the sender wrote neither.
     #[case("GET", "https://example.com*", "HTTP/2.0")]
-    #[case("GET", "https://example.com*", "HTTP/3")]
+    #[case("GET", "https://example.com*", "HTTP/3.0")]
     #[case("GET", "example.com:443", "HTTP/2.0")]
-    #[case("GET", "example.com:443", "HTTP/3")]
-    #[case("GET", "", "HTTP/3")]
+    #[case("GET", "example.com:443", "HTTP/3.0")]
+    #[case("GET", "", "HTTP/3.0")]
     fn a_version_with_no_request_line_is_not_measured(
         #[case] method: &str,
         #[case] uri: &str,

--- a/lint-http-rules/src/rules/client_request_target_no_fragment.rs
+++ b/lint-http-rules/src/rules/client_request_target_no_fragment.rs
@@ -286,7 +286,7 @@ mod tests {
     #[case("HTTP/1.0", "request-target")]
     #[case("HTTP/1.1", "request-target")]
     #[case("HTTP/2.0", "pseudo-header fields")]
-    #[case("HTTP/3", "pseudo-header fields")]
+    #[case("HTTP/3.0", "pseudo-header fields")]
     fn the_version_names_what_carried_it(#[case] version: &str, #[case] expected: &str) {
         let v = judge("/a#frag", version).expect("a fragment is reported on every version");
         assert!(v.message.contains(expected), "{}", v.message);

--- a/lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
+++ b/lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
@@ -325,7 +325,7 @@ mod tests {
     #[case("HTTP/1.1")]
     #[case("HTTP/1.0")]
     #[case("HTTP/2.0")]
-    #[case("HTTP/3")]
+    #[case("HTTP/3.0")]
     fn no_version_is_exempt(#[case] version: &str) {
         assert!(judge("https://example.com/a%2", version).is_some());
     }
@@ -334,7 +334,7 @@ mod tests {
     /// request-target, because two of the three versions have no request-line.
     #[test]
     fn the_finding_names_the_construct_every_version_has() {
-        let msg = judge("https://example.com/a%2", "HTTP/3").expect("must be reported");
+        let msg = judge("https://example.com/a%2", "HTTP/3.0").expect("must be reported");
         assert!(msg.starts_with("Request target "), "{msg}");
         assert!(!msg.contains("request-target"), "{msg}");
     }

--- a/lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
+++ b/lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
@@ -25,7 +25,9 @@ impl Rule for MessageHttp3HostAuthorityConsistency {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions. This gate is scoping, not a normative
         // check, so it carries no citation; the two comparisons below carry theirs.
-        if tx.request.version != "HTTP/3" {
+        // The major digit is what "is this HTTP/3" means; `helpers::version` owns
+        // the production that reads it.
+        if !crate::helpers::version::is_major(&tx.request.version, 3) {
             return None;
         }
 
@@ -156,7 +158,7 @@ mod tests {
         host: Option<&str>,
     ) -> crate::http_transaction::HttpTransaction {
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         tx.request.uri = uri.to_string();
         if let Some(h) = host {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("host", h)]);
@@ -330,7 +332,7 @@ mod tests {
     fn host_non_utf8_is_violation() {
         let rule = MessageHttp3HostAuthorityConsistency;
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         tx.request.uri = "https://example.com/path".into();
         let bad = hyper::header::HeaderValue::from_bytes(&[0xff])
             .expect("should construct non-utf8 header");

--- a/lint-http-rules/src/rules/message_http3_no_connection_header.rs
+++ b/lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -46,7 +46,8 @@ impl Rule for MessageHttp3NoConnectionHeader {
         // re-homed to the reverse-proxy response gate below, and the enforcing
         // "MUST NOT generate … MUST be treated as malformed" now sits on the check.)
         // cite(RFC 9114 § 4.2): "HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means."
-        if tx.request.version != "HTTP/3" {
+        // The gate reads the major digit; `helpers::version` owns the production.
+        if !crate::helpers::version::is_major(&tx.request.version, 3) {
             return None;
         }
 
@@ -76,7 +77,7 @@ impl Rule for MessageHttp3NoConnectionHeader {
         // case the previous version-gate cite was mis-anchored on.
         // cite(RFC 9114 § 4.2): "An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed."
         if let Some(resp) = &tx.response {
-            if resp.version == "HTTP/3" {
+            if crate::helpers::version::is_major(&resp.version, 3) {
                 if let Some(msg) = check_forbidden_headers(&resp.headers) {
                     return Some(Violation {
                         rule: self.id().into(),
@@ -224,7 +225,7 @@ mod tests {
 
     fn make_h3_transaction() -> crate::http_transaction::HttpTransaction {
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         tx
     }
 
@@ -233,9 +234,9 @@ mod tests {
         resp_headers: &[(&str, &str)],
     ) -> crate::http_transaction::HttpTransaction {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, resp_headers);
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         if let Some(ref mut resp) = tx.response {
-            resp.version = "HTTP/3".into();
+            resp.version = "HTTP/3.0".into();
         }
         tx
     }
@@ -460,7 +461,7 @@ mod tests {
                 ("transfer-encoding", "chunked"),
             ],
         );
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         // Response version stays HTTP/1.1 (upstream)
 
         let v = rule.check_transaction(

--- a/lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+++ b/lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
@@ -25,8 +25,10 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions. The version gate is scoping, not a
         // normative check, so it carries no cite; each requirement below cites the
-        // sentence it enforces.
-        if tx.request.version != "HTTP/3" {
+        // sentence it enforces. What it reads is the major digit and not a string:
+        // this version has no version field on the wire, so the value is one a
+        // writer chose, and `helpers::version` is where the production lives.
+        if !crate::helpers::version::is_major(&tx.request.version, 3) {
             return None;
         }
 
@@ -137,7 +139,7 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         // `:status` outside 100–599, and the constraint it enforced was RFC 9110
         // § 15's, not HTTP/3's: RFC 9114 § 4.3.2 defines the field as carrying "the
         // HTTP status code; see Section 15 of [HTTP]" and states no range of its
-        // own. Behind the `version == "HTTP/3"` gate above, the same out-of-range
+        // own. Behind the major-version gate above, the same out-of-range
         // status over HTTP/1.1 or HTTP/2 went unreported here and the HTTP/3 one was
         // reported twice — `server_status_code_valid_range` asks it of every
         // version. Same shape as the three checks `server_http3_status_code_validity`
@@ -255,7 +257,7 @@ mod tests {
 
     fn make_h3_transaction() -> crate::http_transaction::HttpTransaction {
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         tx
     }
 
@@ -264,9 +266,9 @@ mod tests {
         resp_headers: &[(&str, &str)],
     ) -> crate::http_transaction::HttpTransaction {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, resp_headers);
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         if let Some(ref mut resp) = tx.response {
-            resp.version = "HTTP/3".into();
+            resp.version = "HTTP/3.0".into();
         }
         tx
     }
@@ -701,7 +703,7 @@ mod tests {
         // HTTP/3 request but HTTP/1.1 upstream response (reverse-proxy).
         let rule = MessageHttp3PseudoHeadersValidity;
         let mut tx = crate::test_helpers::make_test_transaction_with_response(0, &[]);
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         // Response version stays HTTP/1.1 — status 0 should not be flagged.
 
         let v = rule.check_transaction(

--- a/lint-http-rules/src/rules/message_http_version_syntax_valid.rs
+++ b/lint-http-rules/src/rules/message_http_version_syntax_valid.rs
@@ -285,10 +285,10 @@ mod tests {
     #[test]
     fn http3_version_is_valid() {
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         tx.response = Some(crate::http_transaction::ResponseInfo {
             status: 200,
-            version: "HTTP/3".into(),
+            version: "HTTP/3.0".into(),
             headers: crate::test_helpers::make_headers_from_pairs(&[]),
             body_length: None,
             trailers: None,

--- a/lint-http-rules/src/rules/message_te_header_constraints.rs
+++ b/lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -791,7 +791,7 @@ mod tests {
     #[rstest]
     #[case("HTTP/2")]
     #[case("HTTP/2.0")]
-    #[case("HTTP/3")]
+    #[case("HTTP/3.0")]
     fn the_versions_that_prohibit_the_connection_field_are_not_asked_for_it(#[case] version: &str) {
         let v = request(version, &[b"trailers" as &[u8]], &[]);
         assert!(v.is_none(), "{version}: {v:?}");

--- a/lint-http-rules/src/rules/server_http3_status_code_validity.rs
+++ b/lint-http-rules/src/rules/server_http3_status_code_validity.rs
@@ -24,7 +24,10 @@ impl Rule for ServerHttp3StatusCodeValidity {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 connections. Scoping, not a normative check — no cite.
-        if tx.request.version != "HTTP/3" {
+        // Both gates read the major digit rather than a string: neither direction
+        // of this version carries a version field, so both values are ones a
+        // writer chose. `helpers::version` owns the production.
+        if !crate::helpers::version::is_major(&tx.request.version, 3) {
             return None;
         }
 
@@ -32,7 +35,7 @@ impl Rule for ServerHttp3StatusCodeValidity {
 
         // Only check responses that are themselves HTTP/3. In a reverse-proxy
         // setup the upstream response may be HTTP/1.1 (where 101 is valid).
-        if resp.version != "HTTP/3" {
+        if !crate::helpers::version::is_major(&resp.version, 3) {
             return None;
         }
 
@@ -160,9 +163,9 @@ mod tests {
         resp_headers: &[(&str, &str)],
     ) -> crate::http_transaction::HttpTransaction {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(status, resp_headers);
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         if let Some(ref mut resp) = tx.response {
-            resp.version = "HTTP/3".into();
+            resp.version = "HTTP/3.0".into();
         }
         tx
     }
@@ -337,7 +340,7 @@ mod tests {
             101,
             &[("upgrade", "websocket")],
         );
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
         // response.version stays HTTP/1.1
 
         let v = rule.check_transaction(
@@ -354,7 +357,7 @@ mod tests {
     fn no_response_is_ok() {
         let rule = ServerHttp3StatusCodeValidity;
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.request.version = "HTTP/3".into();
+        tx.request.version = "HTTP/3.0".into();
 
         let v = rule.check_transaction(
             &tx,

--- a/lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
+++ b/lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
@@ -385,8 +385,8 @@ mod tests {
     #[case(100, "HTTP/1.1", &[], None, Some(&[][..]), Some("trailer section"))]
     // --- versions: § 8.6 is every version's, RFC 9112 § 6.1 is HTTP/1.1's ---
     #[case(204, "HTTP/2.0", &[("content-length", "0")], None, None, Some("Content-Length"))]
-    #[case(204, "HTTP/3", &[("content-length", "0")], None, None, Some("Content-Length"))]
-    #[case(204, "HTTP/3", &[("transfer-encoding", "chunked")], None, None, None)]
+    #[case(204, "HTTP/3.0", &[("content-length", "0")], None, None, Some("Content-Length"))]
+    #[case(204, "HTTP/3.0", &[("transfer-encoding", "chunked")], None, None, None)]
     #[case(204, "HTTP/2.0", &[("transfer-encoding", "chunked")], None, None, None)]
     #[case(204, "HTTP/1.0", &[("transfer-encoding", "chunked")], None, None, Some("Transfer-Encoding"))]
     // --- outside the set ---

--- a/lint-http-rules/src/rules/server_status_code_valid_range.rs
+++ b/lint-http-rules/src/rules/server_status_code_valid_range.rs
@@ -236,7 +236,7 @@ mod tests {
     #[rstest]
     #[case("HTTP/1.1")]
     #[case("HTTP/2")]
-    #[case("HTTP/3")]
+    #[case("HTTP/3.0")]
     fn out_of_range_is_reported_on_every_version(#[case] version: &str) {
         let rule = ServerStatusCodeValidRange;
         let mut tx = crate::test_helpers::make_test_transaction_with_response(600, &[]);

--- a/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
@@ -89,7 +89,10 @@ impl Rule for Stateful101SwitchingProtocols {
 
         // ── Check: 101 on HTTP/2 ──
         // cite(RFC 9113 § 8.6): "HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
-        if tx.request.version == "HTTP/2" || tx.request.version == "HTTP/2.0" {
+        // Two spellings were listed here because the value is one a writer chose
+        // — this version carries no version field — and neither listing them nor
+        // guessing which one arrives is the question. The major digit is.
+        if crate::helpers::version::is_major(&tx.request.version, 2) {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
@@ -103,7 +106,7 @@ impl Rule for Stateful101SwitchingProtocols {
         // whose subject is HTTP Message Framing). Also enforced by
         // `server_http3_status_code_validity`; checked here for completeness.
         // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
-        if tx.request.version == "HTTP/3" {
+        if crate::helpers::version::is_major(&tx.request.version, 3) {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
@@ -495,8 +498,15 @@ mod tests {
 
     // ── Violation: HTTP/2 ──
 
+    /// `HTTP/2` is not a version number: RFC 9110 § 2.5 writes two digits and a
+    /// period, and RFC 9113 § 8.3.1 spells this version's implied number `2.0`.
+    /// This test asserted the gate fired on it, which was a claim about a
+    /// spelling nothing in this workspace writes and no production generates.
+    /// The gate now reads the major digit, so a value that fails the production
+    /// names no major version and reaches the checks below it instead — here,
+    /// the ordinary 101 handshake, which this request satisfies.
     #[rstest]
-    fn http2_101_forbidden() {
+    fn a_version_number_missing_its_minor_digit_names_no_major_version() {
         let tx = make_upgrade_tx(
             "HTTP/2",
             &[("upgrade", "websocket")],
@@ -504,16 +514,14 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Stateful101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "stateful_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
-        assert!(v.message.contains("HTTP/2"));
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "stateful_101_switching_protocols",
+            ]),
+        );
+        assert!(v.is_none(), "{v:?}");
     }
 
     #[rstest]
@@ -542,7 +550,7 @@ mod tests {
     #[rstest]
     fn http3_101_forbidden() {
         let tx = make_upgrade_tx(
-            "HTTP/3",
+            "HTTP/3.0",
             &[("upgrade", "websocket")],
             101,
             &[("upgrade", "websocket")],

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1001,7 +1001,7 @@ sources:
     snippet: Although host is case-insensitive, producers and normalizers should use lowercase for registered names and hexadecimal addresses for the sake of uniformity
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
-      line: 67
+      line: 69
   - label: server_location_header_uri_valid
     section: § 4.1
     snippet: URI-reference = URI / relative-ref
@@ -1060,6 +1060,12 @@ sources:
       line: 35
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 70
+  - label: DIGIT
+    section: § B.1
+    snippet: DIGIT          =  %x30-39 ; 0-9
+    cited_by:
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 93
 - label: RFC 5322
   url: https://www.rfc-editor.org/rfc/rfc5322.txt
   type: text/plain
@@ -3159,35 +3165,27 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
       line: 135
-  - label: client_request_target_form_checks
-    section: § 2.5
-    snippet: The first digit (major version) indicates the messaging syntax
-    cited_by:
-    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 164
-    - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
-      line: 86
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 83
-  - label: client_request_target_form_checks (2)
+  - label: client_request_target_form_checks
     section: § 7.1
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 246
-  - label: client_request_target_form_checks (3)
+  - label: client_request_target_form_checks (2)
     section: § 7.1
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 268
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 91
-  - label: client_request_target_form_checks (4)
+      line: 93
+  - label: client_request_target_form_checks (3)
     section: § 7.1
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
@@ -3197,21 +3195,21 @@ sources:
       line: 37
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 40
-  - label: client_request_target_form_checks (5)
+  - label: client_request_target_form_checks (4)
     section: § 7.1
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 238
-  - label: client_request_target_form_checks (6)
+  - label: client_request_target_form_checks (5)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 239
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 92
-  - label: client_request_target_form_checks (7)
+      line: 94
+  - label: client_request_target_form_checks (6)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
@@ -3360,20 +3358,32 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 42
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (3)
+    section: § 2.5
+    snippet: The "0" is used when referring to that protocol within elements that require a minor version identifier.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 58
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
+    section: § 2.5
+    snippet: When a major version of HTTP does not define any minor versions, the minor version "0" is implied.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 57
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (5)
     section: § 7.6.1
     snippet: 'Connection = #connection-option connection-option = token'
     cited_by:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
-      line: 65
-  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
+      line: 88
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (6)
     section: § 7.6.1
     snippet: Connection options are case-insensitive.
     cited_by:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
-      line: 68
+      line: 91
     - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
       line: 105
-  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (5)
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (7)
     section: § 7.6.1
     snippet: Furthermore, intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics.
     cited_by:
@@ -3383,12 +3393,12 @@ sources:
       line: 799
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
       line: 16
-  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (6)
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (8)
     section: § 7.6.1
     snippet: Intermediaries MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header or trailer field(s) from the message with the same name as the connection-option, and then remove the Connection header field itself (or replace it with the intermediary's own control options for the forwarded message).
     cited_by:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
-      line: 85
+      line: 108
     - file: lint-http-rules/src/helpers/headers.rs
       line: 826
     - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
@@ -3400,7 +3410,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket.rs
       line: 144
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
-      line: 55
+      line: 58
     - file: lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
       line: 54
   - label: lint-http-rules/src/helpers/accept_ranges.rs
@@ -4001,6 +4011,28 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 234
+  - label: lint-http-rules/src/helpers/version.rs
+    section: § 2.5
+    snippet: HTTP's version number consists of two decimal digits separated by a "." (period or decimal point).
+    cited_by:
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 28
+  - label: lint-http-rules/src/helpers/version.rs (2)
+    section: § 2.5
+    snippet: The first digit (major version) indicates the messaging syntax
+    cited_by:
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 126
+    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
+      line: 164
+    - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
+      line: 86
+  - label: lint-http-rules/src/helpers/version.rs (3)
+    section: § 2.5
+    snippet: The first digit (major version) indicates the messaging syntax, whereas the second digit (minor version) indicates the highest minor version within that major version to which the sender is conformant (able to understand for future communication).
+    cited_by:
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 29
   - label: message_accept_and_content_type_negotiation
     section: § 12.1
     snippet: A user agent cannot rely on proactive negotiation preferences being consistently honored, since the origin server might not implement proactive negotiation for the requested resource or might decide that sending a response that doesn't conform to the user agent's preferences is better than sending a 406 (Not Acceptable) response.
@@ -6034,19 +6066,19 @@ sources:
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 138
+      line: 141
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 180
+      line: 183
   - label: stateful_101_switching_protocols (3)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 125
+      line: 128
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 167
+      line: 170
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 194
+      line: 197
   - label: stateful_101_switching_protocols (4)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
@@ -6058,7 +6090,7 @@ sources:
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 155
+      line: 158
   - label: stateful_authentication_failure_loop
     section: § 15.5.2
     snippet: If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.
@@ -6565,35 +6597,19 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 121
-  - label: HTTP-version
-    section: § 2.3
-    snippet: HTTP-version  = HTTP-name "/" DIGIT "." DIGIT
-    cited_by:
-    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 168
-    - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
-      line: 87
-    - file: lint-http-rules/src/rules/message_http_version_syntax_valid.rs
-      line: 27
   - label: client_request_target_form_checks
-    section: § 2.3
-    snippet: The version of an HTTP/1.x message is indicated by an HTTP-version field in the start-line.
-    cited_by:
-    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 167
-  - label: client_request_target_form_checks (2)
     section: § 3.2
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 203
-  - label: client_request_target_form_checks (3)
+  - label: client_request_target_form_checks (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 201
-  - label: client_request_target_form_checks (4)
+  - label: client_request_target_form_checks (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
@@ -6601,13 +6617,13 @@ sources:
       line: 222
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 315
-  - label: client_request_target_form_checks (5)
+  - label: client_request_target_form_checks (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 202
-  - label: client_request_target_form_checks (6)
+  - label: client_request_target_form_checks (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
@@ -6621,13 +6637,13 @@ sources:
       line: 62
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 93
-  - label: client_request_target_form_checks (7)
+  - label: client_request_target_form_checks (6)
     section: § 3.2.2
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 308
-  - label: client_request_target_form_checks (8)
+  - label: client_request_target_form_checks (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
@@ -6641,13 +6657,13 @@ sources:
       line: 63
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 92
-  - label: client_request_target_form_checks (9)
+  - label: client_request_target_form_checks (8)
     section: § 3.2.3
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 247
-  - label: client_request_target_form_checks (10)
+  - label: client_request_target_form_checks (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
@@ -6655,13 +6671,13 @@ sources:
       line: 279
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 292
-  - label: client_request_target_form_checks (11)
+  - label: client_request_target_form_checks (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 255
-  - label: client_request_target_form_checks (12)
+  - label: client_request_target_form_checks (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
@@ -6673,13 +6689,13 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 64
-  - label: client_request_target_form_checks (13)
+  - label: client_request_target_form_checks (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 269
-  - label: client_request_target_form_checks (14)
+  - label: client_request_target_form_checks (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
@@ -6699,6 +6715,30 @@ sources:
       line: 111
     - file: lint-http-rules/src/rules/server_status_code_valid_range.rs
       line: 100
+  - label: HTTP-version
+    section: § 2.3
+    snippet: HTTP-version  = HTTP-name "/" DIGIT "." DIGIT
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 56
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 88
+    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
+      line: 168
+    - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
+      line: 87
+    - file: lint-http-rules/src/rules/message_http_version_syntax_valid.rs
+      line: 27
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs
+    section: § 2.3
+    snippet: The version of an HTTP/1.x message is indicated by an HTTP-version field in the start-line.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 55
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 18
+    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
+      line: 167
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 6.3
     snippet: If a message is received without Transfer-Encoding and with an invalid Content-Length header field, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error, unless the field value can be successfully parsed as a comma-separated list (Section 5.6.1 of [HTTP]), all values in the list are valid, and all values in the list are the same (in which case, the message is processed with that single value used as the Content-Length field value).
@@ -6747,6 +6787,18 @@ sources:
       line: 86
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 217
+  - label: lint-http-rules/src/helpers/version.rs
+    section: § 2.3
+    snippet: HTTP-version is case-sensitive.
+    cited_by:
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 62
+  - label: HTTP-name
+    section: § A
+    snippet: HTTP-name = %x48.54.54.50 ; HTTP
+    cited_by:
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 89
   - label: message_compression_and_transfer_encoding_consistency
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed.
@@ -7095,6 +7147,28 @@ sources:
       line: 94
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 41
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs
+    section: § 8.3.1
+    snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 65
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 128
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
+    section: § 8.3.1
+    snippet: Individual HTTP/2 requests do not carry an explicit indicator of protocol version.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 64
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 19
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (3)
+    section: § 8.3.2
+    snippet: HTTP/2 responses implicitly have a protocol version of "2.0".
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 66
   - label: message_header_field_names_token
     section: § 8.2.1
     snippet: HTTP/2 implementations SHOULD validate field names and values according to their definitions in Sections 5.1 and 5.5 of [HTTP], respectively, and treat messages that contain prohibited characters as malformed
@@ -7193,6 +7267,36 @@ sources:
       line: 128
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
       line: 36
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs
+    section: § 4.3.1
+    snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 72
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 20
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
+    section: § 4.3.1
+    snippet: HTTP/3 requests implicitly have a protocol version of "3.0".
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 73
+    - file: lint-http-proxy/src/proxy/http3.rs
+      line: 382
+    - file: lint-http-rules/src/helpers/version.rs
+      line: 127
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (3)
+    section: § 4.3.2
+    snippet: HTTP/3 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 74
+  - label: lint-http-proxy/src/proxy/hop_by_hop.rs (4)
+    section: § 4.3.2
+    snippet: HTTP/3 responses implicitly have a protocol version of "3.0".
+    cited_by:
+    - file: lint-http-proxy/src/proxy/hop_by_hop.rs
+      line: 75
   - label: message_extension_headers_registered
     section: § 4.2
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
@@ -7212,19 +7316,19 @@ sources:
     snippet: If both fields are present, they MUST contain the same value.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
-      line: 66
+      line: 68
   - label: message_http3_host_authority_consistency (2)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_host_authority_consistency.rs
-      line: 53
+      line: 55
   - label: message_http3_no_connection_header
     section: § 4.2
     snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 177
+      line: 178
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 161
   - label: message_http3_no_connection_header (2)
@@ -7232,7 +7336,7 @@ sources:
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 77
+      line: 78
   - label: message_http3_no_connection_header (3)
     section: § 4.2
     snippet: HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means.
@@ -7244,45 +7348,45 @@ sources:
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 94
+      line: 95
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 195
+      line: 196
   - label: message_http3_pseudo_headers_validity
     section: § 4.3.1
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 36
+      line: 38
   - label: message_http3_pseudo_headers_validity (2)
     section: § 4.3.1
     snippet: If the :scheme pseudo-header field identifies a scheme that has a mandatory authority component (including "http" and "https"), the request MUST contain either an :authority pseudo-header field or a Host header field.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 120
+      line: 122
   - label: message_http3_pseudo_headers_validity (3)
     section: § 4.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 105
+      line: 107
   - label: message_http3_pseudo_headers_validity (4)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 151
+      line: 153
   - label: message_http3_pseudo_headers_validity (5)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 152
+      line: 154
   - label: message_http3_pseudo_headers_validity (6)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 52
+      line: 54
   - label: server_alt_svc_h3_advertisement_valid
     section: § 3.1.1
     snippet: An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token.
@@ -7294,9 +7398,9 @@ sources:
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
-      line: 40
+      line: 43
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 105
+      line: 108
   - label: server_no_body_for_1xx_204_304
     section: § 4.1
     snippet: Interim responses do not contain content or trailer sections.


### PR DESCRIPTION
…hort

RFC 9114 § 4.3.1 and § 4.3.2 say HTTP/3 has nowhere to carry a version identifier and that its requests and responses implicitly have a protocol version of "3.0"; RFC 9113 § 8.3.1 and § 8.3.2 say the same for HTTP/2 and "2.0". This workspace wrote the second one and not the first: `HTTP/2.0` for one version and `HTTP/3` for the other, which no version production generates and which RFC 9110 § 2.5's rule for a major version with no minor versions -- the "0" is used where a minor version identifier is required -- declines directly.

Six rules matched that spelling as a string literal, so the value they depended on was one another file happened to choose, and changing it would have turned all six off in silence. They now ask the question they mean: `helpers::version` owns `HTTP-version = HTTP-name "/" DIGIT "." DIGIT` and answers whether a value's major digit is the one the gate wants.

One of those gates listed two spellings of HTTP/2 to cover the same doubt, and a test asserted the arm for the spelling nothing writes. The test now asserts what a value failing the production means: it names no major version at all.

Five further rules read the major version with `starts_with` and are unaffected by the change; they remain hand copies of the production and are left for their own audits.
