### PR TITLE
The normalization was undone by the line after it, and only the fold …

### DIFF
--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -515,6 +515,83 @@ pub fn remove_dot_segments(path: &str) -> String {
     output
 }
 
+/// One URI component with § 6.2.2's two percent-encoding normalizations applied:
+/// every triplet standing for an `unreserved` character written as that
+/// character, and the hexadecimal of every triplet that stays encoded in upper
+/// case.
+///
+/// **Only `unreserved`, and § 2.4 is why.** Decoding a `gen-delims` or a
+/// `sub-delims` octet moves where the component boundaries are — `%2F` inside a
+/// segment is data, and `/` between two segments is not the same thing — so a
+/// caller handing a whole path to a decoder that took every triplet would get
+/// back a string whose structure the sender never wrote. That is the exact
+/// inverse of the decision at
+/// `server_alt_svc_protocol_iana_registered::alpn_protocol_name`, which decodes
+/// **every** triplet because RFC 7301 § 3.1 makes an ALPN protocol name an
+/// opaque octet sequence with no components for a delimiter to bound. One
+/// question, two answers, both cited; the two functions must not be folded.
+///
+/// **The second normalization is free here and required at one caller.** A
+/// triplet this leaves encoded is still put in one form, which is what lets two
+/// authorities that differ only in `%2f` versus `%2F` compare equal. The other
+/// caller compares against a literal made of `unreserved` characters, where a
+/// surviving triplet can never match whatever its case — so applying § 6.2.2.1
+/// cannot change its verdict, and having one function is worth more than having
+/// two that differ by a `format!`.
+///
+/// The walk is over `char`s and not over `str::as_bytes`, because callers hand
+/// this a value carrying one `char` per octet: an octet at or above %x80 is a
+/// single `char` here and two UTF-8 bytes, and a byte walk would take it apart
+/// into two octets that were never on the wire. The two characters after a `%`
+/// are tested for being hexadecimal before they are read as a number, because
+/// `from_str_radix` accepts a leading `+` and no `pct-encoded` does.
+///
+/// **Not part of [`normalize_path_and_query`], which is § 6.2.2's *third*
+/// normalization and named for all of them.** Folding this into it would widen
+/// what every one of that function's callers compares.
+// cite(RFC 3986 § 2.3): "unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~""
+// cite(RFC 3986 § 2.3): "URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent"
+// cite(RFC 3986 § 6.2.2.2): "These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3."
+// cite(RFC 3986 § 6.2.2.1): "For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F."
+// cite(RFC 3986 § 2.4): "When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters."
+pub fn decode_unreserved(component: &str) -> String {
+    let chars: Vec<char> = component.chars().collect();
+    let mut out = String::with_capacity(component.len());
+    let mut i = 0;
+
+    while i < chars.len() {
+        let octet = (chars[i] == '%' && i + 2 < chars.len())
+            .then(|| {
+                let hex: String = chars[i + 1..i + 3].iter().collect();
+                hex.chars()
+                    .all(|c| c.is_ascii_hexdigit())
+                    .then(|| u8::from_str_radix(&hex, 16).ok())
+                    .flatten()
+            })
+            .flatten();
+
+        match octet {
+            Some(octet)
+                if octet.is_ascii_alphanumeric() || matches!(octet, b'-' | b'.' | b'_' | b'~') =>
+            {
+                out.push(octet as char);
+                i += 3;
+            }
+            Some(octet) => {
+                out.push('%');
+                out.push_str(&format!("{:02X}", octet));
+                i += 3;
+            }
+            None => {
+                out.push(chars[i]);
+                i += 1;
+            }
+        }
+    }
+
+    out
+}
+
 /// Apply syntax-based normalization to a path-and-query string: dot-segments
 /// go, the query is carried through untouched.
 ///
