### PR TITLE
The list of copies was built over the wrong key, so it was wrong both…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1198,6 +1198,55 @@ pub fn shown_in_finding(s: &str) -> String {
     s.escape_debug().to_string()
 }
 
+/// The sentence a singleton field says when a message carries more than one of
+/// its field lines.
+///
+/// **Only the first sentence, and that is the whole design.** Five rules say it;
+/// four of them then append a second sentence saying *why* the join is wrong,
+/// and those four are four different facts, because the join is wrong in a
+/// different way per field. For `Max-Forwards` the comma is
+/// malformed inside `1*DIGIT`. For `Location` it is a valid data character
+/// inside a `URI-reference`, so the joined value is a well-formed reference to
+/// neither resource. For `Referer` and `Content-Location`, which share one
+/// production, it is a `sub-delims` character both alternatives admit inside a
+/// path or a query. For `From` it is `mailbox-list`'s separator — a well-formed
+/// production of RFC 5322 that the field does not import. So the caller appends
+/// its own; what is shared ends at the semicolon-joined clause below.
+///
+/// The parameters are in the order the sentence reads them, which is what keeps
+/// two adjacent `&str` arguments from being swappable in silence: the field, how
+/// many lines it was written on, what those lines recombine into, and the
+/// field's own reason for being a singleton.
+///
+/// `shown_value` is already rendered for a finding, because the four callers
+/// render differently on purpose — `escape_debug`, [`shown_in_finding`], and a
+/// `Referer`-specific one that withholds a userinfo. What a finding may print is
+/// the field's question, not this function's.
+///
+/// **Not for a field counted across two sections.** The recombining clause is
+/// § 5.2's, and § 5.2 is *within a section*; § 5.3's MUST NOT is about the whole
+/// message and says so (*"whether in the headers or trailers"*). A rule counting
+/// both sections at once — `message_content_disposition_token_valid` does — is
+/// answering § 5.3 correctly and cannot honestly say what § 5.2 recombines,
+/// which is why it says something else instead.
+///
+// cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
+// cite(RFC 9110 § 5.5): "This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability."
+// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
+// cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
+pub fn singleton_field_preamble(
+    field: &str,
+    lines: usize,
+    shown_value: &str,
+    grammar: &str,
+) -> String {
+    format!(
+        "{field} is written on {lines} header lines, which recombine into the one value \
+         '{shown_value}'; the field is a singleton — {grammar} — so a sender must not generate \
+         more than one field line for it (RFC 9110 §5.3)"
+    )
+}
+
 /// Why a value derives from neither alternative of `( token / quoted-string )`.
 ///
 /// Data rather than a sentence, and that is the whole reason this extraction was

--- a/lint-http-rules/src/rules/message_content_disposition_token_valid.rs
+++ b/lint-http-rules/src/rules/message_content_disposition_token_valid.rs
@@ -109,6 +109,17 @@ impl Rule for MessageContentDispositionTokenValid {
             // recombined value is "attachment; filename="a", inline", which
             // different recipients truncate at different points, so the filename
             // a download is saved under depends on whose parser read it.
+            //
+            // **Not `helpers::headers::singleton_field_preamble`, and the reason
+            // is one line above: `vals` counts the header section and the trailer
+            // section together.** That is what §5.3 asks for -- its MUST NOT is
+            // about the message and says *"whether in the headers or trailers"* --
+            // and it is exactly what the shared preamble may not claim, because
+            // the recombining clause in it is §5.2's and §5.2 recombines *within a
+            // section*. Two lines in two sections are two values, not one. The
+            // five callers of that preamble each read one section; this rule is
+            // out of it by a reason rather than by omission, and it was missed by
+            // both of the hand-maintained copy lists that P3 was written from.
             // cite(RFC 6266 § 4.1): "content-disposition = "Content-Disposition" ":" disposition-type *( ";" disposition-parm )"
             // cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"

--- a/lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
+++ b/lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
@@ -43,17 +43,34 @@ impl Rule for MessageContentLocationAndUriConsistency {
 
         // Neither alternative of the grammar is a `#(...)` list, so the §5.3 exception
         // does not apply and a message carries at most one Content-Location field line.
-        // The damage is quiet rather than loud: "," is a legal sub-delim inside a path
-        // and query, so a recipient combining two field lines gets "/a,/b" — a
-        // well-formed URI that identifies neither representation.
+        //
+        // The preamble is `helpers::headers::singleton_field_preamble`'s, and the
+        // sentence appended to it is the one `message_referer_uri_valid` appends,
+        // word for word, because the two fields carry the same production and the
+        // comma is the same character in it. That sentence used to live in this
+        // comment while the four neighbours put theirs in the message, so the
+        // damage the rule knew about was the one thing it did not tell an
+        // operator — along with how many lines there were and what they join into.
         // cite(RFC 9110 § 8.7): "Content-Location = absolute-URI / partial-URI"
-        // cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
-        // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
+        // cite(RFC 3986 § 2.2): "sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=""
         if vals.len() > 1 {
+            let joined = crate::helpers::headers::combined_field_value_as_written(
+                &resp.headers,
+                "content-location",
+            )
+            .expect("the branch is reached only when the field has more than one line");
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,
-                message: "Multiple Content-Location header fields present; Content-Location is a singleton field with no list alternative (RFC 9110 §8.7), so a message carries at most one Content-Location field line (RFC 9110 §5.3)".into(),
+                message: format!(
+                    "{}. The comma a recipient joins them with is a `sub-delims` character both alternatives admit inside a path or a query (RFC 3986 §2.2), so the joined value is a well-formed reference to a resource neither line named",
+                    crate::helpers::headers::singleton_field_preamble(
+                        "Content-Location",
+                        vals.len(),
+                        &crate::helpers::headers::shown_in_finding(&joined),
+                        "`Content-Location = absolute-URI / partial-URI`, and neither alternative is a comma-separated list",
+                    )
+                ),
             });
         }
 
