### PR TITLE
Seven copies of one four-line body had already grown three signatures

### DIFF
--- a/lint-http-rules/src/rules/client_request_method_token_valid.rs
+++ b/lint-http-rules/src/rules/client_request_method_token_valid.rs
@@ -92,16 +92,6 @@ fn parse_method_token_config(
 
 pub struct ClientRequestMethodTokenValid;
 
-impl ClientRequestMethodTokenValid {
-    fn violation(&self, config: &MethodTokenConfig, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity: config.severity,
-            message,
-        }
-    }
-}
-
 impl Rule for ClientRequestMethodTokenValid {
     fn id(&self) -> &'static str {
         "client_request_method_token_valid"
@@ -160,7 +150,7 @@ impl Rule for ClientRequestMethodTokenValid {
         // the same thing in their own comments.
         if m.is_empty() {
             return Some(self.violation(
-                &config,
+                config.severity,
                 "Request carries an empty method token, and `method = token` has a one-character floor (`token = 1*tchar`), so the empty string derives from no production and names no method to apply to the target resource".into(),
             ));
         }
@@ -174,7 +164,7 @@ impl Rule for ClientRequestMethodTokenValid {
             // that prints as nothing: a raw DEL interpolated here produced a finding
             // whose offending character was an empty pair of quotes.
             return Some(self.violation(
-                &config,
+                config.severity,
                 format!(
                     "Method token contains {}, which is not a `tchar`, so the request's method derives from no `token` and therefore from no `method`",
                     crate::helpers::headers::shown_in_finding(&c.to_string())
@@ -198,7 +188,7 @@ impl Rule for ClientRequestMethodTokenValid {
                 // asks for a method nobody defined.
                 // cite(RFC 9110 § 9.1): "An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code."
                 return Some(self.violation(
-                    &config,
+                    config.severity,
                     format!(
                         "Method token '{m}' is '{folded}' written in another case. The method token is case-sensitive, so a server matching method names sees an unrecognized method here rather than '{folded}', and ought to answer 501 (Not Implemented); by convention a standardized method is defined in all-uppercase US-ASCII letters"
                     ),

--- a/lint-http-rules/src/rules/client_request_target_form_checks.rs
+++ b/lint-http-rules/src/rules/client_request_target_form_checks.rs
@@ -114,16 +114,6 @@ fn classify(target: &str) -> Option<TargetForm<'_>> {
 
 pub struct ClientRequestTargetFormChecks;
 
-impl ClientRequestTargetFormChecks {
-    fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-        }
-    }
-}
-
 impl Rule for ClientRequestTargetFormChecks {
     fn id(&self) -> &'static str {
         "client_request_target_form_checks"

--- a/lint-http-rules/src/rules/message_early_data_header_safe_method.rs
+++ b/lint-http-rules/src/rules/message_early_data_header_safe_method.rs
@@ -87,14 +87,6 @@ fn parse_early_data_config(
 pub struct MessageEarlyDataHeaderSafeMethod;
 
 impl MessageEarlyDataHeaderSafeMethod {
-    fn violation(&self, config: &EarlyDataConfig, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity: config.severity,
-            message,
-        }
-    }
-
     /// Whether this section's `Connection` field names `early-data`.
     ///
     /// The field lines are joined first: `Connection = #connection-option`, so a member
@@ -112,7 +104,7 @@ impl MessageEarlyDataHeaderSafeMethod {
             return None;
         }
         Some(self.violation(
-            config,
+            config.severity,
             format!(
                 "The {section} names Early-Data as a connection-option in its Connection header field, so every intermediary removes the field before forwarding — which is what RFC 8470 §5.1 forbids an intermediary to do to it"
             ),
@@ -177,7 +169,7 @@ impl Rule for MessageEarlyDataHeaderSafeMethod {
             // cite(RFC 9110 § 9.2.1): "Request methods are considered "safe" if their defined semantics are essentially read-only; i.e., the client does not request, and does not expect, any state change on the origin server as a result of applying a safe method to a target resource."
             if !config.safe_methods.iter().any(|m| m == &tx.request.method) {
                 return Some(self.violation(
-                    &config,
+                    config.severity,
                     format!(
                         "Request carrying an Early-Data header field was conveyed in TLS early data on a previous hop (RFC 8470 §5.1), and its method '{}' is not one this deployment lists as safe; RFC 8470 §4 has a client send only safe methods in early data, because a replayed unsafe request takes effect twice",
                         tx.request.method
@@ -190,7 +182,7 @@ impl Rule for MessageEarlyDataHeaderSafeMethod {
             // cite(RFC 8470 § 5.1): "An intermediary that forwards a request prior to the completion of the TLS handshake with its client MUST send it with the Early-Data header field set to "1" (i.e., it adds it if not present in the request)."
             if instances > 1 {
                 return Some(self.violation(
-                    &config,
+                    config.severity,
                     format!(
                         "Request carries {instances} Early-Data header field lines, and a client may send at most one — the field holds a single bit. A server reads them as one instance with the value 1, so the extra lines change nothing about the request; an intermediary marking early data adds the field only when it is not already there"
                     ),
@@ -207,7 +199,7 @@ impl Rule for MessageEarlyDataHeaderSafeMethod {
                 let written = hv.as_bytes();
                 if written != b"1" {
                     return Some(self.violation(
-                        &config,
+                        config.severity,
                         format!(
                             "Early-Data header field carries {}, and the field has exactly one valid value, \"1\". A server treats an invalid instance as though it said 1, so the request is marked as early data all the same — the value is simply wrong",
                             describe_value(written)
@@ -233,7 +225,7 @@ impl Rule for MessageEarlyDataHeaderSafeMethod {
             // cite(RFC 8470 § 5.1): "An Early-Data header field MUST NOT be included in responses or request trailers."
             if resp.headers.contains_key(FIELD) {
                 return Some(self.violation(
-                    &config,
+                    config.severity,
                     "Response carries an Early-Data header field. The field is a request header field: it tells a server that a request reached it through early data, and a response has nothing to mark".to_string(),
                 ));
             }

--- a/lint-http-rules/src/rules/message_priority_header_syntax.rs
+++ b/lint-http-rules/src/rules/message_priority_header_syntax.rs
@@ -73,8 +73,8 @@ impl MessagePriorityHeaderSyntax {
             // and step 1 fails before any type is considered.
             let Ok(v) = hv.to_str() else {
                 return Some(self.violation(
-                    whole_field(section, "contains a byte outside ASCII"),
                     severity,
+                    whole_field(section, "contains a byte outside ASCII"),
                 ));
             };
             lines.push(v);
@@ -82,15 +82,7 @@ impl MessagePriorityHeaderSyntax {
         if lines.is_empty() {
             return None;
         }
-        Some(self.violation(validate_priority(&lines.join(", "), section)?, severity))
-    }
-
-    fn violation(&self, message: String, severity: crate::lint::Severity) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-        }
+        Some(self.violation(severity, validate_priority(&lines.join(", "), section)?))
     }
 }
 

--- a/lint-http-rules/src/rules/message_structured_headers_validity.rs
+++ b/lint-http-rules/src/rules/message_structured_headers_validity.rs
@@ -91,7 +91,7 @@ impl MessageStructuredHeadersValidity {
             // considered.
             // cite(RFC 9651 § 4.2): "Convert input_bytes into an ASCII string input_string; if conversion fails, fail parsing."
             let Ok(v) = hv.to_str() else {
-                return Some(self.violation(
+                return Some(self.parse_failure(
                     hdr,
                     section,
                     "contains a byte outside ASCII",
@@ -104,7 +104,7 @@ impl MessageStructuredHeadersValidity {
             return None;
         }
         let msg = validate_structured_field(&lines.join(", "))?;
-        Some(self.violation(hdr, section, &msg, config.severity))
+        Some(self.parse_failure(hdr, section, &msg, config.severity))
     }
 
     /// The finding, framed as what a recipient does about it.
@@ -114,23 +114,27 @@ impl MessageStructuredHeadersValidity {
     /// RFC 9651 forbids field specifications from softening that, so the price
     /// of one stray character is the whole header.
     ///
+    /// Named for the failure rather than for the `Violation` it returns: an
+    /// inherent `violation` would shadow `Rule::violation` without saying so.
+    /// What is private here is the *wording*, licensed by the sentence below;
+    /// the construction is the trait's.
+    ///
     // cite(RFC 9651 § 4.2): "If parsing fails, either the entire field value MUST be ignored (i.e., treated as if the field were not present in the section), or alternatively the complete HTTP message MUST be treated as malformed."
-    fn violation(
+    fn parse_failure(
         &self,
         hdr: &str,
         section: &str,
         msg: &str,
         severity: crate::lint::Severity,
     ) -> Violation {
-        Violation {
-            rule: self.id().into(),
+        self.violation(
             severity,
-            message: format!(
+            format!(
                 "The {} header '{}' fails Structured Fields parsing, so a recipient discards \
                  the whole field or treats the message as malformed: {}",
                 section, hdr, msg
             ),
-        }
+        )
     }
 }
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -134,6 +134,35 @@ pub trait Rule: Send + Sync {
         RuleScope::Both
     }
 
+    /// Build one of this rule's findings.
+    ///
+    /// `Violation.rule` is the rule id, so a constructor for it needs `self.id()`
+    /// — which is why seven rules had each written this out privately, where
+    /// `id()` already was in scope. Four were byte-identical, one differed only
+    /// in argument order, and two took a whole config struct in order to read
+    /// `severity` off it. That is the argument for the extraction and not merely
+    /// its occasion: seven copies of one four-line body had already grown three
+    /// signatures.
+    ///
+    /// The parameters follow the struct's own field order: `rule` comes from
+    /// `self`, then `severity`, then `message`. A rule whose severity lives in a
+    /// custom config section passes `config.severity`; nothing here reads a
+    /// config, because the trait cannot know the shape of one.
+    ///
+    /// Not generic over the message, so the trait stays object-safe — the engine
+    /// dispatches every rule through `&'static dyn Rule`.
+    ///
+    /// An inherent method of this name on a rule would shadow this one silently,
+    /// which is why `message_structured_headers_validity`'s private finding
+    /// builder is named for its failure rather than for what it returns.
+    fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
+        Violation {
+            rule: self.id().into(),
+            severity,
+            message,
+        }
+    }
+
     /// Evaluate an `HttpTransaction` against this rule. Rules parse whatever
     /// configuration they need directly from the global `cfg: &Config`.
     fn check_transaction(

--- a/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -100,16 +100,6 @@ fn protocol_id_encoding_defect(protocol_id: &str) -> Option<String> {
 /// field value against the grammar RFC 7838 § 3 prints for it.
 pub struct ServerAltSvcHeaderSyntax;
 
-impl ServerAltSvcHeaderSyntax {
-    fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-        }
-    }
-}
-
 /// `alt-authority = quoted-string ; containing [ uri-host ] ":" port`
 ///
 /// Two productions deep, and the outer one is where this rule used to stop:

--- a/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -175,16 +175,6 @@ fn shown_alpn_name(name: &[u8]) -> String {
 /// rule asks whether the name is one this deployment offers.
 pub struct ServerAltSvcProtocolIanaRegistered;
 
-impl ServerAltSvcProtocolIanaRegistered {
-    fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-        }
-    }
-}
-
 impl Rule for ServerAltSvcProtocolIanaRegistered {
     fn id(&self) -> &'static str {
         "server_alt_svc_protocol_iana_registered"

--- a/lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_server_timing_header_syntax.rs
@@ -124,16 +124,6 @@ fn is_valid_floating_point_number(s: &str) -> bool {
 /// § 2 prints.
 pub struct ServerServerTimingHeaderSyntax;
 
-impl ServerServerTimingHeaderSyntax {
-    fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-        }
-    }
-}
-
 impl Rule for ServerServerTimingHeaderSyntax {
     fn id(&self) -> &'static str {
         "server_server_timing_header_syntax"

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -455,32 +455,32 @@ sources:
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 374
+      line: 364
   - label: Server-Timing grammar
     snippet: 'Server-Timing = #server-timing-metric'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 342
+      line: 332
   - label: server-timing-metric grammar
     snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 373
+      line: 363
   - label: server-timing-param grammar
     snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 440
+      line: 430
   - label: server-timing-param-name grammar
     snippet: server-timing-param-name = token
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 441
+      line: 431
   - label: server-timing-param-value grammar
     snippet: server-timing-param-value = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 509
+      line: 499
   - label: server_server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
@@ -492,25 +492,25 @@ sources:
     snippet: All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 496
+      line: 486
   - label: server_server_timing_header_syntax (3)
     section: § 2
     snippet: If any server-timing-param-name is specified more than once, only the first instance is to be considered, even if the server-timing-param is incomplete or invalid.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 495
+      line: 485
   - label: server_server_timing_header_syntax (4)
     section: § 2
     snippet: 'See [RFC7230] for definitions of #, *, OWS, token, and quoted-string.'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 343
+      line: 333
   - label: server_server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 145
+      line: 135
   - label: server_server_timing_header_syntax (6)
     section: § 2
     snippet: This specification establishes the server-timing-params for server-timing-param-names "dur" for duration and "desc" for description, both optional.
@@ -522,31 +522,31 @@ sources:
     snippet: To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 494
+      line: 484
   - label: server_server_timing_header_syntax (8)
     section: § 2
     snippet: User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 524
+      line: 514
   - label: server_server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 616
+      line: 606
   - label: server_server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 615
+      line: 605
   - label: server_server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 599
+      line: 589
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -1211,7 +1211,7 @@ sources:
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
       line: 482
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 149
+      line: 139
   - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
@@ -1225,7 +1225,7 @@ sources:
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
       line: 393
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 161
+      line: 151
   - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
@@ -2011,7 +2011,7 @@ sources:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 93
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 194
+      line: 184
   - label: message_http2_pseudo_headers_validity (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
@@ -2019,7 +2019,7 @@ sources:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 92
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 193
+      line: 183
 - label: RFC 6454
   url: https://www.rfc-editor.org/rfc/rfc6454.txt
   type: text/plain
@@ -3162,7 +3162,7 @@ sources:
     snippet: In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 318
+      line: 308
   - label: server_alt_svc_protocol_iana_registered (5)
     section: § 6
     snippet: 'Identification Sequence: The precise set of octet values that identifies the protocol.'
@@ -3304,9 +3304,9 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
       line: 38
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 377
+      line: 367
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 195
+      line: 185
   - label: server_alt_svc_h3_advertisement_valid (3)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -3318,19 +3318,19 @@ sources:
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 463
+      line: 453
   - label: server_alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 192
+      line: 182
   - label: server_alt_svc_header_syntax (3)
     section: § 3
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 448
+      line: 438
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3344,9 +3344,9 @@ sources:
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 391
+      line: 381
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 218
+      line: 208
   - label: server_alt_svc_header_syntax (5)
     section: § 3
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
@@ -3358,7 +3358,7 @@ sources:
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 222
+      line: 212
   - label: server_alt_svc_header_syntax (7)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
@@ -3370,7 +3370,7 @@ sources:
     snippet: Note that the "quoted-string" syntax needs to be used because ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 124
+      line: 114
   - label: server_alt_svc_header_syntax (9)
     section: § 3
     snippet: Octets in the ALPN protocol name MUST NOT be percent-encoded if they are valid token characters except "%", and
@@ -3390,7 +3390,7 @@ sources:
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 123
+      line: 113
   - label: server_alt_svc_header_syntax (12)
     section: § 3
     snippet: The field value consists either of a list of values, each of which indicates one alternative service, or the keyword "clear".
@@ -3404,7 +3404,7 @@ sources:
     snippet: Unknown parameters MUST be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 223
+      line: 213
   - label: server_alt_svc_header_syntax (14)
     section: § 3
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
@@ -3422,7 +3422,7 @@ sources:
     snippet: alt-authority = quoted-string ; containing [ uri-host ] ":" port
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 122
+      line: 112
   - label: server_alt_svc_header_syntax (17)
     section: § 3
     snippet: alt-value     = alternative *( OWS ";" OWS parameter )
@@ -3430,15 +3430,15 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 32
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 259
+      line: 249
   - label: server_alt_svc_header_syntax (18)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 317
+      line: 307
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 270
+      line: 260
   - label: server_alt_svc_header_syntax (19)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -3446,21 +3446,21 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 19
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 324
+      line: 314
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 237
+      line: 227
   - label: server_alt_svc_header_syntax (20)
     section: § 3
     snippet: parameter     = token "=" ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 221
+      line: 211
   - label: server_alt_svc_header_syntax (21)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 318
+      line: 308
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 127
   - label: server_alt_svc_header_syntax (22)
@@ -3468,43 +3468,43 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 288
+      line: 278
   - label: server_alt_svc_header_syntax (23)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 290
+      line: 280
   - label: server_alt_svc_header_syntax (24)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 289
+      line: 279
   - label: server_alt_svc_header_syntax (25)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 148
+      line: 138
   - label: server_alt_svc_protocol_iana_registered
     section: § 2
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 316
+      line: 306
   - label: server_alt_svc_protocol_iana_registered (2)
     section: § 2
     snippet: The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 317
+      line: 307
   - label: server_alt_svc_protocol_iana_registered (3)
     section: § 2.4
     snippet: If the connection to the alternative service does not negotiate the expected protocol (for example, ALPN fails to negotiate h2, or an Upgrade request to h2c is not accepted), the connection to the alternative service MUST be considered to have failed.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 319
+      line: 309
   - label: server_alt_svc_protocol_iana_registered (4)
     section: § 3
     snippet: ALPN protocol names are octet sequences with no additional constraints on format.
@@ -3850,63 +3850,63 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 822
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 133
+      line: 125
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 233
+      line: 225
   - label: message_early_data_header_safe_method
     section: § 4
     snippet: Absent other information, clients MAY send requests with safe HTTP methods ([RFC7231], Section 4.2.1) in early data when it is available and MUST NOT send unsafe methods (or methods whose safety is not known) in early data.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 176
+      line: 168
   - label: message_early_data_header_safe_method (2)
     section: § 5.1
     snippet: A request that is marked with Early-Data was sent in early data on a previous hop.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 164
+      line: 156
   - label: message_early_data_header_safe_method (3)
     section: § 5.1
     snippet: An intermediary MUST NOT remove this header field if it is present in a request.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 226
+      line: 218
   - label: message_early_data_header_safe_method (4)
     section: § 5.1
     snippet: An intermediary that forwards a request prior to the completion of the TLS handshake with its client MUST send it with the Early-Data header field set to "1" (i.e., it adds it if not present in the request).
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 190
+      line: 182
   - label: message_early_data_header_safe_method (5)
     section: § 5.1
     snippet: Early-Data MUST NOT appear in a Connection header field.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 227
+      line: 219
   - label: message_early_data_header_safe_method (6)
     section: § 5.1
     snippet: 'It has just one valid value: "1".'
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 205
+      line: 197
   - label: message_early_data_header_safe_method (7)
     section: § 5.1
     snippet: Multiple or invalid instances of the header field MUST be treated as equivalent to a single instance with a value of 1 by a server.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 163
+      line: 155
   - label: message_early_data_header_safe_method (8)
     section: § 5.1
     snippet: The Early-Data header field carries a single bit of information, and clients MUST include at most one instance.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 154
+      line: 146
   - label: message_early_data_header_safe_method (9)
     section: § 5.1
     snippet: The Early-Data request header field indicates that the request has been conveyed in early data and that a client understands the 425 (Too Early) status code.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 165
+      line: 157
 - label: RFC 8594
   url: https://www.rfc-editor.org/rfc/rfc8594.txt
   type: text/plain
@@ -4330,15 +4330,15 @@ sources:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 310
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 114
+      line: 104
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 171
+      line: 161
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 205
+      line: 195
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 222
+      line: 212
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 315
+      line: 305
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 109
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
@@ -4406,11 +4406,11 @@ sources:
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
       line: 289
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 464
+      line: 454
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 94
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 356
+      line: 346
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 59
   - label: client_expect_header_valid (13)
@@ -4516,15 +4516,15 @@ sources:
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 125
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 191
-    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 181
+    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
+      line: 171
     - file: lint-http-rules/src/rules/client_request_version_method_validity.rs
       line: 75
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
       line: 76
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 170
+      line: 162
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 242
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
@@ -4740,19 +4740,19 @@ sources:
     snippet: An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 199
+      line: 189
   - label: client_request_method_token_valid (5)
     section: § 9.1
     snippet: By convention, standardized methods are defined in all-uppercase US-ASCII letters.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 192
+      line: 182
   - label: client_request_method_token_valid (6)
     section: § A
     snippet: method = token minute = 2DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 135
+      line: 125
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 115
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
@@ -4768,13 +4768,13 @@ sources:
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 247
+      line: 237
   - label: client_request_target_form_checks (2)
     section: § 7.1
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 269
+      line: 259
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 235
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
@@ -4784,7 +4784,7 @@ sources:
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 166
+      line: 156
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 37
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
@@ -4794,13 +4794,13 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 239
+      line: 229
   - label: client_request_target_form_checks (5)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 240
+      line: 230
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 236
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
@@ -4810,7 +4810,7 @@ sources:
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 167
+      line: 157
   - label: client_request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
@@ -4956,7 +4956,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 155
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 165
+      line: 155
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 89
   - label: lint-http-core/src/http_version.rs (3)
@@ -5274,7 +5274,7 @@ sources:
     - file: lint-http-rules/src/rules/semantic_trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 337
+      line: 327
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 11.6.3
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
@@ -5398,7 +5398,7 @@ sources:
     - file: lint-http-rules/src/rules/message_user_agent_token_valid.rs
       line: 70
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 187
+      line: 177
   - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -5416,7 +5416,7 @@ sources:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 438
+      line: 428
   - label: OWS grammar
     section: § 5.6.3
     snippet: OWS            = *( SP / HTAB )
@@ -5436,7 +5436,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 466
+      line: 456
   - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
@@ -5500,9 +5500,9 @@ sources:
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
       line: 34
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 125
+      line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 319
+      line: 309
   - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
@@ -5616,7 +5616,7 @@ sources:
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 119
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 176
+      line: 166
   - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
@@ -5784,11 +5784,11 @@ sources:
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
       line: 212
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 319
+      line: 309
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 277
+      line: 267
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 389
+      line: 379
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
@@ -6486,7 +6486,7 @@ sources:
     snippet: Request methods are considered "safe" if their defined semantics are essentially read-only; i.e., the client does not request, and does not expect, any state change on the origin server as a result of applying a safe method to a target resource.
     cited_by:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
-      line: 177
+      line: 169
   - label: message_etag_syntax
     section: § 8.8.3
     snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
@@ -7790,23 +7790,23 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 378
+      line: 368
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 196
+      line: 186
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 61
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 146
+      line: 136
   - label: server_alt_svc_header_syntax (2)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 410
+      line: 400
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 228
+      line: 218
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 186
+      line: 176
   - label: server_authentication_challenge_validity
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -8058,7 +8058,7 @@ sources:
     snippet: '#element => [ 1#element ]'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 336
+      line: 326
   - label: server_status_and_caching_semantics
     section: § 15.1
     snippet: Responses with status codes that are defined as heuristically cacheable (e.g., 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, and 501 in this specification) can be reused by a cache with heuristic expiration unless otherwise indicated by the method definition or explicit cache controls
@@ -8656,33 +8656,33 @@ sources:
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 204
+      line: 194
   - label: client_request_target_form_checks (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 202
+      line: 192
   - label: client_request_target_form_checks (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 223
+      line: 213
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 316
+      line: 306
   - label: client_request_target_form_checks (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 203
+      line: 193
   - label: client_request_target_form_checks (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 307
+      line: 297
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
@@ -8696,13 +8696,13 @@ sources:
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 309
+      line: 299
   - label: client_request_target_form_checks (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 308
+      line: 298
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
@@ -8716,27 +8716,27 @@ sources:
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 248
+      line: 238
   - label: client_request_target_form_checks (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 280
+      line: 270
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 293
+      line: 283
   - label: client_request_target_form_checks (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 256
+      line: 246
   - label: client_request_target_form_checks (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 249
+      line: 239
   - label: authority-form
     section: § 3.2.3
     snippet: authority-form = uri-host ":" port
@@ -8750,13 +8750,13 @@ sources:
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 270
+      line: 260
   - label: client_request_target_form_checks (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 271
+      line: 261
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
@@ -8782,7 +8782,7 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 169
+      line: 159
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 90
   - label: lint-http-core/src/http_version.rs
@@ -8800,7 +8800,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 63
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 168
+      line: 158
     - file: lint-http-rules/src/rules/message_http_version_syntax_valid.rs
       line: 145
   - label: HTTP-name
@@ -9204,7 +9204,7 @@ sources:
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 136
+      line: 126
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 154
   - label: client_request_target_form_checks
@@ -9212,7 +9212,7 @@ sources:
     snippet: A request in asterisk form (for OPTIONS) includes the value '*' for the ":path" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 170
+      line: 160
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 241
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
@@ -9222,7 +9222,7 @@ sources:
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 171
+      line: 161
   - label: client_request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
@@ -9412,13 +9412,13 @@ sources:
     snippet: '":method":  Contains the HTTP method (Section 9 of [HTTP])'
     cited_by:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
-      line: 137
+      line: 127
   - label: client_request_target_form_checks
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 172
+      line: 162
   - label: client_request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI
@@ -9716,13 +9716,13 @@ sources:
     snippet: For both the Priority header field and the PRIORITY_UPDATE frame, the set of priority parameters is encoded as a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]).
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 253
+      line: 245
   - label: message_priority_header_syntax (2)
     section: § 4
     snippet: Receivers parse the Dictionary as described in Section 4.2 of [STRUCTURED-FIELDS].
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 254
+      line: 246
   - label: message_priority_header_syntax (3)
     section: § 4
     snippet: When receiving an HTTP request that does not carry these priority parameters, a server SHOULD act as if their default values were specified.
@@ -9734,49 +9734,49 @@ sources:
     snippet: Where the Dictionary is successfully parsed, this document places the additional requirement that unknown priority parameters, priority parameters with out-of-range values, or values of unexpected types MUST be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 292
+      line: 284
   - label: message_priority_header_syntax (5)
     section: § 4.1
     snippet: The urgency (u) parameter value is Integer (see Section 3.3.1 of [STRUCTURED-FIELDS]), between 0 and 7 inclusive, in descending order of priority.
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 306
+      line: 298
   - label: message_priority_header_syntax (6)
     section: § 4.1
     snippet: between 0 and 7 inclusive, in descending order of priority. The default is 3.
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 328
+      line: 320
   - label: message_priority_header_syntax (7)
     section: § 4.2
     snippet: The default value of the incremental parameter is false (0).
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 340
+      line: 332
   - label: message_priority_header_syntax (8)
     section: § 4.2
     snippet: The incremental (i) parameter value is Boolean (see Section 3.3.6 of [STRUCTURED-FIELDS]).
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 337
+      line: 329
   - label: message_priority_header_syntax (9)
     section: § 4.3
     snippet: Since unknown priority parameters are ignored, new priority parameters should not change the interpretation of, or modify, the urgency (see Section 4.1) or incremental (see Section 4.2) priority parameters in a way that is not backwards compatible or fallback safe.
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 359
+      line: 351
   - label: message_priority_header_syntax (10)
     section: § 4.3.1
     snippet: New priority parameters can be defined by registering them in the "HTTP Priority" registry.
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 358
+      line: 350
   - label: message_priority_header_syntax (11)
     section: § 5
     snippet: The Priority HTTP header field is a Dictionary that carries priority parameters (see Section 4).
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 104
+      line: 96
   - label: message_priority_header_syntax (12)
     section: § 8
     snippet: The absence of a priority parameter in an HTTP response indicates the server's disinterest in changing the client-provided value.
@@ -9977,7 +9977,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 452
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 279
+      line: 283
   - label: lint-http-rules/src/helpers/structured_fields.rs (9)
     section: § 4.2
     snippet: The parsing algorithms for both types allow tab characters, since these might be used to combine field lines by some implementations.
@@ -10081,7 +10081,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 481
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 312
+      line: 304
   - label: lint-http-rules/src/helpers/structured_fields.rs (26)
     section: § 4.2.2
     snippet: No structured data has been found; return dictionary (which is empty).
@@ -10091,7 +10091,7 @@ sources:
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 69
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 287
+      line: 291
   - label: lint-http-rules/src/helpers/structured_fields.rs (27)
     section: § 4.2.3
     snippet: Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
@@ -10305,9 +10305,9 @@ sources:
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 91
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 261
+      line: 253
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 117
+      line: 122
   - label: message_permissions_policy_directives_valid (4)
     section: § 4.2
     snippet: When generating input_bytes, parsers MUST combine all field lines in the same section (header or trailer) that case-insensitively match the field name into one comma-separated field-value, as per Section 5.2 of [HTTP]; this assures that the entire field value is processed correctly.
@@ -10327,48 +10327,48 @@ sources:
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 235
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 274
+      line: 266
   - label: message_priority_header_syntax
     section: § 3.3.1
     snippet: While it is possible to serialize Integers with leading zeros (e.g., "0002", "-01") and signed zero ("-0"), these distinctions may not be preserved by implementations.
     cited_by:
     - file: lint-http-rules/src/rules/message_priority_header_syntax.rs
-      line: 307
+      line: 299
   - label: message_structured_headers_validity
     snippet: This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,
     cited_by:
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 162
+      line: 166
   - label: message_structured_headers_validity (2)
     section: § 4.2
     snippet: Given an array of bytes as input_bytes that represent the chosen field's field-value (which is empty if that field is not present) and field_type (one of "dictionary", "list", or "item"), return the parsed field value.
     cited_by:
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 267
+      line: 271
   - label: message_structured_headers_validity (3)
     section: § 4.2
     snippet: If field_type is "dictionary", let output be the result of running Parsing a Dictionary (Section 4.2.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 299
+      line: 303
   - label: message_structured_headers_validity (4)
     section: § 4.2
     snippet: If field_type is "item", let output be the result of running Parsing an Item (Section 4.2.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 292
+      line: 296
   - label: message_structured_headers_validity (5)
     section: § 4.2
     snippet: If field_type is "list", let output be the result of running Parsing a List (Section 4.2.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 294
+      line: 298
   - label: message_structured_headers_validity (6)
     section: § 4.2.1
     snippet: No structured data has been found; return members (which is empty).
     cited_by:
     - file: lint-http-rules/src/rules/message_structured_headers_validity.rs
-      line: 286
+      line: 290
   - label: message_sunset_and_deprecation_consistency
     section: § 3.3.7
     snippet: their serialization in textual HTTP fields is similar to that of Integers, distinguished from them with a leading "@".


### PR DESCRIPTION
`Violation.rule` is the rule id, so a constructor for it needs `self.id()` — which is the whole reason seven rules had each written one out privately rather than sharing it. `trait Rule` already carries defaults and already has `id()` in scope, so the constructor is now a default method there and the seven copies are gone.

The count is the argument, and it was one iteration out of date. Four of the seven were byte-identical (`server_alt_svc_protocol_iana_registered`, `server_alt_svc_header_syntax`, `client_request_target_form_checks`, `server_server_timing_header_syntax`), one differed only in argument order (`message_priority_header_syntax`, taking `(message, severity)`), and two took a whole config struct in order to read `severity` off it (`message_early_data_header_safe_method`, `client_request_method_token_valid`). Seven copies, three signatures.

The parameter order is settled by the struct rather than by the majority: `Violation`'s fields read `rule, severity, message`, and `rule` comes from `self`, so the parameter list is what is left of the struct once `self` has supplied its first field. The message is a `String` and not an `impl Into<String>`, because a generic method would cost `where Self: Sized` and the engine dispatches every rule through `&'static dyn Rule`.

An eighth site is not a constructor and does not fold into one. `message_structured_headers_validity` built the wording that RFC 9651 §4.2's "the entire field value MUST be ignored ... or alternatively the complete HTTP message MUST be treated as malformed" licenses, from four arguments. It stays private, renamed `parse_failure`, and delegates the construction — because an inherent method named `violation` shadows the trait's in silence, and had it kept the name its own call would have recursed into itself instead of reaching the default.

Not touched, on purpose: the 537 sites in 165 files that write the struct literal inline. A struct literal has no signature to drift, so it is not the debt this row named.
