### PR TITLE
One Vary reader, and the third rule was wrong on the axis the other t…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -950,6 +950,81 @@ pub fn is_nominated_by_connection(name: &str, connection_header_value: Option<&s
     list_members(conn).any(|tok| tok.eq_ignore_ascii_case(name_l.as_str()))
 }
 
+/// What a response's `Vary` nominates.
+///
+/// The two arms are the two alternatives of `Vary = #( "*" / field-name )`, and
+/// they are kept apart because a caller cannot treat them the same: `*` says the
+/// response varies on something a request's fields do not name, which RFC 9111
+/// § 4.1 turns into *always fails to match*, while a list of names is something
+/// a cache can compare. A member of `*` anywhere in the list makes the whole
+/// value that, since the sentence says *containing a member*.
+pub enum VaryNomination {
+    /// Some member is `*`.
+    Wildcard,
+    /// The field names nominated, folded to lowercase, in the order written.
+    /// Empty for a field that is absent and for a zero-element list, which
+    /// nominate the same nothing.
+    Fields(Vec<String>),
+}
+
+impl VaryNomination {
+    /// Whether `name` is nominated. `*` nominates every name.
+    pub fn nominates(&self, name: &str) -> bool {
+        match self {
+            Self::Wildcard => true,
+            Self::Fields(fields) => {
+                let name = name.trim().to_ascii_lowercase();
+                fields.contains(&name)
+            }
+        }
+    }
+
+    /// Whether some member is `*`.
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, Self::Wildcard)
+    }
+}
+
+/// Read a response's `Vary` field.
+///
+/// **Three rules asked this question and the three disagreed; two of them were
+/// wrong, and in the same two ways.** Both read `get_all("vary")` line by line
+/// and bailed on a line `to_str` refused — one returning no finding, the other
+/// silently skipping the line — so a single `obs-text` octet anywhere in the
+/// value stood the whole rule down. And neither joined the lines, so a `*`
+/// written on a second field line was a `*` to the third rule and not to them.
+/// § 5.3 makes the lines one value; the field is a `#` list, which is what
+/// licenses the join.
+///
+/// The walk is [`list_members`] — a naive comma split, `OWS`-trimmed, empty
+/// members dropped — and this is its second caller. **Naive is the right answer
+/// here and it is the grammar that says so**: `Vary`'s members are `"*"` and
+/// `field-name`, and a `field-name` is a `token`, which admits no
+/// `quoted-string`. Where an element cannot hold one, a DQUOTE is a character
+/// the member may not have, and reading it as opening a quoted-string makes the
+/// *next* comma data when there is no quoted-string for it to be data in — so
+/// `Vary: "x, prefer` nominates `Prefer`, and the quote-aware walk one caller
+/// used said it did not.
+///
+/// The fold is licensed: a `field-name` is a field name.
+// cite(RFC 9110 § 12.5.5, label: Vary grammar): "Vary = #( "*" / field-name )"
+// cite(RFC 9110 § 5.1): "Field names are case-insensitive"
+// cite(RFC 9110 § 5.3): "A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3)."
+// cite(RFC 9111 § 4.1): "A stored response with a Vary header field value containing a member "*" always fails to match."
+pub fn vary_nomination(response_headers: &HeaderMap) -> VaryNomination {
+    let Some(value) = combined_field_value_as_written(response_headers, "vary") else {
+        return VaryNomination::Fields(Vec::new());
+    };
+    let mut fields = Vec::new();
+    for member in list_members(&value) {
+        if member == "*" {
+            return VaryNomination::Wildcard;
+        }
+        fields.push(member.to_ascii_lowercase());
+    }
+    VaryNomination::Fields(fields)
+}
+
 /// Every member of a `#element` list, `OWS`-trimmed, **with the empty ones
 /// kept**.
 ///
