### PR TITLE
The leniency six rules describe is now a fact the walk hands back

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1629,6 +1629,111 @@ pub struct ParsedMediaType<'a> {
     pub params: Option<&'a str>,
 }
 
+/// One `parameter` of a `parameters` group, split but not judged.
+///
+/// `value` is **as written** — a `quoted-string` still carries its DQUOTEs.
+/// Whether this field's value half is § 5.6.6's `( token / quoted-string )`, a
+/// narrower production, or one literal is the caller's grammar and not this
+/// walk's, and [`token_or_quoted_string`] is what reads it where it is the
+/// former.
+pub struct Parameter<'a> {
+    /// The `parameter-name` as written. Case folding is the caller's — § 5.6.6
+    /// makes the name case-insensitive, but a rule reporting *what a sender
+    /// wrote* often wants the spelling back.
+    pub name: &'a str,
+    /// The `parameter-value` as written, DQUOTEs included.
+    pub value: &'a str,
+    /// Whether whitespace sat beside the `=`.
+    ///
+    /// **This is the "Known leniency" six rules describe in prose, returned as a
+    /// fact instead.** § 5.6.6's Note forbids whitespace there in as many words
+    /// — *"not even 'bad' whitespace"* — and six rules trim it and say so in
+    /// their `description()`, while `client_expect_header_valid` reports it. A
+    /// walk that trimmed silently would have to pick one of those; a walk that
+    /// hands back what it found lets each caller keep the answer its own audit
+    /// reached, and turns a paragraph of prose into a branch a reader can see.
+    pub whitespace_beside_equals: bool,
+}
+
+/// Why a segment of a `parameters` group is not a `parameter`.
+pub enum ParameterDefect<'a> {
+    /// The segment carries no `=`. `parameter = parameter-name "="
+    /// parameter-value` makes neither the delimiter nor the value optional, so a
+    /// bare token among the parameters is not a valueless flag — it is not a
+    /// `parameter` at all. Carries the segment as written.
+    NoEquals(&'a str),
+}
+
+/// Walk `parameters = *( OWS ";" OWS [ parameter ] )`.
+///
+/// Four decisions, and they are the four every hand copy of this production in
+/// the tree had to make: split at the top-level semicolons only (a `;` inside a
+/// `quoted-string` parameter value starts no new parameter), drop the `OWS` the
+/// production prints beside them, **skip an empty segment** — `[ parameter ]` is
+/// bracketed, so `text/plain; charset=utf-8;` is a conforming zero-parameter
+/// repetition rather than a defect — and cut each remaining segment at its
+/// **first** `=`, because `parameter-name` is a `token` and `=` is no `tchar`,
+/// so no name can hold one and every later `=` belongs to the value.
+///
+/// What is *not* decided here: whether the name is a `token`, whether the value
+/// derives from this field's value production, whether an empty name is a
+/// finding, and what whitespace beside the `=` means. Those are four different
+/// answers across the callers, which is why the walk stops where it does.
+///
+/// The input is the run *after* the media type — what [`parse_media_type`] puts
+/// in `params` — not the whole field value.
+///
+// cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
+// cite(RFC 9110 § 5.6.6): "parameter       = parameter-name "=" parameter-value"
+// cite(RFC 9110 § 5.6.6): "parameter-name  = token"
+// cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+pub fn parameters(
+    params: &str,
+) -> impl Iterator<Item = Result<Parameter<'_>, ParameterDefect<'_>>> {
+    split_semicolons_respecting_quotes(params)
+        .into_iter()
+        .filter_map(parameter_of)
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+/// One already-split segment of a `parameters` group, read as a `parameter`.
+///
+/// `None` for an empty segment: `[ parameter ]` is bracketed, so a repetition
+/// that generated a semicolon and nothing after it has still conformed.
+///
+/// Separate from [`parameters`] because two rules reach their parameters through
+/// a split they have already made for another reason — `media-range` and
+/// `expectation` both put the thing the field is *about* in the first segment
+/// and the parameters in the rest — and joining the tail back together only to
+/// split it again would be a second parse of a value already parsed.
+///
+/// The cut is at the **first** `=`: `parameter-name` is a `token` and `=` is no
+/// `tchar`, so no name can hold one and every later `=` belongs to the value.
+///
+// cite(RFC 9110 § 5.6.6): "parameter       = parameter-name "=" parameter-value"
+// cite(RFC 9110 § 5.6.6): "parameter-name  = token"
+pub fn parameter_of(segment: &str) -> Option<Result<Parameter<'_>, ParameterDefect<'_>>> {
+    if segment.is_empty() {
+        return None;
+    }
+    Some(match segment.find('=') {
+        None => Err(ParameterDefect::NoEquals(segment)),
+        Some(eq) => {
+            let (name_written, rest) = segment.split_at(eq);
+            let value_written = &rest[1..];
+            let name = trim_ows(name_written);
+            let value = trim_ows(value_written);
+            Ok(Parameter {
+                name,
+                value,
+                whitespace_beside_equals: name.len() != name_written.len()
+                    || value.len() != value_written.len(),
+            })
+        }
+    })
+}
+
 /// Parse a Media Type string into type, subtype, and optional params.
 ///
 /// This does NOT fully validate the tokens (e.g. wildcards or invalid chars),
@@ -1721,14 +1826,16 @@ pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
 /// name it are measuring a value whose every octet is one `char`, which a
 /// `media-type` reaching this function is not guaranteed to be.
 ///
-/// **One inherited leniency, and it is the fourth copy of it.** `parameter` is
-/// `parameter-name "=" parameter-value` with no `OWS` anywhere in it, and
-/// § 5.6.6 says so again in prose — yet the whitespace beside the `=` is trimmed
-/// here, so `text/example; charset = utf-8` passes. That is the reading the
-/// `Content-Type`, multipart-boundary and charset rules already publish as a
-/// known leniency; it moved in with the code rather than being decided here, and
-/// changing it changes those rules' verdicts. Recorded at the shared site so the
-/// next reader does not take it for the grammar.
+/// **One inherited leniency, and it is now a decision rather than an accident.**
+/// `parameter` is `parameter-name "=" parameter-value` with no `OWS` anywhere in
+/// it, and § 5.6.6 says so again in prose — *"Parameters do not allow whitespace
+/// (not even 'bad' whitespace) around the '=' character"* — yet
+/// `text/example; charset = utf-8` passes here. [`parameters`] hands back
+/// `whitespace_beside_equals` rather than trimming in silence, and this function
+/// reads it and drops it; that is what makes the "Known leniency" paragraph six
+/// rules publish a true statement about the code rather than a plausible one.
+/// Changing the answer changes those rules' verdicts, so it stays theirs.
+/// `client_expect_header_valid` is the one caller in the tree that reports it.
 ///
 /// cite(RFC 9110 § 8.3.1): "type       = token subtype    = token"
 /// cite(RFC 9110 § 8.3.1): "The type and subtype tokens are case-insensitive."
@@ -1758,68 +1865,76 @@ pub fn media_type_parts_defect(parsed: &ParsedMediaType<'_>) -> Option<String> {
     // the `OWS` the production prints beside its semicolons -- re-trimming it
     // with `str::trim` here undid that helper's own fix and put %xA0 and %x85
     // back out of reach.
-    for p in split_semicolons_respecting_quotes(params) {
-        // `[ parameter ]` is bracketed, so a semicolon with nothing after it is
-        // a conforming zero-parameter repetition rather than a defect --
-        // `text/plain; charset=utf-8;` is well formed.
-        // cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
-        if p.is_empty() {
-            continue;
-        }
-
-        let Some(eq) = p.find('=') else {
+    // The walk is `parameters`, which owns the split, the bracketed-empty skip
+    // and the cut at the first `=`. Everything below is this function's: what a
+    // name and a value have to be, and what its callers are told when they are
+    // not.
+    for parameter in parameters(params) {
+        let parameter = match parameter {
+            Ok(p) => p,
             // The "=" is not optional inside `parameter`, so a bare token among
             // the parameters is not a valueless flag.
-            // cite(RFC 9110 § 5.6.6): "parameter       = parameter-name "=" parameter-value"
-            return Some(format!("parameter '{}' missing '='", p.escape_debug()));
+            Err(ParameterDefect::NoEquals(segment)) => {
+                return Some(format!(
+                    "parameter '{}' missing '='",
+                    segment.escape_debug()
+                ))
+            }
         };
 
-        // The two trims are the leniency named above, bounded to `OWS` so that
-        // an `obs-text` octet beside the `=` is not mistaken for whitespace and
-        // removed.
-        let (name, value) = p.split_at(eq);
-        let name = trim_ows(name);
-        let value = trim_ows(&value[1..]); // skip '='
+        // The whitespace beside the `=` is the leniency named in this function's
+        // doc comment, and it is declined *here* rather than absorbed by the
+        // walk: § 5.6.6's Note forbids it, and five of the six rules reading a
+        // media type through this function say in their `description()` that
+        // they tolerate it. Reading the flag and dropping it is what makes that
+        // paragraph true rather than merely plausible.
+        let _ = parameter.whitespace_beside_equals;
 
-        if name.is_empty() {
+        if parameter.name.is_empty() {
             return Some("empty parameter name".to_string());
         }
         // cite(RFC 9110 § 5.6.6): "parameter-name  = token"
-        if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
+        if let Some(c) = crate::helpers::token::find_invalid_token_char(parameter.name) {
             return Some(format!(
                 "invalid character '{}' in parameter name '{}'",
                 c.escape_debug(),
-                name.escape_debug()
+                parameter.name.escape_debug()
             ));
         }
 
-        if value.starts_with('"') {
-            // The `quoted-string` production belongs to the shared helper, which
-            // walks the interior; asking only that the value start and end with
-            // DQUOTE accepts `foo="a\"`, whose closing quote is escaped, and
-            // `foo="a"b"`.
-            if let Err(e) = validate_quoted_string(value) {
-                // The helper's reason quotes the value it was handed, so the
-                // escape goes around the whole clause rather than around the
-                // name alone -- a control octet inside the quoted-string is
-                // exactly what that reason is about, and it arrived raw.
+        // `parameter-value = ( token / quoted-string )`, read by the function
+        // that owns the alternation. This site was an eighth copy of it and was
+        // missed when the other seven were converted, for the reason every stale
+        // count in this campaign has had: the list was of *rules*, and this is a
+        // helper.
+        // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
+        match token_or_quoted_string(parameter.value) {
+            Ok(_) => {}
+            // `parameters` yields the value as written and does not judge it, so
+            // an empty one arrives here. It derives from neither alternative.
+            Err(WordDefect::Empty) => {
                 return Some(format!(
-                    "parameter '{}' has invalid quoted-string: {}",
-                    name.escape_debug(),
-                    e.escape_debug()
-                ));
+                    "parameter '{}' has an empty value, and a parameter-value is a token or a quoted-string",
+                    parameter.name.escape_debug()
+                ))
             }
-        } else {
-            // The alternation is exclusive: a value that does not open with
-            // DQUOTE has to satisfy `token`, which is why an unquoted `utf 8` is
-            // a defect rather than a curiosity.
-            // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
-            if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
+            Err(WordDefect::NotToken(c)) => {
                 return Some(format!(
                     "invalid character '{}' in parameter value '{}'",
                     c.escape_debug(),
-                    value.escape_debug()
-                ));
+                    parameter.value.escape_debug()
+                ))
+            }
+            // The reason quotes the value it was handed, so the escape goes
+            // around the whole clause rather than around the name alone -- a
+            // control octet inside the quoted-string is exactly what that reason
+            // is about, and it arrived raw.
+            Err(WordDefect::NotQuotedString(e)) => {
+                return Some(format!(
+                    "parameter '{}' has invalid quoted-string: {}",
+                    parameter.name.escape_debug(),
+                    e.escape_debug()
+                ))
             }
         }
     }
@@ -1831,49 +1946,59 @@ pub fn media_type_parts_defect(parsed: &ParsedMediaType<'_>) -> Option<String> {
 /// - Returns `Some(boundary)` unquoted/unescaped when present and well-structured, `None` otherwise.
 /// - This helper is intentionally conservative: it returns `None` when the Content-Type cannot be
 ///   parsed or the boundary parameter is missing or not well-formed (e.g., invalid quoted-string).
+///
+/// **That contract used to hold for one alternative only.** "Not well-formed"
+/// was honoured for a `quoted-string` and not for a `token`: an unquoted value
+/// went back to the caller whatever octets it held, so `boundary=a b` — which
+/// derives from no `parameter-value`, since SP is no `tchar` — was handed on as
+/// the boundary `a b`, and the caller hunted a body for `--a b` delimiters on
+/// the strength of a value the grammar does not generate. Both alternatives now
+/// go through [`token_or_quoted_string`], so the function does what its own
+/// second bullet says. What the sender meant by a malformed boundary is not
+/// recoverable, and `message_multipart_boundary_syntax` is the rule that reports
+/// it.
 pub fn extract_multipart_boundary(val: &str) -> Option<String> {
     let parsed = parse_media_type(val).ok()?;
     if !parsed.type_.eq_ignore_ascii_case("multipart") {
         return None;
     }
     let params = parsed.params?;
-    // Quote-aware, because a `;` inside a quoted parameter value does not start
-    // a new parameter. A raw `split(';')` cut such a value apart and read the
-    // pieces as parameters, so `foo="a; boundary=abc; b=1"` — which has no
-    // boundary parameter at all — yielded `abc`, and the caller then hunted a
-    // body for `--abc` delimiters that were never declared.
-    // cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
-    for raw in split_semicolons_respecting_quotes(params) {
-        let p = raw.trim();
-        if p.is_empty() {
+    // The second `parameters` walk this module used to hold, and it disagreed
+    // with the first in two places: it split with the same quote-aware splitter
+    // but then re-trimmed each segment with `str::trim`, putting the %xA0 and
+    // %x85 that splitter had deliberately left alone back out of reach, and it
+    // read a segment with no `=` as something to skip rather than as a defect
+    // -- which is right *here*, because a value that names no boundary is this
+    // function's `None` rather than a finding.
+    for parameter in parameters(params) {
+        // A malformed segment names no boundary, and reporting is not this
+        // function's job: `message_content_type_well_formed` reads the same
+        // value through `media_type_parts_defect` and says so there.
+        let Ok(parameter) = parameter else { continue };
+
+        // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
+        if !parameter.name.eq_ignore_ascii_case("boundary") {
             continue;
         }
-        if let Some(eq) = p.find('=') {
-            let (name, value) = p.split_at(eq);
-            let name = name.trim();
-            let value = value[1..].trim(); // skip '='
-                                           // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
-            if name.eq_ignore_ascii_case("boundary") {
-                if value.is_empty() {
-                    return None;
-                }
-                if value.starts_with('"') {
-                    // quoted-string: unescape using existing helper; if it fails, treat as missing
-                    match unescape_quoted_string(value) {
-                        Ok(u) => {
-                            // Empty boundary (after unquoting) is invalid -> treat as missing
-                            if u.trim().is_empty() {
-                                return None;
-                            }
-                            return Some(u);
-                        }
-                        Err(_) => return None,
-                    }
+
+        // Deliberately conservative in one direction: every answer below that is
+        // not a boundary is `None`, because a caller hunting a body for
+        // `--<boundary>` delimiters must not be handed a guess.
+        return match token_or_quoted_string(parameter.value) {
+            Err(_) => None,
+            Ok(content) => {
+                let unquoted = content.into_owned();
+                // A boundary of nothing delimits nothing. `trim_ows` and not
+                // `str::trim`: RFC 2046's `bcharsnospace` admits no whitespace
+                // of any kind, so an `obs-text` octet here is a defect the
+                // boundary rule reports rather than padding to be removed.
+                if trim_ows(&unquoted).is_empty() {
+                    None
                 } else {
-                    return Some(value.to_string());
+                    Some(unquoted)
                 }
             }
-        }
+        };
     }
     None
 }
@@ -2275,6 +2400,63 @@ mod tests {
     fn quoted_string_inner_trimmed_is_empty_true_cases() {
         assert!(quoted_string_inner_trimmed_is_empty("\"\"").unwrap());
         assert!(quoted_string_inner_trimmed_is_empty("\"   \"").unwrap());
+    }
+
+    /// The four decisions the walk makes, and the one it deliberately does not.
+    #[test]
+    fn parameters_splits_skips_and_cuts_at_the_first_equals() {
+        let read: Vec<_> = parameters("charset=utf-8; foo=\"a;b\"")
+            .map(|p| p.ok().map(|p| (p.name, p.value)))
+            .collect();
+        assert_eq!(
+            read,
+            vec![Some(("charset", "utf-8")), Some(("foo", "\"a;b\""))],
+            "a `;` inside a quoted-string starts no new parameter, and the value keeps its DQUOTEs"
+        );
+
+        // `[ parameter ]` is bracketed, so a trailing or doubled semicolon is a
+        // conforming zero-parameter repetition and yields nothing at all.
+        assert_eq!(parameters("a=b;").count(), 1);
+        assert_eq!(parameters("a=b;;c=d").count(), 2);
+        assert_eq!(parameters(";").count(), 0);
+
+        // The first `=` is the delimiter: `parameter-name` is a `token` and `=`
+        // is no `tchar`, so no name holds one.
+        let base64ish: Vec<_> = parameters("v=a=b=")
+            .map(|p| p.ok().map(|p| (p.name, p.value)))
+            .collect();
+        assert_eq!(base64ish, vec![Some(("v", "a=b="))]);
+
+        // A segment with no `=` is a defect and not a valueless flag -- named,
+        // so each caller can decide whether it is its finding.
+        assert!(matches!(
+            parameters("charset").next(),
+            Some(Err(ParameterDefect::NoEquals("charset")))
+        ));
+    }
+
+    /// § 5.6.6's Note forbids whitespace beside the `=` and six rules tolerate
+    /// it anyway. The walk reports the fact rather than picking a side, which is
+    /// what lets `client_expect_header_valid` enforce the Note while the media
+    /// type readers keep the leniency their descriptions publish.
+    #[test]
+    fn parameters_returns_the_whitespace_beside_the_equals_rather_than_deciding_it() {
+        let ws = |s: &str| {
+            parameters(s)
+                .next()
+                .expect("one parameter")
+                .ok()
+                .expect("well formed")
+                .whitespace_beside_equals
+        };
+        assert!(!ws("a=b"));
+        assert!(ws("a =b"));
+        assert!(ws("a= b"));
+        assert!(ws("a =\tb"));
+        // The name and value still come back trimmed, so a caller that drops the
+        // flag reads exactly what it read before the flag existed.
+        let p = parameters("a = b").next().unwrap().ok().unwrap();
+        assert_eq!((p.name, p.value), ("a", "b"));
     }
 
     /// The empty members are the point. Two of the three list walks in this

--- a/lint-http-rules/src/rules/client_expect_header_valid.rs
+++ b/lint-http-rules/src/rules/client_expect_header_valid.rs
@@ -416,19 +416,39 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
         if seg.is_empty() {
             continue;
         }
-        let Some((pname, pvalue)) = seg.split_once('=') else {
+        let Ok(parameter) =
+            crate::helpers::headers::parameter_of(seg).expect("the empty segment returned above")
+        else {
             return Err(format!(
                 "Expect member '{}' has a parameter with no value: '{}'",
                 crate::helpers::headers::shown_in_finding(member),
                 crate::helpers::headers::shown_in_finding(seg)
             ));
         };
+        let (pname, pvalue) = (parameter.name, parameter.value);
+
         // No `OWS` is written around a parameter's `=`, and the section says so
-        // twice — once by writing the production without any, once in prose. So
-        // the space in `a = b` lands inside a name or a value and is reported as
-        // the octet it is.
+        // twice — once by writing the production without any, once in prose.
+        // **This is the one caller in the tree that reports it.** Six rules
+        // reading a media type trim it and publish that as a known leniency, so
+        // the shared walk hands the fact back rather than deciding it, and this
+        // is where the sentence below is enforced. What changed is the sentence
+        // the finding names, not what it catches: the walk here used not to trim
+        // at all, so the space in `a = b` landed inside the name and came back as
+        // "an octet no `tchar` admits". Every spelling was caught that way --
+        // SP and HTAB are `tchar`s in no position, and the splitter has already
+        // taken the `OWS` off both ends of the segment -- but the requirement
+        // being reported was § 5.6.2's alphabet when the requirement in force is
+        // the Note below, which is about this character and says so.
         //
         // cite(RFC 9110 § 5.6.6): "|  *Note:* Parameters do not allow whitespace (not even "bad" |  whitespace) around the "=" character."
+        if parameter.whitespace_beside_equals {
+            return Err(format!(
+                "Expect member '{}' writes whitespace beside the '=' of parameter '{}'; parameters do not allow whitespace around that character, not even \"bad\" whitespace",
+                crate::helpers::headers::shown_in_finding(member),
+                crate::helpers::headers::shown_in_finding(seg)
+            ));
+        }
         if pname.is_empty() {
             return Err(format!(
                 "Expect member '{}' has a parameter with no name: '{}'",
@@ -443,32 +463,35 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
                 crate::helpers::headers::shown_in_finding(pname)
             ));
         }
-        if pvalue.starts_with('"') {
-            // No second "does the quoted-string end the value" test: everything
-            // such a test would catch, `validate_quoted_string` already rejects
-            // -- it requires the first and last octets to be the DQUOTE and no
-            // unescaped one between them, so a string that closed early is an
-            // unescaped quote to it. Two owners for one production is how they
-            // drift apart.
-            validate_quoted_string(pvalue).map_err(|e| {
-                format!(
+        // `parameter-value = ( token / quoted-string )`, read by the function
+        // that owns the alternation -- a ninth copy of it, found while giving the
+        // `parameters` walk a home. No second "does the quoted-string end the
+        // value" test is needed: everything such a test would catch,
+        // `validate_quoted_string` already rejects, since it requires the first
+        // and last octets to be the DQUOTE with no unescaped one between them.
+        match crate::helpers::headers::token_or_quoted_string(pvalue) {
+            Ok(_) => {}
+            Err(crate::helpers::headers::WordDefect::Empty) => {
+                return Err(format!(
+                    "Expect member '{}' has a parameter with an empty value: '{}'",
+                    crate::helpers::headers::shown_in_finding(member),
+                    crate::helpers::headers::shown_in_finding(seg)
+                ))
+            }
+            Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
+                return Err(format!(
                     "Invalid quoted-string in Expect parameter '{}': {}",
                     crate::helpers::headers::shown_in_finding(seg),
                     e
-                )
-            })?;
-        } else if pvalue.is_empty() {
-            return Err(format!(
-                "Expect member '{}' has a parameter with an empty value: '{}'",
-                crate::helpers::headers::shown_in_finding(member),
-                crate::helpers::headers::shown_in_finding(seg)
-            ));
-        } else if let Some(c) = find_invalid_token_char(pvalue) {
-            return Err(format!(
-                "Invalid octet {} in Expect parameter value '{}'",
-                describe_octet(c as u8),
-                crate::helpers::headers::shown_in_finding(pvalue)
-            ));
+                ))
+            }
+            Err(crate::helpers::headers::WordDefect::NotToken(c)) => {
+                return Err(format!(
+                    "Invalid octet {} in Expect parameter value '{}'",
+                    describe_octet(c as u8),
+                    crate::helpers::headers::shown_in_finding(pvalue)
+                ))
+            }
         }
     }
 
@@ -575,9 +598,13 @@ mod tests {
     #[case("a/b", true)]
     #[case("=value", true)]
     #[case("a=", true)]
+    // Whitespace beside the `=`. All three were caught before the shared walk
+    // existed, as "an octet no tchar admits"; what the finding now names is the
+    // Note that is actually about this character.
     #[case("a= b", true)]
     #[case("a = b", true)]
     #[case("a=b; c = d", true)]
+    #[case("a=\t b", true)]
     #[case("a=\"unterminated", true)]
     #[case("a=b junk", true)]
     #[case("a=b;=x", true)]
@@ -591,6 +618,22 @@ mod tests {
             "case '{}' produced {:?}",
             value,
             v.map(|x| x.message)
+        );
+    }
+
+    /// The one caller in the tree that reports § 5.6.6's whitespace Note, pinned
+    /// whole. A `is_some()` case cannot tell this finding from the `tchar` one it
+    /// replaced, and the whole change is which requirement the message names.
+    #[test]
+    fn whitespace_beside_the_equals_names_the_note_that_forbids_it() {
+        // The parameter level, not the expectation's own `=`: `expectation =
+        // token [ "=" ( token / quoted-string ) parameters ]`, so `a = b` alone
+        // is a name-and-value pair and its whitespace is caught one branch up.
+        let v = judge_value("a=b; c = d").expect("§ 5.6.6 forbids whitespace around the '='");
+        assert_eq!(
+            v.message,
+            "Expect member 'a=b; c = d' writes whitespace beside the '=' of parameter 'c = d'; \
+             parameters do not allow whitespace around that character, not even \"bad\" whitespace"
         );
     }
 

--- a/lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
+++ b/lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -154,15 +154,16 @@ impl Rule for MessageAcceptAndContentTypeNegotiation {
             // weight last, and a recipient should find it wherever it is.
             // cite(RFC 9110 § 12.5.1): "Recipients SHOULD process any parameter named "q" as weight, regardless of parameter ordering."
             // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
+            //
+            // A segment with no `=` names no weight and is skipped rather than
+            // judged: that it derives from no `parameter` is
+            // `message_accept_header_media_type_syntax`'s finding, and this rule
+            // is only asking whether the member refuses what the response sent.
             let mut qval: Option<&str> = None;
-            for p in parts {
-                let p = p.trim();
-                let mut kv = p.splitn(2, '=');
-                let k = kv.next().unwrap().trim();
-                if k.eq_ignore_ascii_case("q") {
-                    if let Some(v) = kv.next() {
-                        qval = Some(v.trim());
-                    }
+            for parameter in parts.filter_map(crate::helpers::headers::parameter_of) {
+                let Ok(parameter) = parameter else { continue };
+                if parameter.name.eq_ignore_ascii_case("q") {
+                    qval = Some(parameter.value);
                 }
             }
 

--- a/lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -205,22 +205,29 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
                     // A parameter is a name, an "=", and a value; none of the
                     // three is optional, so a bare word among the parameters is
                     // not a parameter with a missing value but not a parameter
-                    // at all.
-                    // cite(RFC 9110 § 5.6.6): "parameter       = parameter-name "=" parameter-value"
-                    let mut kv = p.splitn(2, '=');
-                    let k = kv.next().unwrap().trim();
-                    let v = kv.next();
-                    if v.is_none() {
-                        return Some(Violation {
-                            rule: self.id().into(),
-                            severity: config.severity,
-                            message: format!(
-                                "Invalid parameter '{}' in {} header: missing '='",
-                                p, hdr
-                            ),
-                        });
-                    }
-                    let v = v.unwrap().trim();
+                    // at all. The split and the two `OWS` trims are the shared
+                    // walk's; the whitespace beside the `=` it hands back is
+                    // this rule's published leniency, read and dropped here so
+                    // that the paragraph saying so is a statement about the code.
+                    let Some(parsed) = crate::helpers::headers::parameter_of(p) else {
+                        continue;
+                    };
+                    let parsed = match parsed {
+                        Ok(parsed) => parsed,
+                        Err(crate::helpers::headers::ParameterDefect::NoEquals(_)) => {
+                            return Some(Violation {
+                                rule: self.id().into(),
+                                severity: config.severity,
+                                message: format!(
+                                    "Invalid parameter '{}' in {} header: missing '='",
+                                    p, hdr
+                                ),
+                            })
+                        }
+                    };
+                    let _ = parsed.whitespace_beside_equals;
+                    let k = parsed.name;
+                    let v = parsed.value;
                     // `token = 1*tchar`, so a name with no characters is not a
                     // name. Scanning for an invalid character cannot see this:
                     // an empty string has no invalid character in it, and

--- a/lint-http-rules/src/rules/message_charset_iana_registered.rs
+++ b/lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -109,116 +109,115 @@ impl Rule for MessageCharsetIanaRegistered {
                 // finding for a message that has no charset parameter at all.
                 // Every other rule that walks media-type parameters already uses
                 // this helper; this one was the exception.
-                for raw in crate::helpers::headers::split_semicolons_respecting_quotes(params) {
-                    let p = raw.trim();
-                    if p.is_empty() {
-                        continue;
-                    }
-                    if let Some(eq) = p.find('=') {
-                        let (name, value) = p.split_at(eq);
-                        let name = name.trim();
-                        let value = value[1..].trim(); // skip '='
-                                                       // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
-                        if name.eq_ignore_ascii_case("charset") {
-                            // An unquoted value must satisfy `token`, and `token`
-                            // is `1*tchar`, so nothing after the "=" is not a
-                            // charset name that happens to be unregistered — it
-                            // is not a parameter value at all.
-                            // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
-                            if value.is_empty() {
-                                return Some(Violation {
-                                    rule: MessageCharsetIanaRegistered.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "Invalid Content-Type in {}: empty 'charset' parameter",
-                                        which
-                                    ),
-                                });
-                            }
+                //
+                // The walk is `helpers::headers::parameters`, which owns the
+                // split, the bracketed-empty skip and the cut at the first `=`.
+                // A segment with no `=` is not this rule's finding —
+                // `message_content_type_well_formed` reads the same field
+                // through `media_type_parts_defect` and reports it there — so it
+                // is skipped rather than judged, and the whitespace beside the
+                // `=` is the leniency this rule publishes.
+                for parameter in crate::helpers::headers::parameters(params) {
+                    let Ok(parameter) = parameter else { continue };
+                    let value = parameter.value;
+                    // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
+                    if parameter.name.eq_ignore_ascii_case("charset") {
+                        // An unquoted value must satisfy `token`, and `token`
+                        // is `1*tchar`, so nothing after the "=" is not a
+                        // charset name that happens to be unregistered — it
+                        // is not a parameter value at all.
+                        // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
+                        if value.is_empty() {
+                            return Some(Violation {
+                                rule: MessageCharsetIanaRegistered.id().into(),
+                                severity: config.severity,
+                                message: format!(
+                                    "Invalid Content-Type in {}: empty 'charset' parameter",
+                                    which
+                                ),
+                            });
+                        }
 
-                            // The two alternatives of `parameter-value`, each
-                            // handed to the helper that owns its grammar:
-                            // `quoted-string` is unescaped and validated in one
-                            // step, `token` is checked character by character.
-                            // A charset name is compared after unescaping, since
-                            // "the quoted and unquoted values are equivalent".
-                            let mut value_owned: Option<String> = None;
-                            if value.starts_with('"') {
-                                match crate::helpers::headers::unescape_quoted_string(value) {
-                                    Ok(u) => value_owned = Some(u),
-                                    Err(e) => {
-                                        return Some(Violation {
-                                            rule: MessageCharsetIanaRegistered.id().into(),
-                                            severity: config.severity,
-                                            message: format!(
-                                                "Invalid Content-Type in {}: 'charset' quoted-string invalid: {}",
-                                                which, e
-                                            ),
-                                        })
-                                    }
-                                }
-                            } else {
-                                // `token` is not the charset production, and the
-                                // two sets are *incomparable* rather than one
-                                // being a subset. `mime-charset` (RFC 2978 §2.3)
-                                // admits "{" and "}", which `token` does not;
-                                // `token` admits "*", "." and "|", which
-                                // `mime-charset` does not. So this check is
-                                // stricter in one direction and looser in the
-                                // other — `charset=utf.8` reaches the allowlist
-                                // instead of being called malformed.
-                                //
-                                // Neither direction changes a verdict. A name
-                                // with braces is not registered (RFC 9110 §8.3.2
-                                // says so outright), and a name with "." or "*"
-                                // that is not in the allowlist is reported by the
-                                // membership check below. Only the wording of the
-                                // finding differs. (§8.3.2 makes this point in a
-                                // gutter-marked note apycite cannot quote.)
-                                if let Some(c) =
-                                    crate::helpers::token::find_invalid_token_char(value)
-                                {
+                        // The two alternatives of `parameter-value`, each
+                        // handed to the helper that owns its grammar:
+                        // `quoted-string` is unescaped and validated in one
+                        // step, `token` is checked character by character.
+                        // A charset name is compared after unescaping, since
+                        // "the quoted and unquoted values are equivalent".
+                        let mut value_owned: Option<String> = None;
+                        if value.starts_with('"') {
+                            match crate::helpers::headers::unescape_quoted_string(value) {
+                                Ok(u) => value_owned = Some(u),
+                                Err(e) => {
                                     return Some(Violation {
                                         rule: MessageCharsetIanaRegistered.id().into(),
                                         severity: config.severity,
                                         message: format!(
-                                            "Invalid Content-Type in {}: charset contains invalid character '{}'",
-                                            which, c
+                                            "Invalid Content-Type in {}: 'charset' quoted-string invalid: {}",
+                                            which, e
                                         ),
-                                    });
+                                    })
                                 }
                             }
-                            let value = value_owned.as_deref().unwrap_or(value);
-
-                            if value.is_empty() {
+                        } else {
+                            // `token` is not the charset production, and the
+                            // two sets are *incomparable* rather than one
+                            // being a subset. `mime-charset` (RFC 2978 §2.3)
+                            // admits "{" and "}", which `token` does not;
+                            // `token` admits "*", "." and "|", which
+                            // `mime-charset` does not. So this check is
+                            // stricter in one direction and looser in the
+                            // other — `charset=utf.8` reaches the allowlist
+                            // instead of being called malformed.
+                            //
+                            // Neither direction changes a verdict. A name
+                            // with braces is not registered (RFC 9110 §8.3.2
+                            // says so outright), and a name with "." or "*"
+                            // that is not in the allowlist is reported by the
+                            // membership check below. Only the wording of the
+                            // finding differs. (§8.3.2 makes this point in a
+                            // gutter-marked note apycite cannot quote.)
+                            if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
                                 return Some(Violation {
                                     rule: MessageCharsetIanaRegistered.id().into(),
                                     severity: config.severity,
                                     message: format!(
-                                        "Invalid Content-Type in {}: empty 'charset' parameter",
-                                        which
+                                        "Invalid Content-Type in {}: charset contains invalid character '{}'",
+                                        which, c
                                     ),
                                 });
                             }
+                        }
+                        let value = value_owned.as_deref().unwrap_or(value);
 
-                            // The rule's name says IANA; the code says the
-                            // operator's `allowed` array. The registry is never
-                            // consulted — there is no lookup — so this cite is
-                            // the *motivation*, and "ought to" is why the whole
-                            // rule is a policy rather than a conformance check.
-                            // The fold is the matching rule, not a convenience.
-                            // cite(RFC 9110 § 8.3.2): "Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978]."
-                            // cite(RFC 9110 § 8.3.2): "In both cases, charset names are matched case-insensitively."
-                            if !config.allowed.contains(&value.to_ascii_lowercase()) {
-                                return Some(Violation {
-                                    rule: MessageCharsetIanaRegistered.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "Unrecognized charset '{}' in {} header",
-                                        value, which
-                                    ),
-                                });
-                            }
+                        if value.is_empty() {
+                            return Some(Violation {
+                                rule: MessageCharsetIanaRegistered.id().into(),
+                                severity: config.severity,
+                                message: format!(
+                                    "Invalid Content-Type in {}: empty 'charset' parameter",
+                                    which
+                                ),
+                            });
+                        }
+
+                        // The rule's name says IANA; the code says the
+                        // operator's `allowed` array. The registry is never
+                        // consulted — there is no lookup — so this cite is
+                        // the *motivation*, and "ought to" is why the whole
+                        // rule is a policy rather than a conformance check.
+                        // The fold is the matching rule, not a convenience.
+                        // cite(RFC 9110 § 8.3.2): "Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978]."
+                        // cite(RFC 9110 § 8.3.2): "In both cases, charset names are matched case-insensitively."
+                        if !config.allowed.contains(&value.to_ascii_lowercase()) {
+                            return Some(Violation {
+                                rule: MessageCharsetIanaRegistered.id().into(),
+                                severity: config.severity,
+                                message: format!(
+                                    "Unrecognized charset '{}' in {} header",
+                                    value, which
+                                ),
+                            });
                         }
                     }
                 }

--- a/lint-http-rules/src/rules/message_content_type_well_formed.rs
+++ b/lint-http-rules/src/rules/message_content_type_well_formed.rs
@@ -300,6 +300,15 @@ mod tests {
     #[case("text/plain;=value", true)]
     #[case("text/plain; charset=utf 8", true)]
     #[case("text/plain; charset=\"unclosed", true)]
+    // `parameter-value = ( token / quoted-string )` derives no empty string:
+    // `token = 1*tchar` has a one-character floor and the shortest
+    // `quoted-string` is its two DQUOTEs. This reached a `tchar` scan, which
+    // finds no invalid character in the empty string and called it clean — the
+    // same shape `message_accept_header_media_type_syntax` was corrected for,
+    // living one level down in the media-type helper both rules read through.
+    // `charset=""` is a different value and still conforms.
+    #[case("text/plain; charset=", true)]
+    #[case("text/plain; charset=\"\"", false)]
     fn content_type_parsing_cases(#[case] val: &str, #[case] expect_violation: bool) {
         let cfg = crate::test_helpers::make_test_rule_config();
         let res = super::check_content_type("test", val, &cfg);

--- a/lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -201,174 +201,168 @@ fn check_multipart_boundary(
             // production: `[ parameter ]` is bracketed, so a parameter list may
             // end in a separator with nothing after it and still conform.
             // cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
-            for raw in crate::helpers::headers::split_semicolons_respecting_quotes(params) {
-                let p = raw.trim();
-                if p.is_empty() {
-                    continue;
-                }
-                // A segment with no "=" is not a parameter — `parameter` has
-                // both halves and the "=" is not optional. That it is malformed
-                // is `message_content_type_well_formed`'s finding; this rule
-                // only needs to know it is not the boundary.
-                // cite(RFC 9110 § 5.6.6): "parameter       = parameter-name "=" parameter-value"
-                if let Some(eq) = p.find('=') {
-                    let (name, value) = p.split_at(eq);
-                    let name = name.trim();
-                    let value = value[1..].trim(); // skip '='
-                                                   // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
-                    if name.eq_ignore_ascii_case("boundary") {
-                        found = true;
-                        // Nothing after the "=" is not a boundary that happens
-                        // to be too short — it is not a `parameter-value` at
-                        // all, since both alternatives are non-empty.
-                        // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
-                        if value.is_empty() {
-                            return Some(Violation {
-                                rule: MessageMultipartBoundarySyntax.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid multipart Content-Type in {}: empty 'boundary' parameter",
-                                    which
-                                ),
-                            });
-                        }
+            // The split, the bracketed-empty skip and the cut at the first `=`
+            // are `helpers::headers::parameters`'s. A segment with no "=" is not
+            // a parameter — `parameter` has both halves and the "=" is not
+            // optional — but that it is malformed is
+            // `message_content_type_well_formed`'s finding; this rule only needs
+            // to know it is not the boundary, so it is skipped here.
+            for parameter in crate::helpers::headers::parameters(params) {
+                let Ok(parameter) = parameter else { continue };
+                let value = parameter.value;
+                // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
+                if parameter.name.eq_ignore_ascii_case("boundary") {
+                    found = true;
+                    // Nothing after the "=" is not a boundary that happens
+                    // to be too short — it is not a `parameter-value` at
+                    // all, since both alternatives are non-empty.
+                    // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
+                    if value.is_empty() {
+                        return Some(Violation {
+                            rule: MessageMultipartBoundarySyntax.id().into(),
+                            severity: config.severity,
+                            message: format!(
+                                "Invalid multipart Content-Type in {}: empty 'boundary' parameter",
+                                which
+                            ),
+                        });
+                    }
 
-                        // The two alternatives of `parameter-value`, each handed
-                        // to the helper that owns its grammar. Which one was
-                        // written decides nothing about the boundary itself:
-                        // the checks below run on the unescaped value, because
-                        // the two forms name the same value.
-                        //
-                        // The quoting is not a stylistic choice here. Seven
-                        // characters `bchars` allows — "(", ")", ",", "/", ":",
-                        // "=", "?" — and SP are not `tchar`, so a boundary using
-                        // any of them can only be transmitted quoted, which is
-                        // what RFC 2046 warns implementors about.
-                        // cite(RFC 9110 § 5.6.6): "A parameter value that matches the token production can be transmitted either as a token or within a quoted-string."
-                        // cite(RFC 9110 § 5.6.6): "The quoted and unquoted values are equivalent."
-                        // cite(RFC 2046 § 5.1.1): "The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line."
-                        let boundary_unquoted = if value.starts_with('"') {
-                            // Unescape quoted-string interior using helper
-                            match crate::helpers::headers::unescape_quoted_string(value) {
-                                Ok(u) => u,
-                                Err(e) => {
-                                    return Some(Violation {
-                                        rule: MessageMultipartBoundarySyntax.id().into(),
-                                        severity: config.severity,
-                                        message: format!(
-                                            "Invalid multipart Content-Type in {}: boundary quoted-string invalid: {}",
-                                            which, e
-                                        ),
-                                    })
-                                }
-                            }
-                        } else {
-                            // The unquoted alternative is `token`, and it is
-                            // HTTP's `token` that applies: the transport decides
-                            // what may be written bare in a parameter, whatever
-                            // the media type's own definition of the value.
-                            //
-                            // RFC 2045's `token` is the wider of the two, by "{"
-                            // and "}" — neither of which is a `bchars`, so both
-                            // are rejected either way and only the wording of the
-                            // finding differs.
-                            if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
+                    // The two alternatives of `parameter-value`, each handed
+                    // to the helper that owns its grammar. Which one was
+                    // written decides nothing about the boundary itself:
+                    // the checks below run on the unescaped value, because
+                    // the two forms name the same value.
+                    //
+                    // The quoting is not a stylistic choice here. Seven
+                    // characters `bchars` allows — "(", ")", ",", "/", ":",
+                    // "=", "?" — and SP are not `tchar`, so a boundary using
+                    // any of them can only be transmitted quoted, which is
+                    // what RFC 2046 warns implementors about.
+                    // cite(RFC 9110 § 5.6.6): "A parameter value that matches the token production can be transmitted either as a token or within a quoted-string."
+                    // cite(RFC 9110 § 5.6.6): "The quoted and unquoted values are equivalent."
+                    // cite(RFC 2046 § 5.1.1): "The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line."
+                    let boundary_unquoted = if value.starts_with('"') {
+                        // Unescape quoted-string interior using helper
+                        match crate::helpers::headers::unescape_quoted_string(value) {
+                            Ok(u) => u,
+                            Err(e) => {
                                 return Some(Violation {
                                     rule: MessageMultipartBoundarySyntax.id().into(),
                                     severity: config.severity,
                                     message: format!(
-                                        "Invalid multipart Content-Type in {}: boundary contains invalid token character '{}'",
-                                        which, c
+                                        "Invalid multipart Content-Type in {}: boundary quoted-string invalid: {}",
+                                        which, e
                                     ),
-                                });
+                                })
                             }
-                            value.to_string()
-                        };
-
-                        // The character set is judged first, before the length,
-                        // because the length is a count of characters and only a
-                        // value drawn from this set has a meaningful one. A
-                        // boundary of non-ASCII text was measured in bytes and
-                        // reported as too long, which named a limit it might not
-                        // have exceeded instead of the octets that are not
-                        // `bchars` at all.
+                        }
+                    } else {
+                        // The unquoted alternative is `token`, and it is
+                        // HTTP's `token` that applies: the transport decides
+                        // what may be written bare in a parameter, whatever
+                        // the media type's own definition of the value.
                         //
-                        // The set below is `bchars` transcribed: `bcharsnospace`
-                        // plus SP. It is not folded, and nothing here compares
-                        // case — a boundary is matched against the delimiter
-                        // lines in the content literally, which is the case-
-                        // sensitive end of what §5.6.6 leaves to each parameter.
-                        // cite(RFC 2046 § 5.1.1): "bchars := bcharsnospace / " ""
-                        // cite(RFC 2046 § 5.1.1): "bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?""
-                        // cite(RFC 9110 § 5.6.6): "Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name."
-                        for ch in boundary_unquoted.chars() {
-                            if ch.is_ascii_alphanumeric()
-                                || matches!(
-                                    ch,
-                                    '\'' | '('
-                                        | ')'
-                                        | '+'
-                                        | '_'
-                                        | ','
-                                        | '-'
-                                        | '.'
-                                        | '/'
-                                        | ':'
-                                        | '='
-                                        | '?'
-                                )
-                                || ch == ' '
-                            {
-                                continue;
-                            }
+                        // RFC 2045's `token` is the wider of the two, by "{"
+                        // and "}" — neither of which is a `bchars`, so both
+                        // are rejected either way and only the wording of the
+                        // finding differs.
+                        if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
                             return Some(Violation {
                                 rule: MessageMultipartBoundarySyntax.id().into(),
                                 severity: config.severity,
                                 message: format!(
-                                    "Invalid multipart Content-Type in {}: boundary contains invalid character '{}'",
-                                    which, ch
+                                    "Invalid multipart Content-Type in {}: boundary contains invalid token character '{}'",
+                                    which, c
                                 ),
                             });
                         }
+                        value.to_string()
+                    };
 
-                        // 70, not 69 and not 71: the production is 0*69 of
-                        // `bchars` followed by one more character, and the prose
-                        // states the same limit twice over. The zero case is
-                        // what `boundary=""` leaves after unquoting, and the
-                        // grammar has no empty alternative.
-                        // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
-                        // cite(RFC 2046 § 5.1.1): "The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space."
-                        let len = boundary_unquoted.chars().count();
-                        if len == 0 || len > 70 {
-                            return Some(Violation {
-                                rule: MessageMultipartBoundarySyntax.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid multipart Content-Type in {}: 'boundary' must be between 1 and 70 characters",
-                                    which
-                                ),
-                            });
+                    // The character set is judged first, before the length,
+                    // because the length is a count of characters and only a
+                    // value drawn from this set has a meaningful one. A
+                    // boundary of non-ASCII text was measured in bytes and
+                    // reported as too long, which named a limit it might not
+                    // have exceeded instead of the octets that are not
+                    // `bchars` at all.
+                    //
+                    // The set below is `bchars` transcribed: `bcharsnospace`
+                    // plus SP. It is not folded, and nothing here compares
+                    // case — a boundary is matched against the delimiter
+                    // lines in the content literally, which is the case-
+                    // sensitive end of what §5.6.6 leaves to each parameter.
+                    // cite(RFC 2046 § 5.1.1): "bchars := bcharsnospace / " ""
+                    // cite(RFC 2046 § 5.1.1): "bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?""
+                    // cite(RFC 9110 § 5.6.6): "Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name."
+                    for ch in boundary_unquoted.chars() {
+                        if ch.is_ascii_alphanumeric()
+                            || matches!(
+                                ch,
+                                '\'' | '('
+                                    | ')'
+                                    | '+'
+                                    | '_'
+                                    | ','
+                                    | '-'
+                                    | '.'
+                                    | '/'
+                                    | ':'
+                                    | '='
+                                    | '?'
+                            )
+                            || ch == ' '
+                        {
+                            continue;
                         }
+                        return Some(Violation {
+                            rule: MessageMultipartBoundarySyntax.id().into(),
+                            severity: config.severity,
+                            message: format!(
+                                "Invalid multipart Content-Type in {}: boundary contains invalid character '{}'",
+                                which, ch
+                            ),
+                        });
+                    }
 
-                        // Space is the one whitespace character the check above
-                        // lets through, so this is the grammar's "last character
-                        // must be `bcharsnospace`" and nothing wider. The
-                        // production says it in its shape — `bchars` may repeat,
-                        // but the final character comes from the set without SP
-                        // — and the prose says it in words, along with the
-                        // reason: a gateway may have added that space, so a
-                        // recipient cannot tell it from the delimiter's own.
-                        // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
-                        if boundary_unquoted.ends_with(' ') {
-                            return Some(Violation {
-                                rule: MessageMultipartBoundarySyntax.id().into(),
-                                severity: config.severity,
-                                message: format!(
-                                    "Invalid multipart Content-Type in {}: 'boundary' must not end with whitespace",
-                                    which
-                                ),
-                            });
-                        }
+                    // 70, not 69 and not 71: the production is 0*69 of
+                    // `bchars` followed by one more character, and the prose
+                    // states the same limit twice over. The zero case is
+                    // what `boundary=""` leaves after unquoting, and the
+                    // grammar has no empty alternative.
+                    // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
+                    // cite(RFC 2046 § 5.1.1): "The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space."
+                    let len = boundary_unquoted.chars().count();
+                    if len == 0 || len > 70 {
+                        return Some(Violation {
+                            rule: MessageMultipartBoundarySyntax.id().into(),
+                            severity: config.severity,
+                            message: format!(
+                                "Invalid multipart Content-Type in {}: 'boundary' must be between 1 and 70 characters",
+                                which
+                            ),
+                        });
+                    }
+
+                    // Space is the one whitespace character the check above
+                    // lets through, so this is the grammar's "last character
+                    // must be `bcharsnospace`" and nothing wider. The
+                    // production says it in its shape — `bchars` may repeat,
+                    // but the final character comes from the set without SP
+                    // — and the prose says it in words, along with the
+                    // reason: a gateway may have added that space, so a
+                    // recipient cannot tell it from the delimiter's own.
+                    // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
+                    if boundary_unquoted.ends_with(' ') {
+                        return Some(Violation {
+                            rule: MessageMultipartBoundarySyntax.id().into(),
+                            severity: config.severity,
+                            message: format!(
+                                "Invalid multipart Content-Type in {}: 'boundary' must not end with whitespace",
+                                which
+                            ),
+                        });
                     }
                 }
             }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1906
+      line: 2031
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1901
+      line: 2026
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1900
+      line: 2025
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -733,7 +733,7 @@ sources:
     snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 381
+      line: 375
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
       line: 42
   - label: message_multipart_boundary_syntax (3)
@@ -741,7 +741,7 @@ sources:
     snippet: The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 382
+      line: 376
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
       line: 187
   - label: message_multipart_boundary_syntax (4)
@@ -749,33 +749,33 @@ sources:
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 249
+      line: 244
   - label: message_multipart_boundary_syntax (5)
     section: § 5.1.1
     snippet: The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 340
+      line: 335
   - label: message_multipart_boundary_syntax (6)
     section: § 5.1.1
     snippet: bchars := bcharsnospace / " "
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 301
+      line: 296
   - label: message_multipart_boundary_syntax (7)
     section: § 5.1.1
     snippet: bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 302
+      line: 297
   - label: message_multipart_boundary_syntax (8)
     section: § 5.1.1
     snippet: boundary := 0*69<bchars> bcharsnospace
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 339
+      line: 334
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 361
+      line: 356
   - label: message_multipart_content_type_and_body_consistency
     section: § 5.1.1
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
@@ -2031,7 +2031,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1902
+      line: 2027
     - file: lint-http-rules/src/helpers/uri.rs
       line: 222
   - label: lint-http-rules/src/helpers/uri.rs
@@ -4376,7 +4376,7 @@ sources:
     snippet: '|  *Note:* Parameters do not allow whitespace (not even "bad" |  whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 431
+      line: 444
   - label: client_expect_header_valid (14)
     section: § A
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
@@ -5324,7 +5324,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1655
+      line: 1760
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5356,7 +5356,7 @@ sources:
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
-      line: 249
+      line: 248
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 84
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
@@ -5465,6 +5465,8 @@ sources:
       line: 441
     - file: lint-http-rules/src/helpers/headers.rs
       line: 950
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1689
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
@@ -5550,61 +5552,61 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1855
+      line: 1979
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
-      line: 121
+      line: 123
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 218
+      line: 213
   - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1773
+      line: 1687
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1714
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 380
-    - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 209
-    - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 213
   - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1787
+      line: 1688
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1715
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1896
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 231
+      line: 238
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1816
+      line: 1910
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 382
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 278
+      line: 285
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
-      line: 127
+      line: 129
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 224
+      line: 219
   - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1654
+      line: 1686
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1765
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 1845
+      line: 1759
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 379
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -5670,11 +5672,11 @@ sources:
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1734
+      line: 1841
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
-      line: 203
+      line: 204
     - file: lint-http-rules/src/rules/message_content_type_iana_registered.rs
       line: 98
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
@@ -5696,7 +5698,7 @@ sources:
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1753
+      line: 1860
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5704,7 +5706,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1670
+      line: 1775
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 105
   - label: lint-http-rules/src/helpers/headers.rs (33)
@@ -5712,7 +5714,7 @@ sources:
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1733
+      line: 1840
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
@@ -5872,13 +5874,13 @@ sources:
     snippet: If no "q" parameter is present, the default weight is 1.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
-      line: 178
+      line: 179
   - label: message_accept_and_content_type_negotiation (5)
     section: § 12.4.2
     snippet: The weight is normalized to a real number in the range 0 through 1, where 0.001 is the least preferred and 1 is the most preferred; a value of 0 means "not acceptable".
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
-      line: 177
+      line: 178
   - label: message_accept_and_content_type_negotiation (6)
     section: § 12.5.1
     snippet: 'Accept = #( media-range [ weight ] )'
@@ -5892,7 +5894,7 @@ sources:
     snippet: If more than one media range applies to a given type, the most specific reference has precedence.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
-      line: 202
+      line: 203
   - label: message_accept_and_content_type_negotiation (8)
     section: § 12.5.1
     snippet: Recipients SHOULD process any parameter named "q" as weight, regardless of parameter ordering.
@@ -5900,7 +5902,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 155
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 259
+      line: 266
   - label: message_accept_and_content_type_negotiation (9)
     section: § 12.5.1
     snippet: The "Accept" header field can be used by user agents to specify their preferences regarding response media types.
@@ -5914,7 +5916,7 @@ sources:
     snippet: The media-range can include media type parameters that are applicable to that range.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
-      line: 201
+      line: 202
   - label: message_accept_and_content_type_negotiation (11)
     section: § 12.5.1
     snippet: media-range    = ( "*/*" / ( type "/" "*" ) / ( type "/" subtype ) ) parameters
@@ -5936,7 +5938,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 133
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 258
+      line: 265
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 83
   - label: message_accept_encoding_parameter_validity (2)
@@ -6002,7 +6004,7 @@ sources:
     snippet: A sender of qvalue MUST NOT generate more than three digits after the decimal point.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 267
+      line: 274
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 292
   - label: message_accept_header_media_type_syntax (2)
@@ -6036,7 +6038,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
       line: 78
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 232
+      line: 239
     - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
       line: 83
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
@@ -6742,19 +6744,19 @@ sources:
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 247
+      line: 242
   - label: message_multipart_boundary_syntax (2)
     section: § 5.6.6
     snippet: Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 303
+      line: 298
   - label: message_multipart_boundary_syntax (3)
     section: § 5.6.6
     snippet: The quoted and unquoted values are equivalent.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
-      line: 248
+      line: 243
   - label: message_multipart_boundary_syntax (4)
     section: § 8.3.3
     snippet: All multipart types share a common syntax, as defined in Section 5.1.1 of [RFC2046], and include a boundary parameter as part of the media type value.


### PR DESCRIPTION
`helpers::headers::parameters` walks `parameters = *( OWS ";" OWS [ parameter ] )`, and `parameter_of` reads one already-split segment — for the two rules whose own split has already taken the first segment as the thing the field is about, `media-range` and `expectation`.

Both halves of the row were short. Seven hand copies of the walk, not five, and two of them were in `helpers::headers` itself: `media_type_parts_defect` and `extract_multipart_boundary` split with the same quote-aware splitter and then disagreed about the trim. Six "Known leniency" paragraphs about whitespace beside the `=`, not four; a seventh carries that heading for line endings.

The disagreement is the design. §5.6.6's Note forbids whitespace beside the `=` in as many words — not even "bad" whitespace — and the tree does not agree about it: six rules trim it and publish that in `description()`, while `client_expect_header_valid` reports it. A walk that trimmed in silence would have had to pick one, so `Parameter::whitespace_beside_equals` hands the fact back and each caller keeps the answer its own audit reached. The six lenient sites read the flag and drop it, which is what makes their published paragraph a statement about the code rather than a plausible one.

`client_expect_header_valid` had been enforcing the right sentence by accident. Its walk did not trim at all, so the space in `a=b; c = d` landed inside the name and came back as "an octet no `tchar` admits". Every spelling was caught that way, since SP and HTAB are `tchar`s nowhere and the splitter has already taken the OWS off both ends of a segment — but the requirement the finding named was §5.6.2's alphabet when the one in force is the Note, which is about that character. Coverage unchanged, message corrected, message pinned.

Two verdicts changed, and in both a rule now does what it already said it did.

An empty parameter value is reported. `media_type_parts_defect` fell through to a `tchar` scan, which finds no invalid character in the empty string, so `Content-Type: text/plain; charset=` was clean for every caller — the same shape `message_accept_header_media_type_syntax` was corrected for, one level down in the helper both rules read through. It was an eighth copy of the `( token / quoted-string )` alternation and `client_expect_header_valid` held a ninth; neither was in the set that converted the other seven, because that set was of rules and these are helpers. Meanwhile
`message_content_type_well_formed`'s description had said all along that a parameter's value is a token or a quoted-string, which derives no empty string.

And `extract_multipart_boundary` honours its own second bullet. It documents that it returns `None` for a boundary that is not well-formed, and honoured that for a quoted-string only: an unquoted value went back whatever octets it held, so `boundary=a b` was handed on as the boundary `a b` and the caller hunted a body for `--a b` delimiters deriving from no `parameter-value`. Reporting a malformed boundary is `message_multipart_boundary_syntax`'s job; guessing at one is nobody's.

Left alone: `Accept-Encoding` and `Accept-Language` write `weight`, whose production spells the name as the literal text "q=" rather than as a name and a separator, and `Content-Disposition` reads RFC 6266's `disposition-parm` with its own ext-token and `*` forms. Three walks that look alike and are three grammars.

Cites 2162 → 2163.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
