### PR TITLE
Four field sections, one walk, and the shared thing was a third funct…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -242,12 +242,68 @@ pub fn combined_field_value_as_written(headers: &HeaderMap, name: &str) -> Optio
 pub fn response_field_sections(
     resp: &crate::http_transaction::ResponseInfo,
 ) -> impl Iterator<Item = (&'static str, &HeaderMap)> {
-    [
-        Some(("header section", &resp.headers)),
-        resp.trailers.as_ref().map(|t| ("trailer section", t)),
-    ]
-    .into_iter()
-    .flatten()
+    message_field_sections(
+        &resp.headers,
+        resp.trailers.as_ref(),
+        ("header section", "trailer section"),
+    )
+}
+
+/// The field sections of one message, in wire order, under the names its
+/// caller's findings use.
+///
+/// This is the sentence both public walks rest on and the only thing they
+/// share: **a message has exactly two field sections, in this order, and they
+/// are never joined to each other** — appending a field line to the one before
+/// it is defined *within* a field section, which is why a value spanning the
+/// two is two values and not one.
+///
+/// The labels are a parameter because they are the *finding's* wording rather
+/// than a decision the walk makes: a rule that reads one direction says "header
+/// section" because there is no other, and a rule reading both has to say which
+/// direction or its findings are ambiguous. Nothing else turns on the string.
+fn message_field_sections<'a>(
+    headers: &'a HeaderMap,
+    trailers: Option<&'a HeaderMap>,
+    labels: (&'static str, &'static str),
+) -> impl Iterator<Item = (&'static str, &'a HeaderMap)> {
+    [Some((labels.0, headers)), trailers.map(|t| (labels.1, t))]
+        .into_iter()
+        .flatten()
+}
+
+/// Every field section a transaction carries, in wire order, each named by the
+/// direction it belongs to as well as by its position.
+///
+/// Four at most: the request's two, then the response's two when the upstream
+/// answered at all. This is [`response_field_sections`]'s question asked of a
+/// whole transaction, and the two exist separately because their labels differ
+/// and the labels are what a finding prints — a response-only rule saying
+/// *"response header section"* is naming a direction its scope already fixed.
+///
+/// A rule reaching for this is one whose governing sentence names neither a
+/// direction nor a section, which is what makes all four in scope. That is a
+/// claim about the sentence and has to be checked per rule: `User-Agent`'s
+/// SHOULD is about a request's header section, and reading its trailer section
+/// for one would count a field § 6.5.1 forbids as satisfying § 10.1.5.
+///
+/// cite(RFC 9110 § 5): "Fields are sent and received within the header and trailer sections of messages"
+/// cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
+pub fn transaction_field_sections(
+    tx: &crate::http_transaction::HttpTransaction,
+) -> impl Iterator<Item = (&'static str, &HeaderMap)> {
+    message_field_sections(
+        &tx.request.headers,
+        tx.request.trailers.as_ref(),
+        ("request header section", "request trailer section"),
+    )
+    .chain(tx.response.iter().flat_map(|resp| {
+        message_field_sections(
+            &resp.headers,
+            resp.trailers.as_ref(),
+            ("response header section", "response trailer section"),
+        )
+    }))
 }
 
 /// The same combined field value as [`combined_field_value_as_written`], as the