@@ -2908,6 +2983,65 @@ mod tests {
         assert!(validate_ext_value("UTF-8''%ZZ").is_err());
         // Invalid: invalid attr-char
         assert!(validate_ext_value("UTF-8''hello@world").is_err());
+    }
+
+    /// The four axes the three hand copies of this predicate disagreed on: the
+    /// join across field lines, an `obs-text` octet, the walk, and the fold.
+    #[test]
+    fn vary_nomination_reads_the_whole_field() {
+        use hyper::header::{HeaderName, HeaderValue};
+        let read = |lines: &[&[u8]]| {
+            let mut h = HeaderMap::new();
+            for l in lines {
+                h.append(
+                    HeaderName::from_static("vary"),
+                    HeaderValue::from_bytes(l).expect("a test Vary value"),
+                );
+            }
+            vary_nomination(&h)
+        };
+
+        // A `*` written on a second field line is a `*`: §5.3 makes the lines
+        // one value and `#` is what licenses the join. Two of the three rules
+        // read the lines one at a time and said it was not.
+        assert!(read(&[b"accept", b"*"]).is_wildcard());
+        assert!(read(&[b"*"]).is_wildcard());
+        assert!(read(&[b"accept, *, accept-encoding"]).is_wildcard());
+
+        // One `obs-text` octet used to stand the whole rule down, in two rules,
+        // by two different routes. It is a member that nominates nothing and it
+        // does not reach the other members.
+        let n = read(&[b"accept-encoding, caf\xe9", b"*"]);
+        assert!(n.is_wildcard(), "the second line still answers");
+        let n = read(&[b"accept-encoding, caf\xe9"]);
+        assert!(
+            n.nominates("Accept-Encoding"),
+            "the first member still reads"
+        );
+        // The octet stays inside the member it was written in — it is no `OWS`
+        // character and nothing trims it — so that member nominates no field a
+        // request could carry under the name without it.
+        assert!(!n.nominates("caf"), "the octet is part of the member");
+        assert!(
+            n.nominates("caf\u{e9}"),
+            "and the member is read as written"
+        );
+
+        // `field-name = token` admits no `quoted-string`, so a DQUOTE is a
+        // character no member may hold and the comma after it is still a
+        // separator. The quote-aware walk one caller used said otherwise.
+        assert!(read(&[b"\"x, prefer"]).nominates("prefer"));
+
+        // Field names are case-insensitive, both directions.
+        assert!(read(&[b"Accept-Encoding"]).nominates("accept-encoding"));
+        assert!(read(&[b"accept-encoding"]).nominates("ACCEPT-ENCODING"));
+
+        // Absent and zero-element nominate the same nothing, and an empty member
+        // is not an element.
+        assert!(!read(&[]).nominates("accept"));
+        assert!(!read(&[b""]).nominates("accept"));
+        assert!(!read(&[b"a,,b"]).nominates(""));
+        assert!(read(&[b"a,,b"]).nominates("b"));
     }
 
     /// Three of the four `quoted-string` defects are about an octet that would

--- a/lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
+++ b/lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
@@ -69,30 +69,23 @@ fn varies_the_response_entity(name: &str) -> Option<&'static str> {
     None
 }
 
-/// Whether a `Vary` field value nominates `Prefer`, in either of the two
+/// Whether a response's `Vary` nominates `Prefer`, in either of the two
 /// spellings RFC 7240 § 2 admits.
 ///
-/// The caller hands in the value already joined across the field's lines, which
-/// is what makes a `*` written on a second line a `*`.
+/// The reader is `helpers::headers::vary_nomination`, shared with the two
+/// caching rules that ask the same question. This site was the only one of the
+/// three that joined the field's lines — which is what makes a `*` written on a
+/// second line a `*` — and the only one that survived an `obs-text` octet, and
+/// it was the one using the **wrong walk**: it split quote-aware, and
+/// `Vary = #( "*" / field-name )` with `field-name = token` admits no
+/// `quoted-string`, so a stray DQUOTE made the next comma data rather than a
+/// separator and `Vary: "x, prefer` did not nominate `Prefer`. Each of the three
+/// was right about something the other two were not; the shared reader is all
+/// three answers.
 ///
