### PR TITLE
One walk over the interior, and the flag the handover asked for has n…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -1114,30 +1114,14 @@ pub fn quoted_string_end(s: &str) -> Option<usize> {
     None
 }
 
-/// Validate a quoted-string per HTTP rules: must start and end with DQUOTE, support backslash escapes,
-/// must not contain unescaped control characters (except HTAB). Returns Ok(()) on success, Err(msg)
-/// on failure.
-///
-/// The two octet sets below are worth reading side by side, because the whole
-/// function is the difference between them. `qdtext` is what may appear bare;
-/// `quoted-pair` is what may appear after a backslash. HTAB and obs-text are in
-/// both -- HTTP is not Structured Fields, and the same-looking helper in
-/// `structured_fields.rs` is right to reject exactly what this one accepts.
-///
-/// The two DQUOTEs of the production are stripped by [`quoted_string_interior`],
-/// which both this function and [`unescape_quoted_string`] ask, so what counts
-/// as "properly quoted" is decided once.
-///
-/// The walk is over `chars` and not over `as_bytes`, and the difference is the
-/// whole of `obs-text`. A caller reading a value through
-/// [`combined_field_value_as_written`] holds one `char` per octet, so %xE9 in it
-/// is `U+00E9` -- which `as_bytes` re-encodes as the *two* octets %xC3 %xA9, a
-/// pair the sender did not write. `to_str` callers cannot tell the two walks
-/// apart, because that reader admits no octet at or above %x80 in the first
-/// place.
-///
 /// The `*( qdtext / quoted-pair )` between a `quoted-string`'s two DQUOTEs,
 /// with nothing inside it examined.
+///
+/// The five paragraphs that used to stand above this line described
+/// [`validate_quoted_string`] — its two octet sets, its `chars`-not-`as_bytes`
+/// walk — and were separated from it by two other items, so `rustdoc` published
+/// them against a function that strips two characters and reads none. They now
+/// live on [`quoted_string_interior_chars`], which is where that walk went.
 ///
 /// A lone DQUOTE strips its prefix and then has no suffix left to strip, so the
 /// one-character string is `None` rather than an empty interior — which is the
@@ -1150,43 +1134,145 @@ pub fn quoted_string_interior(val: &str) -> Option<&str> {
     val.strip_prefix('"')?.strip_suffix('"')
 }
 