@@ -3087,6 +3143,58 @@ mod tests {
         let got: Vec<&str> = parse_semicolon_list("token=\"a;b\";x").collect();
         // naive split will break the quoted-string into multiple parts
         assert_eq!(got, vec!["token=\"a", "b\"", "x"]);
+    }
+
+    /// Wire order, the four labels, and the two ways a section is absent — a
+    /// framing that carried no trailers, and an upstream that never answered.
+    #[test]
+    fn transaction_field_sections_walks_all_four_in_wire_order() {
+        let labels = |tx: &crate::http_transaction::HttpTransaction| -> Vec<&'static str> {
+            transaction_field_sections(tx)
+                .map(|(label, _)| label)
+                .collect()
+        };
+
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(
+            200,
+            &[("content-type", "text/plain")],
+        );
+        assert_eq!(
+            labels(&tx),
+            vec!["request header section", "response header section"]
+        );
+
+        tx.request.trailers = Some(crate::test_helpers::make_headers_from_pairs(&[(
+            "x-a", "1",
+        )]));
+        tx.response.as_mut().expect("a response").trailers = Some(
+            crate::test_helpers::make_headers_from_pairs(&[("x-b", "2")]),
+        );
+        assert_eq!(
+            labels(&tx),
+            vec![
+                "request header section",
+                "request trailer section",
+                "response header section",
+                "response trailer section",
+            ]
+        );
+
+        // A transaction the upstream never answered has a request half and
+        // nothing else.
+        let unanswered = crate::test_helpers::make_test_transaction();
+        assert_eq!(labels(&unanswered), vec!["request header section"]);
+
+        // The response-only walk answers the same question one direction wide,
+        // and names the sections without a direction because its callers'
+        // scope already fixes one.
+        let resp = tx.response.as_ref().expect("a response");
+        assert_eq!(
+            response_field_sections(resp)
+                .map(|(label, _)| label)
+                .collect::<Vec<_>>(),
+            vec!["header section", "trailer section"]
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_extension_headers_registered.rs
+++ b/lint-http-rules/src/rules/message_extension_headers_registered.rs
@@ -93,27 +93,14 @@ impl Rule for MessageExtensionHeadersRegistered {
     ) -> Option<Violation> {
         let config = parse_allowed_config(cfg, self.id()).ok()?;
 
-        if let Some(v) = check_section("request header section", &tx.request.headers, &config) {
-            return Some(v);
-        }
-        // A trailer field name is a field name, so the allowlist reaches it on the same
-        // terms. The section is `None` unless the framing carried one.
+        // All four, in wire order, from the shared walk. A trailer field name is
+        // a field name, so the allowlist reaches it on the same terms; a
+        // transaction the upstream never answered has no response half; and
+        // which sections exist at all is the framing's answer, not this rule's.
         // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
-        if let Some(trailers) = &tx.request.trailers {
-            if let Some(v) = check_section("request trailer section", trailers, &config) {
+        for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
+            if let Some(v) = check_section(section, headers, &config) {
                 return Some(v);
-            }
-        }
-
-        // A transaction the upstream never answered has no response half to read.
-        if let Some(resp) = &tx.response {
-            if let Some(v) = check_section("response header section", &resp.headers, &config) {
-                return Some(v);
-            }
-            if let Some(trailers) = &resp.trailers {
-                if let Some(v) = check_section("response trailer section", trailers, &config) {
-                    return Some(v);
-                }
             }
         }
 

--- a/lint-http-rules/src/rules/message_header_field_names_token.rs
+++ b/lint-http-rules/src/rules/message_header_field_names_token.rs
@@ -27,27 +27,14 @@ impl Rule for MessageHeaderFieldNamesToken {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
-        if let Some(v) = check_section("request header section", &tx.request.headers, &config) {
-            return Some(v);
-        }
-        // A trailer field name is a field name, so the same grammar reaches it. The
-        // section is `None` unless the framing carried one.
+        // All four, in wire order, from the shared walk. A trailer field name is
+        // a field name, so the same grammar reaches it; a transaction the
+        // upstream never answered has no response half; and which sections exist
+        // at all is the framing's answer, not this rule's.
         // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
-        if let Some(trailers) = &tx.request.trailers {
-            if let Some(v) = check_section("request trailer section", trailers, &config) {
+        for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
+            if let Some(v) = check_section(section, headers, &config) {
                 return Some(v);
-            }
-        }
-
-        // A transaction the upstream never answered has no response half to read.
-        if let Some(resp) = &tx.response {
-            if let Some(v) = check_section("response header section", &resp.headers, &config) {
-                return Some(v);
-            }
-            if let Some(trailers) = &resp.trailers {
-                if let Some(v) = check_section("response trailer section", trailers, &config) {
-                    return Some(v);
-                }
             }
         }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2097
+      line: 2153
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2092
+      line: 2148
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2091
+      line: 2147
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -2035,7 +2035,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2093
+      line: 2149
     - file: lint-http-rules/src/helpers/uri.rs
       line: 259
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3532,25 +3532,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1656
+      line: 1712
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1597
+      line: 1653
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1635
+      line: 1691
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1628
+      line: 1684
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -3860,7 +3860,7 @@ sources:
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 822
+      line: 878
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
       line: 125
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
@@ -4964,7 +4964,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 22
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 854
+      line: 910
     - file: lint-http-rules/src/rules/message_connection_upgrade.rs
       line: 60
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -4976,7 +4976,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 125
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 889
+      line: 945
     - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
       line: 116
   - label: lint-http-proxy/src/proxy/websocket.rs
@@ -5044,9 +5044,9 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 97
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 416
+      line: 472
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 440
+      line: 496
     - file: lint-http-rules/src/rules/client_accept_encoding_present.rs
       line: 61
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5224,19 +5224,19 @@ sources:
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 838
+      line: 894
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 11.7.3
     snippet: Proxy-Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 839
+      line: 895
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1565
+      line: 1621
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -5246,36 +5246,46 @@ sources:
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 321
+      line: 377
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 16.3.2
     snippet: If the field is allowable in trailers; by default, it will not be (see Section 6.5.1).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 768
+      line: 824
   - label: lint-http-rules/src/helpers/headers.rs (4)
+    section: § 5
+    snippet: Fields are sent and received within the header and trailer sections of messages
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 290
+    - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
+      line: 79
+    - file: lint-http-rules/src/rules/message_header_field_names_token.rs
+      line: 18
+  - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.1
     snippet: Field names are case-insensitive
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 887
+      line: 943
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
       line: 90
-  - label: lint-http-rules/src/helpers/headers.rs (5)
+  - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.2
     snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 211
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1363
+      line: 1419
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 64
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 25
     - file: lint-http-rules/src/rules/semantic_status_code_semantics.rs
       line: 21
-  - label: lint-http-rules/src/helpers/headers.rs (6)
+  - label: lint-http-rules/src/helpers/headers.rs (7)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
     cited_by:
@@ -5287,18 +5297,18 @@ sources:
       line: 320
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
       line: 93
-  - label: lint-http-rules/src/helpers/headers.rs (7)
+  - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 181
-  - label: lint-http-rules/src/helpers/headers.rs (8)
+  - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.3
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1364
+      line: 1420
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -5329,12 +5339,12 @@ sources:
       line: 41
     - file: lint-http-rules/src/rules/server_x_xss_protection_value_valid.rs
       line: 40
-  - label: lint-http-rules/src/helpers/headers.rs (9)
+  - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1826
+      line: 1882
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5357,7 +5367,7 @@ sources:
       line: 82
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 138
-  - label: lint-http-rules/src/helpers/headers.rs (10)
+  - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
     cited_by:
@@ -5381,26 +5391,26 @@ sources:
       line: 70
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 180
-  - label: lint-http-rules/src/helpers/headers.rs (11)
+  - label: lint-http-rules/src/helpers/headers.rs (12)
     section: § 5.5
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1361
+      line: 1417
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
       line: 124
-  - label: lint-http-rules/src/helpers/headers.rs (12)
+  - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 5.5
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1362
+      line: 1418
   - label: 1#element expansion
     section: § 5.6.1.1
     snippet: 1#element => element *( OWS "," OWS element )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 949
+      line: 1005
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 241
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -5411,14 +5421,14 @@ sources:
       line: 297
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 81
-  - label: lint-http-rules/src/helpers/headers.rs (13)
+  - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 417
+      line: 473
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 439
+      line: 495
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 49
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5429,24 +5439,24 @@ sources:
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 432
-  - label: lint-http-rules/src/helpers/headers.rs (14)
+  - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1426
+      line: 1482
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 81
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 40
-  - label: lint-http-rules/src/helpers/headers.rs (15)
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1427
+      line: 1483
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -5470,13 +5480,13 @@ sources:
     snippet: OWS            = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 293
+      line: 349
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 441
+      line: 497
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 950
+      line: 1006
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1755
+      line: 1811
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
@@ -5489,62 +5499,62 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 463
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1487
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+      line: 1543
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 292
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+      line: 348
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1217
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+      line: 1273
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1215
+      line: 1271
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 333
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1067
+      line: 1123
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1095
+      line: 1151
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1216
+      line: 1272
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 422
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 467
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 951
+      line: 1007
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1094
+      line: 1150
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1132
+      line: 1188
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1214
+      line: 1270
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1428
+      line: 1484
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 316
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5557,38 +5567,38 @@ sources:
       line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 312
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2045
+      line: 2101
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 123
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 213
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1753
+      line: 1809
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1780
+      line: 1836
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 380
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1754
+      line: 1810
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1781
+      line: 1837
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1962
+      line: 2018
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5598,7 +5608,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1976
+      line: 2032
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 382
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5609,25 +5619,25 @@ sources:
       line: 129
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 219
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1752
+      line: 1808
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1825
+      line: 1881
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 379
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 203
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -5635,22 +5645,24 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 145
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 241
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 291
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 101
+      line: 100
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
-      line: 35
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+      line: 34
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 767
+      line: 823
     - file: lint-http-rules/src/rules/client_user_agent_present.rs
       line: 46
     - file: lint-http-rules/src/rules/message_server_header_product_valid.rs
@@ -5671,18 +5683,18 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 169
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 766
-  - label: lint-http-rules/src/helpers/headers.rs (31)
+      line: 822
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1907
+      line: 1963
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5703,12 +5715,12 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/server_problem_details_content_type.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (32)
+  - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1926
+      line: 1982
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5716,22 +5728,22 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1841
+      line: 1897
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 105
-  - label: lint-http-rules/src/helpers/headers.rs (33)
+  - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1906
+      line: 1962
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (34)
+  - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
@@ -5742,13 +5754,13 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1675
-  - label: lint-http-rules/src/helpers/headers.rs (35)
+      line: 1731
+  - label: lint-http-rules/src/helpers/headers.rs (36)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 525
+      line: 581
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 10.1.2
     snippet: mailbox = <mailbox, see [RFC5322], Section 3.4>
@@ -6520,45 +6532,37 @@ sources:
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
     cited_by:
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 203
+      line: 190
   - label: message_extension_headers_registered (2)
     section: § 16.3.2.1
     snippet: Field names ought not be prefixed with "X-"
     cited_by:
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 165
+      line: 152
   - label: message_extension_headers_registered (3)
-    section: § 5
-    snippet: Fields are sent and received within the header and trailer sections of messages
-    cited_by:
-    - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 79
-    - file: lint-http-rules/src/rules/message_header_field_names_token.rs
-      line: 18
-  - label: message_extension_headers_registered (4)
     section: § 5.1
     snippet: A proxy MUST forward unrecognized header fields unless the field name is listed in the Connection header field
     cited_by:
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 201
-  - label: message_extension_headers_registered (5)
+      line: 188
+  - label: message_extension_headers_registered (4)
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
     cited_by:
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
       line: 58
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 224
+      line: 211
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 56
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 313
-  - label: message_extension_headers_registered (6)
+  - label: message_extension_headers_registered (5)
     section: § 5.1
     snippet: Other recipients SHOULD ignore unrecognized header and trailer fields
     cited_by:
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 202
+      line: 189
   - label: message_from_header_email_syntax
     section: § 10.1.2
     snippet: The "From" header field contains an Internet email address for a human user who controls the requesting user agent.
@@ -6576,7 +6580,7 @@ sources:
     snippet: field-name = token field-value = *field-content
     cited_by:
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
-      line: 155
+      line: 142
     - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
       line: 83
   - label: message_host_and_authority_consistency
@@ -8296,13 +8300,13 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 606
+      line: 662
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 616
+      line: 672
   - label: message_age_header_numeric
     section: § 1.2.2
     snippet: If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648 (2^31) or the greatest positive integer it can conveniently represent.
@@ -9294,7 +9298,7 @@ sources:
     snippet: HTTP/2 implementations SHOULD validate field names and values according to their definitions in Sections 5.1 and 5.5 of [HTTP], respectively, and treat messages that contain prohibited characters as malformed
     cited_by:
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
-      line: 144
+      line: 131
   - label: message_host_and_authority_consistency
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
@@ -9522,15 +9526,15 @@ sources:
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
     cited_by:
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
-      line: 216
+      line: 203
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
-      line: 130
+      line: 117
   - label: message_header_field_names_token
     section: § 4.2
     snippet: Properties of HTTP field names and values are discussed in more detail in Section 5.1 of [HTTP]
     cited_by:
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
-      line: 145
+      line: 132
   - label: message_host_and_authority_consistency
     section: § 4.3.1
     snippet: If both fields are present, they MUST contain the same value.


### PR DESCRIPTION
…ion under both

`helpers::headers::transaction_field_sections` walks every field section a transaction carries — the request's two, then the response's two when the upstream answered — each under the name a finding prints. `message_header_field_names_token` and `message_extension_headers_registered` held byte-identical twenty-line walks; both are three lines now.

The count was right for once, and re-deriving it still changed the design. What it did not say is that the response half already had a home and widening it is the wrong fix: `response_field_sections` labels its two `"header section"` and `"trailer section"`, and its callers are response-scoped rules for which a direction in the label is noise. So there are two public walks, and what they share is a private third, `message_field_sections`, holding the one sentence both rest on — a message has exactly two field sections, in this order, and they are never joined to each other. An extraction that unifies two callers can still be the wrong extraction if their outputs differ; find the sentence they share and put that underneath.

The labels are a parameter, which is the shape that folded the `token / quoted-string` alternation rather than the flag that was refused for the Alt-Svc walk. A boolean saying which document the caller is reading is a disagreement in disguise; a string saying what this rule's finding calls the section is the caller's own wording, and nothing in the walk turns on it.

The boundary is written on the new function, because reaching for it is a claim: all four sections are in scope only when the governing sentence names neither a direction nor a section. `client_user_agent_present` is the counter-example already in the tree — §10.1.5's SHOULD is about a request's header section, and walking its trailer section for one would let a field §6.5.1 forbids count as satisfying it.

Pure extraction: no verdict and no message changed. One new test pins the four labels in wire order and the two ways a section is absent, which is the assertion neither rule's own tests could make.

Cites 2174 → 2176.