-/// The walk is `list_members_as_written`, and this is the one caller of it whose
-/// element grammar admits no `quoted-string`: `Vary = #( "*" / field-name )` and
-/// `field-name = token`. On a conforming value the quote-aware split and a naive
-/// one agree, which is what this comment used to claim outright -- they part on
-/// a *malformed* one, where a stray DQUOTE makes the next comma data rather than
-/// a separator, so `Vary: "x, prefer` nominates `Prefer` to a naive walk and not
-/// to this one. The reader was already the quote-aware one before it had a name,
-/// so nothing here changed; which walk this predicate should use is §6 P16's
-/// question, where the same predicate is hand-written twice more and the three
-/// disagree.
-///
-/// cite(RFC 9110 § 12.5.5, label: Vary grammar): "Vary = #( "*" / field-name )"
-/// cite(RFC 9110 § 5.1): "Field names are case-insensitive"
 /// cite(RFC 7240 § 2): "Alternatively, the server MAY include a Vary header with the special value "*""
-fn vary_nominates_prefer(value: &str) -> bool {
-    list_members_as_written(value)
-        .into_iter()
-        .any(|member| member == "*" || member.eq_ignore_ascii_case("prefer"))
+fn vary_nominates_prefer(response_headers: &hyper::HeaderMap) -> bool {
+    crate::helpers::headers::vary_nomination(response_headers).nominates("prefer")
 }
 
 impl Rule for ClientPreferHeaderAndPreferenceApplied {
@@ -174,8 +167,7 @@ impl Rule for ClientPreferHeaderAndPreferenceApplied {
 
         // Read once and used twice: the value decides the verdict, and on the
         // reporting path it is also what the finding has to show.
-        let vary = combined_field_value_as_written(&resp.headers, "vary");
-        if vary.as_deref().is_some_and(vary_nominates_prefer) {
+        if vary_nominates_prefer(&resp.headers) {
             return None;
         }
 
@@ -187,7 +179,10 @@ impl Rule for ClientPreferHeaderAndPreferenceApplied {
 
         // The name reached here through `parse_token_bws_word`, which admits only
         // `tchar`, so it is safe in a message as written; the `Vary` value is
-        // whatever the server sent.
+        // whatever the server sent, so it is read as written and escaped. Read
+        // here rather than at the gate above, which asks the shared predicate a
+        // question about the field rather than for its text.
+        let vary = combined_field_value_as_written(&resp.headers, "vary");
         let vary_state = match &vary {
             Some(v) => format!("its Vary field is '{}'", shown_in_finding(v)),
             None => "it carries no Vary field".to_string(),

--- a/lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
+++ b/lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
@@ -31,27 +31,19 @@ impl Rule for ServerVaryAndCacheConsistency {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
-        // Detect Vary: * across all Vary header fields. A `Vary: *` can never be matched by a
-        // cache, so any explicit cacheability directive on the same response is ineffective.
-        let mut saw_star = false;
-        for hv in resp.headers.get_all("vary").iter() {
-            let s = match hv.to_str() {
-                Ok(s) => s,
-                Err(_) => return None, // other rules handle non-utf8 vary values
-            };
-            for token in crate::helpers::headers::parse_list_header(s) {
-                // cite(RFC 9111 § 4.1): "A stored response with a Vary header field value containing a member "*" always fails to match."
-                if token == "*" {
-                    saw_star = true;
-                    break;
-                }
-            }
-            if saw_star {
-                break;
-            }
-        }
-
-        if !saw_star {
+        // A `Vary: *` can never be matched by a cache, so any explicit
+        // cacheability directive on the same response is ineffective.
+        //
+        // The walk this replaced read the field lines one at a time and returned
+        // no finding at all when `to_str` refused one — so a single `obs-text`
+        // octet anywhere in the value stood the rule down — and it did not join
+        // them, so a `*` written on a second field line was not a `*` here while
+        // it was one to `client_prefer_header_and_preference_applied`. Both are
+        // `helpers::headers::vary_nomination`'s answer now, for all three rules
+        // that ask.
+        //
+        // cite(RFC 9111 § 4.1): "A stored response with a Vary header field value containing a member "*" always fails to match."
+        if !crate::helpers::headers::vary_nomination(&resp.headers).is_wildcard() {
             return None;
         }
 
@@ -205,6 +197,44 @@ mod tests {
                 v
             );
         }
+    }
+
+    /// The two ways the walk this rule used to hold could not see a `*`.
+    #[test]
+    fn the_star_is_found_across_the_fields_lines_and_past_an_obs_text_octet() {
+        use hyper::header::{HeaderName, HeaderValue};
+        let judge = |vary: &[&[u8]]| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            let headers = &mut tx.response.as_mut().expect("a response").headers;
+            for line in vary {
+                headers.append(
+                    HeaderName::from_static("vary"),
+                    HeaderValue::from_bytes(line).expect("a test Vary value"),
+                );
+            }
+            headers.append(
+                "cache-control",
+                "max-age=3600".parse().expect("a directive"),
+            );
+            ServerVaryAndCacheConsistency.check_transaction(
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "server_vary_and_cache_consistency",
+                ]),
+            )
+        };
+
+        // §5.3 makes the lines one value and `#( "*" / field-name )` is what
+        // licenses the join, so this `*` is a member. Read line by line it was
+        // not one.
+        assert!(judge(&[b"accept-encoding", b"*"]).is_some());
+        // `to_str` refuses %xE9, and refusing it used to end the rule — so a
+        // `*` beside an `obs-text` octet drew nothing at all.
+        assert!(judge(&[b"caf\xe9, *"]).is_some());
+        assert!(judge(&[b"caf\xe9", b"*"]).is_some());
+        // And an `obs-text` octet on its own still nominates no `*`.
+        assert!(judge(&[b"caf\xe9"]).is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
+++ b/lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
@@ -136,34 +136,21 @@ impl Rule for StatefulVaryHeaderCacheValidity {
 
         let past = matched_past?; // no validator candidate found
 
-        // collect Vary header fields from that past response
-        let mut vary_fields: Vec<String> = Vec::new();
-        for hv in past
-            .response
-            .as_ref()
-            .unwrap()
-            .headers
-            .get_all("vary")
-            .iter()
-        {
-            if let Ok(s) = hv.to_str() {
-                for tok in crate::helpers::headers::parse_list_header(s) {
-                    let t = tok.trim();
-                    if t == "*" {
-                        // Vary: * never matches any request, so there is nothing to compare.
-                        // cite(RFC 9111 § 4.1): "A stored response with a Vary header field value containing a member "*" always fails to match."
-                        return None;
-                    }
-                    if !t.is_empty() {
-                        // Vary field names are case-insensitive; lower-case for comparison.
-                        vary_fields.push(t.to_ascii_lowercase());
-                    }
-                }
-            } else {
-                // ignore non-UTF8 Vary values; other rules will handle
-                return None;
-            }
-        }
+        // The field names that past response nominated. A `*` never matches any
+        // request, so there is nothing to compare and the rule stops.
+        //
+        // The walk this replaced read the field lines one at a time, skipped the
+        // whole rule when `to_str` refused one, and did not join them — so a `*`
+        // on a second field line was not a `*` here, and one `obs-text` octet in
+        // any line stood the comparison down. `helpers::headers::vary_nomination`
+        // is the one answer all three rules that ask this now share.
+        //
+        // cite(RFC 9111 § 4.1): "A stored response with a Vary header field value containing a member "*" always fails to match."
+        let crate::helpers::headers::VaryNomination::Fields(vary_fields) =
+            crate::helpers::headers::vary_nomination(&past.response.as_ref().unwrap().headers)
+        else {
+            return None;
+        };
 
         if vary_fields.is_empty() {
             return None;
@@ -322,6 +309,56 @@ mod tests {
                 ]),
             )
             .is_none());
+    }
+
+    /// The two ways the walk this rule used to hold could not read its `Vary`.
+    /// Both fixtures are the `mismatch_on_vary_field_triggers` exchange below
+    /// with the past response's `Vary` written differently — so the finding is
+    /// the same one, and what changes is whether the rule can see the field.
+    #[test]
+    fn the_past_responses_vary_is_read_across_its_lines_and_past_an_obs_text_octet() {
+        use hyper::header::{HeaderName, HeaderValue};
+        let judge = |vary: &[&[u8]]| {
+            let mut past = make_resp_tx("https://example.com/foo", None, Some("\"etag1\""));
+            let headers = &mut past.response.as_mut().expect("a response").headers;
+            for line in vary {
+                headers.append(
+                    HeaderName::from_static("vary"),
+                    HeaderValue::from_bytes(line).expect("a test Vary value"),
+                );
+            }
+            past.request.headers =
+                crate::test_helpers::make_headers_from_pairs(&[("Accept-Encoding", "gzip")]);
+
+            let mut tx = make_tx_with_req("https://example.com/foo");
+            tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
+                ("If-None-Match", "\"etag1\""),
+                ("Accept-Encoding", "deflate"),
+            ]);
+            let history =
+                crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
+            StatefulVaryHeaderCacheValidity.check_transaction(
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "stateful_vary_header_cache_validity",
+                ]),
+            )
+        };
+
+        // The nominated field is on the second line. §5.3 makes the lines one
+        // value; read one at a time the rule saw two one-member lists and this
+        // one still reports, so the case that proves the join is the `*`.
+        assert!(judge(&[b"accept-encoding"]).is_some());
+        assert!(judge(&[b"accept", b"accept-encoding"]).is_some());
+        // A `*` on the second field line is a member of the value, and a `*`
+        // stops the comparison outright. Read line by line it was not one, and
+        // this exchange was reported.
+        assert!(judge(&[b"accept-encoding", b"*"]).is_none());
+        // `to_str` refuses %xE9, and refusing it used to end the rule — so a
+        // nominated field beside an `obs-text` octet drew nothing at all.
+        assert!(judge(&[b"caf\xe9, accept-encoding"]).is_some());
+        assert!(judge(&[b"caf\xe9", b"accept-encoding"]).is_some());
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2195
+      line: 2270
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2190
+      line: 2265
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2189
+      line: 2264
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -264,7 +264,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2254
+      line: 2329
   - label: message_refresh_header_syntax_valid
     snippet: A code point is found that is not a URL unit.
     cited_by:
@@ -2046,7 +2046,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2191
+      line: 2266
     - file: lint-http-rules/src/helpers/uri.rs
       line: 259
   - label: lint-http-rules/src/helpers/uri.rs
@@ -2941,7 +2941,7 @@ sources:
     snippet: Alternatively, the server MAY include a Vary header with the special value "*"
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 91
+      line: 86
   - label: client_prefer_header_and_preference_applied (2)
     section: § 2
     snippet: For both preference token names and parameter names, comparison is case insensitive while values are case sensitive regardless of whether token or quoted-string values are used.
@@ -2963,7 +2963,7 @@ sources:
     snippet: Preference-Applied = "Preference-Applied" ":" 1#applied-pref
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 155
+      line: 148
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
       line: 144
   - label: client_prefer_header_and_preference_applied (4)
@@ -2971,7 +2971,7 @@ sources:
     snippet: The Preference-Applied response header MAY be included within a response message as an indication as to which Prefer tokens were honored by the server and applied to the processing of a request.
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 109
+      line: 102
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
       line: 112
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
@@ -2981,7 +2981,7 @@ sources:
     snippet: applied-pref = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 167
+      line: 160
     - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
       line: 192
   - label: client_prefer_header_and_preference_applied (6)
@@ -3543,25 +3543,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1754
+      line: 1829
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1695
+      line: 1770
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1733
+      line: 1808
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1726
+      line: 1801
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -4530,32 +4530,24 @@ sources:
       line: 41
     - file: lint-http-rules/src/rules/stateful_range_request_and_caching.rs
       line: 81