+/// What a `quoted-string`'s interior can fail to be.
+///
+/// Data rather than a sentence for the same reason [`WordDefect`] is: the two
+/// functions that read this interior word their failures against the whole
+/// value, and the walk sees only the inside of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuotedStringDefect {
+    /// An octet after a backslash that `quoted-pair` does not admit. A backslash
+    /// does not make anything quotable: the escaped octet has its own set, and
+    /// it is not `qdtext`'s.
+    BadQuotedPair,
+    /// A DQUOTE inside the interior that no backslash introduced. The interior
+    /// runs between the production's two DQUOTEs, so a third one closes the
+    /// value early and what follows derives from nothing.
+    UnescapedQuote,
+    /// A control octet `qdtext` excludes. HTAB is not one of them — it is in
+    /// both alphabets.
+    ControlCharacter,
+    /// A backslash with nothing after it. `quoted-pair` is two octets.
+    TrailingEscape,
+}
+
+impl QuotedStringDefect {
+    /// The finding, worded against the whole `quoted-string` rather than against
+    /// the interior the walk was given — which is what every caller embedding
+    /// this in its own message expects to read.
+    pub fn message(self, val: &str) -> String {
+        match self {
+            Self::BadQuotedPair => format!("Invalid quoted-pair in quoted-string: '{}'", val),
+            Self::UnescapedQuote => format!("Unescaped quote in quoted-string: '{}'", val),
+            Self::ControlCharacter => format!("Control character in quoted-string: '{}'", val),
+            Self::TrailingEscape => format!("Quoted-string ends with escape character: '{}'", val),
+        }
+    }
+}
+
+/// The one walk over a `quoted-string`'s interior, yielding each character of
+/// the value it stands for.
+///
+/// **This pair used to be two walks and the cost was visible from outside.**
+/// [`validate_quoted_string`] measured the interior and [`unescape_quoted_string`]
+/// called it and then measured the interior again to substitute, so every caller
+/// that wanted the content paid for two passes and the second one needed an
+/// `expect` to throw away an `Err` the first had already ruled out. Two owners
+/// for one production is also how they drift: a `quoted-pair` fix had to be made
+/// in both, in lockstep, and nothing but attention held them together.
+///
+/// The walk is over `chars` and not over `as_bytes`, and the difference is the
+/// whole of `obs-text`. A caller reading a value through
+/// [`combined_field_value_as_written`] holds one `char` per octet, so %xE9 in it
+/// is `U+00E9` — which `as_bytes` re-encodes as the *two* octets %xC3 %xA9, a
+/// pair the sender did not write. `to_str` callers cannot tell the two walks
+/// apart, because that reader admits no octet at or above %x80 at all.
+///
+/// The two octet sets are worth reading side by side, because the difference
+/// between them is the whole of this function. `qdtext` is what may appear bare;
+/// `quoted-pair` is what may appear after a backslash. HTAB and `obs-text` are in
+/// both — HTTP is not Structured Fields, and the same-looking helper in
+/// `structured_fields.rs` is right to reject exactly what this one accepts.
+///
+/// Substitution is unconditional and there is no escape table here, nor should
+/// there ever be: the sentence is about the octet *following* the backslash and
+/// not about any interpretation of it, so `\n` in a `quoted-string` is the
+/// letter n.
+///
+/// The iterator stops at the first defect, which is what makes a caller
+/// collecting it and a caller draining it report the same thing.
+///
+/// **It yields the character and not `(char, was_escaped)`**, which is what the
+/// handover asking for this scanner specified. Nothing in the tree distinguishes
+/// an octet a backslash introduced from the same octet written bare, and neither
+/// does the production: a `quoted-pair` *is* the octet after the backslash, by
+/// the recipient sentence below. The two functions here differ in whether they
+/// keep the character, not in whether they know how it got there, so a flag no
+/// caller reads would be a second answer to a question nobody asks. It goes in
+/// when a caller needs it, like every other shared answer in this module.
+///
 // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
 // cite(RFC 9110 § 5.6.4): "qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text"
