### PR TITLE
The count was quoted from a neighbour, and the neighbour's list was s…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1198,15 +1198,81 @@ pub fn shown_in_finding(s: &str) -> String {
     s.escape_debug().to_string()
 }
 
+/// Why a value derives from neither alternative of `( token / quoted-string )`.
+///
+/// Data rather than a sentence, and that is the whole reason this extraction was
+/// possible at all. The alternation is one production; the finding is not. Seven
+/// sites read this pair and each says something about its own field — an
+/// `Alt-Svc` parameter, a `Server-Timing` parameter, a `Pragma` directive, a
+/// media type's parameter, a `Keep-Alive` parameter, a `Prefer` preference. Six
+/// of them had also decided, separately and in four different ways, what an
+/// empty value means. So what is shared here is the decision and the two
+/// measurements behind it; **the wording, and the verdict on
+/// [`WordDefect::Empty`], stay at the caller** — which is where each field's own
+/// sentence about it is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WordDefect {
+    /// The value is empty, and neither alternative derives the empty string:
+    /// `token = 1*tchar` has a one-character floor, and the shortest
+    /// `quoted-string` is its two DQUOTEs. That is arithmetic on two
+    /// productions and is not a per-field question — but what a field *does*
+    /// about it is, and two rules in this tree tolerate it on the record.
+    Empty,
+    /// An unquoted value holding a character no `tchar` admits. Unquoted by
+    /// elimination rather than by inspection: see [`token_or_quoted_string`].
+    NotToken(char),
+    /// A leading DQUOTE opened something that is not a well-formed
+    /// `quoted-string`, carrying the interior walk's own account of it.
+    NotQuotedString(String),
+}
+
+/// Read one `( token / quoted-string )` and return what it holds.
+///
+/// The alternation is decided by the first octet and by nothing else: RFC 9110
+/// § 5.6.2 makes DQUOTE a delimiter, so no `token` can open with one and a value
+/// that does is trying to be a `quoted-string` and nothing else. A value that
+/// does not open with one is a `token` by elimination, which is why the `tchar`
+/// scan below is the whole of that half.
+///
+/// The content returned is what the field means by the value: a `token` as
+/// written, a `quoted-string` after `quoted-pair` substitution. A caller that
+/// only judges the value may discard it — [`unescape_quoted_string`] opens by
+/// asking [`validate_quoted_string`], so the two accept exactly the same strings
+/// and the `Err` is the same `Err`.
+///
+/// RFC 7230 named this pair `word`; RFC 9110 kept both halves and dropped the
+/// name, which is why the two productions cited here are the halves and not the
+/// whole. Callers whose own document writes its own name for it —
+/// `server-timing-param-value`, `parameter-value`, RFC 2068's `value` — cite
+/// that at their site.
+///
+// cite(RFC 9110 § 5.6.2): "Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}")."
+// cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
+// cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
+pub fn token_or_quoted_string(value: &str) -> Result<std::borrow::Cow<'_, str>, WordDefect> {
+    if value.is_empty() {
+        return Err(WordDefect::Empty);
+    }
+    if value.starts_with('"') {
+        return unescape_quoted_string(value)
+            .map(std::borrow::Cow::Owned)
+            .map_err(WordDefect::NotQuotedString);
+    }
+    match crate::helpers::token::find_invalid_token_char(value) {
+        Some(c) => Err(WordDefect::NotToken(c)),
+        None => Ok(std::borrow::Cow::Borrowed(value)),
+    }
+}
+
 /// One `token [ BWS "=" BWS word ]` pair, parsed.
 ///
 /// RFC 7240 writes that production three times — `preference`, `parameter` and
 /// `applied-pref` — and says in prose that the third is the first minus its
 /// parameters, so the pair itself is one thing written once here rather than
 /// per field. `word` is the name RFC 7230 gave `( token / quoted-string )`;
-/// RFC 9110 kept both halves and dropped the name, which is why the two
-/// productions cited on [`parse_token_bws_word`] are the halves and not the
-/// whole.
+/// RFC 9110 kept both halves and dropped the name, which is why the pair is
+/// cited by its halves at [`token_or_quoted_string`], where it is read, and not
+/// under a name no document in force writes.
 pub struct TokenBwsWord<'a> {
     /// The `token`, exactly as written. Case folding is the caller's: whether
     /// two names are the same string is a question each field answers for
@@ -1237,10 +1303,10 @@ pub struct TokenBwsWord<'a> {
 ///
 /// The shape itself is cited at the field that has it, not here — a helper
 /// shared by three productions can honestly quote only the halves they agree
-/// on. `token` is transcribed once at [`crate::helpers::token::is_tchar`], which
-/// this function asks rather than re-reading.
+/// on. `token` is transcribed once at [`crate::helpers::token::is_tchar`], and
+/// the `word` half is read by [`token_or_quoted_string`]; what is left here is
+/// the part RFC 7240 owns, which is the optional group and the `BWS`.
 ///
-/// cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
 /// cite(RFC 9110 § 5.6.3): "The BWS rule is used where the grammar allows optional whitespace only for historical reasons."
 pub fn parse_token_bws_word(member: &str) -> Result<TokenBwsWord<'_>, String> {
     // `token` admits neither `=` nor DQUOTE, so nothing can precede the `=` the