-  - label: Vary grammar
-    section: § 12.5.5
-    snippet: 'Vary = #( "*" / field-name )'
-    cited_by:
-    - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 89
-    - file: lint-http-rules/src/rules/server_vary_header_valid.rs
-      line: 37
   - label: client_prefer_header_and_preference_applied
     section: § 9.1
     snippet: The method token is case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 138
+      line: 131
   - label: client_prefer_header_and_preference_applied (2)
     section: § 9.2.3
     snippet: This specification defines caching semantics for GET, HEAD, and POST, although the overwhelming majority of cache implementations only support GET and HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 136
+      line: 129
   - label: client_prefer_header_and_preference_applied (3)
     section: § 9.3.3
     snippet: Responses to POST requests are only cacheable when they include explicit freshness information
     cited_by:
     - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 137
+      line: 130
   - label: client_range_header_syntax_valid
     section: § 14.1.1
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.
@@ -5123,9 +5115,9 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 60
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1005
+      line: 1080
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1034
+      line: 1109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 241
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -5273,11 +5265,19 @@ sources:
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1663
+      line: 1738
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 121
+  - label: Vary grammar
+    section: § 12.5.5
+    snippet: 'Vary = #( "*" / field-name )'
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1010
+    - file: lint-http-rules/src/rules/server_vary_header_valid.rs
+      line: 37
   - label: If-None-Match weak comparison
     section: § 13.1.2
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
@@ -5306,8 +5306,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 943
-    - file: lint-http-rules/src/rules/client_prefer_header_and_preference_applied.rs
-      line: 90
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1011
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.2
     snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
