### PR TITLE
The two list walks were one walk with one wrong line

### DIFF
--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -802,11 +802,11 @@ enum AltSvc {
 /// `":port"` (same-host) advertisement form. Returns `None` when the header
 /// carries no usable h3 route and no `clear`.
 fn parse_alt_svc(header: &str, origin_host: &str) -> Option<AltSvc> {
-    use crate::helpers::headers::{parse_list_header, split_semicolons_respecting_quotes};
+    use crate::helpers::headers::{list_members, split_semicolons_respecting_quotes};
 
     let mut endpoints = Vec::new();
     let mut ma = DEFAULT_ALT_SVC_MA_SECS;
-    for entry in parse_list_header(header) {
+    for entry in list_members(header) {
         let mut parts = entry.splitn(2, ';');
         let proto_auth = parts.next().unwrap_or("").trim();
         let params = parts.next().unwrap_or("");

--- a/lint-http-rules/src/helpers/accept_ranges.rs
+++ b/lint-http-rules/src/helpers/accept_ranges.rs
@@ -95,7 +95,7 @@ pub fn read_advertisement(resp: &crate::http_transaction::ResponseInfo) -> Adver
 
             let mut saw_a_unit = false;
             // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
-            for token in crate::helpers::headers::parse_list_header(value) {
+            for token in crate::helpers::headers::list_members(value) {
                 // A range unit is a token and nothing narrower: the set is open
                 // by design, so a name this code has never heard of is a name it
                 // has to carry rather than reject.

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -47,7 +47,7 @@ pub fn validate_content_length(headers: &HeaderMap) -> Result<Option<u128>, Cont
         //
         // cite(RFC 9112 § 6.3): "If a message is received without Transfer-Encoding and with an invalid Content-Length header field, then the message framing is invalid and the recipient MUST treat it as an unrecoverable error, unless the field value can be successfully parsed as a comma-separated list (Section 5.6.1 of [HTTP]), all values in the list are valid, and all values in the list are the same (in which case, the message is processed with that single value used as the Content-Length field value)."
         let mut saw_value = false;
-        for t in parse_list_header(s) {
+        for t in list_members(s) {
             saw_value = true;
 
             // cite(RFC 9110 § 8.6, label: Content-Length grammar): "Content-Length = 1*DIGIT"
@@ -452,48 +452,50 @@ pub fn extract_strong_validators_from_response(
     (etag, last_modified)
 }
 
-/// Parse a comma-separated list of header values (e.g., Connection, Transfer-Encoding).
+/// Every member of a `#element` list, `OWS`-trimmed, with the empty ones dropped.
 ///
-/// This iterator splits by comma, trims whitespace, and skips empty parts.
+/// A recipient's reader, and "dropping the empty ones" is what makes it one. `a,,b`
+/// is a two-element list and not a malformed one; a *sender* must not generate the
+/// empty element (§ 5.6.1.1), which is a different rule for a different party — so
+/// a rule wanting to flag `a,,b` as bad output cannot ask this function, because by
+/// the time it answers, the evidence is gone. [`list_members_as_written`] is the
+/// walk that keeps it.
 ///
-/// "Skips empty parts" is the interesting one, and it is a requirement rather
-/// than a convenience: `a,,b` is a two-element list, not a malformed one, and the
-/// seventy-odd callers that reach this are all recipients. A sender must not
-/// produce empty elements (§ 5.6.1.1), which is a different rule for a different
-/// party -- so a *rule* wanting to flag `a,,b` as bad output cannot ask this
-/// function, because by the time it answers, the evidence is gone.
+/// § 5.6.1.2 bounds the ignoring — "a reasonable number", but not so many that it
+/// becomes a denial-of-service vector — and this imposes no cap. That is deliberate
+/// rather than overlooked: the bound protects a recipient from the cost of the
+/// ignoring, and `split` + `filter` is linear with no amplification. There is
+/// nothing here to exhaust.
 ///
-/// § 5.6.1.2 bounds the requirement -- ignore "a reasonable number", but not so
-/// many that it becomes a denial-of-service vector -- and this imposes no cap.
-/// That is deliberate rather than overlooked: the bound protects a recipient from
-/// the cost of the ignoring, and `split` + `filter` is linear with no
-/// amplification. There is nothing here to exhaust.
+/// **The trim is `OWS` and not `str::trim`, and this was two functions until it
+/// was read.** Four decisions make up a `#rule` walk — where to split, what to
+/// trim, whether to drop an empty element, and whether to fold case — and
+/// `parse_list_header` differed from this one in exactly the second: `OWS` is
+/// `*( SP / HTAB )`, and `str::trim` removes every character `char::is_whitespace`
+/// admits. That difference cannot show on a value read back through
+/// `HeaderValue::to_str`, which returns `Err` for every octet outside `%x20-7E`
+/// plus HTAB — so the `&str` it hands back holds no other whitespace character to
+/// trim. It shows on the two readers that do not go through it, and it shows
+/// differently on each.
 ///
-// cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
+/// [`combined_field_value_as_written`] carries one `char` per octet, so the
+/// disagreement is exactly two characters wide: U+00A0 and U+0085, which are the
+/// octets %xA0 and %x85. **`String::from_utf8_lossy` is wider than that** — a
+/// field value is octets, and any UTF-8 sequence a sender writes decodes to the
+/// `char` it spells, so U+2003, U+3000, U+1680 and U+2028 are all reachable
+/// alongside %xC2 %xA0 and %xC2 %x85. Every one of them is `obs-text` on the wire
+/// — the very octet class no `token` admits — and trimming any of them hands the
+/// member's own grammar a value the sender did not write.
+///
+/// The split is naive: a DQUOTE is not read as opening a `quoted-string`. That is
+/// the grammar's answer where the element admits none, and the wrong one where it
+/// does; [`list_members_as_written`] is the quote-aware walk and says which is
+/// which at its own doc comment.
+///
 // cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
-pub fn parse_list_header(val: &str) -> impl Iterator<Item = &str> {
-    val.split(',').map(|s| s.trim()).filter(|s| !s.is_empty())
-}
-
-/// The same walk as [`parse_list_header`], trimming the whitespace the production
-/// actually prints.
-///
-/// Four decisions make up a `#rule` walk -- where to split, what to trim, whether
-/// to drop an empty element, and whether to fold case -- and this differs from its
-/// neighbour in exactly one of them. `OWS` is `*( SP / HTAB )`; `str::trim` removes
-/// every character `char::is_whitespace` admits. On a value read back through
-/// `to_str` the two are the same function, because that reader lets no other
-/// whitespace octet into the string at all. On a value read one `char` per octet
-/// ([`combined_field_value_as_written`]) they are not: %xA0 and %x85 are `obs-text`
-/// octets a sender wrote *inside* a member, and trimming them hands the member's
-/// own grammar a value the sender did not write.
-///
-/// [`parse_list_header`] keeps the Unicode trim and its seventy-odd callers. They
-/// read `to_str` values, where the answer is the same one; converting them would
-/// change what every one of those sites reports, which is each of their audits'
-/// work rather than this helper's.
-// cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
 // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
+// cite(RFC 9110 § 5.6.1.2): "A recipient MUST parse and ignore a reasonable number of empty list elements:"
+// cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
 // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
 pub fn list_members(val: &str) -> impl Iterator<Item = &str> {
     val.split(',').map(trim_ows).filter(|s| !s.is_empty())
@@ -1028,17 +1030,17 @@ pub fn vary_nomination(response_headers: &HeaderMap) -> VaryNomination {
 /// Every member of a `#element` list, `OWS`-trimmed, **with the empty ones
 /// kept**.
 ///
-/// The third `#rule` walk in this module, and the axis it differs on is the one
+/// The second `#rule` walk in this module, and the axis it differs on is the one
 /// that makes it a *sender's* reader rather than a recipient's.
-/// [`parse_list_header`] and [`list_members`] both drop an empty member, because
-/// § 5.6.1.2 has a recipient parse and ignore one — so by the time either
-/// answers, the evidence is gone. A rule measuring what a sender wrote needs the
+/// [`list_members`] drops an empty member, because § 5.6.1.2 has a recipient
+/// parse and ignore one — so by the time it answers, the evidence is gone. A
+/// rule measuring what a sender wrote needs the
 /// empty member *in the list*, since § 5.6.1.1 forbids generating it and
 /// § 5.6.1.2's worked example makes a value of nothing but commas the invalid
 /// spelling of a `1#` floor. Neither of those two findings can be made from a
 /// list that has already dropped them.
 ///
-/// It is also the only one of the three that is quote-aware. A comma inside a
+/// It is also the only one of the two that is quote-aware. A comma inside a
 /// `quoted-string` is `qdtext` and not a separator, so a naive split cut
 /// `TE: deflate;ext="a,b"` — one member, one parameter — into a second "member"
 /// of `b"`.
@@ -2351,10 +2353,68 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_list_header() {
+    fn test_list_members() {
         let input = " foo, bar , , baz ";
-        let tokens: Vec<_> = parse_list_header(input).collect();
+        let tokens: Vec<_> = list_members(input).collect();
         assert_eq!(tokens, vec!["foo", "bar", "baz"]);
+    }
+
+    /// The two spellings a caller can hand this walk, characterised rather than
+    /// regressed: [`list_members`] already trimmed `OWS`, so this passes on the
+    /// tree before `parse_list_header` was folded into it. What it pins is which
+    /// *values* now reach here — a value read one `char` per octet carries %xA0
+    /// as U+00A0, and a value read through `String::from_utf8_lossy` carries the
+    /// same octet's UTF-8 spelling %xC2 %xA0 as the same `char`. Either way it is
+    /// `obs-text` a sender wrote *inside* the member, which is the octet class no
+    /// `token` admits, so it has to survive the trim and reach the check that
+    /// owns the member's grammar. The conversion's own regressions are the eight
+    /// rule-level tests named in RULECITES §6's P17 entry.
+    #[test]
+    fn list_members_trims_ows_and_not_the_obs_text_that_looks_like_space() {
+        assert_eq!(
+            list_members(" a ,\tb\t").collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+
+        let per_octet: String = [0xA0u8, b'a', 0xA0].iter().map(|&b| b as char).collect();
+        let members: Vec<_> = list_members(&per_octet).collect();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].chars().count(), 3, "the obs-text octets survive");
+
+        let lossy = String::from_utf8_lossy(b"gzip\xC2\xA0").into_owned();
+        assert_eq!(list_members(&lossy).collect::<Vec<_>>(), vec!["gzip\u{A0}"]);
+
+        // U+0085 is %x85 and tells the same story; `str::trim` removed both.
+        let nel: String = [b'a', 0x85].iter().map(|&b| b as char).collect();
+        assert_eq!(list_members(&nel).next().unwrap().chars().count(), 2);
+    }
+
+    /// Why converting `parse_list_header`'s thirty-six call sites changed
+    /// nothing at twenty-nine of them and everything at seven. Twenty-six read
+    /// their value back through `to_str`, which returns `Err` for every octet
+    /// outside `%x20-7E` plus HTAB, so the `&str` it hands back cannot hold a
+    /// whitespace character the two trims disagree about; three more are Rust
+    /// string literals in a test's own fixture. The disagreement is reachable
+    /// only through a reader that does not refuse those octets.
+    ///
+    /// **The octet is placed at both ends, which is the only place a trim can
+    /// see it.** An earlier spelling of this test wrapped it as `a<octet>b`,
+    /// where both trims are the identity for every input and the assertion says
+    /// `s == s`. A test whose fixture cannot reach the branch it is about is the
+    /// already-clean-fixture shape, one level in from the message it asserts.
+    #[test]
+    fn to_str_admits_no_whitespace_the_two_trims_disagree_about() {
+        for b in 0u8..=0xFF {
+            let Ok(hv) = HeaderValue::from_bytes(&[b, b'a', b]) else {
+                continue;
+            };
+            let Ok(s) = hv.to_str() else { continue };
+            assert_eq!(
+                s.trim(),
+                trim_ows(s),
+                "octet {b:#04x} reached `to_str` and the two trims disagree on it"
+            );
+        }
     }
 
     #[test]
@@ -2707,19 +2767,19 @@ mod tests {
         assert_eq!((p.name, p.value), ("a", "b"));
     }
 
-    /// The empty members are the point. Two of the three list walks in this
-    /// module drop them, which is right for a recipient and destroys the
-    /// evidence for a rule measuring a sender: `1#`'s floor counts non-empty
-    /// members, so a value of nothing but commas has to arrive as several empty
-    /// members rather than as no members at all.
+    /// The empty members are the point. The other list walk in this module drops
+    /// them, which is right for a recipient and destroys the evidence for a rule
+    /// measuring a sender: `1#`'s floor counts non-empty members, so a value of
+    /// nothing but commas has to arrive as several empty members rather than as
+    /// no members at all.
     #[test]
-    fn list_members_as_written_keeps_what_the_other_two_walks_drop() {
+    fn list_members_as_written_keeps_what_the_recipients_walk_drops() {
         assert_eq!(list_members_as_written("a,,b"), vec!["a", "", "b"]);
         assert_eq!(list_members_as_written(""), vec![""]);
         assert_eq!(list_members_as_written(","), vec!["", ""]);
         assert_eq!(list_members_as_written(",   ,"), vec!["", "", ""]);
-        // The same three values through the recipient's walk, which is what the
-        // two findings cannot be made from.
+        // The same values through the recipient's walk, which is what the two
+        // findings cannot be made from.
         assert_eq!(list_members("a,,b").collect::<Vec<_>>(), vec!["a", "b"]);
         assert!(list_members(",   ,").next().is_none());
     }

--- a/lint-http-rules/src/helpers/language.rs
+++ b/lint-http-rules/src/helpers/language.rs
@@ -20,9 +20,19 @@
 /// enforced -- subtags are alphanumeric, hyphen-separated, at most eight
 /// characters, and no whitespace -- and each sits on the line that enforces it.
 ///
+/// **Nothing is trimmed here, and the line that used to do it silenced the line
+/// below it.** `let s = tag.trim()` removed every character `char::is_whitespace`
+/// admits — and the next branch exists to *report* exactly those. On an ASCII
+/// space the two cancelled out into a wrong-but-harmless silence; on U+00A0,
+/// which is how the octet %xA0 and the pair %xC2 %xA0 both reach this function,
+/// it meant `en-US<%xC2%xA0>` was validated as `en-US`. The list's own `OWS` is
+/// the caller's to strip (§ 5.6.1.1 puts it outside the element), and inside the
+/// element the sentence below admits no whitespace at all — so the honest answer
+/// is to measure what was passed.
+///
 /// Returns Ok(()) if the tag looks like a valid language tag, Err(msg) otherwise.
 pub fn validate_language_tag(tag: &str) -> Result<(), String> {
-    let s = tag.trim();
+    let s = tag;
     if s.is_empty() {
         return Err("empty language tag".into());
     }

--- a/lint-http-rules/src/rules/client_accept_encoding_present.rs
+++ b/lint-http-rules/src/rules/client_accept_encoding_present.rs
@@ -64,10 +64,7 @@ impl Rule for ClientAcceptEncodingPresent {
         for hv in tx.request.headers.get_all("accept-encoding").iter() {
             present = true;
             let val = String::from_utf8_lossy(hv.as_bytes());
-            if crate::helpers::headers::parse_list_header(&val)
-                .next()
-                .is_some()
-            {
+            if crate::helpers::headers::list_members(&val).next().is_some() {
                 any_coding = true;
             }
         }
@@ -331,6 +328,23 @@ mod tests {
             v.is_some_and(|v| v.message.contains("declines all content codings")),
             "{value:?} lists no codings"
         );
+    }
+
+    /// **A value holding an `obs-text` octet is not an empty value**, and the
+    /// finding above says "empty" in as many words. The list walk used to trim
+    /// %xC2 %xA0 as whitespace, so a field carrying one member was reported for
+    /// declining every coding — a claim about a value the sender did not write.
+    /// The member derives from no `codings` and this rule does not say so:
+    /// that is the field's syntax and belongs to
+    /// `message_accept_encoding_parameter_validity`.
+    #[test]
+    fn a_member_of_obs_text_is_a_preference_expressed_not_an_empty_field() {
+        let mut tx = req(&[]);
+        tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(
+            "accept-encoding",
+            b"\xC2\xA0".as_slice(),
+        )]);
+        assert!(run(&tx).is_none(), "{:?}", run(&tx));
     }
 
     /// The two findings are distinct, because the states are.

--- a/lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
+++ b/lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
@@ -522,7 +522,7 @@ mod tests {
                         "Content-Range {value:?} does not parse"
                     ),
                     "accept-ranges" => {
-                        for token in crate::helpers::headers::parse_list_header(value) {
+                        for token in crate::helpers::headers::list_members(value) {
                             assert!(
                                 crate::helpers::token::find_invalid_token_char(token).is_none(),
                                 "Accept-Ranges holds {token:?}, which is not a token"

--- a/lint-http-rules/src/rules/client_range_header_syntax_valid.rs
+++ b/lint-http-rules/src/rules/client_range_header_syntax_valid.rs
@@ -242,7 +242,7 @@ fn validate_range_set(unit: &str, range_set: &str) -> Result<(), String> {
         // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
         let spec = spec.trim();
 
-        // Not `parse_list_header`, which drops empty elements: that is the right
+        // Not `list_members`, which drops empty elements: that is the right
         // reading for the recipients that call it and the wrong one here, because
         // the empty element is this rule's evidence. By the time that function
         // answers, what a sender must not have generated is gone.

--- a/lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
+++ b/lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
@@ -47,7 +47,7 @@ impl Rule for MessageAcceptEncodingParameterValidity {
                     // is right — §12.5.3 gives that value a meaning of its own.
                     // cite(RFC 9110 § 12.5.3): "An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response."
                     // cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
-                    for part in crate::helpers::headers::parse_list_header(val) {
+                    for part in crate::helpers::headers::list_members(val) {
                         // Split into token and optional params
                         let mut iter =
                             crate::helpers::headers::split_semicolons_respecting_quotes(part)

--- a/lint-http-rules/src/rules/message_accept_language_weight_validity.rs
+++ b/lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -41,7 +41,7 @@ impl Rule for MessageAcceptLanguageWeightValidity {
             // quoted-string, so there is no quoted comma to protect. Empty list
             // elements are skipped, which §5.6.1.2 permits a recipient to do.
             // cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
-            for member in crate::helpers::headers::parse_list_header(hdr_value) {
+            for member in crate::helpers::headers::list_members(hdr_value) {
                 // Each member: language-range [; params]
                 let mut iter = member.split(';').map(|s| s.trim());
                 // The language-range itself is `message_language_tag_format_valid`'s

--- a/lint-http-rules/src/rules/message_accept_ranges_and_206_consistency.rs
+++ b/lint-http-rules/src/rules/message_accept_ranges_and_206_consistency.rs
@@ -461,7 +461,7 @@ mod tests {
                         "Content-Range {value:?} does not parse"
                     ),
                     "accept-ranges" => {
-                        for token in crate::helpers::headers::parse_list_header(value) {
+                        for token in crate::helpers::headers::list_members(value) {
                             assert!(
                                 crate::helpers::token::find_invalid_token_char(token).is_none(),
                                 "Accept-Ranges holds {token:?}, which is not a token"

--- a/lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
@@ -49,7 +49,7 @@ impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
                     })
                 }
             };
-            for token in crate::helpers::headers::parse_list_header(s) {
+            for token in crate::helpers::headers::list_members(s) {
                 if token == "*" {
                     acao_has_star = true;
                     break;

--- a/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -64,7 +64,7 @@ impl Rule for MessageAccessControlAllowOriginValid {
         };
 
         // Must be a single value (not a comma-separated list)
-        let members: Vec<String> = crate::helpers::headers::parse_list_header(s)
+        let members: Vec<String> = crate::helpers::headers::list_members(s)
             .map(|m| m.to_string())
             .collect();
         if members.len() != 1 {

--- a/lint-http-rules/src/rules/message_cache_control_and_pragma_consistency.rs
+++ b/lint-http-rules/src/rules/message_cache_control_and_pragma_consistency.rs
@@ -37,8 +37,7 @@ impl Rule for MessageCacheControlAndPragmaConsistency {
                     continue;
                 }
             };
-            for member in crate::helpers::headers::parse_list_header(s) {
-                let m = member.trim();
+            for m in crate::helpers::headers::list_members(s) {
                 if m.eq_ignore_ascii_case("no-cache") {
                     // if request also contains Cache-Control: only-if-cached, that's contradictory
                     for cc in tx.request.headers.get_all("cache-control").iter() {

--- a/lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
+++ b/lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
@@ -52,7 +52,7 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
             let mut ce_set = std::collections::HashSet::new();
             for hv in headers.get_all("content-encoding").iter() {
                 let s = decode(hv);
-                for part in crate::helpers::headers::parse_list_header(&s) {
+                for part in crate::helpers::headers::list_members(&s) {
                     // Nothing in this field's grammar sits behind a `;`, so this
                     // strips something that cannot legally be there. It is kept as
                     // a deliberate tolerance: a sender writing `gzip;q=1.0` here
@@ -61,8 +61,15 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
                     // `message_content_encoding_iana_registered` is already
                     // reporting as malformed. It cannot invent an overlap -- the
                     // text before the `;` is text the sender wrote.
+                    // The trim is `OWS`, not `str::trim`: `decode` is
+                    // `from_utf8_lossy`, so %xC2 %xA0 reaches here as one `char`
+                    // `char::is_whitespace` admits and no `token` does, and
+                    // taking it would turn a name no production writes into
+                    // `gzip`.
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
                     // cite(RFC 9110 § 8.4.1): "All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry","
-                    let token = part.split(';').next().unwrap().trim().to_ascii_lowercase();
+                    let token = crate::helpers::headers::trim_ows(part.split(';').next().unwrap())
+                        .to_ascii_lowercase();
                     if token.is_empty() {
                         continue;
                     }
@@ -87,8 +94,13 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
             for hv in headers.get_all("transfer-encoding").iter() {
                 let s = decode(hv);
                 for part in crate::helpers::headers::split_commas_respecting_quotes(&s) {
+                    // `OWS` for the same reason as the `Content-Encoding` loop
+                    // above, and this production prints it: the whitespace around
+                    // the `;` is `OWS` and nothing wider.
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
                     // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
-                    let token = part.split(';').next().unwrap().trim().to_ascii_lowercase();
+                    let token = crate::helpers::headers::trim_ows(part.split(';').next().unwrap())
+                        .to_ascii_lowercase();
                     if token.is_empty() {
                         continue;
                     }
@@ -314,6 +326,38 @@ mod tests {
                 v
             );
         }
+    }
+
+    /// `Some("gzip"), Some("chunked, gzip")` — the first `overlap_cases` row —
+    /// with one `obs-text` octet on the `Content-Encoding` name. `content-coding
+    /// = token`, so `gzip<%xC2%xA0>` is not the `gzip` coding and the two fields
+    /// name nothing in common. The value is read with `from_utf8_lossy`, so the
+    /// pair arrives as one `char`; the list walk trimmed it and the name split
+    /// below trimmed it again, and the finding claimed an overlap between a
+    /// coding and a value that is not one.
+    ///
+    /// Both name splits are exercised, because they are two separate trims on
+    /// two separate productions and only one of them was covered.
+    #[rstest]
+    #[case(b"gzip\xC2\xA0", b"chunked, gzip")]
+    #[case(b"gzip", b"chunked, gzip\xC2\xA0")]
+    fn a_coding_name_carrying_obs_text_overlaps_nothing(#[case] ce: &[u8], #[case] te: &[u8]) {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_octet_pairs(&[
+                ("content-encoding", ce),
+                ("transfer-encoding", te),
+            ]);
+        let rule = MessageCompressionAndTransferEncodingConsistency;
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_compression_and_transfer_encoding_consistency",
+        ]);
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        );
+        assert!(v.is_none(), "{v:?}");
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_content_encoding_and_type_consistency.rs
+++ b/lint-http-rules/src/rules/message_content_encoding_and_type_consistency.rs
@@ -31,7 +31,7 @@ impl Rule for MessageContentEncodingAndTypeConsistency {
                                      seen: &mut std::collections::HashSet<String>|
          -> Option<Violation> {
             // cite(RFC 9110 § 8.4): "Content-Encoding = #content-coding"
-            for part in crate::helpers::headers::parse_list_header(val) {
+            for part in crate::helpers::headers::list_members(val) {
                 // Strip parameters (not expected for Content-Encoding but be forgiving)
                 let token = part.split(';').next().unwrap().trim();
                 if token.is_empty() {

--- a/lint-http-rules/src/rules/message_content_encoding_iana_registered.rs
+++ b/lint-http-rules/src/rules/message_content_encoding_iana_registered.rs
@@ -96,7 +96,7 @@ impl Rule for MessageContentEncodingIanaRegistered {
                            allowed: &Vec<String>,
                            is_accept: bool|
          -> Option<Violation> {
-            for part in crate::helpers::headers::parse_list_header(val) {
+            for part in crate::helpers::headers::list_members(val) {
                 // Split off any parameters (e.g., gzip;q=0.8)
                 let token = part.split(';').next().unwrap().trim();
                 if token == "*" {

--- a/lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
+++ b/lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
@@ -38,7 +38,7 @@ impl Rule for MessageContentTransferEncodingValid {
             }
 
             // RFC 2045 defines a single token value here; if commas are present it's likely malformed
-            let parts: Vec<&str> = crate::helpers::headers::parse_list_header(s).collect();
+            let parts: Vec<&str> = crate::helpers::headers::list_members(s).collect();
             // cite(RFC 2045 § 6.1): "mechanism := "7bit" / "8bit" / "binary" / "quoted-printable" / "base64" / ietf-token / x-token"
             if parts.len() > 1 {
                 return Some(
@@ -46,7 +46,15 @@ impl Rule for MessageContentTransferEncodingValid {
                 );
             }
 
-            let tok = parts[0];
+            // `parts[0]` was an index, and `,` is the value that makes it panic:
+            // every member of that value is empty, none of them is an element, so
+            // the walk hands back nothing at all. The length test above only
+            // refuses *more* than one member. A value listing no member says the
+            // same thing as one with nothing in it, which is the branch above.
+            // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
+            let Some(tok) = parts.first().copied() else {
+                return Some("the value is empty".into());
+            };
             if let Some(c) = crate::helpers::token::find_invalid_token_char(tok) {
                 return Some(format!("the value contains an invalid character: '{}'", c));
             }
@@ -170,6 +178,11 @@ mod tests {
     #[case(Some("X-My-New-Encoding"), true)]
     #[case(Some("base64, gzip"), true)]
     #[case(Some("bad@token"), true)]
+    // A value of nothing but commas listed no member and indexed the walk's
+    // empty result: the linter panicked rather than reporting the field. The
+    // length test above only refused *more* than one member.
+    #[case(Some(","), true)]
+    #[case(Some(" , "), true)]
     fn content_transfer_encoding_cases(
         #[case] hdr: Option<&str>,
         #[case] expect_violation: bool,

--- a/lint-http-rules/src/rules/message_cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/message_cross_origin_embedder_policy_valid.rs
@@ -62,7 +62,7 @@ impl Rule for MessageCrossOriginEmbedderPolicyValid {
         };
 
         // Must not be a comma-separated list
-        if crate::helpers::headers::parse_list_header(val).count() != 1 {
+        if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,

--- a/lint-http-rules/src/rules/message_cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/message_cross_origin_opener_policy_valid.rs
@@ -57,7 +57,7 @@ impl Rule for MessageCrossOriginOpenerPolicyValid {
             };
 
         // Must not be a comma-separated list
-        if crate::helpers::headers::parse_list_header(val).count() != 1 {
+        if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,

--- a/lint-http-rules/src/rules/message_cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/message_cross_origin_resource_policy_valid.rs
@@ -62,7 +62,7 @@ impl Rule for MessageCrossOriginResourcePolicyValid {
         };
 
         // Must not be a comma-separated list
-        if crate::helpers::headers::parse_list_header(val).count() != 1 {
+        if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,

--- a/lint-http-rules/src/rules/message_http3_no_connection_header.rs
+++ b/lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -197,7 +197,7 @@ fn check_forbidden_headers(headers: &hyper::HeaderMap) -> Option<String> {
 fn check_te_header(headers: &hyper::HeaderMap) -> Option<String> {
     if let Some(val) = headers.get("te") {
         if let Ok(s) = val.to_str() {
-            let has_non_trailers = crate::helpers::headers::parse_list_header(s)
+            let has_non_trailers = crate::helpers::headers::list_members(s)
                 .any(|token| !token.eq_ignore_ascii_case("trailers"));
             if has_non_trailers {
                 return Some(
@@ -504,7 +504,7 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
-        // Empty TE is not a violation (parse_list_header filters empty tokens)
+        // Empty TE is not a violation (list_members filters empty tokens)
         assert!(v.is_none());
     }
 

--- a/lint-http-rules/src/rules/message_if_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/message_if_match_etag_syntax.rs
@@ -46,7 +46,7 @@ impl Rule for MessageIfMatchEtagSyntax {
             // strongly (§13.1.1), so weak tags are accepted, not flagged (see §4.1).
             // cite(RFC 9110 § 13.1.1): "If-Match = "*" / #entity-tag"
             let mut seen_any = false;
-            for member in crate::helpers::headers::parse_list_header(s) {
+            for member in crate::helpers::headers::list_members(s) {
                 seen_any = true;
                 if let Err(msg) = crate::helpers::headers::validate_entity_tag(member) {
                     return Some(Violation {

--- a/lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
@@ -47,7 +47,7 @@ impl Rule for MessageIfNoneMatchEtagSyntax {
             // weak-comparison MUST is owned by `inm_matches_known`, which performs it.
             // cite(RFC 9110 § 13.1.2): "If-None-Match = "*" / #entity-tag"
             let mut seen_any = false;
-            for member in crate::helpers::headers::parse_list_header(s) {
+            for member in crate::helpers::headers::list_members(s) {
                 seen_any = true;
                 if let Err(msg) = crate::helpers::headers::validate_entity_tag(member) {
                     return Some(Violation {

--- a/lint-http-rules/src/rules/message_language_tag_format_valid.rs
+++ b/lint-http-rules/src/rules/message_language_tag_format_valid.rs
@@ -96,7 +96,7 @@ impl Rule for MessageLanguageTagFormatValid {
         let content_language = |headers: &hyper::HeaderMap| -> Option<Violation> {
             for hv in headers.get_all("content-language").iter() {
                 let val = decode(hv);
-                for token in crate::helpers::headers::parse_list_header(&val) {
+                for token in crate::helpers::headers::list_members(&val) {
                     if let Some(v) = check_tag("Content-Language", token) {
                         return Some(v);
                     }
@@ -108,11 +108,18 @@ impl Rule for MessageLanguageTagFormatValid {
         let accept_language = |headers: &hyper::HeaderMap| -> Option<Violation> {
             for hv in headers.get_all("accept-language").iter() {
                 let val = decode(hv);
-                for member in crate::helpers::headers::parse_list_header(&val) {
+                for member in crate::helpers::headers::list_members(&val) {
                     // The weight is stripped rather than checked; whether it is
                     // a weight at all is `message_accept_language_weight_validity`'s
                     // subject, and this rule reads only the range in front of it.
-                    let lang = member.split(';').next().unwrap().trim();
+                    // `OWS` and not `str::trim`, which is what the walk above
+                    // settled: `decode` is `from_utf8_lossy`, so %xC2 %xA0
+                    // arrives as one `char` `char::is_whitespace` admits — and
+                    // this rule's own description says an octet outside visible
+                    // US-ASCII is reported rather than skipped.
+                    // cite(RFC 9110 § 12.4.2): "weight = OWS ";" OWS "q=" qvalue"
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                    let lang = crate::helpers::headers::trim_ows(member.split(';').next().unwrap());
                     // `*` is one of the two alternatives of `language-range`,
                     // not a tag — so it is skipped here and reported in
                     // Content-Language, where the production has no such
@@ -497,5 +504,35 @@ mod tests {
         );
         assert!(v.is_none());
         Ok(())
+    }
+
+    /// What `description()`'s *"An octet outside visible US-ASCII is reported,
+    /// not skipped"* claims, on the two spellings that used to escape it. The
+    /// value is read with `from_utf8_lossy` precisely so such an octet reaches
+    /// `check_tag` — and %xC2 %xA0 arrives as one `char` `str::trim` calls
+    /// whitespace, so the list walk took it off `Content-Language` and the
+    /// weight split took it off `Accept-Language`. Both trims are `OWS` now, and
+    /// no `language-tag` or `language-range` admits either octet.
+    #[rstest]
+    #[case("content-language", b"en-US\xC2\xA0")]
+    #[case("accept-language", b"en-US\xC2\xA0")]
+    fn an_obs_text_octet_shaped_like_a_space_is_still_reported(
+        #[case] field: &str,
+        #[case] value: &[u8],
+    ) {
+        let rule = MessageLanguageTagFormatValid;
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_language_tag_format_valid",
+        ]);
+
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(field, value)]);
+
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        );
+        assert!(v.is_some(), "{field} carrying %xC2 %xA0 drew nothing");
     }
 }

--- a/lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
+++ b/lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
@@ -58,7 +58,7 @@ impl Rule for MessageOriginIsolatedHeaderValidity {
 
         // Must not be a comma-separated list
         // cite(HTML): "This header is a structured header whose value must be a boolean."
-        if crate::helpers::headers::parse_list_header(val).count() != 1 {
+        if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
                 severity: config.severity,

--- a/lint-http-rules/src/rules/message_range_and_content_range_consistency.rs
+++ b/lint-http-rules/src/rules/message_range_and_content_range_consistency.rs
@@ -178,7 +178,7 @@ impl Rule for MessageRangeAndContentRangeConsistency {
                 // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
                 let requested_ranges = requested
                     .as_ref()
-                    .map(|(_, set)| crate::helpers::headers::parse_list_header(set).count());
+                    .map(|(_, set)| crate::helpers::headers::list_members(set).count());
                 if requested_ranges == Some(1) {
                     return Some(Violation {
                         rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_te_header_constraints.rs
+++ b/lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -53,10 +53,10 @@ impl MessageTeHeaderConstraints {
 
         let mut saw_an_empty_element = false;
 
-        // `list_members_as_written` and not either of the two older list readers.
-        // Both of those split at every comma, so `TE: deflate;ext="a,b"` — one
+        // `list_members_as_written` and not `list_members`, the recipient's walk.
+        // That one splits at every comma, so `TE: deflate;ext="a,b"` — one
         // member, one parameter — came apart into a second "member" of `b"`; and
-        // both drop the empty elements § 5.6.1.1 forbids a sender from
+        // it drops the empty elements § 5.6.1.1 forbids a sender from
         // generating, which is the finding below. The quote-aware half is right
         // for *this* field because the production quoted here puts a
         // `quoted-string` inside the element; a `#token` list would want the

--- a/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+++ b/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
@@ -35,7 +35,7 @@ impl Rule for MessageTimingAllowOriginValidity {
             return None;
         }
 
-        // Combine members across multiple header fields; parse_list_header handles commas & whitespace.
+        // Combine members across multiple header fields; list_members handles commas & whitespace.
         // Several header fields are explicitly allowed, so this rule checks the members,
         // not the field count — unlike Access-Control-Allow-Origin, which carries one value.
         // cite(Resource Timing): "The sender MAY generate multiple Timing-Allow-Origin header fields."
@@ -87,9 +87,7 @@ impl Rule for MessageTimingAllowOriginValidity {
                     // cite(RFC 9110 § 5.6.1.2): "A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism"
                 }
             }
-            for member in crate::helpers::headers::parse_list_header(s) {
-                let m = member.trim();
-
+            for m in crate::helpers::headers::list_members(s) {
                 // `wildcard` and the case-sensitive lowercase `null` are the two
                 // non-origin members the grammar admits (both productions resolve
                 // into Fetch).

--- a/lint-http-rules/src/rules/message_trailer_fields_validity.rs
+++ b/lint-http-rules/src/rules/message_trailer_fields_validity.rs
@@ -176,7 +176,7 @@ impl Rule for MessageTrailerFieldsValidity {
 fn collect_declared_trailers(headers: &hyper::HeaderMap) -> Option<Vec<String>> {
     let value = crate::helpers::headers::combined_field_value_as_written(headers, "trailer")?;
     Some(
-        crate::helpers::headers::parse_list_header(&value)
+        crate::helpers::headers::list_members(&value)
             .map(|member| member.to_ascii_lowercase())
             .collect(),
     )
@@ -462,6 +462,32 @@ mod tests {
 
         let v = rule.check_transaction(&tx, &empty_history(), &cfg());
         assert!(v.is_none());
+    }
+
+    /// `response_trailer_declared_and_matching_no_violation` with one octet
+    /// added to the declaration, which is the fixture the reading defect hid
+    /// behind. `X-Checksum<%xA0>` is not a `field-name`, so it declares nothing
+    /// an arriving field can be — the answer `collect_declared_trailers`' own doc
+    /// comment states. The recipient's walk used to trim %xA0 as whitespace and
+    /// hand back `x-checksum`, so the undeclared field matched a declaration
+    /// nobody wrote.
+    #[test]
+    fn a_declaration_carrying_obs_text_declares_no_arriving_field() {
+        let rule = MessageTrailerFieldsValidity;
+        let mut tx = make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_octet_pairs(
+            &[("trailer", b"X-Checksum\xA0".as_slice())],
+        );
+        let mut trailers = hyper::HeaderMap::new();
+        trailers.insert("x-checksum", "abc123".parse().unwrap());
+        tx.response.as_mut().unwrap().trailers = Some(trailers);
+
+        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        assert!(
+            v.as_ref()
+                .is_some_and(|v| v.message.contains("not declared")),
+            "{v:?}"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_trailer_headers_valid.rs
+++ b/lint-http-rules/src/rules/message_trailer_headers_valid.rs
@@ -69,7 +69,7 @@ impl MessageTrailerHeadersValid {
                 // list's defect rather than the element's: there is no such thing as
                 // an empty `field-name`, so what the sender generated is a member
                 // that contributes nothing to the list. The recipient's reader
-                // (`parse_list_header`) drops these, which is that party's
+                // (`list_members`) drops these, which is that party's
                 // requirement and erases this one — so it is not used here.
                 //
                 // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
@@ -553,7 +553,7 @@ mod tests {
             let announced: Vec<&str> = pairs
                 .iter()
                 .filter(|(k, _)| k.eq_ignore_ascii_case("trailer"))
-                .flat_map(|(_, v)| crate::helpers::headers::parse_list_header(v))
+                .flat_map(|(_, v)| crate::helpers::headers::list_members(v))
                 .collect();
             if announced.is_empty() {
                 continue;

--- a/lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
+++ b/lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -137,8 +137,8 @@ impl Rule for MessageTransferCodingIanaRegistered {
             // cite(RFC 9110 § 10.1.4): "transfer-parameter = token BWS "=" BWS ( token / quoted-string )"
             for part in crate::helpers::headers::split_commas_respecting_quotes(val) {
                 // `#element` admits empty members, and they are not elements.
-                // `parse_list_header` used to drop these; the quote-aware
-                // splitter does not, so the filter moves here with its licence.
+                // `list_members` drops these; the quote-aware splitter does not,
+                // so the filter moves here with its licence.
                 // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
                 if part.is_empty() {
                     continue;
@@ -952,7 +952,7 @@ mod tests {
     }
 
     /// Empty list members are not elements, and the quote-aware splitter --
-    /// unlike `parse_list_header` -- does not drop them for us.
+    /// unlike `list_members` -- does not drop them for us.
     #[test]
     fn empty_list_members_are_skipped() {
         let rule = MessageTransferCodingIanaRegistered;

--- a/lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
@@ -62,8 +62,14 @@ impl Rule for MessageTransferEncodingChunkedFinal {
                     // being lax about parameters changes the answer rather than
                     // just the message. Whether the parameter should be there at
                     // all is `message_transfer_coding_iana_registered`'s finding.
+                    // The trim is `OWS` because that is the whitespace the
+                    // production prints around the `;`. `str::trim` would take
+                    // more, and on a value read through `from_utf8_lossy` there
+                    // is more to take: %xC2 %xA0 arrives as one `char` that
+                    // `char::is_whitespace` admits and no `token` does.
                     // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
-                    let name = part.split(';').next().unwrap().trim();
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                    let name = crate::helpers::headers::trim_ows(part.split(';').next().unwrap());
                     if name.is_empty() {
                         continue;
                     }
@@ -83,7 +89,7 @@ impl Rule for MessageTransferEncodingChunkedFinal {
                 // Bound rather than returned directly: the iterator borrows
                 // `val`, and as a tail expression it outlives it. Not a style
                 // choice -- inlining it does not compile.
-                let found = crate::helpers::headers::parse_list_header(&val)
+                let found = crate::helpers::headers::list_members(&val)
                     .any(|opt| opt.eq_ignore_ascii_case("close"));
                 found
             })
@@ -632,6 +638,60 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
         assert!(v.is_none(), "{te:?} with Connection: close: {v:?}");
+    }
+
+    /// `a_response_that_announces_close_is_not_reported` with the exemption
+    /// spelled in an octet that is not a `tchar`. `connection-option = token`,
+    /// so `close<%xC2%xA0>` is not the `close` option and the response has said
+    /// nothing — the value is read with `from_utf8_lossy` and the pair arrives as
+    /// one `char` `str::trim` calls whitespace, so the list walk used to hand
+    /// back `close` and excuse the message.
+    ///
+    /// The same octet on the coding itself is the other half: the name in front
+    /// of the `;` is `OWS`-trimmed now, so a request whose only coding is
+    /// `chunked<%xC2%xA0>` has applied something that is not `chunked` and never
+    /// framed the result. Both used to read as the bare token.
+    #[test]
+    fn an_obs_text_octet_is_not_whitespace_in_the_connection_option() {
+        let rule = MessageTransferEncodingChunkedFinal;
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_octet_pairs(&[
+                ("transfer-encoding", b"chunked, gzip".as_slice()),
+                ("connection", b"close\xC2\xA0".as_slice()),
+            ]);
+
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        assert!(
+            v.as_ref()
+                .is_some_and(|v| v.message.contains("final coding")),
+            "{v:?}"
+        );
+    }
+
+    #[test]
+    fn an_obs_text_octet_is_not_whitespace_in_the_coding_name() {
+        let rule = MessageTransferEncodingChunkedFinal;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(
+            "transfer-encoding",
+            b"chunked\xC2\xA0".as_slice(),
+        )]);
+
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        assert!(
+            v.as_ref()
+                .is_some_and(|v| v.message.contains("must apply chunked as the final coding")),
+            "{v:?}"
+        );
     }
 
     /// The option is a token in a list and is matched as one, not by substring.

--- a/lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
@@ -318,12 +318,12 @@ impl Rule for SemanticHeadResponseHeadersMatchGet {
                         // up, which no ordering changes.
                         // cite(RFC 9110 § 12.5.5): "To inform cache recipients that they MUST NOT use this response to satisfy a later request unless the later request has the same values for the listed header fields as the original request"
                         //
-                        // `parse_list_header` drops empty members, which is the
+                        // `list_members` drops empty members, which is the
                         // recipient's reading and the right one for a question
                         // about what was advertised; a sender that writes
                         // `Accept, , Accept-Encoding` is `server_vary_header_valid`'s.
                         let members = |v: &str| {
-                            let mut m: Vec<String> = crate::helpers::headers::parse_list_header(v)
+                            let mut m: Vec<String> = crate::helpers::headers::list_members(v)
                                 .map(|s| s.to_ascii_lowercase())
                                 .collect();
                             m.sort_unstable();
@@ -1030,6 +1030,32 @@ mod tests {
         );
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("Vary"));
+    }
+
+    /// `vary_different_members_reports_violation` with the difference written as
+    /// the one octet the recipient's walk used to erase. `Vary = #( "*" /
+    /// field-name )` and `field-name = token`, so `b<%xA0>` is not the member
+    /// `b` — the two responses advertise different sets, which is the finding.
+    /// `str::trim` made them the same set, and the comparison here is over a
+    /// value read one `char` per octet, so %xA0 arrives as itself.
+    #[test]
+    fn vary_members_differing_by_one_obs_text_octet_report() {
+        let rule = SemanticHeadResponseHeadersMatchGet;
+        let mut prev = make_prev_with_headers(&[]);
+        prev.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_octet_pairs(&[("vary", b"a, b\xA0".as_slice())]);
+        let mut head = make_head_with_headers(&[("vary", "a, b")]);
+        head.request.uri = prev.request.uri.clone();
+
+        let v = rule.check_transaction(
+            &head,
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &make_cfg_with_headers(vec!["vary"]),
+        );
+        assert!(
+            v.as_ref().is_some_and(|v| v.message.contains("Vary")),
+            "{v:?}"
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
@@ -71,7 +71,7 @@ impl Rule for SemanticOriginMatchingForCors {
         // Now we have exactly one header field; validate its value semantics
         let acao_raw = acao_values[0].trim();
         // Must be a single value (not a comma-separated list)
-        let members: Vec<String> = crate::helpers::headers::parse_list_header(acao_raw)
+        let members: Vec<String> = crate::helpers::headers::list_members(acao_raw)
             .map(|m| m.to_string())
             .collect();
         if members.len() != 1 {

--- a/lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
@@ -255,7 +255,7 @@ impl Rule for ServerAcceptRangesValuesValid {
 /// a name this code has never heard of is a name it has to carry rather than
 /// reject.
 ///
-/// The list is split here rather than by `parse_list_header`, which drops empty
+/// The list is split here rather than by `list_members`, which drops empty
 /// elements: that is the reading a recipient of this field is required to take
 /// and the wrong one for the rule measuring what the sender generated. By the
 /// time that function answers, the element a sender must not have written is

--- a/lint-http-rules/src/rules/server_response_405_allow.rs
+++ b/lint-http-rules/src/rules/server_response_405_allow.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: ISC
 
-use crate::helpers::headers::{combined_field_value_as_written, shown_in_finding, trim_ows};
+use crate::helpers::headers::{combined_field_value_as_written, list_members, shown_in_finding};
 use crate::lint::Violation;
 use crate::rules::Rule;
 
@@ -26,21 +26,27 @@ impl ServerResponse405Allow {
     /// the comma is one of the delimiters a `token` excludes, and this field embeds
     /// no `quoted-string` for one to hide inside.
     ///
-    /// Neither list helper in `helpers::headers` answers this. `parse_list_header`
-    /// trims with `str::trim`, which is Unicode whitespace — wrong for a value read
-    /// one `char` per octet, where %xA0 is `obs-text` and not whitespace at all; and
-    /// `is_nominated_by_connection` folds case, because the thing it looks for is a
-    /// field name. A shared answer belongs in that module on its second caller, as
-    /// `shown_in_finding` did; this is the first.
+    /// **`list_members` is the walk, and the argument for writing it out here died
+    /// when that helper stopped trimming Unicode whitespace.** This comment used to
+    /// say no list helper answered the question: `parse_list_header` used `str::trim`,
+    /// wrong for a value read one `char` per octet where %xA0 is `obs-text` and not
+    /// whitespace at all, and `is_nominated_by_connection` folds case because what it
+    /// looks for is a field name. The first half is no longer true — the two walks
+    /// were one walk with one wrong line — and the fourth decision `list_members`
+    /// makes, dropping an empty member, is one this question cannot see anyway: the
+    /// caller keeps an empty method away, and a non-empty method equals no empty
+    /// member.
     ///
     /// The comparison is exact rather than case-folding, and the sentence below is
     /// why: two spellings of a name in two cases are two methods, so a 405 answering
-    /// `get` while advertising `GET` contradicts nothing.
+    /// `get` while advertising `GET` contradicts nothing. Case is the one decision
+    /// the shared walk leaves to its caller, which is why this stays a function
+    /// rather than becoming a call.
     ///
     /// cite(RFC 9110 § 5.6.2): "Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}")."
     /// cite(RFC 9110 § 9.1): "The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names."
     fn advertises(value: &str, method: &str) -> bool {
-        value.split(',').any(|member| trim_ows(member) == method)
+        list_members(value).any(|member| member == method)
     }
 }
 

--- a/lint-http-rules/src/rules/server_vary_header_valid.rs
+++ b/lint-http-rules/src/rules/server_vary_header_valid.rs
@@ -67,7 +67,7 @@ impl Rule for ServerVaryHeaderValid {
                 }
             }
 
-            for token in crate::helpers::headers::parse_list_header(s) {
+            for token in crate::helpers::headers::list_members(s) {
                 // "*" is a valid list member. Under RFC 9110 it may appear alongside
                 // field-names (RFC 7231's "*"-or-a-list exclusivity was dropped), so
                 // no combination check is made — only field-name tokens are validated.

--- a/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/stateful_101_switching_protocols.rs
@@ -163,15 +163,14 @@ impl Rule for Stateful101SwitchingProtocols {
         // Protocol names carry a preferred case but are matched case-insensitively,
         // so both lists are folded to lowercase before comparison.
         // cite(RFC 9110 § 7.8): "Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols."
-        let offered: Vec<String> = crate::helpers::headers::parse_list_header(&req_upgrade_val)
-            .map(|t| t.trim().to_ascii_lowercase())
+        let offered: Vec<String> = crate::helpers::headers::list_members(&req_upgrade_val)
+            .map(str::to_ascii_lowercase)
             .collect();
 
         // The response must indicate at least one chosen protocol.
-        let chosen_list: Vec<String> =
-            crate::helpers::headers::parse_list_header(&resp_upgrade_val)
-                .map(|t| t.trim().to_ascii_lowercase())
-                .collect();
+        let chosen_list: Vec<String> = crate::helpers::headers::list_members(&resp_upgrade_val)
+            .map(str::to_ascii_lowercase)
+            .collect();
 
         // Upgrade present but no valid tokens (e.g. " , , "): still nothing indicated.
         // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."

--- a/lint-http-rules/src/rules/stateful_conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/stateful_conditional_request_handling.rs
@@ -104,11 +104,8 @@ impl Rule for StatefulConditionalRequestHandling {
                         if let Ok(resp_etag) = resp_etag_hv.to_str() {
                             for hv in req.headers.get_all("if-none-match").iter() {
                                 if let Ok(inm_raw) = hv.to_str() {
-                                    for member in
-                                        crate::helpers::headers::parse_list_header(inm_raw)
-                                    {
-                                        if member.trim() == resp_etag.trim() || member.trim() == "*"
-                                        {
+                                    for member in crate::helpers::headers::list_members(inm_raw) {
+                                        if member == resp_etag.trim() || member == "*" {
                                             return Some(Violation {
                                                 rule: self.id().into(),
                                                 severity: config.severity,

--- a/lint-http-rules/src/rules/stateful_no_store_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_no_store_enforcement.rs
@@ -142,8 +142,7 @@ impl Rule for StatefulNoStoreEnforcement {
         // HeaderMap.get_all() returns all values in order.
         for hv in tx.request.headers.get_all("if-none-match").iter() {
             if let Ok(s) = hv.to_str() {
-                for member in crate::helpers::headers::parse_list_header(s) {
-                    let member = member.trim();
+                for member in crate::helpers::headers::list_members(s) {
                     let normalized = crate::helpers::headers::normalize_etag(member);
                     // A validator echoed back from a no-store response is proof the client
                     // stored the thing it was told not to store.

--- a/lint-http-rules/src/rules/stateful_private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/stateful_private_cache_visibility.rs
@@ -64,8 +64,7 @@ impl Rule for StatefulPrivateCacheVisibility {
         // check If-None-Match members
         for hv in tx.request.headers.get_all("if-none-match").iter() {
             if let Ok(s) = hv.to_str() {
-                for member in crate::helpers::headers::parse_list_header(s) {
-                    let member = member.trim();
+                for member in crate::helpers::headers::list_members(s) {
                     let normalized = crate::helpers::headers::normalize_etag(member);
 
                     for past in history.iter() {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2270
+      line: 2272
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2265
+      line: 2267
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2264
+      line: 2266
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -71,7 +71,7 @@ sources:
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
-      line: 96
+      line: 94
   - label: semantic_origin_matching_for_cors
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
@@ -264,7 +264,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2329
+      line: 2331
   - label: message_refresh_header_syntax_valid
     snippet: A code point is found that is not a URL unit.
     cited_by:
@@ -710,7 +710,7 @@ sources:
     snippet: These values are not case sensitive
     cited_by:
     - file: lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
-      line: 61
+      line: 69
   - label: message_content_transfer_encoding_valid (2)
     section: § 6.1
     snippet: mechanism := "7bit" / "8bit" / "binary" / "quoted-printable" / "base64" / ietf-token / x-token
@@ -722,7 +722,7 @@ sources:
     snippet: Implementors may, if necessary, define private Content-Transfer-Encoding values, but must use an x-token, which is a name prefixed by "X-", to indicate its non-standard status
     cited_by:
     - file: lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
-      line: 60
+      line: 68
 - label: RFC 2046
   url: https://www.rfc-editor.org/rfc/rfc2046.txt
   type: text/plain
@@ -1416,9 +1416,9 @@ sources:
     snippet: language-range   = (1*8ALPHA *("-" 1*8alphanum)) / "*"
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
-      line: 64
+      line: 74
     - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
-      line: 121
+      line: 128
   - label: message_language_tag_format_valid
     section: § 2.1
     snippet: A basic language range differs from the language tags defined in [RFC4646] only in that there is no requirement that it be "well-formed" or be validated against the IANA Language Subtag Registry.
@@ -1682,31 +1682,31 @@ sources:
     snippet: A language tag is composed from a sequence of one or more "subtags", each of which refines or narrows the range of language identified by the overall tag.
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
-      line: 51
+      line: 61
   - label: lint-http-rules/src/helpers/language.rs (2)
     section: § 2.1
     snippet: All subtags have a maximum length of eight characters.
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
-      line: 80
+      line: 90
   - label: lint-http-rules/src/helpers/language.rs (3)
     section: § 2.1
     snippet: Subtags, in turn, are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen ("-", [Unicode] U+002D).
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
-      line: 37
+      line: 47
   - label: lint-http-rules/src/helpers/language.rs (4)
     section: § 2.1
     snippet: Whitespace is not permitted in a language tag.
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
-      line: 31
+      line: 41
   - label: lint-http-rules/src/helpers/language.rs (5)
     section: § 2.1
     snippet: language      = 2*3ALPHA            ; shortest ISO 639 code
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
-      line: 67
+      line: 77
 - label: RFC 5789
   url: https://www.rfc-editor.org/rfc/rfc5789.txt
   type: text/plain
@@ -2046,7 +2046,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2266
+      line: 2268
     - file: lint-http-rules/src/helpers/uri.rs
       line: 259
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3543,25 +3543,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1829
+      line: 1831
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1770
+      line: 1772
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1808
+      line: 1810
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1801
+      line: 1803
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -3871,7 +3871,7 @@ sources:
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 878
+      line: 880
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
       line: 125
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
@@ -4099,7 +4099,7 @@ sources:
     snippet: If the representation has no content coding, then it is acceptable by default unless specifically excluded by the Accept-Encoding header field stating either "identity;q=0" or "*;q=0" without a more specific entry for "identity".
     cited_by:
     - file: lint-http-rules/src/rules/client_accept_encoding_present.rs
-      line: 103
+      line: 100
   - label: client_accept_encoding_present (5)
     section: § 12.5.3
     snippet: When sent by a user agent in a request, Accept-Encoding indicates the content codings acceptable in a response.
@@ -4345,72 +4345,24 @@ sources:
     - file: lint-http-rules/src/rules/server_status_code_valid_range.rs
       line: 101
   - label: client_expect_header_valid (12)
-    section: § 5.6.1.1
-    snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
-    cited_by:
-    - file: lint-http-rules/src/rules/client_expect_header_valid.rs
-      line: 96
-    - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
-      line: 250
-    - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
-      line: 93
-    - file: lint-http-rules/src/rules/message_cache_control_directive_validity.rs
-      line: 115
-    - file: lint-http-rules/src/rules/message_cache_control_token_valid.rs
-      line: 116
-    - file: lint-http-rules/src/rules/message_caching_directive_interaction.rs
-      line: 64
-    - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
-      line: 72
-    - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
-      line: 235
-    - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 406
-    - file: lint-http-rules/src/rules/message_pragma_token_valid.rs
-      line: 134
-    - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
-      line: 159
-    - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
-      line: 167
-    - file: lint-http-rules/src/rules/message_te_header_constraints.rs
-      line: 73
-    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
-      line: 77
-    - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
-      line: 75
-    - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
-      line: 259
-    - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
-      line: 329
-    - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
-      line: 301
-    - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
-      line: 458
-    - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
-      line: 92
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 347
-    - file: lint-http-rules/src/rules/server_vary_header_valid.rs
-      line: 59
-  - label: client_expect_header_valid (13)
     section: § 5.6.6
     snippet: '|  *Note:* Parameters do not allow whitespace (not even "bad" |  whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 444
-  - label: client_expect_header_valid (14)
+  - label: client_expect_header_valid (13)
     section: § A
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 80
-  - label: client_expect_header_valid (15)
+  - label: client_expect_header_valid (14)
     section: § B.3
     snippet: List-based grammar for Expect has been restored for compatibility with RFC 2616.
     cited_by:
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 60
-  - label: client_expect_header_valid (16)
+  - label: client_expect_header_valid (15)
     section: § B.3
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
@@ -4527,7 +4479,7 @@ sources:
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 241
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 41
+      line: 47
     - file: lint-http-rules/src/rules/stateful_range_request_and_caching.rs
       line: 81
   - label: client_prefer_header_and_preference_applied
@@ -4967,7 +4919,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 22
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 910
+      line: 912
     - file: lint-http-rules/src/rules/message_connection_upgrade.rs
       line: 60
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -4979,7 +4931,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 125
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 945
+      line: 947
     - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
       line: 116
   - label: lint-http-proxy/src/proxy/websocket.rs
@@ -5047,13 +4999,13 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 97
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 472
-    - file: lint-http-rules/src/helpers/headers.rs
       line: 496
     - file: lint-http-rules/src/rules/client_accept_encoding_present.rs
       line: 61
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
       line: 51
+    - file: lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
+      line: 54
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 252
     - file: lint-http-rules/src/rules/message_range_and_content_range_consistency.rs
@@ -5115,9 +5067,9 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 60
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1080
+      line: 1082
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1109
+      line: 1111
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 241
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -5253,19 +5205,19 @@ sources:
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 894
+      line: 896
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 11.7.3
     snippet: Proxy-Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 895
+      line: 897
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1738
+      line: 1740
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -5275,7 +5227,7 @@ sources:
     snippet: 'Vary = #( "*" / field-name )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1010
+      line: 1012
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 37
   - label: If-None-Match weak comparison
@@ -5289,7 +5241,7 @@ sources:
     snippet: If the field is allowable in trailers; by default, it will not be (see Section 6.5.1).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 824
+      line: 826
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5
     snippet: Fields are sent and received within the header and trailer sections of messages
@@ -5305,9 +5257,9 @@ sources:
     snippet: Field names are case-insensitive
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 943
+      line: 945
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1011
+      line: 1013
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.2
     snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
@@ -5315,7 +5267,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 211
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1536
+      line: 1538
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 64
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -5327,7 +5279,7 @@ sources:
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1012
+      line: 1014
     - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
       line: 78
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -5359,7 +5311,7 @@ sources:
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1537
+      line: 1539
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -5395,7 +5347,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1999
+      line: 2001
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5447,7 +5399,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1534
+      line: 1536
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
       line: 124
   - label: lint-http-rules/src/helpers/headers.rs (14)
@@ -5455,13 +5407,61 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1535
+      line: 1537
   - label: lint-http-rules/src/helpers/headers.rs (15)
+    section: § 5.6.1.1
+    snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 498
+    - file: lint-http-rules/src/rules/client_expect_header_valid.rs
+      line: 96
+    - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
+      line: 250
+    - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
+      line: 93
+    - file: lint-http-rules/src/rules/message_cache_control_directive_validity.rs
+      line: 115
+    - file: lint-http-rules/src/rules/message_cache_control_token_valid.rs
+      line: 116
+    - file: lint-http-rules/src/rules/message_caching_directive_interaction.rs
+      line: 64
+    - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
+      line: 72
+    - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
+      line: 235
+    - file: lint-http-rules/src/rules/message_link_header_validity.rs
+      line: 406
+    - file: lint-http-rules/src/rules/message_pragma_token_valid.rs
+      line: 134
+    - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
+      line: 159
+    - file: lint-http-rules/src/rules/message_preference_applied_header_valid.rs
+      line: 167
+    - file: lint-http-rules/src/rules/message_te_header_constraints.rs
+      line: 73
+    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+      line: 77
+    - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
+      line: 75
+    - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
+      line: 259
+    - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
+      line: 329
+    - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
+      line: 301
+    - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
+      line: 458
+    - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
+      line: 92
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 347
+    - file: lint-http-rules/src/rules/server_vary_header_valid.rs
+      line: 59
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 473
     - file: lint-http-rules/src/helpers/headers.rs
       line: 495
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
@@ -5474,24 +5474,32 @@ sources:
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 432
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
+    section: § 5.6.1.2
+    snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 497
+    - file: lint-http-rules/src/rules/message_trailer_fields_validity.rs
+      line: 175
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1599
+      line: 1601
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 81
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 40
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+      line: 46
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1600
+      line: 1602
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -5517,17 +5525,25 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 349
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 497
+      line: 499
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1081
+      line: 1083
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1110
+      line: 1112
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1928
+      line: 1930
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 242
+    - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
+      line: 69
+    - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
+      line: 100
+    - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
+      line: 121
+    - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
+      line: 71
     - file: lint-http-rules/src/rules/message_x_forwarded_consistency.rs
       line: 66
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
@@ -5536,62 +5552,62 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 463
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1660
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+      line: 1662
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 348
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1375
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+      line: 1377
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1373
+      line: 1375
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 332
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1214
+      line: 1216
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1242
+      line: 1244
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1374
+      line: 1376
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 421
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 477
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1082
+      line: 1084
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1241
+      line: 1243
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1279
+      line: 1281
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1372
+      line: 1374
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1601
+      line: 1603
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 316
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -5604,38 +5620,38 @@ sources:
       line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 312
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2218
+      line: 2220
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 155
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 123
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 213
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1926
+      line: 1928
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1953
+      line: 1955
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 380
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1927
+      line: 1929
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1954
+      line: 1956
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2135
+      line: 2137
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5645,7 +5661,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2149
+      line: 2151
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 382
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
@@ -5656,25 +5672,25 @@ sources:
       line: 129
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 219
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1925
+      line: 1927
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1998
+      line: 2000
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 379
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 203
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -5682,7 +5698,7 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 145
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
@@ -5694,12 +5710,12 @@ sources:
       line: 100
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
       line: 34
-  - label: lint-http-rules/src/helpers/headers.rs (31)
+  - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 823
+      line: 825
     - file: lint-http-rules/src/rules/client_user_agent_present.rs
       line: 46
     - file: lint-http-rules/src/rules/message_server_header_product_valid.rs
@@ -5717,21 +5733,21 @@ sources:
     - file: lint-http-rules/src/rules/semantic_post_creates_resource.rs
       line: 68
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 119
+      line: 125
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 169
-  - label: lint-http-rules/src/helpers/headers.rs (32)
+  - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 822
-  - label: lint-http-rules/src/helpers/headers.rs (33)
+      line: 824
+  - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2080
+      line: 2082
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5752,12 +5768,12 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/server_problem_details_content_type.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (34)
+  - label: lint-http-rules/src/helpers/headers.rs (36)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2099
+      line: 2101
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5765,22 +5781,22 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2014
+      line: 2016
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 105
-  - label: lint-http-rules/src/helpers/headers.rs (35)
+  - label: lint-http-rules/src/helpers/headers.rs (37)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2079
+      line: 2081
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (36)
+  - label: lint-http-rules/src/helpers/headers.rs (38)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
@@ -5791,13 +5807,13 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1848
-  - label: lint-http-rules/src/helpers/headers.rs (37)
+      line: 1850
+  - label: lint-http-rules/src/helpers/headers.rs (39)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 581
+      line: 583
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 10.1.2
     snippet: mailbox = <mailbox, see [RFC5322], Section 3.4>
@@ -6008,6 +6024,8 @@ sources:
       line: 38
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 37
+    - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
+      line: 120
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 88
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -6167,7 +6185,7 @@ sources:
     - file: lint-http-rules/src/rules/semantic_options_method_capabilities.rs
       line: 43
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 117
+      line: 123
   - label: message_allow_header_method_tokens (3)
     section: § 10.2.1
     snippet: The "Allow" header field lists the set of methods advertised as supported by the target resource.
@@ -6179,7 +6197,7 @@ sources:
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 187
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 155
+      line: 161
   - label: message_allow_header_method_tokens (4)
     section: § 10.2.1
     snippet: The purpose of this field is strictly to inform the recipient of valid request methods associated with the resource.
@@ -6251,15 +6269,15 @@ sources:
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 84
+      line: 91
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 65
+      line: 70
   - label: message_compression_and_transfer_encoding_consistency (2)
     section: § 10.1.4
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 85
+      line: 92
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 137
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
@@ -6285,25 +6303,25 @@ sources:
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 134
+      line: 146
   - label: message_compression_and_transfer_encoding_consistency (6)
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 127
+      line: 139
   - label: message_compression_and_transfer_encoding_consistency (7)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 111
+      line: 123
   - label: message_compression_and_transfer_encoding_consistency (8)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 64
+      line: 70
     - file: lint-http-rules/src/rules/message_content_encoding_iana_registered.rs
       line: 146
   - label: message_conditional_headers_consistency
@@ -6357,7 +6375,7 @@ sources:
     - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
       line: 23
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 78
+      line: 84
   - label: message_connection_header_tokens_valid (2)
     section: § 7.6.1
     snippet: The "Connection" header field allows the sender to list desired control options for the current connection.
@@ -7231,18 +7249,12 @@ sources:
     - file: lint-http-rules/src/rules/semantic_post_creates_resource.rs
       line: 61
   - label: message_trailer_fields_validity (2)
-    section: § 5.6.1.2
-    snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
-    cited_by:
-    - file: lint-http-rules/src/rules/message_trailer_fields_validity.rs
-      line: 175
-  - label: message_trailer_fields_validity (3)
     section: § 6.5.1
     snippet: A trailer section is only possible when supported by the version of HTTP in use and enabled by an explicit framing mechanism.
     cited_by:
     - file: lint-http-rules/src/rules/message_trailer_fields_validity.rs
       line: 22
-  - label: message_trailer_fields_validity (4)
+  - label: message_trailer_fields_validity (3)
     section: § 6.6.2
     snippet: A sender that intends to generate one or more trailer fields in a message SHOULD generate a Trailer header field in the header section of that message to indicate which fields might be present in the trailers.
     cited_by:
@@ -7503,7 +7515,7 @@ sources:
     - file: lint-http-rules/src/rules/semantic_options_method_capabilities.rs
       line: 145
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 86
+      line: 92
   - label: semantic_options_method_capabilities (2)
     section: § 15.3
     snippet: The 2xx (Successful) class of status code indicates that the client's request was successfully received, understood, and accepted.
@@ -7845,7 +7857,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
       line: 194
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 61
+      line: 67
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 139
   - label: server_authentication_challenge_validity
@@ -8011,27 +8023,27 @@ sources:
     snippet: The actual set of allowed methods is defined by the origin server at the time of each request.
     cited_by:
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 156
+      line: 162
   - label: server_response_405_allow (2)
     section: § 15.5.6
     snippet: The 405 (Method Not Allowed) status code indicates that the method received in the request-line is known by the origin server but not supported by the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 154
+      line: 160
   - label: server_response_405_allow (3)
     section: § 15.5.6
     snippet: The origin server MUST generate an Allow header field in a 405 response containing a list of the target resource's currently supported methods.
     cited_by:
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 118
+      line: 124
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 153
+      line: 159
   - label: server_response_405_allow (4)
     section: § 9.1
     snippet: However, the set of allowed methods can change dynamically.
     cited_by:
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
-      line: 157
+      line: 163
   - label: server_response_location_on_redirect
     section: § 15.4.1
     snippet: For request methods other than HEAD, the server SHOULD generate content in the 300 response containing a list of representation metadata and URI reference(s) from which the user or user agent can choose the one most preferred.
@@ -8155,7 +8167,7 @@ sources:
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 148
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 190
+      line: 189
   - label: stateful_101_switching_protocols (3)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
@@ -8163,9 +8175,9 @@ sources:
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 135
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 177
+      line: 176
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
-      line: 204
+      line: 203
   - label: stateful_101_switching_protocols (4)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
@@ -8213,13 +8225,13 @@ sources:
     snippet: An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response
     cited_by:
     - file: lint-http-rules/src/rules/stateful_conditional_request_handling.rs
-      line: 134
+      line: 131
   - label: stateful_conditional_request_handling (3)
     section: § 13.2.2
     snippet: When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition
     cited_by:
     - file: lint-http-rules/src/rules/stateful_conditional_request_handling.rs
-      line: 135
+      line: 132
   - label: stateful_range_request_and_caching
     section: § 13.1.5
     snippet: A valid entity-tag can be distinguished from a valid HTTP-date by examining the first three characters for a DQUOTE.
@@ -8325,7 +8337,7 @@ sources:
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1013
+      line: 1015
     - file: lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
       line: 45
     - file: lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
@@ -8335,13 +8347,13 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 662
+      line: 664
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 672
+      line: 674
   - label: message_age_header_numeric
     section: § 1.2.2
     snippet: If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648 (2^31) or the greatest positive integer it can conveniently represent.
@@ -8379,7 +8391,7 @@ sources:
     snippet: However, support for Cache-Control is now widespread.  As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/message_cache_control_and_pragma_consistency.rs
-      line: 71
+      line: 70
   - label: message_cache_control_and_pragma_consistency (2)
     section: § 5.4
     snippet: The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request
@@ -8431,9 +8443,9 @@ sources:
     - file: lint-http-rules/src/rules/message_caching_directive_interaction.rs
       line: 117
     - file: lint-http-rules/src/rules/stateful_no_store_enforcement.rs
-      line: 150
+      line: 149
     - file: lint-http-rules/src/rules/stateful_no_store_enforcement.rs
-      line: 176
+      line: 175
   - label: message_caching_directive_interaction (3)
     section: § 5.2.2.7
     snippet: The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user).
@@ -8441,9 +8453,9 @@ sources:
     - file: lint-http-rules/src/rules/message_caching_directive_interaction.rs
       line: 98
     - file: lint-http-rules/src/rules/stateful_private_cache_visibility.rs
-      line: 87
+      line: 86
     - file: lint-http-rules/src/rules/stateful_private_cache_visibility.rs
-      line: 124
+      line: 123
   - label: message_caching_directive_interaction (4)
     section: § 5.2.2.9
     snippet: The public response directive indicates that a cache MAY store the response even if it would otherwise be prohibited, subject to the constraints defined in Section 3.
@@ -8565,7 +8577,7 @@ sources:
     - file: lint-http-rules/src/rules/stateful_no_cache_revalidation.rs
       line: 159
     - file: lint-http-rules/src/rules/stateful_no_store_enforcement.rs
-      line: 259
+      line: 258
     - file: lint-http-rules/src/rules/stateful_private_cache_visibility.rs
       line: 54
   - label: stateful_immutable_cache_never_stale (2)
@@ -8915,19 +8927,19 @@ sources:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
       line: 21
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 174
+      line: 180
   - label: message_compression_and_transfer_encoding_consistency (2)
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 110
+      line: 122
   - label: message_compression_and_transfer_encoding_consistency (3)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 90
+      line: 101
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 55
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -8935,19 +8947,19 @@ sources:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 291
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 70
+      line: 76
   - label: message_compression_and_transfer_encoding_consistency (4)
     section: § 7.2
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 120
+      line: 132
   - label: message_compression_and_transfer_encoding_consistency (5)
     section: § 7.3
     snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 119
+      line: 131
   - label: message_content_length_vs_transfer_encoding
     section: § 6.2
     snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
@@ -8983,13 +8995,13 @@ sources:
     snippet: HTTP does not use the Content-Transfer-Encoding field of MIME.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
-      line: 76
+      line: 84
   - label: message_content_transfer_encoding_valid (2)
     section: § B.5
     snippet: Proxies and gateways from MIME-compliant protocols to HTTP need to remove any Content-Transfer-Encoding prior to delivering the response message to an HTTP client.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_transfer_encoding_valid.rs
-      line: 77
+      line: 85
   - label: message_host_and_authority_consistency
     section: § 3.2.2
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
@@ -9173,19 +9185,19 @@ sources:
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 109
+      line: 115
   - label: message_transfer_encoding_chunked_final (2)
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 125
+      line: 131
   - label: message_transfer_encoding_chunked_final (3)
     section: § 6.1
     snippet: Transfer-Encoding MAY be sent in a response to a HEAD request or in a 304 (Not Modified) response (Section 15.4.5 of [HTTP]) to a GET request, neither of which includes a message body, to indicate that the origin server would have applied a transfer coding to the message body if the request had been an unconditional GET.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 208
+      line: 214
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 263
     - file: lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
@@ -9195,13 +9207,13 @@ sources:
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 145
+      line: 151
   - label: message_transfer_encoding_chunked_final (5)
     section: § 9.6
     snippet: The "close" connection option is defined as a signal that the sender will close this connection after completion of the response.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
-      line: 79
+      line: 85
   - label: semantic_head_response_headers_match_get
     section: § 6.1
     snippet: This indication is not required, however, because any recipient on the response chain (including the origin server) can remove transfer codings when they are not needed.


### PR DESCRIPTION
`parse_list_header` is gone. Its thirty-six call sites read `list_members`, the `OWS`-correct walk, and the two functions were otherwise the same expression.

The row said the Unicode trim was live at "seventy-odd callers" where the two trims "coincide today and will not always". Both halves were wrong. There are thirty-six sites, not seventy; and at seven of them the trims do not coincide now. `OWS` is `*( SP / HTAB )` and `str::trim` removes every character `char::is_whitespace` admits, so the difference is invisible exactly where the value came back through `to_str` — which returns `Err` for every octet outside %x20-7E plus HTAB, so its `&str` cannot hold another whitespace character at all. Twenty-six sites read such a value and three more are string literals in a test. The other seven read `combined_field_value_as_written`, one `char` per octet, or `String::from_utf8_lossy` — and those carry %xA0, %x85 and every UTF-8 spelling a sender writes, which are `obs-text` octets inside a member and precisely the octet class no `token` admits.

So the walk was repairing malformed members before any check saw them. A `Trailer` declaring `X-Checksum<%xA0>` matched an arriving `X-Checksum`; `Vary: Accept<%xA0>` and `Vary: Accept` were the same set on a HEAD and its GET; `Connection: close<%xC2%xA0>` excused a response from §6.1's framing requirement; and `Accept-Encoding: <%xC2%xA0>` was reported as "empty" when the sender had written two octets.

Three of the seven wrote the trim back one line down, which is the reason the helper's own fix does not finish the job: `part.split(';').next().unwrap().trim()` takes what the walk just kept. Those productions print `OWS` around the `;` and nothing wider, so they are `trim_ows` now — in the two transfer-coding loops, the content-coding loop and `Accept-Language`'s weight split.

`validate_language_tag` had the same line at a third depth, and there it silenced the branch below it: `let s = tag.trim()` removed every character `char::is_whitespace` admits, and the next branch exists to report exactly those. `en-US<%xC2%xA0>` was validated as `en-US`, against a `description()` promising that an octet outside visible US-ASCII is reported rather than skipped. The list's `OWS` is the caller's to strip; inside the element §2.1 admits no whitespace.

`server_response_405_allow::advertises` wrote the walk out privately, and its comment named this trim as the reason no shared helper answered. That reason is gone, so the function calls `list_members` and keeps only the decision the walk leaves to its caller — `method` is case-sensitive.

Two defects found in the review round. `message_content_transfer_encoding_valid` indexed `parts[0]` after a walk that drops empty members, so `Content-Transfer-Encoding: ,` panicked the linter rather than reporting the field; the length test above it only refused *more* than one member. And the test carrying the whole safety argument was vacuous: it wrapped the octet as `a<octet>b`, where both trims are the identity for every input and the assertion reads `s == s`. The octet belongs at both ends, which is the only place a trim can see it.

Nothing in the suite asserted any of the old answers. Eight rule-level tests were added, one per corrected site, each built from that rule's own fixture with only the octet added; each was confirmed to fail with the trim put back. Seven `str::trim` calls on a member the walk had already trimmed were removed — inert today, and the construct that hid this.

Cites 2186 → 2192.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