@@ -1264,17 +1330,20 @@ pub fn parse_token_bws_word(member: &str) -> Result<TokenBwsWord<'_>, String> {
 
     let value = match value_written_trimmed {
         None => None,
-        Some(v) if v.starts_with('"') => Some(unescape_quoted_string(v)?),
-        // `word` is `token / quoted-string` and `token` is `1*tchar`, so the
-        // optional group cannot close on an empty value: a field that means to
-        // say "no value" writes no `=`, or writes `""`.
-        Some("") => return Err("nothing after the \"=\", where the grammar has a word".to_string()),
-        Some(v) => {
-            if let Some(c) = crate::helpers::token::find_invalid_token_char(v) {
-                return Err(format!("value contains {}", describe_char(c)));
+        Some(v) => match token_or_quoted_string(v) {
+            Ok(content) => Some(content.into_owned()),
+            // `word` is `token / quoted-string` and `token` is `1*tchar`, so the
+            // optional group cannot close on an empty value: a field that means
+            // to say "no value" writes no `=`, or writes `""`. RFC 7240 grants
+            // no tolerance for the third spelling, so this is a defect here.
+            Err(WordDefect::Empty) => {
+                return Err("nothing after the \"=\", where the grammar has a word".to_string())
             }
-            Some(v.to_string())
-        }
+            Err(WordDefect::NotToken(c)) => {
+                return Err(format!("value contains {}", describe_char(c)))
+            }
+            Err(WordDefect::NotQuotedString(e)) => return Err(e),
+        },
     };
 
     Ok(TokenBwsWord { name, value, bws })
@@ -2095,6 +2164,57 @@ mod tests {
     fn quoted_string_inner_trimmed_is_empty_true_cases() {
         assert!(quoted_string_inner_trimmed_is_empty("\"\"").unwrap());
         assert!(quoted_string_inner_trimmed_is_empty("\"   \"").unwrap());
+    }
+
+    /// The alternation is decided by the first octet and by nothing else, and
+    /// each of the three defects is a distinct answer rather than one `Err`:
+    /// the seven callers that used to write this out disagree about `Empty` in
+    /// particular, so it has to arrive as something they can match on.
+    #[test]
+    fn token_or_quoted_string_separates_its_three_defects() {
+        assert_eq!(token_or_quoted_string("abc").unwrap(), "abc");
+        // The content is what the field means by the value, so the DQUOTEs come
+        // off and a `quoted-pair` is substituted.
+        assert_eq!(token_or_quoted_string("\"a\\\"b\"").unwrap(), "a\"b");
+        // `""` is two DQUOTEs and derives from the production; its content is
+        // empty, which is not the same fact as the value being empty.
+        assert_eq!(token_or_quoted_string("\"\"").unwrap(), "");
+
+        assert_eq!(token_or_quoted_string(""), Err(WordDefect::Empty));
+        assert_eq!(
+            token_or_quoted_string("a b"),
+            Err(WordDefect::NotToken(' '))
+        );
+        // A leading DQUOTE commits the value to the `quoted-string` half: RFC
+        // 9110 § 5.6.2 makes DQUOTE a delimiter, so this is not a `token`
+        // holding a bad character, it is a malformed `quoted-string`.
+        assert!(matches!(
+            token_or_quoted_string("\"abc"),
+            Err(WordDefect::NotQuotedString(_))
+        ));
+        assert!(matches!(
+            token_or_quoted_string("\"abc\"x"),
+            Err(WordDefect::NotQuotedString(_))
+        ));
+    }
+
+    /// The reader is handed one `char` per octet by every caller that reads a
+    /// field through [`combined_field_value_as_written`], and the two halves
+    /// answer an `obs-text` octet differently on purpose: `qdtext` admits it and
+    /// `tchar` does not.
+    #[test]
+    fn obs_text_lands_on_the_side_of_the_alternation_the_grammar_puts_it() {
+        let quoted: String = [b'"', 0xE9, b'"'].iter().map(|&b| b as char).collect();
+        assert_eq!(
+            token_or_quoted_string(&quoted).unwrap().chars().count(),
+            1,
+            "an obs-text octet is qdtext and comes back as one octet"
+        );
+        let bare: String = [0xE9u8].iter().map(|&b| b as char).collect();
+        assert_eq!(
+            token_or_quoted_string(&bare),
+            Err(WordDefect::NotToken('\u{E9}'))
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -273,11 +273,31 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
                             });
                         }
                     } else {
-                        // The two alternatives of `parameter-value`, each handed
-                        // to the helper that owns its grammar.
+                        // `parameter-value` is `( token / quoted-string )`, and
+                        // the alternation is read by the helper that owns it.
                         // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
-                        if v.starts_with('"') {
-                            if let Err(e) = crate::helpers::headers::validate_quoted_string(v) {
+                        match crate::helpers::headers::token_or_quoted_string(v) {
+                            Ok(_) => {}
+                            // The same shape the parameter *name* above was
+                            // corrected for, left standing on the value half:
+                            // `a/b;x=` reached a `tchar` scan, which finds no
+                            // invalid character in the empty string and called it
+                            // clean. Neither alternative derives the empty string
+                            // -- `token = 1*tchar`, and the shortest
+                            // `quoted-string` is its two DQUOTEs -- so the value
+                            // as written derives from no `parameter-value`.
+                            // (`x=""` is a different value and still conforms.)
+                            Err(crate::helpers::headers::WordDefect::Empty) => {
+                                return Some(Violation {
+                                    rule: self.id().into(),
+                                    severity: config.severity,
+                                    message: format!(
+                                        "Empty parameter value in '{}' of {} header: a parameter-value is a token or a quoted-string, and neither derives the empty string",
+                                        p, hdr
+                                    ),
+                                });
+                            }
+                            Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
                                     severity: config.severity,
@@ -287,15 +307,16 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
                                     ),
                                 });
                             }
-                        } else if let Some(c) = crate::helpers::token::find_invalid_token_char(v) {
-                            return Some(Violation {
-                                rule: self.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid token '{}' in parameter value '{}' of {} header",
-                                    c, v, hdr
-                                ),
-                            });
+                            Err(crate::helpers::headers::WordDefect::NotToken(c)) => {
+                                return Some(Violation {
+                                    rule: self.id().into(),
+                                    severity: config.severity,
+                                    message: format!(
+                                        "Invalid token '{}' in parameter value '{}' of {} header",
+                                        c, v, hdr
+                                    ),
+                                });
+                            }
                         }
                     }
                 }