@@ -5315,7 +5315,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 211
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1461
+      line: 1536
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 64
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -5323,6 +5323,20 @@ sources:
     - file: lint-http-rules/src/rules/semantic_status_code_semantics.rs
       line: 21
   - label: lint-http-rules/src/helpers/headers.rs (7)
+    section: § 5.3
+    snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1012
+    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
+      line: 78
+    - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+      line: 407
+    - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
+      line: 226
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 179
+  - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
     cited_by:
@@ -5334,18 +5348,18 @@ sources:
       line: 319
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
       line: 93
-  - label: lint-http-rules/src/helpers/headers.rs (8)
+  - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 181
-  - label: lint-http-rules/src/helpers/headers.rs (9)
+  - label: lint-http-rules/src/helpers/headers.rs (10)
     section: § 5.3
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1462
+      line: 1537
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -5376,12 +5390,12 @@ sources:
       line: 41
     - file: lint-http-rules/src/rules/server_x_xss_protection_value_valid.rs
       line: 40
-  - label: lint-http-rules/src/helpers/headers.rs (10)
+  - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1924
+      line: 1999
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5404,7 +5418,7 @@ sources:
       line: 82
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 138
-  - label: lint-http-rules/src/helpers/headers.rs (11)
+  - label: lint-http-rules/src/helpers/headers.rs (12)
     section: § 5.5
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
     cited_by:
@@ -5428,21 +5442,21 @@ sources:
       line: 70
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 180
-  - label: lint-http-rules/src/helpers/headers.rs (12)
+  - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 5.5
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1459
+      line: 1534
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
       line: 124