+// cite(RFC 9110 § 5.6.4): "quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )"
+// cite(RFC 9110 § 5.6.4): "Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash."
+pub fn quoted_string_interior_chars(inner: &str) -> QuotedStringChars<'_> {
+    QuotedStringChars {
+        chars: inner.chars(),
+        stopped: false,
+    }
+}
+
+/// [`quoted_string_interior_chars`]'s iterator.
+pub struct QuotedStringChars<'a> {
+    chars: std::str::Chars<'a>,
+    stopped: bool,
+}
+
+impl Iterator for QuotedStringChars<'_> {
+    type Item = Result<char, QuotedStringDefect>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stopped {
+            return None;
+        }
+        let c = self.chars.next()?;
+
+        if c == '\\' {
+            let Some(escaped) = self.chars.next() else {
+                self.stopped = true;
+                return Some(Err(QuotedStringDefect::TrailingEscape));
+            };
+            if !(escaped == '\t' || ('\u{20}'..='\u{7e}').contains(&escaped) || escaped >= '\u{80}')
+            {
+                self.stopped = true;
+                return Some(Err(QuotedStringDefect::BadQuotedPair));
+            }
+            return Some(Ok(escaped));
+        }
+        if c == '"' {
+            self.stopped = true;
+            return Some(Err(QuotedStringDefect::UnescapedQuote));
+        }
+        if (c < '\u{20}' && c != '\t') || c == '\u{7f}' {
+            self.stopped = true;
+            return Some(Err(QuotedStringDefect::ControlCharacter));
+        }
+        Some(Ok(c))
+    }
+}
+
+/// Whether the value is a well-formed `quoted-string`, with nothing kept.
+///
+/// The walk is [`quoted_string_interior_chars`]'s and is run once; a caller that
+/// also wants the content asks [`unescape_quoted_string`] instead of asking
+/// both.
 pub fn validate_quoted_string(val: &str) -> Result<(), String> {
     let Some(inner) = quoted_string_interior(val) else {
         return Err(format!("Quoted-string not properly quoted: '{}'", val));
     };
-
-    // Walk the interior checking for unescaped control chars and ensuring proper escaping
-    let mut prev_backslash = false;
-    for c in inner.chars() {
-        if prev_backslash {
-            // A backslash does not make anything quotable. The escaped octet has its
-            // own set, and it is not the same as qdtext's: SP and VCHAR and HTAB and
-            // obs-text may follow a backslash, the remaining controls may not.
-            //
-            // cite(RFC 9110 § 5.6.4): "quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )"
-            if !(c == '\t' || ('\u{20}'..='\u{7e}').contains(&c) || c >= '\u{80}') {
-                return Err(format!("Invalid quoted-pair in quoted-string: '{}'", val));
-            }
-            prev_backslash = false;
-        } else if c == '\\' {
-            prev_backslash = true;
-        } else if c == '"' {
-            // unescaped quote before the terminating one -> invalid
-            return Err(format!("Unescaped quote in quoted-string: '{}'", val));
-        } else if (c < '\u{20}' && c != '\t') || c == '\u{7f}' {
-            return Err(format!("Control character in quoted-string: '{}'", val));
-        }
+    for step in quoted_string_interior_chars(inner) {
+        step.map_err(|defect| defect.message(val))?;
     }
-
-    if prev_backslash {
-        return Err(format!(
-            "Quoted-string ends with escape character: '{}'",
-            val
-        ));
-    }
-
     Ok(())
 }
 
@@ -1207,40 +1293,20 @@ pub fn quoted_string_inner_trimmed_is_empty(val: &str) -> Result<bool, String> {
 /// - Input must include surrounding DQUOTE characters (e.g., `"a\"b"`).
 /// - Returns `Ok(inner_string)` on success or `Err(msg)` if the input is not a valid quoted-string.
 ///
-/// This helper centralizes quoted-string unescaping to avoid duplication across rules.
-///
-/// Unlike its neighbours, the sentence below is not a grammar -- it is an
-/// instruction about what a recipient must *do*, and every caller here is a
-/// recipient. It also says why the substitution is unconditional: the octet
-/// following the backslash, not some interpretation of it, which is why there is
-/// no escape table in this function and should never be one. `\n` in a
-/// quoted-string is the letter n.
-///
-/// The walk is [`validate_quoted_string`]'s, and over `chars` for the same
-/// reason: `as_bytes` re-encoded a value already holding one `char` per octet,
-/// so an `obs-text` octet inside a `quoted-string` -- which `qdtext` admits --
-/// came back out as the two octets of its UTF-8 form and every finding naming
-/// it named a pair nobody wrote.
-///
-// cite(RFC 9110 § 5.6.4): "Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash."
+/// **One pass.** This used to call [`validate_quoted_string`] and then walk the
+/// interior a second time to substitute, which is two readings of one production
+/// and needed an `expect` to discard an `Err` the first reading had already ruled
+/// out. Both functions now drain [`quoted_string_interior_chars`], which measures
+/// and substitutes in the same step, so the pair cannot disagree and neither pays
+/// for the other.
 pub fn unescape_quoted_string(val: &str) -> Result<String, String> {
-    validate_quoted_string(val)?;
-    let inner = quoted_string_interior(val).expect("validation accepted the quoting");
+    let Some(inner) = quoted_string_interior(val) else {
+        return Err(format!("Quoted-string not properly quoted: '{}'", val));
+    };
     let mut out = String::with_capacity(inner.len());
-    let mut prev_backslash = false;
-    for c in inner.chars() {
-        // One statement, because the sentence cited above is one: a backslash
-        // that is not itself escaped is consumed, and everything else -- escaped
-        // or not -- is the octet it is. A trailing backslash cannot reach the end
-        // of this loop, because the validation above rejects that value.
-        if !prev_backslash && c == '\\' {
-            prev_backslash = true;
-        } else {
-            out.push(c);
-            prev_backslash = false;
-        }
+    for step in quoted_string_interior_chars(inner) {
+        out.push(step.map_err(|defect| defect.message(val))?);
     }
-
     Ok(out)
 }
 
@@ -2550,6 +2616,84 @@ mod tests {
             token_or_quoted_string(&bare),
             Err(WordDefect::NotToken('\u{E9}'))
         );
+    }
+
+    /// The one walk, read directly: each character of the value the interior
+    /// stands for.
+    #[test]
+    fn quoted_string_interior_chars_yields_the_octet_the_quoted_pair_stands_for() {
+        let read = |inner: &str| quoted_string_interior_chars(inner).collect::<Vec<_>>();
+        assert_eq!(
+            read("a\\\"b"),
+            vec![Ok('a'), Ok('"'), Ok('b')],
+            "an escaped DQUOTE is a quoted-pair and the value it stands for is the DQUOTE"
+        );
+        // Substitution is unconditional: the octet following the backslash, not
+        // an interpretation of it. `\n` is the letter n.
+        assert_eq!(read("\\n"), vec![Ok('n')]);
+        // HTAB is in both alphabets, bare and escaped.
+        assert_eq!(read("\t"), vec![Ok('\t')]);
+        assert_eq!(read("\\\t"), vec![Ok('\t')]);
+    }
+
+    /// Each defect, and that the walk stops on the first one — which is what
+    /// makes a caller draining it and a caller collecting it report the same
+    /// thing.
+    #[test]
+    fn quoted_string_interior_chars_stops_at_the_first_defect() {
+        let first = |inner: &str| {
+            quoted_string_interior_chars(inner)
+                .find(|step| step.is_err())
+                .map(|step| step.unwrap_err())
+        };
+        assert_eq!(first("a\"b"), Some(QuotedStringDefect::UnescapedQuote));
+        assert_eq!(first("a\u{1}b"), Some(QuotedStringDefect::ControlCharacter));
+        assert_eq!(first("a\u{7f}"), Some(QuotedStringDefect::ControlCharacter));
+        assert_eq!(first("a\\"), Some(QuotedStringDefect::TrailingEscape));
+        assert_eq!(first("a\\\u{1}"), Some(QuotedStringDefect::BadQuotedPair));
+        assert_eq!(first("plain"), None);
+
+        // Nothing is yielded after the defect, so a collector cannot see past it.
+        let after: Vec<_> = quoted_string_interior_chars("a\"bcd").collect();
+        assert_eq!(after.len(), 2, "the 'a', then the defect, then nothing");
+    }
+
+    /// The pair used to be two walks and could disagree; now one drains the
+    /// scanner and the other collects it, so every value they are given gets one
+    /// verdict. `obs-text` is the case that matters: `qdtext` admits it, and a
+    /// byte walk would have split it into two octets nobody sent.
+    #[test]
+    fn validate_and_unescape_agree_on_every_value_because_they_are_one_walk() {
+        let cases = [
+            "\"\"",
+            "\"a\"",
+            "\"a\\\"b\"",
+            "\"a\\\\b\"",
+            "\"\t\"",
+            "\"a\"b\"",
+            "\"a\u{1}\"",
+            "\"a\\\"",
+            "\"unterminated",
+            "a\"",
+            "\"",
+            "",
+        ];
+        for case in cases {
+            assert_eq!(
+                validate_quoted_string(case).is_ok(),
+                unescape_quoted_string(case).is_ok(),
+                "the two disagreed on {:?}",
+                case
+            );
+            if let Err(v) = validate_quoted_string(case) {
+                assert_eq!(
+                    Some(v),
+                    unescape_quoted_string(case).err(),
+                    "same value, two messages, for {:?}",
+                    case
+                );
+            }
+        }
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2031
+      line: 2097
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2026
+      line: 2092
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2025
+      line: 2091
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -2033,7 +2033,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2027
+      line: 2093
     - file: lint-http-rules/src/helpers/uri.rs
       line: 222
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3524,25 +3524,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1590
+      line: 1656
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1531
+      line: 1597
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1569
+      line: 1635
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1562
+      line: 1628
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -5228,7 +5228,7 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1499
+      line: 1565
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -5260,7 +5260,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 211
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1297
+      line: 1363
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 64
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -5290,7 +5290,7 @@ sources:
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1298
+      line: 1364
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -5326,7 +5326,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1760
+      line: 1826
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5378,7 +5378,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1295
+      line: 1361
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
       line: 124
   - label: lint-http-rules/src/helpers/headers.rs (12)
@@ -5386,7 +5386,7 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1296
+      line: 1362
   - label: 1#element expansion
     section: § 5.6.1.1
     snippet: 1#element => element *( OWS "," OWS element )
@@ -5426,7 +5426,7 @@ sources:
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1360
+      line: 1426
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5438,7 +5438,7 @@ sources:
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1361
+      line: 1427
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -5468,7 +5468,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 950
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1689
+      line: 1755
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
@@ -5486,7 +5486,7 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1421
+      line: 1487
   - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
@@ -5498,13 +5498,13 @@ sources:
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1225
+      line: 1217
   - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1154
+      line: 1215
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5518,7 +5518,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1095
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1168
+      line: 1216
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 422
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
@@ -5532,11 +5532,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1094
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1148
+      line: 1132
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1153
+      line: 1214
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1362
+      line: 1428
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 316
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5554,7 +5554,7 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1979
+      line: 2045
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -5566,9 +5566,9 @@ sources:
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1687
+      line: 1753
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1714
+      line: 1780
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 380
   - label: lint-http-rules/src/helpers/headers.rs (24)
@@ -5576,11 +5576,11 @@ sources:
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1688
+      line: 1754
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1715
+      line: 1781
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1896
+      line: 1962
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5590,7 +5590,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1910
+      line: 1976
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 382
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5606,9 +5606,9 @@ sources:
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1686
+      line: 1752
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1759
+      line: 1825
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 379
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -5674,7 +5674,7 @@ sources:
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1841
+      line: 1907
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5700,7 +5700,7 @@ sources:
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1860
+      line: 1926
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5708,7 +5708,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1775
+      line: 1841
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 105
   - label: lint-http-rules/src/helpers/headers.rs (33)
@@ -5716,7 +5716,7 @@ sources:
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1840
+      line: 1906
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
@@ -5734,7 +5734,7 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1609
+      line: 1675
   - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".


### PR DESCRIPTION
…o reader

`quoted_string_interior_chars` is the single scanner over a `quoted-string`'s interior. `validate_quoted_string` drains it and keeps nothing; `unescape_quoted_string` collects it. The `expect("validation accepted the quoting")` the row named as the visible consequence is gone, and so is the second pass that made it necessary.

The row was right and its design was not. It asked for a scanner yielding `(char, was_escaped)`, and nothing in the tree distinguishes an octet a backslash introduced from the same octet written bare — nor does the production, since a `quoted-pair` is the octet after the backslash by §5.6.4's recipient sentence. The two functions differ in whether they keep the character, not in whether they know how it got there, so the flag would be a second answer to a question nobody asks. It goes in when a caller needs it. Six rows of re-deriving counts, and this is the same step one level up: derive the signature from the callers, not from the note that asked for it.

What the duplication cost was worse than the second pass. A `quoted-pair` fix had to be applied to both walks in lockstep, and nothing but attention held them together. The defect is data now — `BadQuotedPair`, `UnescapedQuote`, `ControlCharacter`, `TrailingEscape` — with `message(val)` wording it against the whole value, so every caller that embeds the reason in its own finding reads exactly what it read before. No message and no verdict changed.

The pair is now asserted to agree, over twelve values including the empty quoted-string, a lone DQUOTE, a trailing escape and an unterminated one. That test could not have meant anything while they were two walks: it would have been checking that two implementations happened to match.

Also: a doc block was published against the wrong function. The five paragraphs describing `validate_quoted_string` — its two octet sets, its chars-not-as_bytes walk, its relation to the Structured Fields sibling — stood above `quoted_string_interior`, separated from the function they describe by two other items, so rustdoc rendered them on a function that strips two characters and reads none, and `validate_quoted_string` had no documentation of its own. The tell is structural rather than textual: a doc comment whose first sentence names a function that is not the next item.

Cites unchanged at 2164 — four §5.6.4 sentences moved from the two functions onto the scanner that now reads them.