@@ -498,6 +519,12 @@ mod tests {
     // `token = 1*tchar`: a name with no characters is not a name, and scanning
     // for an invalid character cannot notice that there are none.
     #[case(Some("text/html; =value"), true)]
+    // The same shape on the value half, which the audit that fixed the name half
+    // left standing: `parameter-value = ( token / quoted-string )` derives no
+    // empty string either, and `charset=` used to be clean for exactly the
+    // reason `=value` used to be. `""` is a different value and conforms.
+    #[case(Some("text/html; charset="), true)]
+    #[case(Some("text/html; charset=\"\""), false)]
     // No whitespace inside a media-range. The OWS in these grammars sits around
     // list elements and around the `;`, never between a type and its subtype.
     #[case(Some("text /html"), true)]
@@ -619,6 +646,32 @@ mod tests {
         // `Both`: the rule reads a response's Accept as well as a request's,
         // and §12.5.1 gives that one a meaning of its own.
         assert_eq!(rule.scope(), crate::rules::RuleScope::Both);
+    }
+
+    /// The empty-value branch, pinned rather than merely asserted to exist. A
+    /// case that only checks `is_some()` cannot see a message whose subject and
+    /// verb phrase disagree, and this one has to name the value half so it is
+    /// not read as the parameter-name finding twelve lines above it.
+    #[test]
+    fn the_empty_parameter_value_finding_names_the_value_half() {
+        let rule = MessageAcceptHeaderMediaTypeSyntax;
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_header_media_type_syntax",
+        ]);
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("accept", "text/html; charset=")]);
+        let v = rule
+            .check_transaction(
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+            .expect("an empty parameter-value derives from neither alternative");
+        assert_eq!(
+            v.message,
+            "Empty parameter value in 'charset=' of Accept header: a parameter-value is a token or a quoted-string, and neither derives the empty string"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/message_cache_control_token_valid.rs
@@ -141,23 +141,23 @@ fn check_cache_control_value(s: &str) -> Option<String> {
 
         if let Some(vpart) = kv.next() {
             let vpart = vpart.trim();
-            // Leniency, recorded rather than changed: `foo=` does not match the
-            // grammar above — once "=" is present the optional group requires a
-            // token (`1*tchar`) or a quoted-string, neither of which can be empty.
-            // The rule accepts it anyway, so it under-reports this one shape. That
-            // is the safe direction for a linter, and tightening it would be a
-            // behavior change. (`foo=""` is genuinely valid: quoted-string permits
-            // empty content.)
-            if vpart.is_empty() {
-                continue;
-            }
-            if vpart.starts_with('"') {
-                if let Err(e) = crate::helpers::headers::validate_quoted_string(vpart) {
+            // The `( token / quoted-string )` alternation is read by the shared
+            // helper that owns it; what stays here is what this field says about
+            // each answer.
+            match crate::helpers::headers::token_or_quoted_string(vpart) {
+                Ok(_) => {}
+                // Leniency, recorded rather than changed: `foo=` does not match the
+                // grammar above — once "=" is present the optional group requires a
+                // token (`1*tchar`) or a quoted-string, neither of which can be empty.
+                // The rule accepts it anyway, so it under-reports this one shape. That
+                // is the safe direction for a linter, and tightening it would be a
+                // behavior change. (`foo=""` is genuinely valid: quoted-string permits
+                // empty content.)
+                Err(crate::helpers::headers::WordDefect::Empty) => continue,
+                Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
                     return Some(format!("Invalid quoted-string in directive value: {}", e));
                 }
-            } else {
-                // Unquoted value must be a token
-                if let Some(c) = crate::helpers::token::find_invalid_token_char(vpart) {
+                Err(crate::helpers::headers::WordDefect::NotToken(c)) => {
                     return Some(format!(
                         "Directive value contains invalid character: '{}'",
                         c

--- a/lint-http-rules/src/rules/message_keep_alive_header_validity.rs
+++ b/lint-http-rules/src/rules/message_keep_alive_header_validity.rs
@@ -4,9 +4,8 @@
 
 use crate::helpers::headers::{
     combined_field_value_as_written, describe_char, is_nominated_by_connection, shown_in_finding,
-    split_commas_respecting_quotes, trim_ows, validate_quoted_string,
+    split_commas_respecting_quotes, token_or_quoted_string, trim_ows, WordDefect,
 };
-use crate::helpers::token::find_invalid_token_char;
 use crate::lint::Violation;
 use crate::rules::Rule;
 
@@ -536,58 +535,55 @@ fn validate_keepalive_param(member: &str, max_timeout_seconds: u64) -> Result<()
 ///
 /// The alternation is decided by the first octet, because only one branch of it
 /// can begin with a DQUOTE: `token` excludes that character as a `tspecials`.
+/// That decision, and the two measurements behind it, is
+/// [`token_or_quoted_string`]'s -- **written out seven times in this tree until
+/// P2 gave it a home**, here and in `message_pragma_token_valid`,
+/// `message_cache_control_token_valid`,
+/// `message_accept_header_media_type_syntax`,
+/// `server_alt_svc_header_syntax::check_parameter`,
+/// `server_server_timing_header_syntax::check_param` and privately inside
+/// [`parse_token_bws_word`]. What could not be shared and is not shared is the
+/// wording, and the verdict on an empty value: two of the seven tolerate it on
+/// the record and five do not.
 ///
-/// That decision -- leading DQUOTE means measure a `quoted-string`, otherwise
-/// measure a `token` -- is now written out **five** times: here,
-/// `message_pragma_token_valid`, `message_cache_control_token_valid`,
-/// `message_accept_header_media_type_syntax`, and privately inside
-/// [`parse_token_bws_word`]. The five agree today. They are not converted here
-/// because each carries its own sentence for the empty case and its own wording
-/// for the finding, so a shared version changes what four rules report and is
-/// their own audits' work -- but the divergence is recorded at the site that
-/// created the fifth copy.
+/// This document's `token` and `quoted-string` are RFC 2068's, and the reader's
+/// are RFC 9110's. The seventeen `tspecials` are § 5.6.2's delimiters, both
+/// alphabets stop at US-ASCII, and RFC 2068's own prose licenses the backslash
+/// inside a quoted-string -- which is what RFC 2616 § 2.2 later wrote into the
+/// production and RFC 9110 § 5.6.4 still has. So the two documents' pairs are
+/// the same pair, and the cites below are why that is a reading rather than an
+/// assumption.
 ///
+/// [`token_or_quoted_string`]: crate::helpers::headers::token_or_quoted_string
 /// [`parse_token_bws_word`]: crate::helpers::headers::parse_token_bws_word
 // cite(RFC 2068 § 3.7): "value          = token | quoted-string"
+// cite(RFC 2068 § 2.2): "token          = 1*<any CHAR except CTLs or tspecials>"
+// cite(RFC 2068 § 2.2): "quoted-string  = ( <"> *(qdtext) <"> )"
+// cite(RFC 2068 § 2.2): "The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs."
 fn validate_param_value(value: &str) -> Result<(), String> {
-    // Neither alternative derives the empty string -- `token` is `1*<...>` and a
-    // `quoted-string` is at least its two DQUOTEs -- so a member ending on its
-    // `=` has a value the grammar cannot generate.
-    let Some(first) = value.chars().next() else {
-        return Err(
+    match token_or_quoted_string(value) {
+        Ok(_) => Ok(()),
+        // Neither alternative derives the empty string -- `token` is `1*<...>`
+        // and a `quoted-string` is at least its two DQUOTEs -- so a member
+        // ending on its `=` has a value the grammar cannot generate. No
+        // sentence in this document tolerates it, so it is a finding here.
+        Err(WordDefect::Empty) => Err(
             "has nothing after its \"=\", and neither a token nor a quoted-string derives the \
              empty string"
                 .into(),
-        );
-    };
-
-    if first == '"' {
-        // This document's production omits `quoted-pair` from the alternation
-        // while its own prose licenses the backslash inside a quoted-string;
-        // the reading here follows the prose, which is what RFC 2616 §2.2
-        // later wrote into the production and what RFC 9110 §5.6.4 still has.
-        // cite(RFC 2068 § 2.2): "quoted-string  = ( <"> *(qdtext) <"> )"
-        // cite(RFC 2068 § 2.2): "The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs."
-        //
-        // The helper builds its own message and puts the value into it raw. The
-        // only octets a `HeaderValue` can carry that `describe_octet` would have
-        // named are `obs-text`, and those are `qdtext` -- so one reaches a
-        // finding here only inside a quoted-string that is already malformed.
-        // Rendering them is the helper's to fix, at its twenty-odd callers.
-        return validate_quoted_string(value)
-            .map_err(|e| format!("has a value that is not a well-formed quoted-string: {e}"));
-    }
-
-    // The seventeen `tspecials` are RFC 9110 §5.6.2's delimiters and both
-    // alphabets stop at US-ASCII, so the shared `tchar` helper is this
-    // document's `token` under another name and no second copy is written here.
-    // cite(RFC 2068 § 2.2): "token          = 1*<any CHAR except CTLs or tspecials>"
-    match find_invalid_token_char(value) {
-        Some(c) => Err(format!(
+        ),
+        Err(WordDefect::NotToken(c)) => Err(format!(
             "has {} in its value, and a value that is not a quoted-string is a token",
             describe_char(c)
         )),
-        None => Ok(()),
+        // The reader builds this half of its message and puts the value into it
+        // raw. The only octets a `HeaderValue` can carry that `describe_octet`
+        // would have named are `obs-text`, and those are `qdtext` -- so one
+        // reaches a finding here only inside a quoted-string that is already
+        // malformed. Rendering them is the helper's to fix, at its callers.
+        Err(WordDefect::NotQuotedString(e)) => Err(format!(
+            "has a value that is not a well-formed quoted-string: {e}"
+        )),
     }
 }
 

--- a/lint-http-rules/src/rules/message_pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/message_pragma_token_valid.rs
@@ -159,22 +159,26 @@ fn check_pragma_value(s: &str) -> Option<String> {
 
         if let Some(vpart) = kv.next() {
             let vpart = vpart.trim();
-            // A bare `directive=` (the `=` present with no value) is more permissive than the
-            // grammar, which requires a `token` or `quoted-string` after `=`; accepted as a
-            // deliberate tolerance for this deprecated field.
-            if vpart.is_empty() {
-                continue;
-            }
-            // Value grammars owned by the helpers (RFC 9110 §5.6.4 `quoted-string`, §5.6.2 `token`).
-            if vpart.starts_with('"') {
-                if let Err(e) = crate::helpers::headers::validate_quoted_string(vpart) {
+            // The `( token / quoted-string )` alternation is read by the shared
+            // helper that owns it; what stays here is what this field says about
+            // each answer.
+            match crate::helpers::headers::token_or_quoted_string(vpart) {
+                Ok(_) => {}
+                // A bare `directive=` (the `=` present with no value) is more permissive than the
+                // grammar, which requires a `token` or `quoted-string` after `=`; accepted as a
+                // deliberate tolerance for this deprecated field. Written as an
+                // arm rather than as a pre-check, because it is a verdict this
+                // rule reaches and not a step of reading the value.
+                Err(crate::helpers::headers::WordDefect::Empty) => continue,
+                Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
                     return Some(format!("Invalid quoted-string in directive value: {}", e));
                 }
-            } else if let Some(c) = crate::helpers::token::find_invalid_token_char(vpart) {
-                return Some(format!(
-                    "Directive value contains invalid character: '{}'",
-                    c
-                ));
+                Err(crate::helpers::headers::WordDefect::NotToken(c)) => {
+                    return Some(format!(
+                        "Directive value contains invalid character: '{}'",
+                        c
+                    ));
+                }
             }
         }
     }

--- a/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -4,8 +4,8 @@
 
 use crate::helpers::headers::{
     combined_field_value_as_written, describe_char, quoting_is_balanced, shown_in_finding,
-    split_commas_respecting_quotes, split_semicolons_respecting_quotes, trim_ows,
-    unescape_quoted_string,
+    split_commas_respecting_quotes, split_semicolons_respecting_quotes, token_or_quoted_string,
+    trim_ows, unescape_quoted_string, WordDefect,
 };
 use crate::lint::Violation;
 use crate::rules::Rule;
@@ -208,6 +208,13 @@ fn check_alt_authority(shown: &str, authority: &str) -> Option<String> {
 /// here, so a bare `ma` is a finding rather than a name with no value. Three
 /// independent reviews have now proposed the fold; the two grammars disagree
 /// on both halves, which is what `BWS` is a tell for in either direction.
+///
+/// P2 settled it by folding the half that does *not* disagree. The value is
+/// `( token / quoted-string )` -- the same pair RFC 7838 imports from RFC 7230
+/// by name and RFC 9110 carries unchanged -- so the alternation is read by
+/// `helpers::headers::token_or_quoted_string` and every sentence about what it
+/// found is still this field's. The name, the `=` and the whitespace beside it
+/// stay here, because that is where this document differs from the other two.
 // cite(RFC 7838 § 3): "parameter     = token "=" ( token / quoted-string )"
 // cite(RFC 7838 § 3): "Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value."
 // cite(RFC 7838 § 3): "Unknown parameters MUST be ignored."
@@ -244,31 +251,31 @@ fn check_parameter(shown: &str, parameter: &str) -> Option<String> {
             describe_char(c)
         ));
     }
-    let unquoted: std::borrow::Cow<'_, str> = if value.starts_with('"') {
-        match unescape_quoted_string(value) {
-                Ok(inner) => std::borrow::Cow::Owned(inner),
-                Err(e) => {
-                    return Some(format!(
-                        "Alt-Svc parameter '{}' in '{shown}' has a value that is not a well-formed `quoted-string`: {e}",
-                        shown_in_finding(name)
-                    ))
-                }
-            }
-    } else {
-        if value.is_empty() {
+    // The value half is `( token / quoted-string )`, read by the shared reader
+    // that owns the alternation; every sentence below is this field's own answer
+    // to what the reader found, because "empty" in particular is a verdict two
+    // other rules in this tree deliberately do not share.
+    let unquoted = match token_or_quoted_string(value) {
+        Ok(content) => content,
+        Err(WordDefect::Empty) => {
             return Some(format!(
                     "Alt-Svc parameter '{}' in '{shown}' has an empty value. The value half is `token / quoted-string`, and the empty string derives from neither -- a `token` is `1*tchar` and a `quoted-string` is at least its two DQUOTEs",
                     shown_in_finding(name)
-                ));
+                ))
         }
-        if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
+        Err(WordDefect::NotToken(c)) => {
             return Some(format!(
                     "Alt-Svc parameter '{}' in '{shown}' has {} in an unquoted value. The value half is `token / quoted-string`, so a character no `tchar` admits has to be written inside DQUOTEs",
                     shown_in_finding(name),
                     describe_char(c)
-                ));
+                ))
         }
-        std::borrow::Cow::Borrowed(value)
+        Err(WordDefect::NotQuotedString(e)) => {
+            return Some(format!(
+                    "Alt-Svc parameter '{}' in '{shown}' has a value that is not a well-formed `quoted-string`: {e}",
+                    shown_in_finding(name)
+                ))
+        }
     };
 
     // § 3.1 prints a syntax for this parameter, and the syntax is one

--- a/lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_server_timing_header_syntax.rs
@@ -5,12 +5,11 @@
 use crate::helpers::headers::{
     combined_field_value_as_written, describe_char, quoted_string_end, quoting_is_balanced,
     response_field_sections, shown_in_finding, split_commas_respecting_quotes,
-    split_semicolons_respecting_quotes, trim_ows, unescape_quoted_string,
+    split_semicolons_respecting_quotes, token_or_quoted_string, trim_ows, WordDefect,
 };
 use crate::helpers::token::find_invalid_token_char;
 use crate::lint::Violation;
 use crate::rules::Rule;
-use std::borrow::Cow;
 
 /// The two `server-timing-param-name`s this specification establishes, spelled
 /// as the two getters that read them spell their lookups.
@@ -409,8 +408,8 @@ fn check_metric(metric: &str) -> Option<String> {
 /// One `server-timing-param`, and what the two established names mean for it.
 ///
 /// **The third hand-written copy of `token <ws> "=" <ws> ( token /
-/// quoted-string )`, and the divergence is recorded here because this is the
-/// site that creates it.** `helpers::headers::parse_token_bws_word` owns
+/// quoted-string )`, and P2 answered it by splitting the walk rather than by
+/// folding it.** `helpers::headers::parse_token_bws_word` owns
 /// `token [ BWS "=" BWS word ]`; `server_alt_svc_header_syntax::check_parameter`
 /// owns RFC 7838's `parameter = token "=" ( token / quoted-string )`; and this
 /// one is that second production with `OWS` printed either side of the `=`.
@@ -419,14 +418,20 @@ fn check_metric(metric: &str) -> Option<String> {
 /// other two is, so a bare `db;desc` is a finding here and a valueless name
 /// there) and **what whitespace beside the `=` means** (a tolerated historical
 /// artefact reported separately in the helper, a *defect* in Alt-Svc, and part
-/// of the production here -- so the one thing a shared reader would have to be
-/// told per caller is the one thing all three disagree about). Alt-Svc's and
-/// this one are one terminal apart and could be folded on a flag; that is
-/// `server_alt_svc_header_syntax`'s question as much as this rule's, and
-/// neither audit may answer it alone.
+/// of the production here). Those two axes are the *left* half of the walk, and
+/// they stay at each site: a flag naming the difference would be a parameter
+/// whose only job is to say which document the caller is reading, which is what
+/// `BWS` has been the tell against in either direction.
 ///
-/// The leading-DQUOTE alternation below is separately the **sixth** copy in the
-/// tree, counted at `message_keep_alive_header_validity::validate_param_value`.
+/// What did fold is the *right* half. `( token / quoted-string )` is one
+/// production all three import from RFC 9110 unchanged, so the alternation and
+/// its two measurements are now `helpers::headers::token_or_quoted_string`'s,
+/// and this rule's three sentences about the answers are below. That reader was
+/// the **seventh** copy in the tree when it was made, not the sixth: the count
+/// this comment used to carry came from
+/// `message_keep_alive_header_validity::validate_param_value`'s list of five and
+/// added one, and the list had not been extended when Alt-Svc's audit wrote the
+/// sixth. **A copy count quoted from a neighbour is a copy count one short.**
 // cite(Server Timing, label: server-timing-param grammar): "server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value"
 // cite(Server Timing, label: server-timing-param-name grammar): "server-timing-param-name = token"
 fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Option<String> {
@@ -493,25 +498,17 @@ fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Opt
     }
     seen.push(name);
 
-    // `server-timing-param-value = token / quoted-string`. Neither alternative
-    // derives the empty string: `token = 1*tchar`, and the shortest
-    // `quoted-string` is the two DQUOTEs.
-    // cite(Server Timing, label: server-timing-param-value grammar): "server-timing-param-value = token / quoted-string"
-    if value.is_empty() {
-        return Some(format!(
-            "Server-Timing parameter '{}' has an empty value: a server-timing-param-value is a token or a quoted-string, and neither of those is nothing",
-            shown_in_finding(param)
-        ));
-    }
-
-    let text = if value.starts_with('"') {
-        // Where the `quoted-string` ends decides whether anything follows it,
-        // and something following it is the case § 2 has a user agent ignore.
-        // Being told to ignore a thing is not being told one may write it --
-        // the value still has to derive from one of the two alternatives, and
-        // `"abc"x` derives from neither.
-        //
-        // cite(Server Timing § 2): "User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric."
+    // Where a leading `quoted-string` ends decides whether anything follows it,
+    // and something following it is the case § 2 has a user agent ignore. Being
+    // told to ignore a thing is not being told one may write it -- the value
+    // still has to derive from one of the two alternatives, and `"abc"x` derives
+    // from neither. Asked here rather than left to the shared reader, which
+    // reports an unbalanced or trailing-content value as one defect: this field
+    // has a sentence about exactly the trailing-content half and says what a
+    // recipient does with it, which the generic message cannot.
+    //
+    // cite(Server Timing § 2): "User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric."
+    if value.starts_with('"') {
         let end = quoted_string_end(value).expect("the field value's quoting is balanced");
         if end + 1 != value.len() {
             return Some(format!(
@@ -520,45 +517,50 @@ fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Opt
                 shown_in_finding(&value[end + 1..])
             ));
         }
-        // Balanced quoting and nothing after the close still leaves the
-        // interior to judge, and the value a user agent stores is the
-        // unescaped one -- it collects the quoted string with the extract-value
-        // flag set. Those are one call rather than two: `unescape_quoted_string`
-        // opens by asking `validate_quoted_string`, so validating separately
-        // would run the interior walk twice and leave a discarded `Err` behind.
-        // The neighbour records the same fold at the same production.
-        //
-        // **The error arm is a boundary rather than a live finding, and saying
-        // so is the point.** Every value reaching this rule crossed a
-        // `hyper::HeaderValue`, whose own predicate is `b >= 32 && b != 127 ||
-        // b == b'\t'` -- so no octet that could fail the interior walk is in the
-        // string at all: the controls are refused at the door, HTAB and every
-        // `obs-text` octet are admitted by both `qdtext` and `quoted-pair`, an
-        // unescaped DQUOTE before the end was found by `quoted_string_end`
-        // above, and a trailing backslash would have unbalanced the quoting. The
-        // arm stays because the grammar's reader is where the grammar's question
-        // is answered; a rule that decided it by omission would be one capture
-        // format away from being wrong.
-        match unescape_quoted_string(value) {
-            Ok(inner) => Cow::Owned(inner),
-            Err(e) => {
-                return Some(format!(
-                    "Server-Timing parameter '{}' has a malformed quoted-string value: {e}",
-                    shown_in_finding(name)
-                ))
-            }
+    }
+
+    // `server-timing-param-value = token / quoted-string` is the shared reader's
+    // alternation under this document's name for it, so the reading is its and
+    // the three sentences below are this field's. The value a user agent stores
+    // is the unescaped one -- it collects the quoted string with the
+    // extract-value flag set -- which is what the reader returns.
+    //
+    // **The malformed-quoted-string arm is a boundary rather than a live
+    // finding, and saying so is the point.** Every value reaching this rule
+    // crossed a `hyper::HeaderValue`, whose own predicate is `b >= 32 && b != 127
+    // || b == b'\t'` -- so no octet that could fail the interior walk is in the
+    // string at all: the controls are refused at the door, HTAB and every
+    // `obs-text` octet are admitted by both `qdtext` and `quoted-pair`, an
+    // unescaped DQUOTE before the end was found by `quoted_string_end` above, and
+    // a trailing backslash would have unbalanced the quoting. The arm stays
+    // because the grammar's reader is where the grammar's question is answered; a
+    // rule that decided it by omission would be one capture format away from
+    // being wrong.
+    //
+    // cite(Server Timing, label: server-timing-param-value grammar): "server-timing-param-value = token / quoted-string"
+    let text = match token_or_quoted_string(value) {
+        Ok(content) => content,
+        // Neither alternative derives the empty string: `token = 1*tchar`, and
+        // the shortest `quoted-string` is the two DQUOTEs.
+        Err(WordDefect::Empty) => {
+            return Some(format!(
+                "Server-Timing parameter '{}' has an empty value: a server-timing-param-value is a token or a quoted-string, and neither of those is nothing",
+                shown_in_finding(param)
+            ))
         }
-    } else {
-        if let Some(c) = find_invalid_token_char(value) {
+        Err(WordDefect::NotToken(c)) => {
             return Some(format!(
                 "Server-Timing server-timing-param-value '{}' holds {}, and the value is not quoted: a bare value is a token, whose characters are all visible US-ASCII and not delimiters",
                 shown_in_finding(value),
                 describe_char(c)
-            ));
+            ))
         }
-        // A `token` is its own unescaping, so this half borrows where the other
-        // owns.
-        Cow::Borrowed(value)
+        Err(WordDefect::NotQuotedString(e)) => {
+            return Some(format!(
+                "Server-Timing parameter '{}' has a malformed quoted-string value: {e}",
+                shown_in_finding(name)
+            ))
+        }
     };
 
     established_param_advice(metric, name, &text)

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1726
+      line: 1795
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1721
+      line: 1790
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1720
+      line: 1789
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -223,25 +223,25 @@ sources:
     snippet: 'A string is a valid floating-point number if it consists of:'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 57
+      line: 56
   - label: server_server_timing_header_syntax (2)
     section: § 2.3.4.3
     snippet: Advance position to the next character. (The "+" is ignored, but it is not conforming.)
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 68
+      line: 67
   - label: server_server_timing_header_syntax (3)
     section: § 2.3.4.3
     snippet: The Infinity and Not-a-Number (NaN) values are not valid floating-point numbers.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 58
+      line: 57
   - label: server_server_timing_header_syntax (4)
     section: § 2.3.4.3
     snippet: The valid floating-point number concept is typically only used to restrict what is allowed for authors, while the user agent requirements use the rules for parsing floating-point number values below
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 59
+      line: 58
 - label: HTML Document Lifecycle
   url: https://html.spec.whatwg.org/multipage/document-lifecycle.html
   type: text/html
@@ -455,98 +455,98 @@ sources:
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 364
+      line: 363
   - label: Server-Timing grammar
     snippet: 'Server-Timing = #server-timing-metric'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 332
+      line: 331
   - label: server-timing-metric grammar
     snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 363
+      line: 362
   - label: server-timing-param grammar
     snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 430
+      line: 435
   - label: server-timing-param-name grammar
     snippet: server-timing-param-name = token
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 431
+      line: 436
   - label: server-timing-param-value grammar
     snippet: server-timing-param-value = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 499
+      line: 540
   - label: server_server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 30
+      line: 29
   - label: server_server_timing_header_syntax (2)
     section: § 2
     snippet: All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 486
+      line: 491
   - label: server_server_timing_header_syntax (3)
     section: § 2
     snippet: If any server-timing-param-name is specified more than once, only the first instance is to be considered, even if the server-timing-param is incomplete or invalid.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 485
+      line: 490
   - label: server_server_timing_header_syntax (4)
     section: § 2
     snippet: 'See [RFC7230] for definitions of #, *, OWS, token, and quoted-string.'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 333
+      line: 332
   - label: server_server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 135
+      line: 134
   - label: server_server_timing_header_syntax (6)
     section: § 2
     snippet: This specification establishes the server-timing-params for server-timing-param-names "dur" for duration and "desc" for description, both optional.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 29
+      line: 28
   - label: server_server_timing_header_syntax (7)
     section: § 2
     snippet: To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 484
+      line: 489
   - label: server_server_timing_header_syntax (8)
     section: § 2
     snippet: User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 514
+      line: 510
   - label: server_server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 606
+      line: 608
   - label: server_server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 605
+      line: 607
   - label: server_server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 589
+      line: 591
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -620,19 +620,19 @@ sources:
     snippet: keep-alive-extension = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 485
+      line: 484
   - label: message_keep_alive_header_validity (2)
     section: § 2
     snippet: keep-alive-info      =   "timeout" "=" delta-seconds
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 526
+      line: 525
   - label: message_keep_alive_header_validity (3)
     section: § 2.1
     snippet: The value of the "timeout" parameter is a single integer in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 600
+      line: 596
 - label: MDN Content-Type
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
   fragments:
@@ -841,85 +841,85 @@ sources:
     snippet: HTTP/1.1 does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 527
+      line: 526
   - label: message_keep_alive_header_validity (2)
     section: § 19.7.1.1
     snippet: If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 416
+      line: 415
   - label: message_keep_alive_header_validity (3)
     section: § 19.7.1.1
     snippet: Keep-Alive-header = "Keep-Alive" ":" 0# keepalive-param
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 429
+      line: 428
   - label: message_keep_alive_header_validity (4)
     section: § 19.7.1.1
     snippet: The Keep-Alive header itself is optional, and is used only if a parameter is being sent.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 451
+      line: 450
   - label: message_keep_alive_header_validity (5)
     section: § 19.7.1.1
     snippet: When the Keep-Alive connection-token has been transmitted with a request or a response, a Keep-Alive header field MAY also be included.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 79
+      line: 78
   - label: message_keep_alive_header_validity (6)
     section: § 19.7.1.1
     snippet: keepalive-param = param-name "=" value
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 484
+      line: 483
   - label: message_keep_alive_header_validity (7)
     section: § 2.1
     snippet: At least one delimiter (tspecials) must exist between any two tokens, since they would otherwise be interpreted as a single token.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 494
+      line: 493
   - label: message_keep_alive_header_validity (8)
     section: § 2.1
     snippet: Wherever this construct is used, null elements are allowed, but do not contribute
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 450
+      line: 449
   - label: message_keep_alive_header_validity (9)
     section: § 2.1
     snippet: linear whitespace (LWS) can be included between any two adjacent words (token or quoted-string), and between adjacent tokens and delimiters (tspecials), without changing the interpretation of a field.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 507
+      line: 506
   - label: LWS grammar
     section: § 2.2
     snippet: LWS            = [CRLF] 1*( SP | HT )
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 508
+      line: 507
   - label: message_keep_alive_header_validity (10)
     section: § 2.2
     snippet: The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs.
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 570
+      line: 562
   - label: message_keep_alive_header_validity (11)
     section: § 2.2
     snippet: quoted-string  = ( <"> *(qdtext) <"> )
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 569
+      line: 561
   - label: message_keep_alive_header_validity (12)
     section: § 2.2
     snippet: token          = 1*<any CHAR except CTLs or tspecials>
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 584
+      line: 560
   - label: message_keep_alive_header_validity (13)
     section: § 3.7
     snippet: value          = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 551
+      line: 559
 - label: RFC 3230
   url: https://www.rfc-editor.org/rfc/rfc3230.txt
   type: text/plain
@@ -2029,7 +2029,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1722
+      line: 1791
     - file: lint-http-rules/src/helpers/uri.rs
       line: 222
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3304,7 +3304,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
       line: 38
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 367
+      line: 374
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 185
   - label: server_alt_svc_h3_advertisement_valid (3)
@@ -3318,7 +3318,7 @@ sources:
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 453
+      line: 460
   - label: server_alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
@@ -3330,7 +3330,7 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 438
+      line: 445
   - label: Alt-Svc grammar
     section: § 3
     snippet: Alt-Svc       = clear / 1#alt-value
@@ -3344,7 +3344,7 @@ sources:
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 381
+      line: 388
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 208
   - label: server_alt_svc_header_syntax (5)
@@ -3358,7 +3358,7 @@ sources:
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 212
+      line: 219
   - label: server_alt_svc_header_syntax (7)
     section: § 3
     snippet: 'In order to have precisely one way to represent any ALPN protocol name, the following additional constraints apply:'
@@ -3404,7 +3404,7 @@ sources:
     snippet: Unknown parameters MUST be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 213
+      line: 220
   - label: server_alt_svc_header_syntax (14)
     section: § 3
     snippet: When using percent-encoding, uppercase hex digits MUST be used.
@@ -3436,7 +3436,7 @@ sources:
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 307
+      line: 314
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 260
   - label: server_alt_svc_header_syntax (19)
@@ -3446,7 +3446,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 19
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 314
+      line: 321
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 227
   - label: server_alt_svc_header_syntax (20)
@@ -3454,13 +3454,13 @@ sources:
     snippet: parameter     = token "=" ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 211
+      line: 218
   - label: server_alt_svc_header_syntax (21)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 308
+      line: 315
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 127
   - label: server_alt_svc_header_syntax (22)
@@ -3468,19 +3468,19 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 278
+      line: 285
   - label: server_alt_svc_header_syntax (23)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 280
+      line: 287
   - label: server_alt_svc_header_syntax (24)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 279
+      line: 286
   - label: server_alt_svc_header_syntax (25)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
@@ -3520,25 +3520,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1410
+      line: 1479
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1351
+      line: 1420
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1389
+      line: 1458
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1382
+      line: 1451
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -4352,7 +4352,7 @@ sources:
     - file: lint-http-rules/src/rules/message_http_version_syntax_valid.rs
       line: 153
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 428
+      line: 427
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 387
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -4406,11 +4406,11 @@ sources:
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
       line: 289
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 454
+      line: 461
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 94
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 346
+      line: 345
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 59
   - label: client_expect_header_valid (13)
@@ -4703,16 +4703,6 @@ sources:
       line: 285
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 81
-  - label: client_range_header_syntax_valid (11)
-    section: § 5.6.2
-    snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
-    cited_by:
-    - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
-      line: 54
-    - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
-      line: 81
-    - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 40
   - label: client_request_method_token_valid
     section: § 16.1.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Method Registry", maintained by IANA at <https://www.iana.org/assignments/http-methods>, registers method names.
@@ -5262,7 +5252,7 @@ sources:
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 110
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 431
+      line: 430
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 390
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -5274,7 +5264,7 @@ sources:
     - file: lint-http-rules/src/rules/semantic_trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 327
+      line: 326
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 11.6.3
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
@@ -5292,7 +5282,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1319
+      line: 1388
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -5352,7 +5342,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1475
+      line: 1544
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5398,7 +5388,7 @@ sources:
     - file: lint-http-rules/src/rules/message_user_agent_token_valid.rs
       line: 70
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 177
+      line: 176
   - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -5416,7 +5406,43 @@ sources:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 428
+      line: 435
+  - label: lint-http-rules/src/helpers/headers.rs (11)
+    section: § 5.6.2
+    snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1249
+    - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
+      line: 54
+    - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
+      line: 81
+    - file: lint-http-rules/src/rules/server_response_405_allow.rs
+      line: 40
+  - label: lint-http-rules/src/helpers/headers.rs (12)
+    section: § 5.6.2
+    snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1250
+    - file: lint-http-rules/src/helpers/token.rs
+      line: 7
+    - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
+      line: 168
+    - file: lint-http-rules/src/rules/message_pragma_token_valid.rs
+      line: 143
+    - file: lint-http-rules/src/rules/message_te_header_constraints.rs
+      line: 244
+    - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
+      line: 174
+    - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
+      line: 212
+    - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+      line: 316
+    - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
+      line: 267
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 378
   - label: OWS grammar
     section: § 5.6.3
     snippet: OWS            = *( SP / HTAB )
@@ -5436,26 +5462,26 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 456
-  - label: lint-http-rules/src/helpers/headers.rs (11)
+      line: 461
+  - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1244
-  - label: lint-http-rules/src/helpers/headers.rs (12)
+      line: 1310
+  - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 292
-  - label: lint-http-rules/src/helpers/headers.rs (13)
+  - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1163
-  - label: lint-http-rules/src/helpers/headers.rs (14)
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
@@ -5465,7 +5491,7 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 333
-  - label: lint-http-rules/src/helpers/headers.rs (15)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
@@ -5479,7 +5505,7 @@ sources:
       line: 422
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 467
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
@@ -5490,7 +5516,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1091
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1243
+      line: 1251
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 315
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5502,37 +5528,37 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 309
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+      line: 308
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1675
+      line: 1744
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 121
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 218
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1593
+      line: 1662
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 385
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
       line: 209
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 213
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1607
+      line: 1676
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 386
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5542,7 +5568,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1636
+      line: 1705
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 387
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5553,27 +5579,27 @@ sources:
       line: 127
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 224
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1474
+      line: 1543
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1585
+      line: 1654
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1665
+      line: 1734
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 384
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 203
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -5581,7 +5607,7 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 145
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
@@ -5591,7 +5617,7 @@ sources:
       line: 101
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
       line: 35
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
@@ -5616,19 +5642,19 @@ sources:
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 119
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 166
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+      line: 165
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 766
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1554
+      line: 1623
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5649,12 +5675,12 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/server_problem_details_content_type.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1573
+      line: 1642
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5662,22 +5688,22 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1490
+      line: 1559
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 107
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1553
+      line: 1622
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
@@ -5688,8 +5714,8 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1429
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+      line: 1498
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
@@ -5767,28 +5793,6 @@ sources:
       line: 7
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 79
-  - label: lint-http-rules/src/helpers/token.rs
-    section: § 5.6.2
-    snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
-    cited_by:
-    - file: lint-http-rules/src/helpers/token.rs
-      line: 7
-    - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
-      line: 168
-    - file: lint-http-rules/src/rules/message_pragma_token_valid.rs
-      line: 143
-    - file: lint-http-rules/src/rules/message_te_header_constraints.rs
-      line: 244
-    - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 174
-    - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
-      line: 212
-    - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 309
-    - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 267
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 379
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
@@ -6642,7 +6646,7 @@ sources:
     snippet: Keep-Alive (Section 19.7.1 of [RFC2068])
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 410
+      line: 409
   - label: message_language_tag_format_valid
     section: § 8.5
     snippet: 'Content-Language = #language-tag'
@@ -7790,23 +7794,23 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 368
+      line: 375
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 186
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 61
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 136
+      line: 135
   - label: server_alt_svc_header_syntax (2)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 400
+      line: 407
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 218
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 176
+      line: 175
   - label: server_authentication_challenge_validity
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -8058,7 +8062,7 @@ sources:
     snippet: '#element => [ 1#element ]'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 326
+      line: 325
   - label: server_status_and_caching_semantics
     section: § 15.1
     snippet: Responses with status codes that are defined as heuristically cacheable (e.g., 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, and 501 in this specification) can be reused by a cache with heuristic expiration unless otherwise indicated by the method definition or explicit cache controls
@@ -8426,7 +8430,7 @@ sources:
     snippet: delta-seconds  = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
-      line: 601
+      line: 597
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 51
   - label: message_pragma_token_valid


### PR DESCRIPTION
…tale

`( token / quoted-string )` is now read once, by
`helpers::headers::token_or_quoted_string`, which returns the value's content or a `WordDefect`. Seven sites had written that decision and its two measurements out by hand; all seven call it.

Seven, not six. The tracker's number came from
`server_server_timing_header_syntax`, which said "the sixth copy in the tree, counted at `message_keep_alive_header_validity::validate_param_value`" — and that site's list named five, having been written before Alt-Svc's audit wrote a sixth and never extended after. Adding one to a stale five publishes six. The standing move of recording a divergence at the site that creates the next copy needs its other half: that site re-counts, it does not increment.

The `Err` is data because the callers do not agree about it. Six of the seven had separately decided what an empty value means, and they answer differently: five report it, and `Pragma` and `Cache-Control` tolerate it under a leniency each rule's own audit wrote down. A helper returning a sentence would have had to pick one. `WordDefect::{Empty, NotToken, NotQuotedString}` lets every caller keep both its wording and its verdict, and turns two `is_empty()` pre-checks that read as parsing into two match arms that read as the decisions they are.

The three-copy *walk* is deliberately not folded, and that is an answer rather than a deferral. Alt-Svc's `parameter` and Server-Timing's `server-timing-param` are one terminal apart and would fold on a flag; the flag would be a boolean whose only job is to say which document the caller is reading, on exactly the axis `BWS` has been the tell for in both directions — whitespace beside the `=` is a tolerated historical artefact in RFC 7240, a defect in RFC 7838, and part of the production in Server Timing. So the walk splits instead: the name, the `=`, the whitespace and the optionality stay at each site, and the value half — which all three import from RFC 9110 unchanged — moves.

One verdict changed, and it was a check resting on nothing. `message_accept_header_media_type_syntax` handed `a/b;x=` to a `tchar` scan, which finds no invalid character in the empty string and called it clean. That rule's own audit had found and fixed the identical shape twelve lines above, on the parameter name, and left a comment saying a character scan cannot see it — then did not look down. `parameter-value = ( token / quoted-string )` derives no empty string, so it reports now, with two cases and a pinned message. `x=""` is a different value and still conforms. The two written-down leniencies were left alone: what separates them from this one is that they were reached by a sentence and this one by an accident of what a scan cannot see.

Everything else is verdict-preserving. `validate_quoted_string` gives way to `unescape_quoted_string` at three sites, which accepts the same strings and yields the same `Err` because the second opens by calling the first; Server-Timing keeps its own trailing-characters branch ahead of the reader, since § 2 has a sentence about that half alone.

Cites 2163 → 2165. RFC 2068's `token`, `quoted-string` and backslash sentences move from the branch that used to read them onto `validate_param_value` itself, where they now license the delegation: the argument that its document's pair and RFC 9110's are the same pair.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