-  - label: lint-http-rules/src/helpers/headers.rs (13)
+  - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.5
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1460
-  - label: lint-http-rules/src/helpers/headers.rs (14)
+      line: 1535
+  - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
@@ -5460,24 +5474,24 @@ sources:
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 432
-  - label: lint-http-rules/src/helpers/headers.rs (15)
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1524
+      line: 1599
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 81
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 40
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1525
+      line: 1600
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -5505,11 +5519,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 497
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1006
+      line: 1081
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1035
+      line: 1110
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1853
+      line: 1928
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
@@ -5522,62 +5536,62 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 463
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1585
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+      line: 1660
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 348
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1300
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+      line: 1375
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1298
+      line: 1373
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 332
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1139
+      line: 1214
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1167
+      line: 1242
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1299
+      line: 1374
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 421
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 477
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1007
+      line: 1082
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1166
+      line: 1241
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1204
+      line: 1279
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1297
+      line: 1372
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1526
+      line: 1601
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 316
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5590,38 +5604,38 @@ sources:
       line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 312
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2143
+      line: 2218
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 155
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 123
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 213
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1851
+      line: 1926
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1878
+      line: 1953
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 380
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1852
+      line: 1927
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1879
+      line: 1954
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2060
+      line: 2135
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5631,7 +5645,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2074
+      line: 2149
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 382
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5642,25 +5656,25 @@ sources:
       line: 129
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 219
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1850
+      line: 1925
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1923
+      line: 1998
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 379
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 203
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -5668,7 +5682,7 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 145
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
@@ -5680,7 +5694,7 @@ sources:
       line: 100
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
       line: 34
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
@@ -5706,18 +5720,18 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 169
-  - label: lint-http-rules/src/helpers/headers.rs (31)
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 822
-  - label: lint-http-rules/src/helpers/headers.rs (32)
+  - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2005
+      line: 2080
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5738,12 +5752,12 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/server_problem_details_content_type.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (33)
+  - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2024
+      line: 2099
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5751,22 +5765,22 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1939
+      line: 2014
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 105
-  - label: lint-http-rules/src/helpers/headers.rs (34)
+  - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2004
+      line: 2079
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (35)
+  - label: lint-http-rules/src/helpers/headers.rs (36)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
@@ -5777,8 +5791,8 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1773
-  - label: lint-http-rules/src/helpers/headers.rs (36)
+      line: 1848
+  - label: lint-http-rules/src/helpers/headers.rs (37)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
@@ -7822,18 +7836,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
       line: 72
-  - label: server_alt_svc_h3_advertisement_valid
-    section: § 5.3
-    snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
-    cited_by:
-    - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
-      line: 78
-    - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 407
-    - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 226
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 179
   - label: server_alt_svc_header_syntax
     section: § 3.7
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
@@ -8319,12 +8321,22 @@ sources:
   type: text/plain
   fragments:
   - label: lint-http-rules/src/helpers/headers.rs
+    section: § 4.1
+    snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 1013
+    - file: lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
+      line: 45
+    - file: lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
+      line: 148
+  - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 662
-  - label: lint-http-rules/src/helpers/headers.rs (2)
+  - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
@@ -8518,14 +8530,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_status_and_caching_semantics.rs
       line: 75
-  - label: server_vary_and_cache_consistency
-    section: § 4.1
-    snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
-    cited_by:
-    - file: lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
-      line: 43
-    - file: lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
-      line: 154
   - label: stateful_cache_validation_chain
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI.
@@ -8673,7 +8677,7 @@ sources:
     snippet: the cache MUST NOT use that stored response without revalidation unless all the presented request header fields nominated by that Vary field value match those fields in the original request
     cited_by:
     - file: lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
-      line: 182
+      line: 169
 - label: RFC 9112
   url: https://www.rfc-editor.org/rfc/rfc9112.txt
   type: text/plain


### PR DESCRIPTION
…wo got right

`helpers::headers::vary_nomination` reads a response's `Vary` once, for the three rules that asked.

Two of the three were wrong in the same two ways: both walked `get_all("vary")` line by line, both bailed on a line `to_str` refused — one returning no finding, the other skipping the line — and neither joined the lines, so a `*` on a second field line was not a `*` and one `obs-text` octet stood the whole rule down. §5.3 makes the lines one value and `#( "*" / field-name )` is what licenses the join.

The third was the one held up as correct, and it used the wrong walk. It split quote-aware, and `field-name = token` admits no `quoted-string`, so a stray DQUOTE made the next comma data and `Vary: "x, prefer` did not nominate `Prefer`. Where an element cannot hold a quoted-string, a DQUOTE is a character the member may not have, and reading it as opening one makes the next comma data when there is no quoted-string for it to be data in.

So each of the three was right about something the other two were not — the join, the octet, and the walk. The two-against-one shape invites picking the majority; here the majority was wrong twice and the minority once, and the shared reader is all three answers rather than any one rule's. Its walk is `list_members`, whose second caller this is.

Nothing in three rules' tests could see any of it — the whole suite passed before the conversion. Two rule-level tests were added, one per corrected rule, each built from that rule's own reporting fixture with only the `Vary` spelling changed, so what they pin is whether the field can be read rather than a new finding.

Cites 2184 → 2186.
