### PR TITLE
The quoted-string helpers walked the bytes of a value already holding…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1031,38 +1031,60 @@ pub fn quoted_string_end(s: &str) -> Option<usize> {
 /// both -- HTTP is not Structured Fields, and the same-looking helper in
 /// `structured_fields.rs` is right to reject exactly what this one accepts.
 ///
+/// The two DQUOTEs of the production are stripped by [`quoted_string_interior`],
+/// which both this function and [`unescape_quoted_string`] ask, so what counts
+/// as "properly quoted" is decided once.
+///
+/// The walk is over `chars` and not over `as_bytes`, and the difference is the
+/// whole of `obs-text`. A caller reading a value through
+/// [`combined_field_value_as_written`] holds one `char` per octet, so %xE9 in it
+/// is `U+00E9` -- which `as_bytes` re-encodes as the *two* octets %xC3 %xA9, a
+/// pair the sender did not write. `to_str` callers cannot tell the two walks
+/// apart, because that reader admits no octet at or above %x80 in the first
+/// place.
+///
+/// The `*( qdtext / quoted-pair )` between a `quoted-string`'s two DQUOTEs,
+/// with nothing inside it examined.
+///
+/// A lone DQUOTE strips its prefix and then has no suffix left to strip, so the
+/// one-character string is `None` rather than an empty interior — which is the
+/// distinction the production draws, `DQUOTE DQUOTE` being the shortest value it
+/// generates. [`validate_quoted_string`] and [`unescape_quoted_string`] both ask
+/// this rather than each slicing the ends off, because "is this quoted at all"
+/// has to be one answer for the pair of them.
+// cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
+pub fn quoted_string_interior(val: &str) -> Option<&str> {
+    val.strip_prefix('"')?.strip_suffix('"')
+}
+
 // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
 // cite(RFC 9110 § 5.6.4): "qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text"
 pub fn validate_quoted_string(val: &str) -> Result<(), String> {
-    let bytes = val.as_bytes();
-    if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
+    let Some(inner) = quoted_string_interior(val) else {
         return Err(format!("Quoted-string not properly quoted: '{}'", val));
-    }
+    };
 
     // Walk the interior checking for unescaped control chars and ensuring proper escaping
-    let mut i = 1usize;
     let mut prev_backslash = false;
-    while i + 1 < bytes.len() {
-        let b = bytes[i];
+    for c in inner.chars() {
         if prev_backslash {
             // A backslash does not make anything quotable. The escaped octet has its
             // own set, and it is not the same as qdtext's: SP and VCHAR and HTAB and
             // obs-text may follow a backslash, the remaining controls may not.
             //
             // cite(RFC 9110 § 5.6.4): "quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )"
-            if !(b == b'\t' || (0x20..=0x7e).contains(&b) || b >= 0x80) {
+            if !(c == '\t' || ('\u{20}'..='\u{7e}').contains(&c) || c >= '\u{80}') {
                 return Err(format!("Invalid quoted-pair in quoted-string: '{}'", val));
             }
             prev_backslash = false;
-        } else if b == b'\\' {
+        } else if c == '\\' {
             prev_backslash = true;
-        } else if b == b'"' {
+        } else if c == '"' {
             // unescaped quote before the terminating one -> invalid
             return Err(format!("Unescaped quote in quoted-string: '{}'", val));
-        } else if (b < 0x20 && b != b'\t') || b == 0x7f {
+        } else if (c < '\u{20}' && c != '\t') || c == '\u{7f}' {
             return Err(format!("Control character in quoted-string: '{}'", val));
         }
-        i += 1;
     }
 
     if prev_backslash {
@@ -1101,31 +1123,29 @@ pub fn quoted_string_inner_trimmed_is_empty(val: &str) -> Result<bool, String> {
 /// no escape table in this function and should never be one. `\n` in a
 /// quoted-string is the letter n.
 ///
+/// The walk is [`validate_quoted_string`]'s, and over `chars` for the same
+/// reason: `as_bytes` re-encoded a value already holding one `char` per octet,
+/// so an `obs-text` octet inside a `quoted-string` -- which `qdtext` admits --
+/// came back out as the two octets of its UTF-8 form and every finding naming
+/// it named a pair nobody wrote.
+///
 // cite(RFC 9110 § 5.6.4): "Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash."
 pub fn unescape_quoted_string(val: &str) -> Result<String, String> {
     validate_quoted_string(val)?;
-    let bytes = val.as_bytes();
-    let mut out = String::with_capacity(bytes.len());
-    let mut i = 1usize; // skip leading DQUOTE
+    let inner = quoted_string_interior(val).expect("validation accepted the quoting");
+    let mut out = String::with_capacity(inner.len());
     let mut prev_backslash = false;
-    while i + 1 < bytes.len() {
-        let b = bytes[i];
-        if prev_backslash {
-            out.push(b as char);
-            prev_backslash = false;
-        } else if b == b'\\' {
+    for c in inner.chars() {
+        // One statement, because the sentence cited above is one: a backslash
+        // that is not itself escaped is consumed, and everything else -- escaped
+        // or not -- is the octet it is. A trailing backslash cannot reach the end
+        // of this loop, because the validation above rejects that value.
+        if !prev_backslash && c == '\\' {
             prev_backslash = true;
         } else {
-            out.push(b as char);
+            out.push(c);
+            prev_backslash = false;
         }
-        i += 1;
-    }
-
-    if prev_backslash {
-        return Err(format!(
-            "Quoted-string ends with escape character: '{}'",
-            val
-        ));
     }
 
     Ok(out)
@@ -2052,6 +2072,32 @@ mod tests {
         assert_eq!(unescape_quoted_string("\"a\"").unwrap(), "a");
         assert_eq!(unescape_quoted_string("\"a\\\"b\"").unwrap(), "a\"b");
         assert_eq!(unescape_quoted_string("\"a\\\\b\"").unwrap(), "a\\b");
+    }
+
+    /// `qdtext` admits `obs-text`, so an octet at or above %x80 inside a
+    /// `quoted-string` is conforming and has to come back out as itself. Both
+    /// functions used to walk `as_bytes`, which re-encoded the one `char` per
+    /// octet a caller reading through `combined_field_value_as_written` holds:
+    /// %xE9 went in and %xC3 %xA9 came out, so a finding naming the octet named
+    /// a pair the sender never wrote.
+    #[test]
+    fn an_obs_text_octet_survives_the_round_trip_as_one_octet() {
+        let as_written: String = [b'"', 0xE9, b'x', b'"']
+            .iter()
+            .map(|&b| b as char)
+            .collect();
+        assert!(validate_quoted_string(&as_written).is_ok());
+        let inner = unescape_quoted_string(&as_written).expect("qdtext admits obs-text");
+        assert_eq!(inner.chars().count(), 2);
+        assert_eq!(inner.chars().next().map(|c| c as u32), Some(0xE9));
+
+        // The same octet after a backslash: `quoted-pair` admits it too.
+        let escaped: String = [b'"', b'\\', 0xE9, b'"']
+            .iter()
+            .map(|&b| b as char)
+            .collect();
+        let inner = unescape_quoted_string(&escaped).expect("quoted-pair admits obs-text");
+        assert_eq!(inner.chars().map(|c| c as u32).collect::<Vec<_>>(), [0xE9]);
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1675
+      line: 1695
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1670
+      line: 1690
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1669
+      line: 1689
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -1902,7 +1902,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1671
+      line: 1691
     - file: lint-http-rules/src/helpers/uri.rs
       line: 222
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3153,25 +3153,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1359
+      line: 1379
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1300
+      line: 1320
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1338
+      line: 1358
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1331
+      line: 1351
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -4909,7 +4909,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1268
+      line: 1288
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -4969,7 +4969,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1424
+      line: 1444
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5051,7 +5051,7 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1193
+      line: 1213
   - label: lint-http-rules/src/helpers/headers.rs (12)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
@@ -5063,13 +5063,13 @@ sources:
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1104
+      line: 1132
   - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1035
+      line: 1061
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5083,7 +5083,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1002
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1052
+      line: 1075
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 422
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
@@ -5095,9 +5095,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1001
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1034
+      line: 1055
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1192
+      line: 1060
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1212
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 315
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5111,7 +5113,7 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1624
+      line: 1644
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -5123,7 +5125,7 @@ sources:
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1542
+      line: 1562
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 385
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5135,7 +5137,7 @@ sources:
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1556
+      line: 1576
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 386
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5145,7 +5147,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1585
+      line: 1605
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 387
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5161,11 +5163,11 @@ sources:
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1423
+      line: 1443
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1534
+      line: 1554
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1614
+      line: 1634
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 384
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -5219,7 +5221,7 @@ sources:
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1503
+      line: 1523
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5245,7 +5247,7 @@ sources:
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1522
+      line: 1542
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5253,7 +5255,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1439
+      line: 1459
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 107
   - label: lint-http-rules/src/helpers/headers.rs (27)
@@ -5261,7 +5263,7 @@ sources:
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1502
+      line: 1522
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
@@ -5279,7 +5281,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1378
+      line: 1398
   - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".


### PR DESCRIPTION
… one char per octet

`qdtext` admits `obs-text`, so an octet at or above %x80 inside a `quoted-string` is conforming and has to come back out as itself. Both `validate_quoted_string` and `unescape_quoted_string` iterated `val.as_bytes()`; a value read through `combined_field_value_as_written` stores %xE9 as U+00E9, which `as_bytes` re-encodes as %xC3 %xA9 — so the first caller to read its input as octets got back a pair the sender never wrote, and the finding naming the octet named the wrong one.

Both walks are now over `chars`, which is the same function for every `to_str` caller: that reader admits no octet at or above %x80 in the first place. `quoted_string_interior` settles in one place what the two DQUOTEs enclose, so neither function slices the ends off for itself, and the unreachable trailing-backslash branch in `unescape_quoted_string` — which `validate_quoted_string` already rejects with the same message — is gone.

Pinned with a test that round-trips an `obs-text` octet bare and after a `quoted-pair`.
