### PR TITLE
Five readings of where an authority ends, and the uncited one read fo…

### DIFF
--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -149,6 +149,44 @@ pub fn split_userinfo(authority: &str) -> (Option<&str>, &str) {
     }
 }
 
+/// The `authority` a URI reference carries, or `None` when it carries none.
+///
+/// § 3.2's sentence is the whole of this function, in both directions: the
+/// component is *preceded* by a double slash and *terminated* by the next "/",
+/// "?" or "#" character, or by the end of the value. The two slashes are what
+/// the search is for, and a scheme in front of them is optional — both
+/// alternatives of the generic syntax that reach an authority open with them
+/// and only with them, `hier-part` and `relative-part` each writing
+/// `"//" authority path-abempty`.
+///
+/// **`Some("")` is an authority; `None` is the absence of one.** `host` may be
+/// a `reg-name`, which is `*( ... )`, so `http://` carries an empty authority
+/// where `http:/path` carries none — and RFC 9110 § 4.2.1's and § 4.2.2's MUST
+/// NOTs are about exactly the first of those, which is why the empty one is
+/// returned rather than folded away here. A caller that compares one authority
+/// against another has nothing to compare in that case and folds it itself;
+/// [`reference_authority`] is that caller, and says so at its own site.
+///
+/// The `//` must follow the scheme's colon immediately, which is why the scheme
+/// is taken with [`scheme_prefix`] rather than by looking for a `://`: in
+/// `a:b://c` the scheme is `a` and `b://c` is a `path-rootless`, so the value
+/// carries no authority at all.
+// cite(RFC 3986 § 4.3, label: absolute-URI): "absolute-URI  = scheme ":" hier-part [ "?" query ]"
+// cite(RFC 3986 § 3): "hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty"
+// cite(RFC 3986 § 4.2, label: relative-part): "relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty"
+// cite(RFC 3986 § 3.2): "The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI."
+// cite(RFC 3986 § 3.2.2): "reg-name    = *( unreserved / pct-encoded / sub-delims )"
+pub fn authority_component(value: &str) -> Option<&str> {
+    let after_slashes = match scheme_prefix(value) {
+        Some(scheme) => value[scheme.len() + 1..].strip_prefix("//")?,
+        None => value.strip_prefix("//")?,
+    };
+    let end = after_slashes
+        .find(['/', '?', '#'])
+        .unwrap_or(after_slashes.len());
+    Some(&after_slashes[..end])
+}
+
 /// Byte offset of the `://` that separates a scheme from an authority, or
 /// `None` when the value is not in absolute form.
 ///