@@ -568,8 +585,22 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
         );
-        assert!(v.is_some());
-        assert!(v.unwrap().message.contains("Multiple Content-Location"));
+        // Pinned rather than `contains`-ed: the message is the shared preamble
+        // plus this field's own second sentence, and a `contains` on the field
+        // name would still pass if either half went missing. It has to name how
+        // many lines there were and what a recipient joins them into, because
+        // that joined value is the whole finding — `/foo,/bar` is a well-formed
+        // reference to neither representation.
+        assert_eq!(
+            v.expect("two field lines for a singleton").message,
+            "Content-Location is written on 2 header lines, which recombine into the one value \
+             '/foo,/bar'; the field is a singleton — `Content-Location = absolute-URI / \
+             partial-URI`, and neither alternative is a comma-separated list — so a sender must \
+             not generate more than one field line for it (RFC 9110 §5.3). The comma a recipient \
+             joins them with is a `sub-delims` character both alternatives admit inside a path or \
+             a query (RFC 3986 §2.2), so the joined value is a well-formed reference to a resource \
+             neither line named"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_from_header_email_syntax.rs
+++ b/lint-http-rules/src/rules/message_from_header_email_syntax.rs
@@ -75,25 +75,20 @@ impl Rule for MessageFromHeaderEmailSyntax {
             // joins two `From` lines into is a well-formed production of the same
             // document — just not the one this field imports.
             //
-            // This is the **fourth** hand copy of the singleton preamble — count
-            // the lines, quote § 5.5 and § 5.3, name the field's grammar, show
-            // the joined value. `message_max_forwards_numeric`,
-            // `server_location_header_uri_valid` and
-            // `message_content_location_and_uri_consistency` are the other three,
-            // and their second sentences already differ, because *why* the join
-            // is wrong is a different fact per field: a comma is data inside a
-            // `URI-reference`, it is malformed inside `1*DIGIT`, and here it is a
-            // neighbouring production's separator. Only the first sentence is
-            // shared, so converting them changes what three audited rules report
-            // — recorded here rather than harmonised, at the site that creates
-            // the copy.
-            //
-            // cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
-            // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
+            // The preamble is `helpers::headers::singleton_field_preamble`'s.
+            // What is appended is the sharpest of the five: the other four join
+            // into something malformed or into a reference naming the wrong
+            // resource, and this one joins into a *well-formed production of the
+            // same document* — `mailbox-list`, two lines below `mailbox` in
+            // RFC 5322 § 3.4 and not imported by this field.
             return violation(format!(
-                "From is written on {} header lines, which recombine into the one value '{}'; the field is a singleton — its value is a single RFC 5322 `mailbox`, which has no comma-separated-list alternative — so a sender must not generate more than one field line for it (RFC 9110 §5.3). The comma a recipient joins them with is `mailbox-list`'s separator (RFC 5322 §3.4), a production this field does not import, so the joined value names no one address",
-                lines,
-                shown_in_finding(&value)
+                "{}. The comma a recipient joins them with is `mailbox-list`'s separator (RFC 5322 §3.4), a production this field does not import, so the joined value names no one address",
+                crate::helpers::headers::singleton_field_preamble(
+                    "From",
+                    lines,
+                    &shown_in_finding(&value),
+                    "its value is a single RFC 5322 `mailbox`, which has no comma-separated-list alternative",
+                )
             ));
         }
 
@@ -411,13 +406,20 @@ mod tests {
             ("from", "bob@example.org"),
         ]))
         .expect("two field lines are a finding");