@@ -815,6 +892,35 @@ pub fn validate_host_and_optional_port(value: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// The two normalizations § 6.2.2 asks for on percent-encoding, and the one
+    /// § 2.4 forbids.
+    #[test]
+    fn decode_unreserved_leaves_delimiters_encoded() {
+        // `%2F` is a `gen-delims` octet: decoding it would move a component
+        // boundary, which is the mistake RFC 3986 § 2.4 names.
+        assert_eq!(decode_unreserved("a%2Fb"), "a%2Fb");
+        assert_eq!(decode_unreserved("a%2Cb"), "a%2Cb");
+        // An `unreserved` octet is decoded, in either hexadecimal case.
+        assert_eq!(decode_unreserved("%2Ewell%2dknown"), ".well-known");
+        // A triplet that stays encoded is still put in one form, which is what
+        // lets two authorities differing only in the case of their hexadecimal
+        // compare equal (§ 6.2.2.1).
+        assert_eq!(decode_unreserved("a%2fb"), "a%2Fb");
+        // A truncated or non-hexadecimal run is left exactly as written; whether
+        // it is well formed is another rule's finding.
+        assert_eq!(decode_unreserved("%2"), "%2");
+        assert_eq!(decode_unreserved("%zz"), "%zz");
+        assert_eq!(decode_unreserved("%%41"), "%A");
+        // `from_str_radix` would read this as %x0A; no `pct-encoded` writes a
+        // sign, so the two characters are measured against `HEXDIG` first.
+        assert_eq!(decode_unreserved("%+A"), "%+A");
+        // A captured target read back through `lint` is an arbitrary string:
+        // the two positions after a `%` can be inside a multi-byte code point,
+        // and slicing them would panic.
+        assert_eq!(decode_unreserved("%é4"), "%é4");
+        assert_eq!(decode_unreserved("café"), "café");
+    }
     use super::*;
 
     #[test]

--- a/lint-http-rules/src/rules/message_host_and_authority_consistency.rs
+++ b/lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -74,7 +74,25 @@ impl MessageHostAndAuthorityConsistency {
             out.push_str(userinfo);
             out.push('@');
         }
-        out.push_str(&Self::decoded_unreserved(host).to_ascii_lowercase());
+        // The order is forced and the second pass is not decoration. Decoding
+        // has to run *before* the case fold, because `%50` is `P` and only a
+        // fold after the decode makes `EXAM%50LE.com` and `example.com` one
+        // host. But that fold then reaches the hexadecimal of the triplets the
+        // decode left behind — `%2F` comes back out as `%2f` — which undoes
+        // § 6.2.2.1, the sentence cited on the decoder itself. So the decode is
+        // run once more over the folded value: it re-uppercases those digits and
+        // can decode nothing new, every `unreserved` triplet having gone in the
+        // first pass. This was invisible while the decoder was private here,
+        // because the step it performs was undone one line later and only the
+        // comparison was ever looked at — both sides being folded the same way,
+        // the contradiction cost a verdict nothing and cost the *published
+        // normal form* its cited spelling.
+        //
+        // cite(RFC 3986 § 6.2.2.1): "For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F."
+        let host = crate::helpers::uri::decode_unreserved(host);
+        out.push_str(&crate::helpers::uri::decode_unreserved(
+            &host.to_ascii_lowercase(),
+        ));
 
         if let Some(port) = port {
             let elided = match default_port {
@@ -93,63 +111,6 @@ impl MessageHostAndAuthorityConsistency {
 
         out
     }
-
-    /// The value with every percent-encoded octet that stands for an unreserved
-    /// character written as that character, and the hexadecimal of the triplets
-    /// that stay in upper case.
-    ///
-    /// Both halves are one sentence each, and the second is why a triplet this
-    /// leaves encoded still ends up in a normal form: the digits of a triplet
-    /// are case-insensitive, so `%2F` and `%2f` are one octet.
-    ///
-    /// cite(RFC 3986 § 6.2.2.2): "These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3."
-    /// cite(RFC 3986 § 6.2.2.1): "For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F."
-    /// cite(RFC 3986 § 2.3, label: unreserved): "unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~""
-    fn decoded_unreserved(value: &str) -> String {
-        // The walk is over `char`s and not over `str::as_bytes`, because the
-        // value carries one `char` per octet: an octet at or above %x80 is a
-        // single `char` here and two UTF-8 bytes, and a byte walk would take it
-        // apart into two octets that were never on the wire. The two characters
-        // after a `%` are checked for being hexadecimal before they are read as
-        // a number, because `from_str_radix` accepts a leading `+` and no
-        // `pct-encoded` does.
-        let chars: Vec<char> = value.chars().collect();
-        let mut out = String::with_capacity(value.len());
-        let mut i = 0;
-
-        while i < chars.len() {
-            let triplet = (chars[i] == '%' && i + 2 < chars.len())
-                .then(|| {
-                    let hex: String = chars[i + 1..i + 3].iter().collect();
-                    hex.chars()
-                        .all(|c| c.is_ascii_hexdigit())
-                        .then(|| u8::from_str_radix(&hex, 16).ok())
-                        .flatten()
-                })
-                .flatten();
-
-            match triplet {
-                Some(octet) => {
-                    let unreserved =
-                        octet.is_ascii_alphanumeric() || matches!(octet, b'-' | b'.' | b'_' | b'~');
-                    if unreserved {
-                        out.push(octet as char);
-                    } else {
-                        out.push('%');
-                        out.push_str(&format!("{:02X}", octet));
-                    }
-                    i += 3;
-                }
-                None => {
-                    out.push(chars[i]);
-                    i += 1;
-                }
-            }
-        }
-
-        out
-    }
-
     /// Compare the two values as written, and say separately when they are one
     /// authority under the normalization above.
     ///
@@ -595,6 +556,7 @@ mod tests {
     // digits in one that does not.
     #[case("https://exam%70le.com/path", "example.com")]
     #[case("https://exam%2Fle.com/path", "exam%2fle.com")]
+    #[case("https://exam%2fle.com/path", "exam%2FLE.com")]
     fn a_difference_normalization_removes_is_reported_over_http3_only(
         #[case] uri: &str,
         #[case] host: &str,

--- a/lint-http-rules/src/rules/message_well_known_uri_format.rs
+++ b/lint-http-rules/src/rules/message_well_known_uri_format.rs
@@ -50,61 +50,28 @@ fn first_non_pchar(name: &str) -> Option<char> {
     })
 }
 
-/// `segment` with every percent-encoded octet standing for an `unreserved`
-/// character replaced by that character, so that the segment can be compared
-/// against a literal.
-///
-/// `%2Ewell-known` and `.well-known` are the same segment — the generic syntax
-/// says so in as many words — and a comparison that misses it reads a
-/// well-known URI as an ordinary path, which is the direction a path-confusion
-/// trick is written in. Only `unreserved` octets are decoded: decoding a
-/// `sub-delims` or a `gen-delims` octet would change where the component
-/// boundaries are, which is exactly what § 2.4 warns against.
-///
-/// Everything else is left as written, hexadecimal case included, because this
-/// value is compared and never printed. Private for the same reason as
-/// [`first_non_pchar`]; `helpers::uri::normalize_path_and_query` is the natural
-/// home, but it performs one of § 6.2.2's three normalizations today and
-/// widening it would change the verdicts of its existing callers.
-// cite(RFC 3986 § 2.3): "URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent"
-// cite(RFC 3986 § 6.2.2.2): "These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3."
-// cite(RFC 3986 § 2.4): "When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters."
-fn decode_unreserved(segment: &str) -> String {
-    let mut out = String::with_capacity(segment.len());
-    let mut chars = segment.char_indices();
-    while let Some((i, c)) = chars.next() {
-        // `get` and not a slice: a captured target read back through `lint` is
-        // an arbitrary string, so the two positions after a `%` may be inside a
-        // multi-byte code point, and indexing them would be a panic rather than
-        // a finding. The explicit `HEXDIG` test is not redundant either —
-        // `from_str_radix` accepts a leading `+`, which no `pct-encoded` writes.
-        let decoded = (c == '%')
-            .then(|| segment.get(i + 1..i + 3))
-            .flatten()
-            .filter(|hex| hex.bytes().all(|b| b.is_ascii_hexdigit()))
-            .and_then(|hex| u8::from_str_radix(hex, 16).ok())
-            .map(char::from)
-            .filter(|d| d.is_ascii_alphanumeric() || matches!(d, '-' | '.' | '_' | '~'));
-        match decoded {
-            Some(d) => {
-                out.push(d);
-                chars.next();
-                chars.next();
-            }
-            None => out.push(c),
-        }
-    }
-    out
-}
-
 /// Whether one path segment *is* the reserved segment.
 ///
 /// The literal comparison first, and the decode only when there is a `%` to
 /// decode: this predicate is asked of every segment of every request path, and
 /// the decoding path allocates.
+///
+/// `%2Ewell-known` and `.well-known` are the same segment — the generic syntax
+/// says so in as many words — and a comparison that misses it reads a well-known
+/// URI as an ordinary path, which is the direction a path-confusion trick is
+/// written in. Only `unreserved` octets are decoded, because decoding a
+/// `sub-delims` or `gen-delims` octet would move the component boundaries; that
+/// reasoning, and § 2.4's sentence, live with the shared decoder.
+///
+/// The decoder also puts a surviving triplet's hexadecimal in upper case, which
+/// cannot change this answer: `WELL_KNOWN_SEGMENT` is made of `unreserved`
+/// characters, so a segment still holding a `%` after the decode matches it in
+/// no case at all.
+// cite(RFC 3986 § 2.3): "URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent"
 fn is_well_known_segment(segment: &str) -> bool {
     segment == WELL_KNOWN_SEGMENT
-        || (segment.contains('%') && decode_unreserved(segment) == WELL_KNOWN_SEGMENT)
+        || (segment.contains('%')
+            && crate::helpers::uri::decode_unreserved(segment) == WELL_KNOWN_SEGMENT)
 }
 
 impl Rule for MessageWellKnownUriFormat {
@@ -564,27 +531,19 @@ mod tests {
         assert!(check("HTTPS://example.com/foo/.well-known/example").is_some());
     }
 
+    /// The predicate, not the decoder — that moved to `helpers::uri` with its
+    /// own tests. What stays here is the question this rule asks of it: an
+    /// escaped spelling of the reserved segment is the reserved segment, and an
+    /// escaped delimiter does not make an ordinary segment into it.
     #[test]
-    fn decode_unreserved_leaves_delimiters_encoded() {
-        // `%2F` is a `gen-delims` octet: decoding it would move a component
-        // boundary, which is the mistake RFC 3986 §2.4 names.
-        assert_eq!(decode_unreserved("a%2Fb"), "a%2Fb");
-        assert_eq!(decode_unreserved("a%2Cb"), "a%2Cb");
-        // An `unreserved` octet is decoded, in either hexadecimal case.
-        assert_eq!(decode_unreserved("%2Ewell%2dknown"), ".well-known");
-        // A truncated or non-hexadecimal run is left exactly as written; whether
-        // it is well formed is another rule's finding.
-        assert_eq!(decode_unreserved("%2"), "%2");
-        assert_eq!(decode_unreserved("%zz"), "%zz");
-        assert_eq!(decode_unreserved("%%41"), "%A");
-        // `from_str_radix` would read this as %x0A; no `pct-encoded` writes a
-        // sign, so the two characters are measured against `HEXDIG` first.
-        assert_eq!(decode_unreserved("%+A"), "%+A");
-        // A captured target read back through `lint` is an arbitrary string:
-        // the two positions after a `%` can be inside a multi-byte code point,
-        // and slicing them would panic.
-        assert_eq!(decode_unreserved("%é4"), "%é4");
-        assert_eq!(decode_unreserved("café"), "café");
+    fn an_escaped_spelling_of_the_reserved_segment_is_the_reserved_segment() {
+        assert!(is_well_known_segment(".well-known"));
+        assert!(is_well_known_segment("%2Ewell%2Dknown"));
+        assert!(is_well_known_segment("%2ewell-known"));
+        // `%2F` is a `gen-delims` octet and stays encoded, so this is a segment
+        // whose name merely contains the text — not the reserved one.
+        assert!(!is_well_known_segment("%2Fwell-known"));
+        assert!(!is_well_known_segment(".well-knownfoo"));
     }
 
     #[test]

--- a/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -113,6 +113,14 @@ fn parse_allowed_config(
 
 /// The `protocol-id` written back out as the octets it stands for.
 ///
+/// **Deliberately not `helpers::uri::decode_unreserved`, and the two must not be
+/// folded.** That function decodes an `unreserved` triplet and leaves every
+/// other one alone, because § 2.4 warns that decoding a delimiter moves the
+/// component boundaries. This one decodes them all, because § 3.1 makes an ALPN
+/// protocol name an opaque octet sequence — there are no components inside it
+/// for a decoded delimiter to bound. One question, two callers, two answers,
+/// each resting on its own sentence.
+///
 /// RFC 7838 § 3 makes the production a percent-*encoding* of the name rather
 /// than the name itself, and its own escaping table is the round trip:
 /// `w%3Dx%3Ay#z` is the ALPN protocol name `w=x:y#z`. So every triplet is

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -998,14 +998,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 59
-  - label: client_request_uri_percent_encoding_valid (5)
-    section: § 2.4
-    snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
-    cited_by:
-    - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
-      line: 60
-    - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 71
   - label: query
     section: § 3.4
     snippet: query       = *( pchar / "/" / "?" )
@@ -1033,7 +1025,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 77
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 774
+      line: 851
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 142
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
@@ -1043,7 +1035,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 78
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 775
+      line: 852
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 2
     snippet: A URI is composed from a limited set of characters consisting of digits, letters, and a few graphic symbols.
@@ -1093,7 +1085,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 57
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 130
+      line: 138
   - label: lint-http-rules/src/helpers/uri.rs (7)
     section: § 2.2
     snippet: A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component.
@@ -1113,17 +1105,25 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 86
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 692
+      line: 769
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 55
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 244
+      line: 205
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 447
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 135
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 39
+  - label: lint-http-rules/src/helpers/uri.rs (9)
+    section: § 2.3
+    snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 553
+    - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
+      line: 70
   - label: unreserved
     section: § 2.3
     snippet: unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
@@ -1131,37 +1131,45 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 84
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 691
-    - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 107
+      line: 552
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 768
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 38
-  - label: lint-http-rules/src/helpers/uri.rs (9)
+  - label: lint-http-rules/src/helpers/uri.rs (10)
+    section: § 2.4
+    snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 556
+    - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
+      line: 60
+  - label: lint-http-rules/src/helpers/uri.rs (11)
     section: § 3.1
     snippet: Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 665
-  - label: lint-http-rules/src/helpers/uri.rs (10)
+      line: 742
+  - label: lint-http-rules/src/helpers/uri.rs (12)
     section: § 3.1
     snippet: scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 168
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 664
+      line: 741
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 728
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 247
-  - label: lint-http-rules/src/helpers/uri.rs (11)
+  - label: lint-http-rules/src/helpers/uri.rs (13)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 187
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 557
+      line: 634
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 33
   - label: authority grammar
@@ -1170,70 +1178,70 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 142
-  - label: lint-http-rules/src/helpers/uri.rs (12)
+  - label: lint-http-rules/src/helpers/uri.rs (14)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 144
-  - label: lint-http-rules/src/helpers/uri.rs (13)
+  - label: lint-http-rules/src/helpers/uri.rs (15)
     section: § 3.2.1
     snippet: userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 143
-  - label: lint-http-rules/src/helpers/uri.rs (14)
+  - label: lint-http-rules/src/helpers/uri.rs (16)
     section: § 3.2.2
     snippet: IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 695
-  - label: lint-http-rules/src/helpers/uri.rs (15)
+      line: 772
+  - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2.2
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 739
-  - label: lint-http-rules/src/helpers/uri.rs (16)
+      line: 816
+  - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.2
     snippet: host        = IP-literal / IPv4address / reg-name
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 689
+      line: 766
   - label: reg-name
     section: § 3.2.2
     snippet: reg-name    = *( unreserved / pct-encoded / sub-delims )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 690
+      line: 767
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 107
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 243
+      line: 204
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
       line: 479
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 139
-  - label: lint-http-rules/src/helpers/uri.rs (17)
+  - label: lint-http-rules/src/helpers/uri.rs (19)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 776
+      line: 853
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 801
+      line: 878
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 51
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
       line: 393
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 151
-  - label: lint-http-rules/src/helpers/uri.rs (18)
+  - label: lint-http-rules/src/helpers/uri.rs (20)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 802
+      line: 879
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
@@ -1244,7 +1252,7 @@ sources:
       line: 105
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 37
-  - label: lint-http-rules/src/helpers/uri.rs (19)
+  - label: lint-http-rules/src/helpers/uri.rs (21)
     section: § 4.2
     snippet: A path segment that contains a colon character (e.g., "this:that") cannot be used as the first segment of a relative-path reference, as it would be mistaken for a scheme name.
     cited_by:
@@ -1254,38 +1262,52 @@ sources:
       line: 91
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 248
-  - label: lint-http-rules/src/helpers/uri.rs (20)
+  - label: lint-http-rules/src/helpers/uri.rs (22)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 550
-  - label: lint-http-rules/src/helpers/uri.rs (21)
+      line: 627
+  - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 5.2.3
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 532
-  - label: lint-http-rules/src/helpers/uri.rs (22)
+      line: 609
+  - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 5.2.3
     snippet: return a string consisting of the reference's path component appended to all but the last segment of the base URI's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 536
-  - label: lint-http-rules/src/helpers/uri.rs (23)
+      line: 613
+  - label: lint-http-rules/src/helpers/uri.rs (25)
     section: § 5.2.4
     snippet: This is done after the path is extracted from a reference, whether or not the path was relative, in order to remove any invalid or extraneous dot-segments prior to forming the target URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 474
-  - label: lint-http-rules/src/helpers/uri.rs (24)
+  - label: lint-http-rules/src/helpers/uri.rs (26)
+    section: § 6.2.2.1
+    snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 555
+    - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
+      line: 91
+  - label: lint-http-rules/src/helpers/uri.rs (27)
+    section: § 6.2.2.2
+    snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 554
+  - label: lint-http-rules/src/helpers/uri.rs (28)
     section: § 6.2.2.3
     snippet: URI normalizers should remove dot-segments by applying the remove_dot_segments algorithm to the path, as described in Section 5.2.4.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 523
+      line: 600
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 192
+      line: 159
   - label: message_content_location_and_uri_consistency
     section: § 6.2.2.1
     snippet: The other generic syntax components are assumed to be case-sensitive unless specifically defined otherwise by the scheme (see Section 6.2.3).
@@ -1293,7 +1315,7 @@ sources:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 189
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 182
+      line: 149
   - label: message_content_location_and_uri_consistency (2)
     section: § 6.2.2.1
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
@@ -1303,20 +1325,6 @@ sources:
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 193
   - label: message_host_and_authority_consistency
-    section: § 6.2.2.1
-    snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 106
-  - label: message_host_and_authority_consistency (2)
-    section: § 6.2.2.2
-    snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 105
-    - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 70
-  - label: message_host_and_authority_consistency (3)
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
     cited_by:
@@ -1367,29 +1375,23 @@ sources:
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
       line: 128
   - label: message_well_known_uri_format
-    section: § 2.3
-    snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
-    cited_by:
-    - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 69
-  - label: message_well_known_uri_format (2)
     section: § 3.3
     snippet: The path is terminated by the first question mark ("?") or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 168
+      line: 135
   - label: path-absolute
     section: § 3.3
     snippet: path-absolute = "/" [ segment-nz *( "/" segment ) ]
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 181
+      line: 148
   - label: segment-nz
     section: § 3.3
     snippet: segment-nz    = 1*pchar
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 267
+      line: 234
   - label: server_location_header_uri_valid
     section: § 4.1
     snippet: URI-reference = URI / relative-ref
@@ -3164,7 +3166,7 @@ sources:
     snippet: In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 307
+      line: 315
   - label: server_alt_svc_protocol_iana_registered (5)
     section: § 6
     snippet: 'Identification Sequence: The precise set of octet values that identifies the protocol.'
@@ -3308,7 +3310,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 374
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 185
+      line: 193
   - label: server_alt_svc_h3_advertisement_valid (3)
     section: § 3.1
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
@@ -3348,7 +3350,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 388
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 208
+      line: 216
   - label: server_alt_svc_header_syntax (5)
     section: § 3
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
@@ -3386,7 +3388,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 51
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 129
+      line: 137
   - label: server_alt_svc_header_syntax (11)
     section: § 3
     snippet: The "alt-authority" component consists of an OPTIONAL uri-host ("host" in Section 3.2.2 of [RFC3986]), a colon (":"), and a port number.
@@ -3432,7 +3434,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 32
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 248
+      line: 256
   - label: server_alt_svc_header_syntax (18)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
@@ -3440,7 +3442,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 314
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 259
+      line: 267
   - label: server_alt_svc_header_syntax (19)
     section: § 3
     snippet: clear         = %s"clear"; "clear", case-sensitive
@@ -3450,7 +3452,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 321
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 227
+      line: 235
   - label: server_alt_svc_header_syntax (20)
     section: § 3
     snippet: parameter     = token "=" ( token / quoted-string )
@@ -3464,7 +3466,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 315
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 127
+      line: 135
   - label: server_alt_svc_header_syntax (22)
     section: § 3.1
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
@@ -3494,25 +3496,25 @@ sources:
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 305
+      line: 313
   - label: server_alt_svc_protocol_iana_registered (2)
     section: § 2
     snippet: The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 306
+      line: 314
   - label: server_alt_svc_protocol_iana_registered (3)
     section: § 2.4
     snippet: If the connection to the alternative service does not negotiate the expected protocol (for example, ALPN fails to negotiate h2, or an Upgrade request to h2c is not accepted), the connection to the alternative service MUST be considered to have failed.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 308
+      line: 316
   - label: server_alt_svc_protocol_iana_registered (4)
     section: § 3
     snippet: ALPN protocol names are octet sequences with no additional constraints on format.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 128
+      line: 136
 - label: RFC 8187
   url: https://www.rfc-editor.org/rfc/rfc8187.txt
   type: text/plain
@@ -3930,79 +3932,79 @@ sources:
     snippet: Furthermore, defining well-known locations usurps the origin's control over its own URI space [RFC7320].
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 237
+      line: 204
   - label: message_well_known_uri_format (2)
     section: § 1
     snippet: To address these uses, this memo reserves a path prefix in HTTP, HTTPS, WebSocket (WS), and Secure WebSocket (WSS) URIs for these "well-known locations", "/.well-known/".
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 249
+      line: 216
   - label: message_well_known_uri_format (3)
     section: § 1
     snippet: Well-known URIs can also be used with other URI schemes, but only when those schemes' definitions explicitly allow it.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 153
+      line: 120
   - label: message_well_known_uri_format (4)
     section: § 3
     snippet: A well-known URI is a URI [RFC3986] whose path component begins with the characters "/.well-known/", provided that the scheme is explicitly defined to support well-known URIs.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 151
+      line: 118
   - label: message_well_known_uri_format (5)
     section: § 3
     snippet: Also, this specification does not define a format or media type for the resource located at "/.well-known/", and clients should not expect a resource to exist at that location.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 268
+      line: 235
   - label: message_well_known_uri_format (6)
     section: § 3
     snippet: Applications that wish to mint new well-known URIs MUST register them, following the procedures in Section 5.1, subject to the following requirements.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 124
+      line: 91
   - label: message_well_known_uri_format (7)
     section: § 3
     snippet: For example, "/.well-known/example" is a well-known URI, whereas "/foo/.well-known/example" is not.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 236
+      line: 203
   - label: message_well_known_uri_format (8)
     section: § 3
     snippet: Registered names MUST conform to the "segment-nz" production in [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 266
+      line: 233
   - label: message_well_known_uri_format (9)
     section: § 3
     snippet: Registrations MAY also contain additional information, such as the syntax of additional path components, query strings, and/or fragment identifiers to be appended to the well-known URI
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 282
+      line: 249
   - label: message_well_known_uri_format (10)
     section: § 3
     snippet: This means they cannot contain the "/" character.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 281
+      line: 248
   - label: message_well_known_uri_format (11)
     section: § 3
     snippet: This specification updates the "http" [RFC7230] and "https" [RFC7230] schemes to support well-known URIs.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 152
+      line: 119
   - label: message_well_known_uri_format (12)
     section: § 3
     snippet: Well-known URIs are rooted in the top of the path's hierarchy; they are not well-known by definition in other parts of the path.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 235
+      line: 202
   - label: message_well_known_uri_format (13)
     section: § 5.2
     snippet: If a URI scheme explicitly has been specified to use well-known URIs as per Section 3, the value changes to a reference to that specification.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 154
+      line: 121
 - label: RFC 9000
   url: https://www.rfc-editor.org/rfc/rfc9000.txt
   type: text/plain
@@ -4484,7 +4486,7 @@ sources:
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
       line: 162
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 242
+      line: 203
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 180
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
@@ -5302,7 +5304,7 @@ sources:
     - file: lint-http-rules/src/rules/message_etag_syntax.rs
       line: 77
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 256
+      line: 217
     - file: lint-http-rules/src/rules/message_retry_after_date_or_delay.rs
       line: 34
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
@@ -5334,7 +5336,7 @@ sources:
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
       line: 99
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 282
+      line: 243
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 88
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
@@ -5452,7 +5454,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 316
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 266
+      line: 274
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 376
   - label: OWS grammar
@@ -5826,7 +5828,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 800
+      line: 877
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 161
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -5842,7 +5844,7 @@ sources:
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 203
+      line: 164
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 210
   - label: lint-http-rules/src/helpers/uri.rs (3)
@@ -7792,7 +7794,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 375
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 186
+      line: 194
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 61
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
@@ -7804,7 +7806,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 407
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 218
+      line: 226
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 175
   - label: server_authentication_challenge_validity
@@ -8836,7 +8838,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 13
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 167
+      line: 134
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 3.3
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
@@ -8946,7 +8948,7 @@ sources:
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 204
+      line: 165
   - label: message_http_version_syntax_valid
     section: § 3
     snippet: A request-line begins with a method token, followed by a single space (SP), the request-target, and another single space (SP), and ends with the protocol version.
@@ -9214,7 +9216,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 160
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 241
+      line: 202
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 234
   - label: client_request_target_form_checks (2)
@@ -9282,27 +9284,27 @@ sources:
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 366
+      line: 327
   - label: message_host_and_authority_consistency (2)
     section: § 8.3.1
     snippet: An origin server can apply any normalization method, whereas other servers MUST perform scheme-based normalization (see Section 6.2.3 of [RFC3986]) of the two fields.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 344
+      line: 305
   - label: message_host_and_authority_consistency (3)
     section: § 8.3.1
     snippet: Clients MUST NOT generate a request with a Host header field that differs from the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 181
+      line: 142
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 365
+      line: 326
   - label: message_host_and_authority_consistency (4)
     section: § 8.3.1
     snippet: The ":authority" pseudo-header field conveys the authority portion (Section 3.2 of [RFC3986]) of the target URI (Section 7.1 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 224
+      line: 185
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 274
   - label: message_host_and_authority_consistency (5)
@@ -9310,7 +9312,7 @@ sources:
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 343
+      line: 304
   - label: message_http2_pseudo_headers_validity
     section: § 8.2.1
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
@@ -9518,17 +9520,17 @@ sources:
     snippet: If both fields are present, they MUST contain the same value.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 345
+      line: 306
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 367
+      line: 328
   - label: message_host_and_authority_consistency (2)
     section: § 4.3.1
     snippet: If the :scheme pseudo-header field identifies a scheme that has a mandatory authority component (including "http" and "https"), the request MUST contain either an :authority pseudo-header field or a Host header field.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 255
+      line: 216
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 308
+      line: 269
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
       line: 122
   - label: message_host_and_authority_consistency (3)
@@ -9536,7 +9538,7 @@ sources:
     snippet: If these fields are present, they MUST NOT be empty.
     cited_by:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
-      line: 309
+      line: 270
   - label: message_http3_no_connection_header
     section: § 4.2
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.


### PR DESCRIPTION
…was read

`helpers::uri::decode_unreserved` performs §6.2.2's two percent-encoding normalizations on one URI component: every triplet standing for an `unreserved` character written as that character, and the hexadecimal of every triplet that stays encoded in upper case. Two rules had a copy.

The row's count was right — the first in six that was — and a name grep still found only one of the two. The second was spelled `decoded_unreserved`, an associated function one letter away. Grep the shape, not the name.

The two copies were not identical. The well-known one decodes `unreserved` and leaves everything else as written, hexadecimal case included, because its value is compared and never printed; the authority one also uppercases the hexadecimal of surviving triplets. Sharing means applying that step everywhere, which cannot change the well-known verdict: `WELL_KNOWN_SEGMENT` is made of `unreserved` characters, so a segment still holding a `%` after the decode matches it in no case at all.

What the extraction found is that the step was undone one line after it was performed. The authority caller wrote
`decoded_unreserved(host).to_ascii_lowercase()`, and that fold reaches the hexadecimal the function had just uppercased — `%2F` came back out as `%2f`. So §6.2.2.1 was cited on the function and contradicted by its only call. No verdict was wrong, both sides of the comparison being folded the same way; what was wrong is the normal form the finding prints and the description describes. It stayed invisible while the decoder was private, because the only thing ever looked at was whether two values compared equal.

The order is forced in both directions, which is why the fix is a second pass and not a swap. Decoding has to run before the fold, since `%50` is `P` and only a fold after the decode makes `EXAM%50LE.com` and `example.com` one host; the fold then damages what the decode normalized. The second pass re-uppercases the survivors and can decode nothing new — every `unreserved` triplet went in the first pass, and the one triplet that could reintroduce a percent sign, `%25`, is not `unreserved` and is re-emitted as `%25`.

The two decoders stay two, which the row decided and both ends now say. `decode_unreserved` takes `unreserved` triplets and no others because §2.4 warns that decoding a delimiter moves the component boundaries; `alpn_protocol_name` takes them all because RFC 7301 §3.1 makes an ALPN protocol name an opaque octet sequence with no components for a delimiter to bound. It stays private too: one caller, and a shared answer moves on the second.

The new function sits beside `normalize_path_and_query` rather than inside it — that one is §6.2.2.3's dot-segment removal and is named for all three, which is P20's row, and folding them would widen what every one of its callers compares.

Cites 2163 → 2164.