@@ -178,31 +216,30 @@ pub fn scheme_authority_marker(s: &str) -> Option<usize> {
 /// component as `scheme://host[:port]`. Returns `None` if input is not absolute
 /// or if it does not contain a valid origin.
 pub fn extract_origin_if_absolute(s: &str) -> Option<String> {
-    let idx = scheme_authority_marker(s)?;
-    let after = &s[idx + 3..];
-    // The authority ends at the first '/', '?' or '#'. `path-abempty` may be
-    // empty, so `http://example.com?x=1` is a legal absolute-form target whose
-    // authority stops before the query — terminating on '/' alone swallows the
-    // query into the origin.
-    // cite(RFC 3986 § 3.2): "The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI."
-    let end = after
-        .find(['/', '?', '#'])
-        .map(|p| idx + 3 + p)
-        .unwrap_or(s.len());
-    let origin = &s[..end];
-
-    // Basic validation: scheme valid, no whitespace, authority part present
-    if validate_scheme_if_present(origin).is_some() {
-        return None;
-    }
-    if contains_whitespace(origin) {
-        return None;
-    }
-    let authority = &origin[idx + 3..];
+    // An origin is a scheme, the `://` between them, and an authority — so it is
+    // rebuilt from its two parts rather than sliced out of the value by
+    // arithmetic over their lengths. Where the authority ends is
+    // [`authority_component`]'s question and § 3.2's sentence: `path-abempty`
+    // may be empty, so `http://example.com?x=1` is a legal absolute-form target
+    // whose authority ends before the query.
+    //
+    // Requiring a scheme is what makes this *absolute*-form only. A network-path
+    // reference carries an authority and no scheme, and it has no origin.
+    let scheme = scheme_prefix(s)?;
+    let authority = authority_component(s)?;
     if authority.is_empty() {
         return None;
     }
-    Some(origin.to_string())
+    let origin = format!("{scheme}://{authority}");
+
+    // Basic validation: scheme valid, no whitespace
+    if validate_scheme_if_present(&origin).is_some() {
+        return None;
+    }
+    if contains_whitespace(&origin) {
+        return None;
+    }
+    Some(origin)
 }
 
 /// Validate an `Origin` header value. Accepts `null` or a serialized origin
@@ -309,21 +346,27 @@ pub fn extract_authority_from_request_target(s: &str) -> Option<String> {
         return None;
     }
 
-    // Absolute-form: scheme://authority/path...
-    if let Some(idx) = scheme_authority_marker(s_trim) {
-        let after = &s_trim[idx + 3..];
-        // Authority ends at first '/', '?', or '#'
-        let end = after.find(&['/', '?', '#'][..]).unwrap_or(after.len());
-        let authority = &after[..end];
-        if authority.is_empty() {
-            None
-        } else {
-            Some(authority.to_string())
-        }
-    } else {
-        // Authority-form: the entire target is the authority (e.g. CONNECT host:port).
-        Some(s_trim.to_string())
+    // Absolute-form: scheme://authority/path... Where the authority ends is
+    // § 3.2's sentence and [`authority_component`]'s question; a value whose
+    // authority is empty names no host, which is what this function's `None`
+    // says and what the origin-form and asterisk-form returns above say too.
+    //
+    // The two readings of the scheme are both wanted here, and they answer
+    // different questions. [`scheme_authority_marker`] decides which *form* the
+    // target is in, which is all four forms' shared question and the one this
+    // branch is selecting on; [`authority_component`] then asks whether the
+    // value in that form carries an authority at all. They part on `a:b://c`,
+    // where the scheme is `a` and `b://c` is a `path-rootless` — a target in
+    // absolute form carrying no authority, which is `None` and not an
+    // authority-form target named `a:b://c`.
+    if scheme_authority_marker(s_trim).is_some() {
+        return authority_component(s_trim)
+            .filter(|authority| !authority.is_empty())
+            .map(str::to_string);
     }
+
+    // Authority-form: the entire target is the authority (e.g. CONNECT host:port).
+    Some(s_trim.to_string())
 }
 
 /// Extract the host portion (without port) from an absolute URI or
@@ -331,29 +374,33 @@ pub fn extract_authority_from_request_target(s: &str) -> Option<String> {
 /// host; origin-form targets (starting with `/`) and the special `*` or
 /// authority-form have no host and will return `None`.
 ///
-/// The returned value is lowercased.  Ports are stripped off, since cookie
-/// matching and other rules operate on the hostname alone.
+/// The returned value is lowercased, which is § 6.2.2.1's case normalization
+/// and applies to the host and to nothing else in a URI. Ports are stripped
+/// off, since cookie matching and other rules operate on the hostname alone.
+///
+/// **The host is the authority's, and each of the three steps between them is a
+/// separate reading.** Where the authority ends is [`authority_component`]'s
+/// question and § 3.2's sentence; where the userinfo ends is
+/// [`split_userinfo`]'s; where the port begins is [`split_host_and_port`]'s, and
+/// that one is why the colon cannot simply be searched for — an `IP-literal` is
+/// bracketed and holds colons of its own.
 ///
 /// This helper is primarily used by cookie-related stateful rules and keeps
 /// the shared parsing logic in one place.
+// cite(RFC 3986 § 3.2.2, label: host grammar): "host        = IP-literal / IPv4address / reg-name"
+// cite(RFC 3986 § 6.2.2.1): "the scheme and host are case-insensitive and therefore should be normalized to lowercase"
 pub fn extract_host_from_request_target(s: &str) -> Option<String> {
-    if let Some(idx) = scheme_authority_marker(s) {
-        let after = &s[idx + 3..];
-        let host = after
-            .split('/')
-            .next()
-            .unwrap_or("")
-            .split(':')
-            .next()
-            .unwrap_or("");
-        if host.is_empty() {
-            None
-        } else {
-            Some(host.to_ascii_lowercase())
-        }
-    } else {
-        None
+    // Absolute form and only absolute form, which is what the doc above
+    // promises: `//host/p` carries an authority to [`authority_component`] and
+    // is an origin-form request-target whose path happens to open with two
+    // slashes, so the marker is asked first and its offset is not wanted.
+    scheme_authority_marker(s)?;
+    let (_, host_and_port) = split_userinfo(authority_component(s)?);
+    let (host, _) = split_host_and_port(host_and_port);
+    if host.is_empty() {
+        return None;
     }
+    Some(host.to_ascii_lowercase())
 }
 
 /// Extract the path component from a request-target or absolute URI.
@@ -624,22 +671,21 @@ fn merge_paths(base_path: &str, ref_path: &str) -> String {
 /// (`scheme://authority/…`) and a network-path reference (`//authority/…`).
 /// Every other form — absolute-path, relative-path, empty, query-only — resolves
 /// against the base and takes the base's authority.
+///
+/// **The empty authority is folded into `None` here, and that is this function's
+/// own decision rather than [`authority_component`]'s.** Every caller is
+/// comparing this reference's authority against another one, and an empty
+/// authority defines nothing to compare: a reference carrying one names no host,
+/// so the honest answer to *"which authority does this reference define"* is that
+/// it defines none. A caller asking whether the component is **present** — which
+/// is what RFC 9110 § 4.2.1's empty-host MUST NOT is about — has to ask
+/// [`authority_component`] instead, and the two answers stay apart for that
+/// reason.
 // cite(RFC 3986 § 4.2): "A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used."
 pub fn reference_authority(reference: &str) -> Option<String> {
-    let r = reference.trim();
-    let after_marker = match scheme_authority_marker(r) {
-        Some(idx) => &r[idx + 3..],
-        None => r.strip_prefix("//")?,
-    };
-    // cite(RFC 3986 § 3.2): "The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI."
-    let end = after_marker
-        .find(['/', '?', '#'])
-        .unwrap_or(after_marker.len());
-    let authority = &after_marker[..end];
-    if authority.is_empty() {
-        return None;
-    }
-    Some(authority.to_string())
+    authority_component(reference.trim())
+        .filter(|authority| !authority.is_empty())
+        .map(str::to_string)
 }
 
 /// Resolve a URI reference against a base path-and-query and return the
@@ -665,6 +711,13 @@ pub fn resolve_reference_path_and_query(
 
     // A network-path reference supplies its own authority, so §5.2.2 takes its
     // path verbatim; only the scheme is inherited from the base.
+    //
+    // This is the far side of the same boundary and not a copy of
+    // [`authority_component`]: what is wanted is everything *after* the
+    // authority, and the fragment was already taken off two lines above — which
+    // is why the terminator set here is two characters rather than § 3.2's
+    // three, and why converting this to the shared reader would need the
+    // authority's length back out of it for no gain.
     if let Some(after_slashes) = r.strip_prefix("//") {
         let rest = match after_slashes.find(['/', '?']) {
             Some(i) => &after_slashes[i..],
@@ -1198,6 +1251,54 @@ mod tests {
         );
     }
 
+    /// The three axes the four readers of this question used to disagree on:
+    /// which characters terminate the component, whether an empty authority is
+    /// an authority, and how close the `//` has to sit to the scheme's colon.
+    #[test]
+    fn authority_component_reads_section_3_2s_sentence_and_nothing_else() {
+        // All three terminators, and the end of the value.
+        assert_eq!(
+            authority_component("http://example.com/p"),
+            Some("example.com")
+        );
+        assert_eq!(
+            authority_component("http://example.com?x=1"),
+            Some("example.com")
+        );
+        assert_eq!(
+            authority_component("http://example.com#f"),
+            Some("example.com")
+        );
+        assert_eq!(
+            authority_component("http://example.com"),
+            Some("example.com")
+        );
+        // The `//` is what the search is for; a scheme in front of it is
+        // optional, and a network-path reference carries one without any.
+        assert_eq!(authority_component("//example.com/p"), Some("example.com"));
+        // Every subcomponent stays in: this function answers where the
+        // component ends and nothing about what is inside it.
+        assert_eq!(
+            authority_component("http://user:pass@[::1]:8080/p"),
+            Some("user:pass@[::1]:8080")
+        );
+        // `Some("")` and `None` are different answers — `reg-name` is
+        // `*( ... )`, so the first value carries an empty authority and the
+        // second carries none.
+        assert_eq!(authority_component("http://"), Some(""));
+        assert_eq!(authority_component("http:///p"), Some(""));
+        assert_eq!(authority_component("http:/p"), None);
+        // No `//` at all, in each of the forms that reach this.
+        for none in ["/p", "p", "", "mailto:a@b", "example.com:443", "*", "?x"] {
+            assert_eq!(authority_component(none), None, "{none}");
+        }
+        // The `//` must follow the scheme's colon immediately. Here the scheme
+        // is `a` and `b://c` is a `path-rootless`, so the value carries no
+        // authority — which a bare search for `://` reads the other way.
+        assert_eq!(authority_component("a:b://c"), None);
+        assert!(scheme_authority_marker("a:b://c").is_some());
+    }
+
     #[test]
     fn reference_authority_reports_only_a_self_defined_authority() {
         // Forms that carry their own authority.
@@ -1310,6 +1411,48 @@ mod tests {
         assert_eq!(extract_host_from_request_target("/relative/path"), None);
         assert_eq!(extract_host_from_request_target("*"), None);
         assert_eq!(extract_host_from_request_target("example.com:443"), None);
+    }
+
+    /// The four values the `/`-terminated, first-colon reading answered wrongly.
+    /// Each is what a cookie rule compares a `Domain` attribute against, so each
+    /// was a host the message never named.
+    #[test]
+    fn the_host_is_the_authoritys_and_stops_where_section_3_2_says() {
+        // `path-abempty` may be empty, so the authority can end at a '?' or a
+        // '#'; terminating on '/' alone glued the query onto the host.
+        assert_eq!(
+            extract_host_from_request_target("http://example.com?x=1"),
+            Some("example.com".into())
+        );
+        assert_eq!(
+            extract_host_from_request_target("http://example.com#f"),
+            Some("example.com".into())
+        );
+        // An `IP-literal` is bracketed and holds colons of its own, so the port
+        // is not at the first one. This used to be the host `[`.
+        assert_eq!(
+            extract_host_from_request_target("http://[2001:db8::1]:8080/p"),
+            Some("[2001:db8::1]".into())
+        );
+        assert_eq!(
+            extract_host_from_request_target("http://[::1]/p"),
+            Some("[::1]".into())
+        );
+        // A userinfo is a subcomponent of the authority and not of the host; its
+        // own colon used to be read as the port delimiter, making the host
+        // `user`.
+        assert_eq!(
+            extract_host_from_request_target("http://user:pass@example.com/p"),
+            Some("example.com".into())
+        );
+        assert_eq!(
+            extract_host_from_request_target("http://user@Example.com/p"),
+            Some("example.com".into())
+        );
+        // An empty authority carries no host to compare, and neither does a
+        // value whose authority is absent.
+        assert_eq!(extract_host_from_request_target("http:///p"), None);
+        assert_eq!(extract_host_from_request_target("http:/p"), None);
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/message_referer_uri_valid.rs
@@ -6,41 +6,14 @@ use crate::helpers::headers::{
     combined_field_value_as_written, describe_char, shown_in_finding, trim_ows,
 };
 use crate::helpers::uri::{
-    check_percent_encoding, find_non_uri_char, scheme_authority_marker, scheme_prefix,
-    split_host_and_port, split_userinfo, validate_host_and_optional_port, validate_scheme_name,
+    authority_component, check_percent_encoding, find_non_uri_char, scheme_authority_marker,
+    scheme_prefix, split_host_and_port, split_userinfo, validate_host_and_optional_port,
+    validate_scheme_name,
 };
 use crate::lint::Violation;
 use crate::rules::Rule;
 
 pub struct MessageRefererUriValid;
-
-/// The `authority` the value carries, or `None` when it carries none.
-///
-/// Both alternatives of the field's grammar reach an authority the same way and
-/// only that way — `hier-part` and `relative-part` each open with
-/// `"//" authority path-abempty` — so the two slashes are what the search is
-/// for, whether or not a scheme precedes them.
-///
-/// [`crate::helpers::uri::reference_authority`] answers a neighbouring question
-/// and cannot be used here: it returns `None` for `http://` as well as for
-/// `/path`, because a reference carrying an empty authority defines none *to
-/// compare against*. An empty authority is exactly what one of the requirements
-/// below is about, so the two answers have to stay apart. Written privately with
-/// that reason rather than shared, because nothing else asks it yet.
-// cite(RFC 3986 § 4.3, label: absolute-URI): "absolute-URI  = scheme ":" hier-part [ "?" query ]"
-// cite(RFC 3986 § 3): "hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty"
-// cite(RFC 3986 § 4.2, label: relative-part): "relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty"
-// cite(RFC 3986 § 3.2): "The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI."
-fn authority_component(value: &str) -> Option<&str> {
-    let after_slashes = match scheme_prefix(value) {
-        Some(scheme) => value[scheme.len() + 1..].strip_prefix("//")?,
-        None => value.strip_prefix("//")?,
-    };
-    let end = after_slashes
-        .find(['/', '?', '#'])
-        .unwrap_or(after_slashes.len());
-    Some(&after_slashes[..end])
-}
 
 /// The value as a finding may print it: escaped, and with the password half of a
 /// userinfo subcomponent withheld.
@@ -257,6 +230,13 @@ impl Rule for MessageRefererUriValid {
             }
         }
 
+        // The shared reader, which returns `Some("")` for a value carrying an
+        // empty authority and `None` for one carrying no authority at all. This
+        // rule is the reason it keeps the two apart: the empty-host branch below
+        // is a MUST NOT about exactly the first of them, and
+        // `helpers::uri::reference_authority` — the neighbouring question —
+        // folds it away, because a reference with an empty authority defines
+        // none *to compare against*.
         if let Some(authority) = authority_component(value) {
             let (userinfo, host_and_port) = split_userinfo(authority);
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -940,16 +940,6 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc3986.txt
   type: text/plain
   fragments:
-  - label: absolute-URI
-    section: § 4.3
-    snippet: absolute-URI  = scheme ":" hier-part [ "?" query ]
-    cited_by:
-    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
-      line: 65
-    - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
-      line: 94
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 30
   - label: client_request_target_no_fragment
     section: § 2.2
     snippet: If data for a URI component would conflict with a reserved character's purpose as a delimiter, then the conflicting data must be percent-encoded before the URI is formed.
@@ -1025,7 +1015,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 77
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 851
+      line: 904
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 142
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
@@ -1035,7 +1025,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 78
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 852
+      line: 905
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 2
     snippet: A URI is composed from a limited set of characters consisting of digits, letters, and a few graphic symbols.
@@ -1105,7 +1095,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 86
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 769
+      line: 822
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 55
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -1113,7 +1103,7 @@ sources:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 447
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 135
+      line: 108
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 39
   - label: lint-http-rules/src/helpers/uri.rs (9)
@@ -1121,7 +1111,7 @@ sources:
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 553
+      line: 600
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 70
   - label: unreserved
@@ -1131,9 +1121,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 84
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 552
+      line: 599
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 768
+      line: 821
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 38
   - label: lint-http-rules/src/helpers/uri.rs (10)
@@ -1141,79 +1131,85 @@ sources:
     snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 556
+      line: 603
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 60
   - label: lint-http-rules/src/helpers/uri.rs (11)
+    section: § 3
+    snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 175
+  - label: lint-http-rules/src/helpers/uri.rs (12)
     section: § 3.1
     snippet: Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 742
-  - label: lint-http-rules/src/helpers/uri.rs (12)
+      line: 795
+  - label: lint-http-rules/src/helpers/uri.rs (13)
     section: § 3.1
     snippet: scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 168
+      line: 206
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 741
+      line: 794
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 728
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 247
-  - label: lint-http-rules/src/helpers/uri.rs (13)
+      line: 220
+  - label: lint-http-rules/src/helpers/uri.rs (14)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 187
-    - file: lint-http-rules/src/helpers/uri.rs
-      line: 634
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 33
+      line: 177
   - label: authority grammar
     section: § 3.2
     snippet: authority   = [ userinfo "@" ] host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 142
-  - label: lint-http-rules/src/helpers/uri.rs (14)
+  - label: lint-http-rules/src/helpers/uri.rs (15)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 144
-  - label: lint-http-rules/src/helpers/uri.rs (15)
+  - label: lint-http-rules/src/helpers/uri.rs (16)
     section: § 3.2.1
     snippet: userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 143
-  - label: lint-http-rules/src/helpers/uri.rs (16)
+  - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2.2
     snippet: IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 772
-  - label: lint-http-rules/src/helpers/uri.rs (17)
+      line: 825
+  - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.2
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 816
-  - label: lint-http-rules/src/helpers/uri.rs (18)
+      line: 869
+  - label: host grammar
     section: § 3.2.2
     snippet: host        = IP-literal / IPv4address / reg-name
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 766
+      line: 390
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 819
   - label: reg-name
     section: § 3.2.2
     snippet: reg-name    = *( unreserved / pct-encoded / sub-delims )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 767
+      line: 178
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 820
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 107
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -1227,9 +1223,9 @@ sources:
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 853
+      line: 906
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 878
+      line: 931
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 51
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
@@ -1241,7 +1237,7 @@ sources:
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 879
+      line: 932
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
@@ -1261,51 +1257,77 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 91
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 248
+      line: 221
   - label: lint-http-rules/src/helpers/uri.rs (22)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 627
+      line: 684
+  - label: relative-part
+    section: § 4.2
+    snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 176
+  - label: absolute-URI
+    section: § 4.3
+    snippet: absolute-URI  = scheme ":" hier-part [ "?" query ]
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 174
+    - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
+      line: 65
+    - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
+      line: 94
   - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 5.2.3
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 609
+      line: 656
   - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 5.2.3
     snippet: return a string consisting of the reference's path component appended to all but the last segment of the base URI's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 613
+      line: 660
   - label: lint-http-rules/src/helpers/uri.rs (25)
     section: § 5.2.4
     snippet: This is done after the path is extracted from a reference, whether or not the path was relative, in order to remove any invalid or extraneous dot-segments prior to forming the target URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 474
+      line: 521
   - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 6.2.2.1
     snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 555
+      line: 602
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 91
   - label: lint-http-rules/src/helpers/uri.rs (27)
+    section: § 6.2.2.1
+    snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 391
+    - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
+      line: 188
+    - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
+      line: 193
+  - label: lint-http-rules/src/helpers/uri.rs (28)
     section: § 6.2.2.2
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 554
-  - label: lint-http-rules/src/helpers/uri.rs (28)
+      line: 601
+  - label: lint-http-rules/src/helpers/uri.rs (29)
     section: § 6.2.2.3
     snippet: URI normalizers should remove dot-segments by applying the remove_dot_segments algorithm to the path, as described in Section 5.2.4.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 600
+      line: 647
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 159
   - label: message_content_location_and_uri_consistency
@@ -1316,14 +1338,6 @@ sources:
       line: 189
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 149
-  - label: message_content_location_and_uri_consistency (2)
-    section: § 6.2.2.1
-    snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
-    cited_by:
-    - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
-      line: 188
-    - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
-      line: 193
   - label: message_host_and_authority_consistency
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1331,47 +1345,35 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 54
   - label: message_referer_uri_valid
-    section: § 3
-    snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
-    cited_by:
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 31
-  - label: message_referer_uri_valid (2)
     section: § 3.2.1
     snippet: Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password).
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 53
-  - label: message_referer_uri_valid (3)
+      line: 26
+  - label: message_referer_uri_valid (2)
     section: § 3.2.1
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 272
-  - label: message_referer_uri_valid (4)
+      line: 252
+  - label: message_referer_uri_valid (3)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 230
-  - label: relative-part
-    section: § 4.2
-    snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
-    cited_by:
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 32
-  - label: message_referer_uri_valid (5)
+      line: 203
+  - label: message_referer_uri_valid (4)
     section: § 4.3
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 229
-  - label: message_referer_uri_valid (6)
+      line: 202
+  - label: message_referer_uri_valid (5)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 174
+      line: 147
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
       line: 128
   - label: message_well_known_uri_format
@@ -2035,13 +2037,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2093
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 222
+      line: 259
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 215
+      line: 252
 - label: RFC 6455
   url: https://www.rfc-editor.org/rfc/rfc6455.txt
   type: text/plain
@@ -4224,7 +4226,7 @@ sources:
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
       line: 22
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 84
+      line: 57
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 386
   - label: client_expect_header_valid (2)
@@ -4318,7 +4320,7 @@ sources:
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 229
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 194
+      line: 167
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
       line: 303
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
@@ -5340,7 +5342,7 @@ sources:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 88
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 151
+      line: 124
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 49
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
@@ -5818,7 +5820,7 @@ sources:
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 269
+      line: 306
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 111
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
@@ -5828,7 +5830,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 877
+      line: 930
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 161
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -5840,7 +5842,7 @@ sources:
     snippet: In HTTP/2 [HTTP/2] and HTTP/3 [HTTP/3], the Host header field is, in some cases, supplanted by the ":authority" pseudo-header field of a request's control data.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 271
+      line: 308
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -5852,7 +5854,7 @@ sources:
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 270
+      line: 307
   - label: message_accept_and_content_type_negotiation
     section: § 12.1
     snippet: A user agent cannot rely on proactive negotiation preferences being consistently honored, since the origin server might not implement proactive negotiation for the requested resource or might decide that sending a response that doesn't conform to the user agent's preferences is better than sending a 406 (Not Acceptable) response.
@@ -6602,7 +6604,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 49
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 296
+      line: 276
   - label: message_http2_pseudo_headers_validity
     section: § 9.3.6
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
@@ -6936,91 +6938,91 @@ sources:
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 226
+      line: 199
   - label: message_referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 348
+      line: 328
   - label: message_referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 175
+      line: 148
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 113
+      line: 86
   - label: message_referer_uri_valid (4)
     section: § 10.1.3
     snippet: The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled).
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 112
+      line: 85
   - label: message_referer_uri_valid (5)
     section: § 17.9
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 353
+      line: 333
   - label: message_referer_uri_valid (6)
     section: § 4.1
     snippet: A "partial-URI" rule is defined for protocol elements that can contain a relative URI but not a fragment component.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 227
+      line: 200
   - label: message_referer_uri_valid (7)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 228
+      line: 201
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 173
+      line: 146
   - label: message_referer_uri_valid (8)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 294
+      line: 274
   - label: message_referer_uri_valid (9)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 351
+      line: 331
   - label: message_referer_uri_valid (10)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 350
+      line: 330
   - label: message_referer_uri_valid (11)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 295
+      line: 275
   - label: message_referer_uri_valid (12)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 352
+      line: 332
   - label: message_referer_uri_valid (13)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 349
+      line: 329
   - label: message_response_body_length_accuracy
     section: § 8.6
     snippet: A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 15.4.5); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a 200 (OK) response to the same request.
@@ -8824,7 +8826,7 @@ sources:
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 275
+      line: 312
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 77
   - label: request-target forms
@@ -8832,9 +8834,9 @@ sources:
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 307
+      line: 344
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 370
+      line: 417
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 13
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
@@ -8844,19 +8846,19 @@ sources:
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 273
+      line: 310
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.3
     snippet: If there is no Host header field or if its field value is empty or invalid, the target URI's authority component is empty.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 274
+      line: 311
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 3.3
     snippet: The target URI is the request-target when the request-target is in absolute-form.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 272
+      line: 309
     - file: lint-http-rules/src/rules/semantic_post_creates_resource.rs
       line: 86
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs


### PR DESCRIPTION
…ur things wrong

`helpers::uri::authority_component` is RFC 3986 §3.2's sentence in both directions — the `//` that precedes the component and the `/`, `?` or `#` that terminates it. Four other sites computed that boundary and all four call it now.

The count was three when it was written down and five in the tree, and the two that were missed were both in `helpers::uri` itself: `extract_origin_if_absolute`, which carried the §3.2 sentence as a cite, and `extract_host_from_request_target`, which carried nothing at all and was the one that mattered. The grep that finds copies is a grep for the name, and a helper that writes the answer out inline has no name to find. The shape search is `find(['/', '?', '#'])`, and it is what turns up a copy that never mentions an authority.

That fifth reading was `after.split('/').next().split(':').next()`, and it was wrong four times over — each of them a host the three cookie rules compared a `Domain` attribute against. It terminated on `/` alone, so `http://example.com?x=1` came back as the host `example.com?x=1`. It took the port at the first colon, so every IPv6-literal target came back as the host `[` — `split_host_and_port` has answered that four lines away in the same module since it was written. It kept the userinfo, so `http://user:pass@example.com/p` came back as the host `user`. All four were silent code, in a function whose doc described a lowercase and a stripped port and nothing else; nine assertions pinned it and not one used a query, a fragment, an IPv6 literal or a userinfo, so the whole suite passed before the fix and after it.

The empty authority is the axis the five disagreed on and it is a returned fact now. `host` may be a `reg-name`, which is `*( ... )`, so `http://` carries an empty authority where `http:/path` carries none, and RFC 9110 §4.2.1's and §4.2.2's empty-host MUST NOTs are about exactly the first of those. The shared reader returns `Some("")`; `reference_authority` folds it into `None` with its reason at its own site, because every one of its callers is comparing this reference's authority against another one and an empty authority defines nothing to compare.

Two readings of a scheme survive, and they part on one value. `scheme_authority_marker` looks for a `://`; `authority_component` requires the `//` to follow the scheme's colon immediately. On `a:b://c` the first says absolute form and the second says no authority — the scheme is `a` and `b://c` is a `path-rootless` — and both are right about their own question. `extract_authority_from_request_target` asks them in that order, which form is this and then does a value in that form carry an authority, so that value now draws `None` where it drew the authority `c`. A second reading of the same component is not automatically a copy.

Cites 2164 → 2165. Four RFC 3986 sentences moved onto the shared reader with `reg-name` beside them, two moved off the helper copies, and `host` plus §6.2.2.1's fold are new on the host reader, which had none.