-        assert!(
-            v.message
-                .contains("From is written on 2 header lines, which recombine into the one value 'alice@example.com,bob@example.org'"),
-            "{}",
-            v.message
+        // Pinned whole. The finding is written in two functions now -- the shared
+        // preamble and this field's own second sentence -- and an assertion that
+        // stops at the preamble would still pass if the half naming
+        // `mailbox-list` went missing, which is the half that says what is
+        // actually wrong here.
+        assert_eq!(
+            v.message,
+            "From is written on 2 header lines, which recombine into the one value \
+             'alice@example.com,bob@example.org'; the field is a singleton — its value is a \
+             single RFC 5322 `mailbox`, which has no comma-separated-list alternative — so a \
+             sender must not generate more than one field line for it (RFC 9110 §5.3). The comma \
+             a recipient joins them with is `mailbox-list`'s separator (RFC 5322 §3.4), a \
+             production this field does not import, so the joined value names no one address"
         );
-        assert!(v.message.contains("singleton"), "{}", v.message);
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/message_max_forwards_numeric.rs
+++ b/lint-http-rules/src/rules/message_max_forwards_numeric.rs
@@ -68,16 +68,15 @@ impl Rule for MessageMaxForwardsNumeric {
         if lines > 1 {
             // `Max-Forwards = 1*DIGIT` has no `#(...)` alternative anywhere in it, so
             // § 5.3's exception does not apply and one message carries at most one
-            // field line. § 5.5 says the detection is worth doing: a singleton sent
-            // with several members is exactly the error it names.
-            //
-            // cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
-            // cite(RFC 9110 § 5.5): "This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability."
-            // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
-            return violation(format!(
-                "Max-Forwards is written on {} header lines, which recombine into the one value '{}'; the field is a singleton — `Max-Forwards = 1*DIGIT` has no comma-separated-list alternative — so a sender must not generate more than one field line for it (RFC 9110 §5.3)",
+            // field line. The sentence saying so is the shared one, and this is the
+            // only one of the five callers with nothing to append to it: a comma is
+            // not a `DIGIT`, so the joined value is simply malformed, which the
+            // production named in the preamble already tells the reader.
+            return violation(crate::helpers::headers::singleton_field_preamble(
+                "Max-Forwards",
                 lines,
-                value.escape_debug()
+                &value.escape_debug().to_string(),
+                "`Max-Forwards = 1*DIGIT` has no comma-separated-list alternative",
             ));
         }
 
@@ -317,13 +316,28 @@ mod tests {
     /// conforming value on its own, and the message carries a field it must not
     /// carry twice. The rule measured the lines apart and reported neither.
     #[rstest]
-    #[case(&[b"120" as &[u8], b"240"])]
-    #[case(&[b"5" as &[u8], b"5"])]
-    #[case(&[b"1" as &[u8], b"2", b"3"])]
-    fn a_singleton_field_written_on_several_lines_is_reported(#[case] lines: &[&[u8]]) {
+    #[case(&[b"120" as &[u8], b"240"], "2", "120,240")]
+    #[case(&[b"5" as &[u8], b"5"], "2", "5,5")]
+    #[case(&[b"1" as &[u8], b"2", b"3"], "3", "1,2,3")]
+    fn a_singleton_field_written_on_several_lines_is_reported(
+        #[case] lines: &[&[u8]],
+        #[case] count: &str,
+        #[case] joined: &str,
+    ) {
         let v = max_forwards(lines).expect("violation");
-        assert!(v.message.contains("singleton"), "{}", v.message);
-        assert!(v.message.contains("header lines"), "{}", v.message);
+        // This is the only one of the five callers of the shared preamble with
+        // nothing to append, so the pin is the preamble exactly -- which is also
+        // what makes it the case that would notice the shared sentence changing
+        // under the other four.
+        assert_eq!(
+            v.message,
+            format!(
+                "Max-Forwards is written on {count} header lines, which recombine into the one \
+                 value '{joined}'; the field is a singleton — `Max-Forwards = 1*DIGIT` has no \
+                 comma-separated-list alternative — so a sender must not generate more than one \
+                 field line for it (RFC 9110 §5.3)"
+            )
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/message_referer_uri_valid.rs
@@ -127,27 +127,20 @@ impl Rule for MessageRefererUriValid {
             // exception does not apply and one message carries at most one
             // `Referer` line.
             //
-            // This is the **fifth** hand copy of the singleton preamble — count
-            // the lines, quote § 5.5 and § 5.3, name the field's grammar, show
-            // the joined value. `message_max_forwards_numeric`,
-            // `server_location_header_uri_valid`,
-            // `message_content_location_and_uri_consistency` and
-            // `message_from_header_email_syntax` are the other four, and only the
-            // first sentence is shared, because *why* the join is wrong is a
-            // different fact per field: a comma is malformed inside `1*DIGIT`,
-            // it is data inside a `URI-reference`, and here — as for the sibling
-            // field carrying the same production — it is a `sub-delims`
-            // character both alternatives admit inside a path or a query, so the
-            // joined value is a well-formed reference to a resource neither line
-            // named.
+            // The preamble is `helpers::headers::singleton_field_preamble`'s;
+            // what is appended is this field's, and the sibling carrying the same
+            // production (`Content-Location`) appends the same fact because it is
+            // the same fact.
             //
-            // cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
-            // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             // cite(RFC 3986 § 2.2): "sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=""
             return violation(format!(
-                "Referer is written on {} header lines, which recombine into the one value '{}'; the field is a singleton — `Referer = absolute-URI / partial-URI`, and neither alternative is a comma-separated list — so a sender must not generate more than one field line for it (RFC 9110 §5.3). The comma a recipient joins them with is a `sub-delims` character both alternatives admit inside a path or a query (RFC 3986 §2.2), so the joined value is a well-formed reference to a resource neither line named",
-                lines,
-                shown_referer(&value)
+                "{}. The comma a recipient joins them with is a `sub-delims` character both alternatives admit inside a path or a query (RFC 3986 §2.2), so the joined value is a well-formed reference to a resource neither line named",
+                crate::helpers::headers::singleton_field_preamble(
+                    "Referer",
+                    lines,
+                    &shown_referer(&value),
+                    "`Referer = absolute-URI / partial-URI`, and neither alternative is a comma-separated list",
+                )
             ));
         }
 

--- a/lint-http-rules/src/rules/server_location_header_uri_valid.rs
+++ b/lint-http-rules/src/rules/server_location_header_uri_valid.rs
@@ -90,16 +90,18 @@ impl Rule for ServerLocationHeaderUriValid {
             // names this very field as the counter-example new field definitions
             // should not emulate.
             //
-            // cite(RFC 9110 § 5.5): "Fields that only anticipate a single member as the field value are referred to as "singleton fields"."
             // cite(RFC 9110 § 5.5): "Fields that expect to contain a comma within a member, such as within an HTTP-date or URI-reference element, ought to be defined with delimiters around that element to distinguish any comma within that data from potential list separators."
-            // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             // cite(RFC 9110 § 10.2.2): "A Location field value cannot | allow a list of members because the comma list separator is a | valid data character within a URI-reference."
             // cite(RFC 9110 § 10.2.2): "If an invalid | message is sent with multiple Location field lines, a recipient | along the path might combine those field lines into one value."
             // cite(RFC 9110 § 16.3.2.2): "because URIs can include commas, it is not possible to reliably distinguish between a single value that includes a comma from two values"
             return violation(format!(
-                "Location is written on {} header lines, which recombine into the one value '{}'; the field is a singleton — `Location = URI-reference` has no comma-separated-list alternative — so a sender must not generate more than one field line for it (RFC 9110 §5.3). The comma a recipient joins them with is a valid data character inside a URI-reference, so the combined value is a well-formed reference to neither resource (RFC 9110 §10.2.2)",
-                lines,
-                value.escape_debug()
+                "{}. The comma a recipient joins them with is a valid data character inside a URI-reference, so the combined value is a well-formed reference to neither resource (RFC 9110 §10.2.2)",
+                crate::helpers::headers::singleton_field_preamble(
+                    "Location",
+                    lines,
+                    &value.escape_debug().to_string(),
+                    "`Location = URI-reference` has no comma-separated-list alternative",
+                )
             ));
         }
 
@@ -342,13 +344,18 @@ mod tests {
         // and the reason it cannot be the join every other singleton in the tree
         // uses.
         let v = judge(&make_tx_with_locs(&[b"/first", b"/second"])).expect("expected a finding");
-        assert!(
-            v.message.contains("written on 2 header lines"),
-            "{}",
-            v.message
+        // Pinned whole, because the finding is written in two functions now and
+        // the second one carries § 10.2.2's reason -- the half that distinguishes
+        // this field from a singleton whose join is merely malformed.
+        assert_eq!(
+            v.message,
+            "Location is written on 2 header lines, which recombine into the one value \
+             '/first,/second'; the field is a singleton — `Location = URI-reference` has no \
+             comma-separated-list alternative — so a sender must not generate more than one field \
+             line for it (RFC 9110 §5.3). The comma a recipient joins them with is a valid data \
+             character inside a URI-reference, so the combined value is a well-formed reference \
+             to neither resource (RFC 9110 §10.2.2)"
         );
-        assert!(v.message.contains("/first,/second"), "{}", v.message);
-        assert!(v.message.contains("singleton"), "{}", v.message);
         assert!(judge(&make_tx_with_locs(&[b"/first"])).is_none());
     }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1795
+      line: 1844
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1790
+      line: 1839
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1789
+      line: 1838
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -1053,7 +1053,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 109
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 90
+      line: 107
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 2.1
     snippet: A percent-encoded octet is encoded as a character triplet, consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value.
@@ -1114,12 +1114,14 @@ sources:
       line: 86
     - file: lint-http-rules/src/helpers/uri.rs
       line: 692
+    - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
+      line: 55
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 244
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 447
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 146
+      line: 135
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 39
   - label: unreserved
@@ -1151,7 +1153,7 @@ sources:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 728
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 254
+      line: 247
   - label: lint-http-rules/src/helpers/uri.rs (11)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
@@ -1251,7 +1253,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 91
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 255
+      line: 248
   - label: lint-http-rules/src/helpers/uri.rs (20)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
@@ -1289,7 +1291,7 @@ sources:
     snippet: The other generic syntax components are assumed to be case-sensitive unless specifically defined otherwise by the scheme (see Section 6.2.3).
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 172
+      line: 189
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 182
   - label: message_content_location_and_uri_consistency (2)
@@ -1297,7 +1299,7 @@ sources:
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 171
+      line: 188
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 193
   - label: message_host_and_authority_consistency
@@ -1337,13 +1339,13 @@ sources:
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 279
+      line: 272
   - label: message_referer_uri_valid (4)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 237
+      line: 230
   - label: relative-part
     section: § 4.2
     snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
@@ -1355,15 +1357,15 @@ sources:
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 236
+      line: 229
   - label: message_referer_uri_valid (6)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 181
+      line: 174
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 126
+      line: 128
   - label: message_well_known_uri_format
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
@@ -1581,7 +1583,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 34
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 167
+      line: 162
   - label: lint-http-rules/src/helpers/mailbox.rs (20)
     section: § 3.4
     snippet: mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list
@@ -1589,7 +1591,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 35
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 168
+      line: 163
   - label: lint-http-rules/src/helpers/mailbox.rs (21)
     section: § 3.4
     snippet: name-addr = [display-name] angle-addr
@@ -1609,7 +1611,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 52
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 149
+      line: 144
   - label: lint-http-rules/src/helpers/mailbox.rs (24)
     section: § 3.4.1
     snippet: The locally interpreted string is either a quoted-string or a dot-atom.
@@ -1653,13 +1655,13 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 37
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 182
+      line: 177
   - label: message_from_header_email_syntax
     section: § 3.4.1
     snippet: It is therefore incumbent upon implementations to conform to the syntax of addresses for the context in which they are used.
     cited_by:
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 150
+      line: 145
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.txt
   type: text/plain
@@ -1963,7 +1965,7 @@ sources:
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
       line: 41
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
-      line: 112
+      line: 123
   - label: message_content_disposition_token_valid
     section: § 1
     snippet: This document does not apply to Content-Disposition header fields appearing in payload bodies transmitted over HTTP, such as when using the media type "multipart/form-data" ([RFC2388]).
@@ -2029,7 +2031,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1791
+      line: 1840
     - file: lint-http-rules/src/helpers/uri.rs
       line: 222
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3520,25 +3522,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1479
+      line: 1528
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1420
+      line: 1469
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1458
+      line: 1507
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1451
+      line: 1500
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -4186,56 +4188,12 @@ sources:
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 164
   - label: client_accept_ranges_on_partial_content (11)
-    section: § 5.3
-    snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
-    cited_by:
-    - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
-      line: 28
-    - file: lint-http-rules/src/rules/client_host_header.rs
-      line: 76
-    - file: lint-http-rules/src/rules/message_conditional_headers_consistency.rs
-      line: 101
-    - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
-      line: 114
-    - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 51
-    - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
-      line: 59
-    - file: lint-http-rules/src/rules/message_etag_syntax.rs
-      line: 77
-    - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 92
-    - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 256
-    - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 76
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 145
-    - file: lint-http-rules/src/rules/message_retry_after_date_or_delay.rs
-      line: 34
-    - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
-      line: 43
-    - file: lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
-      line: 40
-    - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
-      line: 40
-    - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
-      line: 40
-    - file: lint-http-rules/src/rules/server_deprecation_header_syntax.rs
-      line: 40
-    - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 95
-    - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
-      line: 41
-    - file: lint-http-rules/src/rules/server_x_xss_protection_value_valid.rs
-      line: 40
-  - label: client_accept_ranges_on_partial_content (12)
     section: § A
     snippet: Range = ranges-specifier
     cited_by:
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 27
-  - label: client_accept_ranges_on_partial_content (13)
+  - label: client_accept_ranges_on_partial_content (12)
     section: § A
     snippet: range-unit = token ranges-specifier = range-unit "=" range-set
     cited_by:
@@ -4346,7 +4304,7 @@ sources:
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 173
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 116
+      line: 111
     - file: lint-http-rules/src/rules/message_http_version_syntax_valid.rs
       line: 21
     - file: lint-http-rules/src/rules/message_http_version_syntax_valid.rs
@@ -4358,7 +4316,7 @@ sources:
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 232
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 201
+      line: 194
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
       line: 303
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
@@ -5282,7 +5240,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1388
+      line: 1437
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -5313,6 +5271,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 211
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1235
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 64
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -5338,11 +5298,47 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 181
   - label: lint-http-rules/src/helpers/headers.rs (8)
+    section: § 5.3
+    snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1236
+    - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
+      line: 28
+    - file: lint-http-rules/src/rules/client_host_header.rs
+      line: 76
+    - file: lint-http-rules/src/rules/message_conditional_headers_consistency.rs
+      line: 101
+    - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
+      line: 125
+    - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
+      line: 59
+    - file: lint-http-rules/src/rules/message_etag_syntax.rs
+      line: 77
+    - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
+      line: 256
+    - file: lint-http-rules/src/rules/message_retry_after_date_or_delay.rs
+      line: 34
+    - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
+      line: 43
+    - file: lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
+      line: 40
+    - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
+      line: 40
+    - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
+      line: 40
+    - file: lint-http-rules/src/rules/server_deprecation_header_syntax.rs
+      line: 40
+    - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
+      line: 41
+    - file: lint-http-rules/src/rules/server_x_xss_protection_value_valid.rs
+      line: 40
+  - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1544
+      line: 1593
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5350,22 +5346,22 @@ sources:
     - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
       line: 56
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 104
+      line: 99
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 282
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 89
+      line: 88
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 158
+      line: 151
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 49
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 111
+      line: 113
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 82
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 138
-  - label: lint-http-rules/src/helpers/headers.rs (9)
+  - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
     cited_by:
@@ -5389,7 +5385,21 @@ sources:
       line: 70
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 176
-  - label: lint-http-rules/src/helpers/headers.rs (10)
+  - label: lint-http-rules/src/helpers/headers.rs (11)
+    section: § 5.5
+    snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1233
+    - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
+      line: 124
+  - label: lint-http-rules/src/helpers/headers.rs (12)
+    section: § 5.5
+    snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1234
+  - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
@@ -5407,24 +5417,24 @@ sources:
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 435
-  - label: lint-http-rules/src/helpers/headers.rs (11)
+  - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1249
+      line: 1298
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 81
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 40
-  - label: lint-http-rules/src/helpers/headers.rs (12)
+  - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1250
+      line: 1299
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -5463,25 +5473,25 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 461
-  - label: lint-http-rules/src/helpers/headers.rs (13)
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1310
-  - label: lint-http-rules/src/helpers/headers.rs (14)
+      line: 1359
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 292
-  - label: lint-http-rules/src/helpers/headers.rs (15)
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1163
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
@@ -5491,7 +5501,7 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 333
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
@@ -5505,7 +5515,7 @@ sources:
       line: 422
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 467
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
@@ -5516,7 +5526,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1091
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1251
+      line: 1300
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 315
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5529,36 +5539,36 @@ sources:
       line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 308
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1744
+      line: 1793
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 121
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 218
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1662
+      line: 1711
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 385
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
       line: 209
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 213
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1676
+      line: 1725
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 386
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5568,7 +5578,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1705
+      line: 1754
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 387
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5579,27 +5589,27 @@ sources:
       line: 127
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 224
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1543
+      line: 1592
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1654
+      line: 1703
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1734
+      line: 1783
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 384
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 203
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -5607,7 +5617,7 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 145
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
@@ -5617,7 +5627,7 @@ sources:
       line: 101
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
       line: 35
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
@@ -5643,18 +5653,18 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 165
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 766
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1623
+      line: 1672
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5675,12 +5685,12 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/server_problem_details_content_type.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1642
+      line: 1691
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5688,22 +5698,22 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1559
+      line: 1608
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 107
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+  - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1622
+      line: 1671
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (31)
+  - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
@@ -5714,8 +5724,8 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1498
-  - label: lint-http-rules/src/helpers/headers.rs (32)
+      line: 1547
+  - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
@@ -6338,25 +6348,9 @@ sources:
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
     cited_by:
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
-      line: 140
+      line: 151
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 63
-  - label: message_content_disposition_token_valid (2)
-    section: § 5.5
-    snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
-    cited_by:
-    - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
-      line: 113
-    - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 50
-    - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
-      line: 91
-    - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 74
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 144
-    - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 93
+      line: 80
   - label: message_content_encoding_and_type_consistency
     section: § 15.4.5
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
@@ -6400,37 +6394,37 @@ sources:
     snippet: Content-Location = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 49
+      line: 54
   - label: message_content_location_and_uri_consistency (2)
     section: § 8.7
     snippet: For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 204
+      line: 221
   - label: message_content_location_and_uri_consistency (3)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its field value refers to a URI that differs from the target URI, then the origin server claims that the URI is an identifier for a different resource corresponding to the enclosed representation.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 203
+      line: 220
   - label: message_content_location_and_uri_consistency (4)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its value refers (after conversion to absolute form) to a URI that is the same as the target URI, then the recipient MAY consider the content to be a current representation of that resource at the time indicated by the message origination date.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 122
+      line: 139
   - label: message_content_location_and_uri_consistency (5)
     section: § 8.7
     snippet: In the latter case (Section 4), the referenced URI is relative to the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 144
+      line: 161
   - label: message_content_location_and_uri_consistency (6)
     section: § 8.7
     snippet: Such a claim can only be trusted if both identifiers share the same resource owner, which cannot be programmatically determined via HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 205
+      line: 222
   - label: message_content_location_and_uri_consistency (7)
     section: § 8.7
     snippet: The "Content-Location" header field references a URI that can be used as an identifier for a specific resource corresponding to the representation in this message's content.
@@ -6442,7 +6436,7 @@ sources:
     snippet: The field value is either an absolute-URI or a partial-URI.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 89
+      line: 106
   - label: message_content_type_iana_registered
     section: § 8.3.1
     snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
@@ -6598,7 +6592,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 49
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 303
+      line: 296
   - label: message_http2_pseudo_headers_validity
     section: § 9.3.6
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
@@ -6696,53 +6690,47 @@ sources:
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
       line: 213
   - label: message_max_forwards_numeric
-    section: § 5.5
-    snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 75
-  - label: message_max_forwards_numeric (2)
     section: § 7.6.2
     snippet: A recipient MAY ignore a Max-Forwards header field received with any other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 46
-  - label: message_max_forwards_numeric (3)
+  - label: message_max_forwards_numeric (2)
     section: § 7.6.2
     snippet: Each intermediary that receives a TRACE or OPTIONS request containing a Max-Forwards header field MUST check and update its value prior to forwarding the request.
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 130
-  - label: message_max_forwards_numeric (4)
+      line: 129
+  - label: message_max_forwards_numeric (3)
     section: § 7.6.2
     snippet: If the received value is zero (0), the intermediary MUST NOT forward the request; instead, the intermediary MUST respond as the final recipient.
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 131
+      line: 130
   - label: Max-Forwards grammar
     section: § 7.6.2
     snippet: Max-Forwards = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 99
-  - label: message_max_forwards_numeric (5)
+      line: 98
+  - label: message_max_forwards_numeric (4)
     section: § 7.6.2
     snippet: The "Max-Forwards" header field provides a mechanism with the TRACE (Section 9.3.8) and OPTIONS (Section 9.3.7) request methods to limit the number of times that the request is forwarded by proxies.
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 19
-  - label: message_max_forwards_numeric (6)
+  - label: message_max_forwards_numeric (5)
     section: § 7.6.2
     snippet: The Max-Forwards value is a decimal integer indicating the remaining number of times this request message can be forwarded.
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 129
-  - label: message_max_forwards_numeric (7)
+      line: 128
+  - label: message_max_forwards_numeric (6)
     section: § 9.3.7
     snippet: A proxy MUST NOT generate a Max-Forwards header field while forwarding a request unless that request was received with a Max-Forwards field.
     cited_by:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
-      line: 132
+      line: 131
   - label: message_multipart_boundary_syntax
     section: § 5.6.6
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.
@@ -6938,19 +6926,19 @@ sources:
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 233
+      line: 226
   - label: message_referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 355
+      line: 348
   - label: message_referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 182
+      line: 175
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
@@ -6968,61 +6956,61 @@ sources:
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 360
+      line: 353
   - label: message_referer_uri_valid (6)
     section: § 4.1
     snippet: A "partial-URI" rule is defined for protocol elements that can contain a relative URI but not a fragment component.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 234
+      line: 227
   - label: message_referer_uri_valid (7)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 235
+      line: 228
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 180
+      line: 173
   - label: message_referer_uri_valid (8)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 301
+      line: 294
   - label: message_referer_uri_valid (9)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 358
+      line: 351
   - label: message_referer_uri_valid (10)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 357
+      line: 350
   - label: message_referer_uri_valid (11)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 302
+      line: 295
   - label: message_referer_uri_valid (12)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 359
+      line: 352
   - label: message_referer_uri_valid (13)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 356
+      line: 349
   - label: message_response_body_length_accuracy
     section: § 8.6
     snippet: A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 15.4.5); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a 200 (OK) response to the same request.
@@ -7872,13 +7860,13 @@ sources:
     snippet: A Location field value cannot | allow a list of members because the comma list separator is a | valid data character within a URI-reference.
     cited_by:
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 96
+      line: 94
   - label: server_location_header_uri_valid (2)
     section: § 10.2.2
     snippet: If an invalid | message is sent with multiple Location field lines, a recipient | along the path might combine those field lines into one value.
     cited_by:
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 97
+      line: 95
   - label: Location grammar
     section: § 10.2.2
     snippet: Location = URI-reference
@@ -7898,13 +7886,13 @@ sources:
     snippet: because URIs can include commas, it is not possible to reliably distinguish between a single value that includes a comma from two values
     cited_by:
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 98
+      line: 96
   - label: server_location_header_uri_valid (5)
     section: § 5.5
     snippet: Fields that expect to contain a comma within a member, such as within an HTTP-date or URI-reference element, ought to be defined with delimiters around that element to distinguish any comma within that data from potential list separators.
     cited_by:
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
-      line: 94
+      line: 93
   - label: server_no_body_for_1xx_204_304
     section: § 15.4.5
     snippet: A 304 response is terminated by the end of the header section; it cannot contain content or trailers.


### PR DESCRIPTION
… ways

`helpers::headers::singleton_field_preamble` writes the one sentence five singleton fields say when a message carries more than one of their field lines. Four of the five append a second sentence saying why the join is wrong, and those four are four different facts — a comma is malformed inside `1*DIGIT`, a data character inside a `URI-reference`, a `sub-delims` character inside a path or query for the two fields carrying `absolute-URI / partial-URI`, and `mailbox-list`'s separator for `From`. Only the first sentence is shared, which is why it is the only thing that moved.

The row said five copies and the tree held something else in both directions. `message_content_location_and_uri_consistency` was on the list and did not write the preamble: it said "Multiple Content-Location header fields present", with no count and no joined value, and kept its second sentence in a comment while the four neighbours put theirs in the message — so the damage the rule knew about was the one thing it did not tell an operator. And `message_content_disposition_token_valid` states the same fact and was on neither of the two hand-maintained lists. Both lists had been built from which rules cite §5.5, which is neither necessary nor sufficient for writing this sentence.

Content-Location now says what Referer says, word for word, because the two fields carry the same production and the comma is the same character in it.

Content-Disposition stays out for a reason rather than by omission: it counts the header section and the trailer section together, which is what §5.3 asks for — its MUST NOT is about the message and says "whether in the headers or trailers" — and is exactly what the shared preamble may not claim, because the recombining clause in it is §5.2's and §5.2 recombines within a section. Two lines in two sections are two values, not one. That boundary is written at both ends.

Four cites replace eleven. §5.5's definition, §5.5's "detecting such errors improves interoperability" (carried by one of the five, and the sentence that licenses the check existing at all), §5.2's recombination and §5.3's MUST NOT now sit once on the function that writes the sentence they license. Every rule keeps its own grammar cite, because why *this* field is a singleton is the half that differs.

Three tests stopped before the second sentence. From's would have passed with the `mailbox-list` half gone; Location's and Max-Forwards's asserted only that the word "singleton" appeared. The finding is written in two functions now, so all four are pinned whole.

Cites 2165 → 2159.
