### PR TITLE
One sixteen-bit namespace, and the third copy was filed under IPv6

### DIFF
--- a/lint-http-rules/src/helpers/forwarded_node.rs
+++ b/lint-http-rules/src/helpers/forwarded_node.rs
@@ -179,10 +179,12 @@ pub fn validate_node(value: &str, form: NodeForm) -> Result<(), String> {
 ///
 /// `1*5DIGIT` is the whole of what a numeric port may be here: five digits, no
 /// range. The `Forwarded` rule used to measure it with the shared TCP-port
-/// reader, which rejects `0` and anything over 65535 and so reported
-/// `for=192.0.2.1:0` and `for="192.0.2.1:99999"` — both of which the production
+/// reader, which reported `for="192.0.2.1:99999"` — a value the production
 /// generates — while the obfuscated form it has no idea about was rejected
-/// outright.
+/// outright. It also rejected `for=192.0.2.1:0` at the time, which
+/// `helpers::uri::port_number` no longer does; the ceiling is still not this
+/// production's, so the two answers stay apart for the reason above rather than
+/// by how far they happen to differ.
 ///
 // cite(RFC 7239 § 6, label: node-port grammar): "node-port     = port / obfport port          = 1*5DIGIT obfport       = "_" 1*(ALPHA / DIGIT / "." / "_" / "-")"
 fn validate_node_port(port: Option<&str>) -> Result<(), String> {

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -2191,7 +2191,7 @@ pub fn is_valid_serialized_origin(val: &str) -> bool {
             // Use the ipv6 helper to parse bracketed IPv6 and optional port
             if let Some((_, port_opt)) = crate::helpers::ipv6::parse_bracketed_ipv6(rest) {
                 if let Some(port_str) = port_opt {
-                    return crate::helpers::ipv6::parse_port_str(port_str).is_some();
+                    return crate::helpers::uri::port_number(port_str).is_some();
                 }
                 return true;
             } else {
@@ -2204,8 +2204,13 @@ pub fn is_valid_serialized_origin(val: &str) -> bool {
         if host.is_empty() || port.is_empty() {
             return false;
         }
-        // Parse and validate port using helper
-        return crate::helpers::ipv6::parse_port_str(port).is_some();
+        // Sixteen bits, and the licence to ask that of *this* value is the URL
+        // Standard's rather than a transport's: an origin's port is not a run of
+        // digits that happens to reach a TCP port, it is declared to be an
+        // integer of that width. `0` is one of them, so an origin naming it is a
+        // serialized origin; the shared reader rejected it until this was read.
+        // cite(URL): "A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port."
+        return crate::helpers::uri::port_number(port).is_some();
     }
 
     // No port: ensure host is non-empty
@@ -2357,8 +2362,12 @@ mod tests {
         assert!(is_valid_serialized_origin("http://example.com:1"));
         assert!(is_valid_serialized_origin("http://example.com:65535"));
         assert!(is_valid_serialized_origin("http://example.com:080")); // leading zero allowed -> 80
+                                                                       // `0` is a 16-bit unsigned integer and RFC 6335 §6 calls it a value
+                                                                       // *inside* the namespace, reserved rather than invalid. This asserted
+                                                                       // the opposite until the port reading was shared with the two rules
+                                                                       // that had already audited the bound.
+        assert!(is_valid_serialized_origin("http://example.com:0"));
 
-        assert!(!is_valid_serialized_origin("http://example.com:0")); // port 0 invalid
         assert!(!is_valid_serialized_origin("http://example.com:65536")); // out of range
         assert!(!is_valid_serialized_origin(
             "http://example.com:999999999999"

--- a/lint-http-rules/src/helpers/ipv6.rs
+++ b/lint-http-rules/src/helpers/ipv6.rs
@@ -48,20 +48,11 @@ pub fn parse_bracketed_ipv6(s: &str) -> Option<(&str, Option<&str>)> {
     Some((inner, Some(port)))
 }
 
-/// Parse a port string (only digits) into `u16` and ensure it is in 1..=65535.
-pub fn parse_port_str(port: &str) -> Option<u16> {
-    if port.is_empty() {
-        return None;
-    }
-    // Reject leading '+' or '-' signs; only digits allowed.
-    if !port.chars().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    match port.parse::<u32>() {
-        Ok(n) if (1..=65535).contains(&n) => Some(n as u16),
-        _ => None,
-    }
-}
+// `parse_port_str` was here. It answered "is this a port in the sixteen-bit
+// namespace", which is a question about a URI component and not about an IPv6
+// literal, and it answered it a third time and differently: `1..=65535` where
+// the two rules that had audited the bound both admit `0`. It is
+// `crate::helpers::uri::port_number` now, with the sentences on it.
 
 /// Detects an unbracketed IPv6-ish string that contains a port-like suffix,
 /// e.g., `fe80::1:80` — callers should treat these as violations for headers
@@ -125,21 +116,6 @@ mod tests {
         assert_eq!(parse_bracketed_ipv6("[]"), None);
         assert_eq!(parse_bracketed_ipv6("[::1]extra"), None);
         assert_eq!(parse_bracketed_ipv6("[::1]:notnum"), None);
-    }
-
-    #[test]
-    fn parse_port_str_ok_and_bounds() {
-        assert_eq!(parse_port_str("1"), Some(1));
-        assert_eq!(parse_port_str("65535"), Some(65535));
-        assert_eq!(parse_port_str("0"), None);
-        assert_eq!(parse_port_str("65536"), None);
-        assert_eq!(parse_port_str("+80"), None);
-        assert_eq!(parse_port_str("080"), Some(80));
-    }
-
-    #[test]
-    fn parse_port_str_empty_returns_none() {
-        assert_eq!(parse_port_str(""), None);
     }
 
     #[test]

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -920,6 +920,48 @@ pub fn split_host_and_port(value: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// The port a run of digits designates, or `None` when it designates none.
+///
+/// **This is not `port`'s grammar and must never be confused for it.**
+/// `port = *DIGIT` bounds nothing at either end, which is why
+/// [`validate_host_and_optional_port`] declines the range and why
+/// `client_host_header` reports no port for being out of range. What this
+/// answers is the *other* question — whether the number lands in the sixteen-bit
+/// namespace a transport registers its ports in — and **the licence to ask it is
+/// the caller's**, because it takes a sentence naming the transport or the type.
+/// Its three callers each carry their own: RFC 9113 § 8.5's TCP connection for a
+/// CONNECT `:authority`, RFC 7838 § 2's ALPN-name-includes-TLS for an
+/// `alt-authority`, and the URL Standard's *16-bit unsigned integer* for a
+/// serialized origin, which is the only one of the three where the width is
+/// stated of the value itself rather than reached through the transport.
+///
+/// **`0` is a port.** It is inside the namespace — a reserved value at the edge
+/// of a range, held back for extending the ranges later — and reserved is not
+/// invalid. Two of the three callers already read it that way after their own
+/// audits; the third rejected it, so `Origin: https://example.com:0` was not a
+/// serialized origin.
+///
+/// Empty and non-digit inputs are `None` too, which is the same answer for a
+/// different reason: they derive from no `port` at all. A caller wanting to tell
+/// the two apart measures the characters first, and all three do.
+// cite(RFC 3986 § 3.2.3): "The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character."
+// cite(RFC 6335 § 6): "TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries."
+// cite(RFC 6335 § 6): "Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future."
+pub fn port_number(digits: &str) -> Option<u16> {
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    // Sixteen bits, written as sixteen bits rather than as the literal 65535:
+    // the width is the whole of what the cited sentence says, and a type cannot
+    // be spelled wrong. A `*DIGIT` of any length either fits or overflows, and
+    // both mean the same thing here — a number outside the namespace — so the
+    // overflow is the answer rather than an early return.
+    //
+    // The digit scan above is what makes this parser safe to reach for: on its
+    // own, `u16::from_str` accepts a leading '+', which no `*DIGIT` writes.
+    digits.parse::<u16>().ok()
+}
+
 /// Validate a `Host` field value: a `uri-host` and, optionally, a port.
 ///
 /// The port is `*DIGIT` — no upper bound and no lower one. A number no
@@ -1320,6 +1362,31 @@ mod tests {
         }
     }
 
+    /// The axis the three copies of this predicate disagreed on was `0`, and
+    /// the ones either side of the namespace are what it is not.
+    #[test]
+    fn port_number_holds_the_sixteen_bit_namespace_including_its_reserved_edge() {
+        assert_eq!(port_number("0"), Some(0));
+        assert_eq!(port_number("1"), Some(1));
+        assert_eq!(port_number("443"), Some(443));
+        assert_eq!(port_number("65535"), Some(65535));
+        assert_eq!(port_number("65536"), None);
+        // A `*DIGIT` has no length bound, so an overflow is an answer rather
+        // than an early return.
+        assert_eq!(port_number("999999999999999999999999"), None);
+        // Leading zeros are digits: `port = *DIGIT` writes no canonical form,
+        // and the number is what it is.
+        assert_eq!(port_number("080"), Some(80));
+        assert_eq!(port_number("00000"), Some(0));
+        // Not a run of digits at all, which is a different reason for the same
+        // answer — `u16::from_str` would have taken the sign.
+        assert_eq!(port_number(""), None);
+        assert_eq!(port_number("+80"), None);
+        assert_eq!(port_number("-1"), None);
+        assert_eq!(port_number("8o8"), None);
+        assert_eq!(port_number(" 80"), None);
+    }
+
     #[test]
     fn scheme_prefix_names_the_candidate_without_judging_it() {
         assert_eq!(scheme_prefix("https://ex"), Some("https"));
@@ -1519,7 +1586,10 @@ mod tests {
         // The authority is validated too, not merely required to be non-empty.
         assert!(validate_origin_value("http://host:notaport").is_some());
         assert!(validate_origin_value("https://user@example.com").is_some());
-        assert!(validate_origin_value("http://example.com:0").is_some());
+        // A port outside the sixteen-bit namespace is the finding; `0` is
+        // inside it, reserved rather than invalid.
+        assert!(validate_origin_value("http://example.com:65536").is_some());
+        assert!(validate_origin_value("http://example.com:0").is_none());
         // invalid scheme in Origin
         let m = validate_origin_value("1http://example.com").unwrap();
         assert!(m.contains("Invalid scheme"));

--- a/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -216,6 +216,12 @@ mod tests {
     #[case("null")]
     #[case("https://example.com")]
     #[case("  https://example.com  ")]
+    // A port is a 16-bit unsigned integer and `0` is one of them — reserved at
+    // the edge of a range rather than invalid. The shared origin reader rejected
+    // it until the port reading was shared with the two rules that had audited
+    // the bound, so this value drew a finding naming an origin that is one.
+    #[case("https://example.com:0")]
+    #[case("https://example.com:65535")]
     fn valid_single_values(#[case] val: &str) {
         let rule = MessageAccessControlAllowOriginValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(

--- a/lint-http-rules/src/rules/message_forwarded_header_validity.rs
+++ b/lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -515,8 +515,9 @@ mod tests {
     #[test]
     fn a_node_port_is_five_digits_or_an_obfuscated_port() {
         // `port = 1*5DIGIT` has no range in it. The shared TCP-port reader this
-        // rule used to call rejects `0` and everything over 65535, and knows
-        // nothing of an obfuscated port at all.
+        // rule used to call reports everything over 65535 and knows nothing of
+        // an obfuscated port at all; `99999` is where the two part, and it is
+        // five digits.
         for value in [
             "for=\"192.0.2.1:0\"",
             "for=\"192.0.2.1:99999\"",

--- a/lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
+++ b/lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
@@ -92,13 +92,11 @@ fn connect_authority_finding(authority: &str) -> Option<String> {
 // cite(RFC 6335 § 6): "TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries."
 // cite(RFC 6335 § 6): "Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future."
 fn connect_port_range_finding(port: &str) -> Option<String> {
-    // A `*DIGIT` of any length parses or overflows; both mean the same thing
-    // here, so an overflow is the finding rather than an early return.
-    let too_large = match port.parse::<u64>() {
-        Ok(n) => n > u16::MAX as u64,
-        Err(_) => true,
-    };
-    too_large.then(|| {
+    // The range itself is `helpers::uri::port_number`'s, shared with the two
+    // other callers that have a sentence naming a transport. The sentences
+    // above are what license *this* caller to ask it; the reader holds the
+    // width and the reserved-value reading and nothing about CONNECT.
+    crate::helpers::uri::port_number(port).is_none().then(|| {
         format!(
             "a TCP port number is one of 65536 values and '{port}' is not among them, so the \
              connection this CONNECT asks for cannot be opened to it"

--- a/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -182,7 +182,7 @@ fn check_alt_authority(shown: &str, authority: &str) -> Option<String> {
     // cite(RFC 7838 § 2): "Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition."
     // cite(RFC 6335 § 6): "TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries."
     // cite(RFC 6335 § 6): "Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future."
-    if port.parse::<u64>().ok().is_none_or(|n| n > 65535) {
+    if crate::helpers::uri::port_number(port).is_none() {
         return Some(format!(
                 "Alt-Svc alternative '{shown}' names port {port}, which designates no port: the transports an ALPN protocol name is carried over register theirs in a sixteen-bit namespace"
             ));

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -260,6 +260,11 @@ sources:
   url: https://url.spec.whatwg.org/
   type: text/html
   fragments:
+  - label: lint-http-rules/src/helpers/headers.rs
+    snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 2212
   - label: message_refresh_header_syntax_valid
     snippet: A code point is found that is not a URL unit.
     cited_by:
@@ -1013,7 +1018,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 26
     - file: lint-http-rules/src/helpers/ipv6.rs
-      line: 77
+      line: 68
     - file: lint-http-rules/src/helpers/uri.rs
       line: 904
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -1023,7 +1028,7 @@ sources:
     snippet: This is the only place where square bracket characters are allowed in the URI syntax.
     cited_by:
     - file: lint-http-rules/src/helpers/ipv6.rs
-      line: 78
+      line: 69
     - file: lint-http-rules/src/helpers/uri.rs
       line: 905
   - label: lint-http-rules/src/helpers/uri.rs
@@ -1225,7 +1230,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 906
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 931
+      line: 947
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 973
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 51
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
@@ -1237,7 +1244,7 @@ sources:
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 932
+      line: 974
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
@@ -2010,18 +2017,22 @@ sources:
   url: https://www.rfc-editor.org/rfc/rfc6335.txt
   type: text/plain
   fragments:
-  - label: message_http2_pseudo_headers_validity
+  - label: lint-http-rules/src/helpers/uri.rs
     section: § 6
     snippet: Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future.
     cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 949
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 93
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 184
-  - label: message_http2_pseudo_headers_validity (2)
+  - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
     cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 948
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 92
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -2740,7 +2751,7 @@ sources:
     snippet: node-port     = port / obfport port          = 1*5DIGIT obfport       = "_" 1*(ALPHA / DIGIT / "." / "_" / "-")
     cited_by:
     - file: lint-http-rules/src/helpers/forwarded_node.rs
-      line: 187
+      line: 189
   - label: nodename grammar
     section: § 6
     snippet: nodename = IPv4address / "[" IPv6address "]" / "unknown" / obfnode
@@ -3834,13 +3845,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 196
+      line: 194
   - label: message_http2_pseudo_headers_validity (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 197
+      line: 195
 - label: RFC 8447
   url: https://www.rfc-editor.org/rfc/rfc8447.txt
   type: text/plain
@@ -4496,7 +4507,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 203
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 180
+      line: 178
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 205
     - file: lint-http-rules/src/rules/semantic_options_method_capabilities.rs
@@ -4700,7 +4711,7 @@ sources:
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 115
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 158
+      line: 156
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
@@ -4720,7 +4731,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 259
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 235
+      line: 233
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
       line: 93
   - label: client_request_target_form_checks (3)
@@ -4746,7 +4757,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 230
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 236
+      line: 234
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
       line: 94
   - label: client_request_target_form_checks (6)
@@ -5848,7 +5859,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 930
+      line: 972
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 161
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -5866,7 +5877,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 164
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 210
+      line: 208
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -9228,7 +9239,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
       line: 126
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 154
+      line: 152
   - label: client_request_target_form_checks
     section: § 8.3.1
     snippet: A request in asterisk form (for OPTIONS) includes the value '*' for the ":path" pseudo-header field.
@@ -9238,7 +9249,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 202
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 234
+      line: 232
   - label: client_request_target_form_checks (2)
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
@@ -9326,7 +9337,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 185
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 274
+      line: 272
   - label: message_host_and_authority_consistency (5)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -9338,61 +9349,61 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 170
+      line: 168
   - label: message_http2_pseudo_headers_validity (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 159
+      line: 157
   - label: message_http2_pseudo_headers_validity (3)
     section: § 8.3.1
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 312
+      line: 310
   - label: message_http2_pseudo_headers_validity (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 279
+      line: 277
   - label: message_http2_pseudo_headers_validity (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 250
+      line: 248
   - label: message_http2_pseudo_headers_validity (6)
     section: § 8.3.1
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 273
+      line: 271
   - label: message_http2_pseudo_headers_validity (7)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 249
+      line: 247
   - label: message_http2_pseudo_headers_validity (8)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 360
+      line: 358
   - label: message_http2_pseudo_headers_validity (9)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 361
+      line: 359
   - label: message_http2_pseudo_headers_validity (10)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 202
+      line: 200
   - label: message_http2_pseudo_headers_validity (11)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
@@ -9406,13 +9417,13 @@ sources:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 20
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 201
+      line: 199
   - label: message_http2_pseudo_headers_validity (13)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 181
+      line: 179
   - label: message_te_header_constraints
     section: § 8.2.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".


### PR DESCRIPTION
`helpers::uri::port_number` answers whether a run of digits designates a port in the sixteen-bit namespace a transport registers its ports in. Three sites asked it; all three call it now, and `helpers::ipv6::parse_port_str` is gone.

There were three renderings, not two. `server_alt_svc_header_syntax` and `message_http2_pseudo_headers_validity` each wrote the bound after their own audits and agree — over 65535 is a finding, `0` is not, because RFC 6335 §6 calls it a reserved value inside the namespace and reserved is not invalid. `parse_port_str` wrote `(1..=65535)` and was the outlier. What hid it is that it had a name and the name was on the wrong shelf: `helpers::ipv6` is shelved for "is this a bracketed IPv6 literal", while a port's numeric range is a URI-component question belonging beside `split_host_and_port`. A grep for the predicate where it belongs found nothing, because it was filed under the address format its one caller happened to be parsing. A function on the wrong shelf is a function the next reader writes again.

Two rules' origins gained a port. `is_valid_serialized_origin`'s callers — `message_access_control_allow_origin_valid` and
`message_timing_allow_origin_validity` — reported `https://example.com:0` as not being a serialized origin. It is one, and the licence here is stronger than the chain the two RFC rules had to build: they reach the width through a transport, while the URL Standard states it of the value itself, "A URL's port is either null or a 16-bit unsigned integer that identifies a networking port." One predicate, three callers, three licences, each cited at its own site. Nothing in either rule's tests had pinned the old answer, so both suites passed before and after; the case lives in the rule now.

The bound is written as sixteen bits rather than as 65535 — `parse::<u16>()` is the namespace, and a type cannot be spelled wrong. It is only safe because the digit scan runs first: on its own `u16::from_str` accepts a leading `+`, which no `*DIGIT` writes.

Two comments described the old reader and are corrected here. `helpers::forwarded_node::validate_node_port` and the `Forwarded` rule's test both said the shared reader "rejects `0` and everything over 65535" as the justification for `Forwarded` writing its own `1*5DIGIT` check. Half of that stopped being true in this commit. The reason the two stay apart does not change, but the sentence naming where they part now names `99999`, which is five digits, rather than a bound that no longer exists.

Cites 2176 → 2180.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
