### PR TITLE
The octet-level reader existed, but only in its line-joining form

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -219,6 +219,58 @@ pub fn combined_field_value_as_written(headers: &HeaderMap, name: &str) -> Optio
     )
 }
 
+/// One field line's value, one `char` per octet.
+///
+/// [`combined_field_value_as_written`]'s per-line sibling, and the one the tree
+/// was missing. A field whose grammar is *not* a list — `Content-Type` is the
+/// example, and a second field line of one is another rule's finding — is read
+/// line by line, and joining the lines first would answer a question § 5.2 only
+/// asks of a list. So the loop is `get_all(name)` and what it needs is this: the
+/// same octet-for-`char` decode, applied to the line in hand.
+///
+/// **`String::from_utf8_lossy(hv.as_bytes())` is not this function**, which is
+/// what eleven rules reached for while it did not exist. That decoder reads the
+/// octets as UTF-8 and hands back the text they spell: a sender's %xC3 %xA9 —
+/// two `obs-text` octets — arrives as the single `char` U+00E9, and an octet that
+/// begins no valid sequence arrives as U+FFFD, which is a character no sender can
+/// write and no `field-content` admits. Every verdict of the shape *"is this
+/// US-ASCII"* survives either decode, because both put the result at or above
+/// %x80. What does not survive is anything that **counts** the octets, every
+/// finding that **names** one — `boundary contains invalid character '<U+FFFD>'`
+/// reports a character the message did not carry — and, the one that actually
+/// moved verdicts when the callers were converted, **anything that trims Unicode
+/// whitespace**. U+FFFD is not whitespace and U+00A0 is, so a `str::trim` that
+/// left a lossy value alone removes an as-written one; three sites had that trim
+/// and are `trim_ows` now. Converting a caller means sweeping it for `str::trim`,
+/// not only for `len` and `format!`.
+///
+/// cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
+/// cite(RFC 9110 § 5.5): "field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]"
+pub fn field_line_as_written(hv: &hyper::header::HeaderValue) -> String {
+    hv.as_bytes().iter().copied().map(char::from).collect()
+}
+
+/// The octets an as-written value stands for, or `None` if it is not one.
+///
+/// The inverse of [`field_line_as_written`] and of
+/// [`combined_field_value_as_written`], and the answer for the one caller shape
+/// that needs it: a rule comparing a *value* against the *body*, where the body
+/// is octets and no amount of care with `char`s will make the two meet.
+/// `str::as_bytes` is the trap — on a string holding one `char` per octet it
+/// re-encodes, so U+00A0 comes back out as %xC2 %xA0 and a boundary the sender
+/// wrote as three octets is hunted for as four.
+///
+/// `None` rather than a truncation when a `char` will not fit in an octet, so a
+/// caller that hands this a string from somewhere else finds out. Every `char` in
+/// an as-written value is below U+0100 by construction — and that is also the
+/// limit of what the guard can notice: U+00E9 *is* what the octet %xE9 reads as,
+/// so a genuine `"é"` and an as-written %xE9 are one string and no function can
+/// separate them. What `None` catches is a string that was never an as-written
+/// value at all, which is the mistake that produces octets nobody wrote.
+pub fn as_written_octets(s: &str) -> Option<Vec<u8>> {
+    s.chars().map(|c| u8::try_from(c as u32).ok()).collect()
+}
+
 /// The field sections a response can carry, in the order they arrive on the
 /// wire, each with the name a finding calls it by.
 ///
@@ -478,14 +530,18 @@ pub fn extract_strong_validators_from_response(
 /// trim. It shows on the two readers that do not go through it, and it shows
 /// differently on each.
 ///
-/// [`combined_field_value_as_written`] carries one `char` per octet, so the
-/// disagreement is exactly two characters wide: U+00A0 and U+0085, which are the
-/// octets %xA0 and %x85. **`String::from_utf8_lossy` is wider than that** — a
-/// field value is octets, and any UTF-8 sequence a sender writes decodes to the
-/// `char` it spells, so U+2003, U+3000, U+1680 and U+2028 are all reachable
-/// alongside %xC2 %xA0 and %xC2 %x85. Every one of them is `obs-text` on the wire
-/// — the very octet class no `token` admits — and trimming any of them hands the
-/// member's own grammar a value the sender did not write.
+/// [`combined_field_value_as_written`] and [`field_line_as_written`] carry one
+/// `char` per octet, so the disagreement is exactly two characters wide: U+00A0
+/// and U+0085, which are the octets %xA0 and %x85. Both are `obs-text` a sender
+/// wrote *inside* a member — the very octet class no `token` admits — and
+/// trimming either hands the member's own grammar a value the sender did not
+/// write.
+///
+/// It used to be wider, because some callers read their value with
+/// `String::from_utf8_lossy`, which decodes the octets as UTF-8 and so admits
+/// every whitespace `char` there is — U+2003, U+3000, U+1680, U+2028. No caller
+/// does that now; the reason it was wrong for more than the trim is written at
+/// [`field_line_as_written`].
 ///
 /// The split is naive: a DQUOTE is not read as opening a `quoted-string`. That is
 /// the grammar's answer where the element admits none, and the wrong one where it
@@ -2352,6 +2408,52 @@ mod tests {
         assert_eq!(get_header_str(&map, "x-missing"), None);
     }
 
+    /// The three decodes of one field line, side by side, on the value that
+    /// tells them apart. `to_str` refuses it outright; `from_utf8_lossy` reads
+    /// the octets as UTF-8 and hands back the text they spell; this one hands
+    /// back the octets. %xC3 %xA9 is two `obs-text` octets a sender wrote and
+    /// U+00E9 is not either of them, and %xA0 begins no valid sequence at all —
+    /// so the lossy reading names a character (U+FFFD) that no `field-content`
+    /// admits and no message carried.
+    #[test]
+    fn field_line_as_written_is_the_octets_and_from_utf8_lossy_is_not() {
+        let hv = HeaderValue::from_bytes(b"caf\xC3\xA9").unwrap();
+        assert!(hv.to_str().is_err());
+        assert_eq!(String::from_utf8_lossy(hv.as_bytes()), "café");
+        assert_eq!(
+            field_line_as_written(&hv)
+                .chars()
+                .map(|c| c as u32)
+                .collect::<Vec<_>>(),
+            [0x63, 0x61, 0x66, 0xC3, 0xA9]
+        );
+
+        let lone = HeaderValue::from_bytes(b"x\xA0y").unwrap();
+        assert!(String::from_utf8_lossy(lone.as_bytes()).contains('\u{FFFD}'));
+        assert_eq!(field_line_as_written(&lone), "x\u{A0}y");
+    }
+
+    /// The inverse round-trips. A caller comparing a value against a body needs
+    /// the octets back; `as_bytes` would re-encode U+00A0 into the two it is not.
+    ///
+    /// **The `None` guard reaches above U+00FF and no lower, and that is not a
+    /// gap that can be closed.** `as_written_octets("é")` is `Some([0xE9])`,
+    /// because U+00E9 is exactly what the octet %xE9 reads as — the two strings
+    /// are the same string, and no function can tell which one a caller meant.
+    /// What the guard catches is a string that was never an as-written value at
+    /// all, which is the mistake worth catching: it fails loudly instead of
+    /// truncating U+1F600 into one octet nobody wrote.
+    #[test]
+    fn as_written_octets_inverts_the_reader_and_refuses_what_was_never_one() {
+        let hv = HeaderValue::from_bytes(b"x\xA0y\xFF").unwrap();
+        let written = field_line_as_written(&hv);
+        assert_eq!(as_written_octets(&written).as_deref(), Some(hv.as_bytes()));
+        assert_ne!(written.as_bytes(), hv.as_bytes(), "as_bytes re-encodes");
+
+        assert_eq!(as_written_octets("é"), Some(vec![0xE9]));
+        assert_eq!(as_written_octets("😀"), None);
+    }
+
     #[test]
     fn test_list_members() {
         let input = " foo, bar , , baz ";
@@ -2359,16 +2461,15 @@ mod tests {
         assert_eq!(tokens, vec!["foo", "bar", "baz"]);
     }
 
-    /// The two spellings a caller can hand this walk, characterised rather than
-    /// regressed: [`list_members`] already trimmed `OWS`, so this passes on the
-    /// tree before `parse_list_header` was folded into it. What it pins is which
-    /// *values* now reach here — a value read one `char` per octet carries %xA0
-    /// as U+00A0, and a value read through `String::from_utf8_lossy` carries the
-    /// same octet's UTF-8 spelling %xC2 %xA0 as the same `char`. Either way it is
-    /// `obs-text` a sender wrote *inside* the member, which is the octet class no
-    /// `token` admits, so it has to survive the trim and reach the check that
-    /// owns the member's grammar. The conversion's own regressions are the eight
-    /// rule-level tests named in RULECITES §6's P17 entry.
+    /// Characterised rather than regressed: [`list_members`] already trimmed
+    /// `OWS`, so this passes on the tree before `parse_list_header` was folded
+    /// into it. What it pins is which *values* now reach here — every caller
+    /// reads its field one `char` per octet, so %xA0 arrives as U+00A0 and %x85
+    /// as U+0085. Both are `obs-text` a sender wrote *inside* the member, which
+    /// is the octet class no `token` admits, so they have to survive the trim and
+    /// reach the check that owns the member's grammar. The conversion's own
+    /// regressions are the eight rule-level tests named in RULECITES §6's P17
+    /// entry.
     #[test]
     fn list_members_trims_ows_and_not_the_obs_text_that_looks_like_space() {
         assert_eq!(

--- a/lint-http-rules/src/helpers/language.rs
+++ b/lint-http-rules/src/helpers/language.rs
@@ -24,8 +24,8 @@
 /// below it.** `let s = tag.trim()` removed every character `char::is_whitespace`
 /// admits — and the next branch exists to *report* exactly those. On an ASCII
 /// space the two cancelled out into a wrong-but-harmless silence; on U+00A0,
-/// which is how the octet %xA0 and the pair %xC2 %xA0 both reach this function,
-/// it meant `en-US<%xC2%xA0>` was validated as `en-US`. The list's own `OWS` is
+/// which is how the octet %xA0 reaches this function, it meant `en-US<%xA0>` was
+/// validated as `en-US`. The list's own `OWS` is
 /// the caller's to strip (§ 5.6.1.1 puts it outside the element), and inside the
 /// element the sentence below admits no whitespace at all — so the honest answer
 /// is to measure what was passed.

--- a/lint-http-rules/src/rules/client_accept_encoding_present.rs
+++ b/lint-http-rules/src/rules/client_accept_encoding_present.rs
@@ -63,7 +63,7 @@ impl Rule for ClientAcceptEncodingPresent {
         let mut any_coding = false;
         for hv in tx.request.headers.get_all("accept-encoding").iter() {
             present = true;
-            let val = String::from_utf8_lossy(hv.as_bytes());
+            let val = crate::helpers::headers::field_line_as_written(hv);
             if crate::helpers::headers::list_members(&val).next().is_some() {
                 any_coding = true;
             }
@@ -332,7 +332,7 @@ mod tests {
 
     /// **A value holding an `obs-text` octet is not an empty value**, and the
     /// finding above says "empty" in as many words. The list walk used to trim
-    /// %xC2 %xA0 as whitespace, so a field carrying one member was reported for
+    /// %xA0 as whitespace, so a field carrying one member was reported for
     /// declining every coding — a claim about a value the sender did not write.
     /// The member derives from no `codings` and this rule does not say so:
     /// that is the field's syntax and belongs to
@@ -342,7 +342,7 @@ mod tests {
         let mut tx = req(&[]);
         tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(
             "accept-encoding",
-            b"\xC2\xA0".as_slice(),
+            b"\xA0".as_slice(),
         )]);
         assert!(run(&tx).is_none(), "{:?}", run(&tx));
     }

--- a/lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -56,7 +56,13 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
                 // does not start a parameter.
                 let mut parts =
                     crate::helpers::headers::split_semicolons_respecting_quotes(member).into_iter();
-                let media = parts.next().unwrap_or("").trim();
+                // `OWS`, not `str::trim`: the `;` this split on prints `OWS`
+                // around it and nothing wider, and on a value read one `char`
+                // per octet `str::trim` removes %xA0 and %x85 — which are
+                // `obs-text`, and no `subtype` admits one.
+                // cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
+                // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                let media = crate::helpers::headers::trim_ows(parts.next().unwrap_or(""));
                 // A member that is all parameters has no media-range to carry
                 // them: `[ weight ]` is optional, the media-range is not.
                 if media.is_empty() {
@@ -346,7 +352,7 @@ impl Rule for MessageAcceptHeaderMediaTypeSyntax {
                 // a value carrying one is a value this rule still has to judge.
                 // Skipping it meant a bare `*` sitting on the same line as an
                 // obs-text parameter was reported by nothing at all.
-                let val = String::from_utf8_lossy(hv.as_bytes());
+                let val = crate::helpers::headers::field_line_as_written(hv);
                 if let Some(v) = check_val(hdr, &val) {
                     return Some(v);
                 }
@@ -475,6 +481,32 @@ static REGISTRATION: &dyn crate::rules::Rule = &MessageAcceptHeaderMediaTypeSynt
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// The media-range is `OWS`-trimmed after the split on `;`, not
+    /// `str::trim`-trimmed, and the two differ only on a value read one `char`
+    /// per octet. %xA0 is `obs-text` and no `subtype` admits one, so
+    /// `text/html<%xA0>` is a finding — `str::trim` removed it and left a
+    /// conforming media-range behind. Invisible while the value came through
+    /// `from_utf8_lossy`, which spelled the octet U+FFFD and left it in place.
+    #[test]
+    fn an_obs_text_octet_is_part_of_the_media_range() {
+        let rule = MessageAcceptHeaderMediaTypeSyntax;
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "message_accept_header_media_type_syntax",
+        ]);
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(
+            "accept",
+            b"text/html\xA0".as_slice(),
+        )]);
+
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        );
+        assert!(v.is_some(), "text/html carrying %xA0 drew nothing");
+    }
 
     #[rstest]
     #[case(Some("text/html"), false)]

--- a/lint-http-rules/src/rules/message_charset_iana_registered.rs
+++ b/lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -246,7 +246,7 @@ impl Rule for MessageCharsetIanaRegistered {
                 // reported by nothing at all. Where obs-text is not legal, in an
                 // unquoted `token`, the check below already rejects it.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
-                let s = String::from_utf8_lossy(hv.as_bytes());
+                let s = crate::helpers::headers::field_line_as_written(hv);
                 if let Some(v) = check_header(which, &s) {
                     return Some(v);
                 }

--- a/lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
+++ b/lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
@@ -41,8 +41,7 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
         // octet -- both are `token` -- so one appearing where a name belongs
         // simply fails to match anything, which is the right outcome; dropping
         // the line instead hid every *other* name on it.
-        let decode =
-            |hv: &hyper::header::HeaderValue| String::from_utf8_lossy(hv.as_bytes()).into_owned();
+        let decode = crate::helpers::headers::field_line_as_written;
 
         let check = |headers: &hyper::HeaderMap, side: &str| -> Option<Violation> {
             // `content-coding` is a bare `token` with no parameters, so every comma
@@ -61,9 +60,9 @@ impl Rule for MessageCompressionAndTransferEncodingConsistency {
                     // `message_content_encoding_iana_registered` is already
                     // reporting as malformed. It cannot invent an overlap -- the
                     // text before the `;` is text the sender wrote.
-                    // The trim is `OWS`, not `str::trim`: `decode` is
-                    // `from_utf8_lossy`, so %xC2 %xA0 reaches here as one `char`
-                    // `char::is_whitespace` admits and no `token` does, and
+                    // The trim is `OWS`, not `str::trim`: the value is read one
+                    // `char` per octet, so %xA0 reaches here as U+00A0 —
+                    // `char::is_whitespace` admits it and no `token` does, and
                     // taking it would turn a name no production writes into
                     // `gzip`.
                     // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
@@ -330,7 +329,7 @@ mod tests {
 
     /// `Some("gzip"), Some("chunked, gzip")` — the first `overlap_cases` row —
     /// with one `obs-text` octet on the `Content-Encoding` name. `content-coding
-    /// = token`, so `gzip<%xC2%xA0>` is not the `gzip` coding and the two fields
+    /// = token`, so `gzip<%xA0>` is not the `gzip` coding and the two fields
     /// name nothing in common. The value is read with `from_utf8_lossy`, so the
     /// pair arrives as one `char`; the list walk trimmed it and the name split
     /// below trimmed it again, and the finding claimed an overlap between a
@@ -339,8 +338,8 @@ mod tests {
     /// Both name splits are exercised, because they are two separate trims on
     /// two separate productions and only one of them was covered.
     #[rstest]
-    #[case(b"gzip\xC2\xA0", b"chunked, gzip")]
-    #[case(b"gzip", b"chunked, gzip\xC2\xA0")]
+    #[case(b"gzip\xA0", b"chunked, gzip")]
+    #[case(b"gzip", b"chunked, gzip\xA0")]
     fn a_coding_name_carrying_obs_text_overlaps_nothing(#[case] ce: &[u8], #[case] te: &[u8]) {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =

--- a/lint-http-rules/src/rules/message_content_type_well_formed.rs
+++ b/lint-http-rules/src/rules/message_content_type_well_formed.rs
@@ -82,7 +82,7 @@ impl Rule for MessageContentTypeWellFormed {
                 // obs-text is *not* legal, in a `token`, the checks below already
                 // reject it, so the decode decides nothing on its own.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
-                let s = String::from_utf8_lossy(hv.as_bytes());
+                let s = crate::helpers::headers::field_line_as_written(hv);
                 if let Some(v) = check_content_type(which, &s, &config) {
                     return Some(v);
                 }

--- a/lint-http-rules/src/rules/message_language_tag_format_valid.rs
+++ b/lint-http-rules/src/rules/message_language_tag_format_valid.rs
@@ -84,9 +84,12 @@ impl Rule for MessageLanguageTagFormatValid {
         // The replacement character the decode leaves behind is not
         // alphanumeric, so the character check below reports it like any other
         // octet the grammar does not admit.
-        fn decode(hv: &hyper::header::HeaderValue) -> std::borrow::Cow<'_, str> {
-            String::from_utf8_lossy(hv.as_bytes())
-        }
+        // One `char` per octet, and not `String::from_utf8_lossy`: that decoder
+        // reads the octets as UTF-8, so a sender's two `obs-text` octets arrive
+        // as the one `char` they spell and an octet beginning no valid sequence
+        // arrives as U+FFFD — a character no sender can write, and the one a
+        // finding naming the character would then name.
+        use crate::helpers::headers::field_line_as_written as decode;
 
         // `#language-tag`: a list of tags and nothing else. There is no
         // wildcard and no weight here, so a `*` or a `;q=` reaches the tag
@@ -113,10 +116,10 @@ impl Rule for MessageLanguageTagFormatValid {
                     // a weight at all is `message_accept_language_weight_validity`'s
                     // subject, and this rule reads only the range in front of it.
                     // `OWS` and not `str::trim`, which is what the walk above
-                    // settled: `decode` is `from_utf8_lossy`, so %xC2 %xA0
-                    // arrives as one `char` `char::is_whitespace` admits — and
-                    // this rule's own description says an octet outside visible
-                    // US-ASCII is reported rather than skipped.
+                    // settled: the value is read one `char` per octet, so %xA0
+                    // arrives as U+00A0, which `char::is_whitespace` admits —
+                    // and this rule's own description says an octet outside
+                    // visible US-ASCII is reported rather than skipped.
                     // cite(RFC 9110 § 12.4.2): "weight = OWS ";" OWS "q=" qvalue"
                     // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
                     let lang = crate::helpers::headers::trim_ows(member.split(';').next().unwrap());
@@ -509,13 +512,13 @@ mod tests {
     /// What `description()`'s *"An octet outside visible US-ASCII is reported,
     /// not skipped"* claims, on the two spellings that used to escape it. The
     /// value is read with `from_utf8_lossy` precisely so such an octet reaches
-    /// `check_tag` — and %xC2 %xA0 arrives as one `char` `str::trim` calls
+    /// `check_tag` — and %xA0 arrives as U+00A0, which `str::trim` calls
     /// whitespace, so the list walk took it off `Content-Language` and the
     /// weight split took it off `Accept-Language`. Both trims are `OWS` now, and
     /// no `language-tag` or `language-range` admits either octet.
     #[rstest]
-    #[case("content-language", b"en-US\xC2\xA0")]
-    #[case("accept-language", b"en-US\xC2\xA0")]
+    #[case("content-language", b"en-US\xA0")]
+    #[case("accept-language", b"en-US\xA0")]
     fn an_obs_text_octet_shaped_like_a_space_is_still_reported(
         #[case] field: &str,
         #[case] value: &[u8],
@@ -533,6 +536,6 @@ mod tests {
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
         );
-        assert!(v.is_some(), "{field} carrying %xC2 %xA0 drew nothing");
+        assert!(v.is_some(), "{field} carrying %xA0 drew nothing");
     }
 }

--- a/lint-http-rules/src/rules/message_media_type_suffix_validity.rs
+++ b/lint-http-rules/src/rules/message_media_type_suffix_validity.rs
@@ -94,7 +94,15 @@ impl Rule for MessageMediaTypeSuffixValidity {
                 Ok(p) => p,
                 Err(_) => return None,
             };
-            let subtype = parsed.subtype.trim();
+            // Not trimmed again. `parse_media_type` has already excluded the
+            // `OWS` its production prints, and it prints none inside
+            // `type "/" subtype` — so a second `str::trim` here removed nothing
+            // legal and, on a value read one `char` per octet, removed %xA0 from
+            // a malformed subtype and left this rule judging the suffix of a
+            // name that is not well formed. That is the finding its own
+            // `description()` promises to leave to the rule that owns it.
+            // cite(RFC 9110 § 8.3.1, label: media-type grammar): "media-type = type "/" subtype parameters"
+            let subtype = parsed.subtype;
 
             // `parse_media_type` is structural — it finds the "/" and checks that
             // neither half is empty — so a subtype full of characters no subtype
@@ -194,7 +202,7 @@ impl Rule for MessageMediaTypeSuffixValidity {
             headers
                 .get_all(name)
                 .iter()
-                .map(|hv| String::from_utf8_lossy(hv.as_bytes()).into_owned())
+                .map(crate::helpers::headers::field_line_as_written)
                 .collect()
         };
 
@@ -423,6 +431,13 @@ mod tests {
     // here as bad *suffixes*, naming the wrong defect and saying it twice.
     #[case(b"application/ld+json\xe4", false)]
     #[case("application/ld+jso\u{ad}n".as_bytes(), false)]
+    // %xA0 is the one the second trim reached. `parse_media_type` has already
+    // excluded the `OWS` its production prints and prints none inside
+    // `type "/" subtype`, so the extra `str::trim` this rule ran took an
+    // `obs-text` octet off a malformed subtype and then judged its suffix —
+    // reporting `+bogus` about a name that is not a name.
+    #[case(b"application/vnd.x+bogus\xA0", false)]
+    #[case(b"application/vnd.x+json\xA0", false)]
     // A subtype that is only a suffix has no base name to qualify.
     #[case(b"application/+json", true)]
     // Well-formed names are still judged on their suffix.

--- a/lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
@@ -47,7 +47,7 @@ impl Rule for MessageMultipartBoundarySyntax {
                 // obs-text appears in the boundary itself the character check
                 // below rejects it, as `bcharsnospace` is US-ASCII throughout.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
-                let s = String::from_utf8_lossy(hv.as_bytes());
+                let s = crate::helpers::headers::field_line_as_written(hv);
                 if let Some(v) = check_multipart_boundary(which, &s, &config) {
                     return Some(v);
                 }

--- a/lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
+++ b/lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
@@ -63,8 +63,14 @@ impl Rule for MessageMultipartContentTypeAndBodyConsistency {
                 // which refuses `obs-text` — legal inside a `quoted-string`, so
                 // a boundary is not unreadable merely because a neighbouring
                 // parameter carries one.
+                //
+                // One `char` per octet, and not `String::from_utf8_lossy`, which
+                // is what this said until the boundary was followed as far as the
+                // body: that decoder reads the octets as UTF-8 and hands back the
+                // text they spell, so %xA0 arrives as U+FFFD — a character no
+                // sender can write — and the scan hunted the body for it.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
-                let s = String::from_utf8_lossy(hv.as_bytes());
+                let s = crate::helpers::headers::field_line_as_written(hv);
                 if let Some(boundary) = crate::helpers::headers::extract_multipart_boundary(&s) {
                     if let Some(v) = check_body_delimiters(which, &boundary, body.as_ref(), &config)
                     {
@@ -180,13 +186,25 @@ struct DelimiterScan {
     appears_off_line: bool,
 }
 
-fn scan_delimiter_lines(body: &[u8], boundary: &str) -> DelimiterScan {
+/// `boundary` is the octets the field line carried, not text.
+///
+/// The body is octets and the comparison below is octet for octet, so the
+/// boundary has to arrive the same way. It used to arrive as a `&str` from
+/// `String::from_utf8_lossy`, and both halves of that were wrong: an octet
+/// beginning no valid UTF-8 sequence became U+FFFD, so a boundary of `x<%xA0>y`
+/// was hunted for as `x<%xEF %xBF %xBD>y`; and `str::as_bytes` on the `char`-per
+/// -octet reading that replaces it would re-encode, making the same boundary
+/// `x<%xC2 %xA0>y`. Neither is in the body. `obs-text` is legal in the
+/// `quoted-string` alternative a boundary may be written in, so this is a value a
+/// conforming sender can produce — and it was reported for a body that carried it
+/// correctly.
+fn scan_delimiter_lines(body: &[u8], boundary: &[u8]) -> DelimiterScan {
     // The two hyphens are not decoration: `dash-boundary` is what the body
     // carries, and the boundary parameter is only its tail.
     // cite(RFC 2046 § 5.1.1): "dash-boundary := "--" boundary"
     // cite(RFC 2046 § 5.1.1): "The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF."
-    let dash_boundary = ["--", boundary].concat();
-    let db = dash_boundary.as_bytes();
+    let dash_boundary = [b"--".as_slice(), boundary].concat();
+    let db = dash_boundary.as_slice();
     let mut scan = DelimiterScan::default();
 
     if db.len() > body.len() {
@@ -263,7 +281,15 @@ fn check_body_delimiters(
     body: &[u8],
     config: &crate::rules::RuleConfig,
 ) -> Option<Violation> {
-    let scan = scan_delimiter_lines(body, boundary);
+    // The boundary is text for the three findings below and octets for the scan,
+    // and the two are not the same string. `boundary` is the as-written reading —
+    // one `char` per octet — so this is the exact inverse of the decode that made
+    // it, and the only reason it can fail is a caller passing a value from
+    // somewhere else. There is no such caller, and `None` says so rather than
+    // truncating one into a boundary nobody wrote.
+    let octets = crate::helpers::headers::as_written_octets(boundary)?;
+    let scan = scan_delimiter_lines(body, &octets);
+    let shown = crate::helpers::headers::shown_in_finding(boundary);
 
     // Nothing outside the delimiter lines is judged, and that is the spec's
     // instruction rather than this rule's convenience: the preamble and the
@@ -274,10 +300,10 @@ fn check_body_delimiters(
         let detail = if scan.appears_off_line {
             format!(
                 "the text '--{}' occurs in the body but never at the start of a line, so it delimits nothing",
-                boundary
+                shown
             )
         } else {
-            format!("body does not contain boundary marker '--{}'", boundary)
+            format!("body does not contain boundary marker '--{}'", shown)
         };
         return Some(Violation {
             rule: MessageMultipartContentTypeAndBodyConsistency.id().into(),
@@ -297,7 +323,7 @@ fn check_body_delimiters(
             severity: config.severity,
             message: format!(
                 "Invalid multipart Content-Type in {}: the only boundary delimiter line is the terminating '--{}--', so the body encapsulates no part",
-                which, boundary
+                which, shown
             ),
         });
     }
@@ -344,6 +370,62 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
         assert!(v.is_none());
+    }
+
+    /// `valid_multipart_with_final_boundary_ok` with one `obs-text` octet in the
+    /// boundary, which is legal inside the `quoted-string` alternative and is the
+    /// case this rule has to compare octet for octet. The delimiter lines carry
+    /// the same octet the field line did, so the body encapsulates its part and
+    /// there is nothing to report.
+    ///
+    /// It was reported, because the boundary reached the body scan as *text*: the
+    /// field line went through `String::from_utf8_lossy`, which turns %xA0 into
+    /// U+FFFD, and the scan then compared `--x<U+FFFD>y` against a body holding
+    /// `--x<%xA0>y`. Re-encoding the same string as UTF-8 does not help either —
+    /// U+00A0 is two octets — so what this needs is the boundary as the octets it
+    /// was written in.
+    #[test]
+    fn a_boundary_carrying_obs_text_is_matched_octet_for_octet() {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers =
+            crate::test_helpers::make_headers_from_octet_pairs(&[(
+                "content-type",
+                b"multipart/mixed; boundary=\"x\xA0y\"".as_slice(),
+            )]);
+        tx.response_body = Some(Bytes::from_static(
+            b"--x\xA0y\r\nContent-Type: text/plain\r\n\r\nhi\r\n--x\xA0y--\r\n",
+        ));
+        let rule = MessageMultipartContentTypeAndBodyConsistency;
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        assert!(v.is_none(), "{v:?}");
+    }
+
+    /// The other half of reading the boundary as octets: the three findings name
+    /// it, and a boundary may hold characters that corrupt the sentence carrying
+    /// them. `shown_in_finding` escapes those and leaves `obs-text` legible, so a
+    /// backslash a `quoted-pair` produced reads as a backslash rather than as an
+    /// escape nobody wrote.
+    #[test]
+    fn a_boundary_named_in_a_finding_is_escaped() {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(
+            200,
+            &[("content-type", r#"multipart/mixed; boundary="a\\b""#)],
+        );
+        tx.response_body = Some(Bytes::from_static(b"no delimiter here"));
+        let rule = MessageMultipartContentTypeAndBodyConsistency;
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        let message = v
+            .expect("a body with no delimiter line is a finding")
+            .message;
+        assert!(message.contains(r"--a\\b"), "{message}");
     }
 
     #[test]
@@ -748,7 +830,11 @@ mod tests {
         body.resize(16 * 1024 * 1024, b'x');
 
         let started = std::time::Instant::now();
-        let scan = scan_delimiter_lines(&body, &boundary);
+        // The same conversion production uses. `boundary.as_bytes()` happens to
+        // agree here because this fixture is ASCII, and copying that spelling is
+        // exactly the re-encoding trap `scan_delimiter_lines` documents.
+        let octets = crate::helpers::headers::as_written_octets(&boundary).expect("as-written");
+        let scan = scan_delimiter_lines(&body, &octets);
         let elapsed = started.elapsed();
 
         assert!(scan.opens_a_part && scan.closes);

--- a/lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
+++ b/lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
@@ -147,7 +147,15 @@ impl Rule for MessageTransferCodingIanaRegistered {
                 // awareness: a `quoted-string` can only appear in a
                 // transfer-parameter value, which is behind a `;` already, so
                 // nothing quoted ever precedes the first one.
-                let token = part.split(';').next().unwrap().trim();
+                // `OWS` and not `str::trim`. The production prints `OWS` around
+                // the `;` and nothing wider, and the value reaching here is read
+                // one `char` per octet — so `str::trim` took %xA0 and %x85 off a
+                // coding name and handed the lookup below a name the sender did
+                // not write. It was invisible while the value came through
+                // `from_utf8_lossy`, which spelled those octets U+FFFD.
+                // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
+                // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                let token = crate::helpers::headers::trim_ows(part.split(';').next().unwrap());
                 // `trailers` occupies the first alternative of `t-codings`, so
                 // it is a member of TE that is not a coding name and has no
                 // registry question to answer. It is skipped rather than looked
@@ -330,9 +338,12 @@ impl Rule for MessageTransferCodingIanaRegistered {
         // other octet the production excludes.
         // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
         // cite(RFC 9110 § 5.6.4): "qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text"
-        fn decode(hv: &hyper::header::HeaderValue) -> std::borrow::Cow<'_, str> {
-            String::from_utf8_lossy(hv.as_bytes())
-        }
+        // One `char` per octet, and not `String::from_utf8_lossy`: that decoder
+        // reads the octets as UTF-8, so a sender's two `obs-text` octets arrive
+        // as the one `char` they spell and an octet beginning no valid sequence
+        // arrives as U+FFFD — a character no sender can write, and the one a
+        // finding naming the character would then name.
+        use crate::helpers::headers::field_line_as_written as decode;
 
         // Transfer-Encoding is defined for both directions: it names the codings
         // applied to *this message's* body, whichever way it is travelling.
@@ -511,6 +522,28 @@ mod tests {
             }),
         );
         cfg
+    }
+
+    /// The coding name is `OWS`-trimmed and not `str::trim`-trimmed, and the
+    /// difference is only visible on a value read one `char` per octet. %xA0 is
+    /// `obs-text`, which no `token` admits, so `gzip<%xA0>` is a coding name this
+    /// rule must report — `str::trim` removed it and looked up `gzip`, which is
+    /// registered. It was hidden while the value came through `from_utf8_lossy`,
+    /// where the same octet spelled U+FFFD and no trim touched it.
+    #[test]
+    fn an_obs_text_octet_is_part_of_the_coding_name() {
+        let rule = MessageTransferCodingIanaRegistered;
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_octet_pairs(
+            &[("transfer-encoding", b"gzip\xA0".as_slice())],
+        );
+
+        let v = rule.check_transaction(
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &make_cfg(),
+        );
+        assert!(v.is_some(), "gzip carrying %xA0 drew nothing");
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
@@ -43,7 +43,7 @@ impl Rule for MessageTransferEncodingChunkedFinal {
                 // finding: it silently reorders the sequence this rule exists
                 // to judge, because the codings on that line are the ones
                 // between the lines that remain.
-                let val = String::from_utf8_lossy(hv.as_bytes());
+                let val = crate::helpers::headers::field_line_as_written(hv);
                 if !crate::helpers::headers::quoting_is_balanced(&val) {
                     return None;
                 }
@@ -64,8 +64,8 @@ impl Rule for MessageTransferEncodingChunkedFinal {
                     // all is `message_transfer_coding_iana_registered`'s finding.
                     // The trim is `OWS` because that is the whitespace the
                     // production prints around the `;`. `str::trim` would take
-                    // more, and on a value read through `from_utf8_lossy` there
-                    // is more to take: %xC2 %xA0 arrives as one `char` that
+                    // more, and on a value read one `char` per octet there is
+                    // more to take: %xA0 arrives as U+00A0, which
                     // `char::is_whitespace` admits and no `token` does.
                     // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
                     // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
@@ -85,7 +85,7 @@ impl Rule for MessageTransferEncodingChunkedFinal {
         // cite(RFC 9112 § 9.6): "The "close" connection option is defined as a signal that the sender will close this connection after completion of the response."
         let announces_close = |headers: &hyper::HeaderMap| -> bool {
             headers.get_all("connection").iter().any(|hv| {
-                let val = String::from_utf8_lossy(hv.as_bytes());
+                let val = crate::helpers::headers::field_line_as_written(hv);
                 // Bound rather than returned directly: the iterator borrows
                 // `val`, and as a tail expression it outlives it. Not a style
                 // choice -- inlining it does not compile.
@@ -642,14 +642,14 @@ mod tests {
 
     /// `a_response_that_announces_close_is_not_reported` with the exemption
     /// spelled in an octet that is not a `tchar`. `connection-option = token`,
-    /// so `close<%xC2%xA0>` is not the `close` option and the response has said
+    /// so `close<%xA0>` is not the `close` option and the response has said
     /// nothing — the value is read with `from_utf8_lossy` and the pair arrives as
     /// one `char` `str::trim` calls whitespace, so the list walk used to hand
     /// back `close` and excuse the message.
     ///
     /// The same octet on the coding itself is the other half: the name in front
     /// of the `;` is `OWS`-trimmed now, so a request whose only coding is
-    /// `chunked<%xC2%xA0>` has applied something that is not `chunked` and never
+    /// `chunked<%xA0>` has applied something that is not `chunked` and never
     /// framed the result. Both used to read as the bare token.
     #[test]
     fn an_obs_text_octet_is_not_whitespace_in_the_connection_option() {
@@ -658,7 +658,7 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_octet_pairs(&[
                 ("transfer-encoding", b"chunked, gzip".as_slice()),
-                ("connection", b"close\xC2\xA0".as_slice()),
+                ("connection", b"close\xA0".as_slice()),
             ]);
 
         let v = rule.check_transaction(
@@ -679,7 +679,7 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(
             "transfer-encoding",
-            b"chunked\xC2\xA0".as_slice(),
+            b"chunked\xA0".as_slice(),
         )]);
 
         let v = rule.check_transaction(

--- a/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
+++ b/lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -168,6 +168,15 @@ fn alpn_protocol_name(protocol_id: &str) -> Vec<u8> {
 /// exactly the ones a message will not hold as themselves — so a name that is
 /// visible US-ASCII throughout reads as itself and any other is named octet by
 /// octet.
+///
+/// The `from_utf8_lossy` here is the one in this tree that is exact, and the
+/// guard above it is why: inside that branch every octet is visible US-ASCII, so
+/// the decode has nothing to substitute and nothing to fold. Everywhere else the
+/// same call was a defect, because it reads octets as UTF-8 and hands back the
+/// text they spell — [`field_line_as_written`] is the reader those callers
+/// wanted. Left as it is on purpose, with the reason at the site.
+///
+/// [`field_line_as_written`]: crate::helpers::headers::field_line_as_written
 fn shown_alpn_name(name: &[u8]) -> String {
     if name.iter().all(|b| (0x20..0x7f).contains(b)) {
         format!("'{}'", shown_in_finding(&String::from_utf8_lossy(name)))

--- a/lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
+++ b/lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
@@ -154,7 +154,7 @@ impl Rule for ServerNoBodyFor1xx204304 {
                 // first field line and that is all this is -- a second line is
                 // another instance of the same forbidden field, not a second
                 // finding, and nothing here is measuring a length.
-                let shown = String::from_utf8_lossy(value.as_bytes()).into_owned();
+                let shown = crate::helpers::headers::field_line_as_written(value);
                 return Some(self.report(
                     config.severity,
                     status,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2272
+      line: 2328
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2267
+      line: 2323
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2266
+      line: 2322
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -264,7 +264,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2331
+      line: 2387
   - label: message_refresh_header_syntax_valid
     snippet: A code point is found that is not a URL unit.
     cited_by:
@@ -748,7 +748,7 @@ sources:
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 376
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 187
+      line: 205
   - label: message_multipart_boundary_syntax (4)
     section: § 5.1.1
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
@@ -786,57 +786,57 @@ sources:
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 233
+      line: 251
   - label: message_multipart_content_type_and_body_consistency (2)
     section: § 5.1.1
     snippet: Boundary string comparisons must compare the boundary value with the beginning of each candidate line.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 232
+      line: 250
   - label: message_multipart_content_type_and_body_consistency (3)
     section: § 5.1.1
     snippet: Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 245
+      line: 263
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 307
+      line: 333
   - label: message_multipart_content_type_and_body_consistency (4)
     section: § 5.1.1
     snippet: The boundary delimiter MUST occur at the beginning of a line, i.e., following a CRLF, and the initial CRLF is considered to be attached to the boundary delimiter line rather than part of the preceding part.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 207
+      line: 225
   - label: message_multipart_content_type_and_body_consistency (5)
     section: § 5.1.1
     snippet: The boundary delimiter line following the last body part is a distinguished delimiter that indicates that no further body parts will follow.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 292
+      line: 318
   - label: message_multipart_content_type_and_body_consistency (6)
     section: § 5.1.1
     snippet: The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 293
+      line: 319
   - label: message_multipart_content_type_and_body_consistency (7)
     section: § 5.1.1
     snippet: close-delimiter := delimiter "--"
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 244
+      line: 262
   - label: message_multipart_content_type_and_body_consistency (8)
     section: § 5.1.1
     snippet: dash-boundary := "--" boundary
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 186
+      line: 204
   - label: message_multipart_content_type_and_body_consistency (9)
     section: § 5.1.1
     snippet: implementations must ignore anything that appears before the first boundary delimiter line or after the last one.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 272
+      line: 298
 - label: RFC 2068
   url: https://www.rfc-editor.org/rfc/rfc2068.txt
   type: text/plain
@@ -1418,7 +1418,7 @@ sources:
     - file: lint-http-rules/src/helpers/language.rs
       line: 74
     - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
-      line: 128
+      line: 131
   - label: message_language_tag_format_valid
     section: § 2.1
     snippet: A basic language range differs from the language tags defined in [RFC4646] only in that there is no requirement that it be "well-formed" or be validated against the IANA Language Subtag Registry.
@@ -2046,7 +2046,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2268
+      line: 2324
     - file: lint-http-rules/src/helpers/uri.rs
       line: 259
   - label: lint-http-rules/src/helpers/uri.rs
@@ -2638,31 +2638,31 @@ sources:
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
     cited_by:
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 112
+      line: 120
   - label: message_media_type_suffix_validity (2)
     section: § 4.2
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 125
+      line: 133
   - label: message_media_type_suffix_validity (3)
     section: § 4.2
     snippet: restricted-name-chars =/ "+" ; Characters after last plus always ; specify a structured syntax suffix
     cited_by:
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 120
+      line: 128
   - label: message_media_type_suffix_validity (4)
     section: § 4.2.8
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
     cited_by:
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 166
+      line: 174
   - label: message_media_type_suffix_validity (5)
     section: § 4.2.8
     snippet: By the same token, media types MUST NOT be given names incorporating suffixes for structured syntaxes they do not actually employ.
     cited_by:
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 167
+      line: 175
 - label: RFC 7231
   url: https://www.rfc-editor.org/rfc/rfc7231.txt
   type: text/plain
@@ -3179,7 +3179,7 @@ sources:
     snippet: In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 315
+      line: 324
   - label: server_alt_svc_protocol_iana_registered (5)
     section: § 6
     snippet: 'Identification Sequence: The precise set of octet values that identifies the protocol.'
@@ -3327,7 +3327,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 374
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 193
+      line: 202
   - label: server_alt_svc_h3_advertisement_valid (2)
     section: § 3
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
@@ -3355,7 +3355,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 321
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 235
+      line: 244
   - label: server_alt_svc_h3_advertisement_valid (5)
     section: § 3
     snippet: parameter     = token "=" ( token / quoted-string )
@@ -3397,7 +3397,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 388
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 216
+      line: 225
   - label: server_alt_svc_header_syntax (5)
     section: § 3
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
@@ -3469,7 +3469,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 32
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 256
+      line: 265
   - label: server_alt_svc_header_syntax (16)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
@@ -3477,7 +3477,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 314
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 267
+      line: 276
   - label: server_alt_svc_header_syntax (17)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
@@ -3515,19 +3515,19 @@ sources:
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 313
+      line: 322
   - label: server_alt_svc_protocol_iana_registered (2)
     section: § 2
     snippet: The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 314
+      line: 323
   - label: server_alt_svc_protocol_iana_registered (3)
     section: § 2.4
     snippet: If the connection to the alternative service does not negotiate the expected protocol (for example, ALPN fails to negotiate h2, or an Upgrade request to h2c is not accepted), the connection to the alternative service MUST be considered to have failed.
     cited_by:
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 316
+      line: 325
   - label: server_alt_svc_protocol_iana_registered (4)
     section: § 3
     snippet: ALPN protocol names are octet sequences with no additional constraints on format.
@@ -3543,25 +3543,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1831
+      line: 1887
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1772
+      line: 1828
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1810
+      line: 1866
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1803
+      line: 1859
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.txt
   type: text/plain
@@ -3871,7 +3871,7 @@ sources:
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 880
+      line: 936
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
       line: 125
     - file: lint-http-rules/src/rules/message_early_data_header_safe_method.rs
@@ -4401,7 +4401,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 143
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 93
+      line: 99
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 244
   - label: client_patch_method_content_type_match (5)
@@ -4439,7 +4439,7 @@ sources:
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 42
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 122
+      line: 128
   - label: client_patch_method_content_type_match (9)
     section: § 9.1
     snippet: The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names.
@@ -4933,7 +4933,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 22
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 912
+      line: 968
     - file: lint-http-rules/src/rules/message_connection_upgrade.rs
       line: 60
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -4945,7 +4945,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 125
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 947
+      line: 1003
     - file: lint-http-rules/src/rules/message_trailer_headers_valid.rs
       line: 116
   - label: lint-http-proxy/src/proxy/websocket.rs
@@ -5013,7 +5013,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 97
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 496
+      line: 552
     - file: lint-http-rules/src/rules/client_accept_encoding_present.rs
       line: 61
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5081,9 +5081,9 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 60
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1082
+      line: 1138
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1111
+      line: 1167
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 241
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -5219,19 +5219,19 @@ sources:
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 896
+      line: 952
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 11.7.3
     snippet: Proxy-Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 897
+      line: 953
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1740
+      line: 1796
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 171
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
@@ -5241,7 +5241,7 @@ sources:
     snippet: 'Vary = #( "*" / field-name )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1012
+      line: 1068
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 37
   - label: If-None-Match weak comparison
@@ -5249,19 +5249,19 @@ sources:
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 377
+      line: 429
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 16.3.2
     snippet: If the field is allowable in trailers; by default, it will not be (see Section 6.5.1).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 826
+      line: 882
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5
     snippet: Fields are sent and received within the header and trailer sections of messages
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 290
+      line: 342
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
       line: 79
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
@@ -5271,9 +5271,9 @@ sources:
     snippet: Field names are case-insensitive
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 945
+      line: 1001
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1013
+      line: 1069
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.2
     snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
@@ -5281,7 +5281,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 211
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1538
+      line: 1594
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 64
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -5293,13 +5293,13 @@ sources:
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1014
+      line: 1070
     - file: lint-http-rules/src/rules/server_alt_svc_h3_advertisement_valid.rs
       line: 78
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 407
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 226
+      line: 235
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 179
   - label: lint-http-rules/src/helpers/headers.rs (8)
@@ -5311,7 +5311,7 @@ sources:
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 81
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 319
+      line: 327
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
       line: 93
   - label: lint-http-rules/src/helpers/headers.rs (9)
@@ -5325,7 +5325,7 @@ sources:
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1539
+      line: 1595
     - file: lint-http-rules/src/rules/client_accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -5361,7 +5361,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2001
+      line: 2057
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 151
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
@@ -5390,6 +5390,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 212
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 247
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 156
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
@@ -5397,11 +5399,11 @@ sources:
     - file: lint-http-rules/src/rules/message_content_type_well_formed.rs
       line: 84
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 192
+      line: 200
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 49
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 66
+      line: 72
     - file: lint-http-rules/src/rules/message_server_header_product_valid.rs
       line: 50
     - file: lint-http-rules/src/rules/message_user_agent_token_valid.rs
@@ -5413,7 +5415,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1536
+      line: 1592
     - file: lint-http-rules/src/rules/message_content_disposition_token_valid.rs
       line: 124
   - label: lint-http-rules/src/helpers/headers.rs (14)
@@ -5421,13 +5423,19 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1537
+      line: 1593
   - label: lint-http-rules/src/helpers/headers.rs (15)
+    section: § 5.5
+    snippet: field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 248
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.1.1
     snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 498
+      line: 554
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 96
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
@@ -5472,12 +5480,12 @@ sources:
       line: 347
     - file: lint-http-rules/src/rules/server_vary_header_valid.rs
       line: 59
-  - label: lint-http-rules/src/helpers/headers.rs (16)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 495
+      line: 551
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 49
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
@@ -5488,32 +5496,32 @@ sources:
       line: 398
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 432
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 497
+      line: 553
     - file: lint-http-rules/src/rules/message_trailer_fields_validity.rs
       line: 175
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1601
+      line: 1657
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 81
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 46
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1602
+      line: 1658
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/client_sec_websocket_headers_consistency.rs
@@ -5523,13 +5531,13 @@ sources:
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 245
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 173
+      line: 181
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
       line: 212
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 316
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 274
+      line: 283
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 380
   - label: OWS grammar
@@ -5537,29 +5545,33 @@ sources:
     snippet: OWS            = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 349
+      line: 401
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 499
+      line: 555
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1083
+      line: 1139
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1112
+      line: 1168
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1930
+      line: 1986
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 109
     - file: lint-http-rules/src/rules/client_range_header_syntax_valid.rs
       line: 242
+    - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
+      line: 64
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 69
+      line: 68
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 100
+      line: 99
     - file: lint-http-rules/src/rules/message_if_modified_since_date_format.rs
       line: 44
     - file: lint-http-rules/src/rules/message_if_unmodified_since_date_format.rs
       line: 44
     - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
-      line: 121
+      line: 124
+    - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
+      line: 157
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
       line: 71
     - file: lint-http-rules/src/rules/message_x_forwarded_consistency.rs
@@ -5570,147 +5582,149 @@ sources:
       line: 33
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 463
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1662
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+      line: 1718
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 348
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+      line: 400
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1377
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+      line: 1433
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1375
+      line: 1431
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 33
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 332
+      line: 340
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
       line: 527
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1216
+      line: 1272
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1244
+      line: 1300
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1376
+      line: 1432
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 421
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 477
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1084
+      line: 1140
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1243
+      line: 1299
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1281
+      line: 1337
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1374
+      line: 1430
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1603
+      line: 1659
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 316
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 118
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 331
+      line: 339
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
       line: 34
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 115
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 312
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2220
+      line: 2276
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 155
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 123
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 213
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1928
+      line: 1984
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1955
+      line: 2011
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 380
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1929
+      line: 1985
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1956
+      line: 2012
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2137
+      line: 2193
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 237
+      line: 243
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2151
+      line: 2207
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 382
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 284
+      line: 290
     - file: lint-http-rules/src/rules/message_charset_iana_registered.rs
       line: 129
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 219
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1927
+      line: 1983
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2000
+      line: 2056
     - file: lint-http-rules/src/rules/client_expect_header_valid.rs
       line: 379
+    - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
+      line: 63
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 203
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (31)
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -5718,24 +5732,24 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 145
-  - label: lint-http-rules/src/helpers/headers.rs (32)
+  - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 241
+      line: 293
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 291
+      line: 343
     - file: lint-http-rules/src/rules/message_extension_headers_registered.rs
       line: 100
     - file: lint-http-rules/src/rules/message_header_field_names_token.rs
       line: 34
-  - label: lint-http-rules/src/helpers/headers.rs (33)
+  - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 825
+      line: 881
     - file: lint-http-rules/src/rules/client_user_agent_present.rs
       line: 46
     - file: lint-http-rules/src/rules/message_server_header_product_valid.rs
@@ -5756,18 +5770,18 @@ sources:
       line: 125
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 169
-  - label: lint-http-rules/src/helpers/headers.rs (34)
+  - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 824
-  - label: lint-http-rules/src/helpers/headers.rs (35)
+      line: 880
+  - label: lint-http-rules/src/helpers/headers.rs (36)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2082
+      line: 2138
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
@@ -5777,7 +5791,7 @@ sources:
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
       line: 48
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
-      line: 138
+      line: 146
     - file: lint-http-rules/src/rules/message_multipart_boundary_syntax.rs
       line: 180
     - file: lint-http-rules/src/rules/message_problem_details_structure.rs
@@ -5788,12 +5802,12 @@ sources:
       line: 40
     - file: lint-http-rules/src/rules/server_problem_details_content_type.rs
       line: 58
-  - label: lint-http-rules/src/helpers/headers.rs (36)
+  - label: lint-http-rules/src/helpers/headers.rs (37)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2101
+      line: 2157
     - file: lint-http-rules/src/rules/client_patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -5801,22 +5815,24 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2016
+      line: 2072
+    - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
+      line: 104
     - file: lint-http-rules/src/rules/server_patch_accept_patch_header.rs
       line: 105
-  - label: lint-http-rules/src/helpers/headers.rs (37)
+  - label: lint-http-rules/src/helpers/headers.rs (38)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2081
+      line: 2137
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (38)
+  - label: lint-http-rules/src/helpers/headers.rs (39)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
@@ -5827,13 +5843,13 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1850
-  - label: lint-http-rules/src/helpers/headers.rs (39)
+      line: 1906
+  - label: lint-http-rules/src/helpers/headers.rs (40)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 583
+      line: 639
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 10.1.2
     snippet: mailbox = <mailbox, see [RFC5322], Section 3.4>
@@ -5997,7 +6013,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 154
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 265
+      line: 271
   - label: message_accept_and_content_type_negotiation (9)
     section: § 12.5.1
     snippet: The "Accept" header field can be used by user agents to specify their preferences regarding response media types.
@@ -6019,7 +6035,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_and_content_type_negotiation.rs
       line: 142
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 92
+      line: 98
   - label: message_accept_and_content_type_negotiation (12)
     section: § 15.5.7
     snippet: The 406 (Not Acceptable) status code indicates that the target resource does not have a current representation that would be acceptable to the user agent
@@ -6033,7 +6049,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 133
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 264
+      line: 270
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 83
   - label: message_accept_encoding_parameter_validity (2)
@@ -6045,7 +6061,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 37
     - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
-      line: 120
+      line: 123
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 88
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
@@ -6095,13 +6111,13 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_encoding_parameter_validity.rs
       line: 68
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 51
+      line: 50
   - label: message_accept_header_media_type_syntax
     section: § 12.4.2
     snippet: A sender of qvalue MUST NOT generate more than three digits after the decimal point.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 273
+      line: 279
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 292
   - label: message_accept_header_media_type_syntax (2)
@@ -6115,13 +6131,13 @@ sources:
     snippet: Senders using weights SHOULD send "q" last (after all media-range parameters).
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 193
+      line: 199
   - label: message_accept_header_media_type_syntax (4)
     section: § 12.5.1
     snippet: The accept extension grammar (accept-params, accept-ext) has been removed because it had a complicated definition, was not being used in practice, and is more easily deployed through new header fields.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 192
+      line: 198
   - label: message_accept_header_media_type_syntax (5)
     section: § 12.5.1
     snippet: When sent by a server in a response, Accept provides information about which content types are preferred in the content of a subsequent request to the same resource.
@@ -6133,9 +6149,9 @@ sources:
     snippet: Tokens are short textual identifiers that do not include whitespace or delimiters.
     cited_by:
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 77
+      line: 83
     - file: lint-http-rules/src/rules/message_accept_header_media_type_syntax.rs
-      line: 238
+      line: 244
     - file: lint-http-rules/src/rules/message_connection_header_tokens_valid.rs
       line: 83
     - file: lint-http-rules/src/rules/server_accept_ranges_values_valid.rs
@@ -6289,7 +6305,9 @@ sources:
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 91
+      line: 90
+    - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
+      line: 156
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
       line: 70
   - label: message_compression_and_transfer_encoding_consistency (2)
@@ -6297,7 +6315,7 @@ sources:
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 92
+      line: 91
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 137
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
@@ -6313,7 +6331,7 @@ sources:
     snippet: 'Content-Encoding = #content-coding'
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 50
+      line: 49
     - file: lint-http-rules/src/rules/message_content_encoding_and_type_consistency.rs
       line: 33
     - file: lint-http-rules/src/rules/message_content_encoding_iana_registered.rs
@@ -6323,25 +6341,25 @@ sources:
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 146
+      line: 145
   - label: message_compression_and_transfer_encoding_consistency (6)
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 139
+      line: 138
   - label: message_compression_and_transfer_encoding_consistency (7)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 123
+      line: 122
   - label: message_compression_and_transfer_encoding_consistency (8)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 70
+      line: 69
     - file: lint-http-rules/src/rules/message_content_encoding_iana_registered.rs
       line: 146
   - label: message_conditional_headers_consistency
@@ -6753,7 +6771,7 @@ sources:
     snippet: 'Content-Language = #language-tag'
     cited_by:
     - file: lint-http-rules/src/rules/message_language_tag_format_valid.rs
-      line: 95
+      line: 98
   - label: message_language_tag_format_valid (2)
     section: § 8.5
     snippet: The "Content-Language" header field describes the natural language(s) of the intended audience for the representation.
@@ -6875,7 +6893,7 @@ sources:
     snippet: The message body is itself a protocol element; a sender MUST generate only CRLF to represent line breaks between body parts.
     cited_by:
     - file: lint-http-rules/src/rules/message_multipart_content_type_and_body_consistency.rs
-      line: 208
+      line: 226
   - label: message_prefer_header_valid
     section: § 5.6.1.2
     snippet: 'In contrast, the following values would be invalid, since at least one non-empty element is required by the example-list production:'
@@ -7225,7 +7243,7 @@ sources:
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 26
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 363
+      line: 374
   - label: message_te_header_constraints (4)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
@@ -7315,7 +7333,7 @@ sources:
     snippet: 'TE                 = #t-codings t-codings          = "trailers" / ( transfer-coding [ weight ] ) transfer-coding    = token *( OWS ";" OWS transfer-parameter ) transfer-parameter = token BWS "=" BWS ( token / quoted-string )'
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 257
+      line: 265
   - label: message_user_agent_token_valid
     section: § 10.1.5
     snippet: A sender SHOULD NOT generate information in product-version that is not a version identifier
@@ -7885,7 +7903,7 @@ sources:
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 375
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
-      line: 194
+      line: 203
     - file: lint-http-rules/src/rules/server_response_405_allow.rs
       line: 67
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
@@ -8367,7 +8385,7 @@ sources:
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1015
+      line: 1071
     - file: lint-http-rules/src/rules/server_vary_and_cache_consistency.rs
       line: 45
     - file: lint-http-rules/src/rules/stateful_vary_header_cache_validity.rs
@@ -8377,13 +8395,13 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 664
+      line: 720
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 674
+      line: 730
   - label: message_age_header_numeric
     section: § 1.2.2
     snippet: If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648 (2^31) or the greatest positive integer it can conveniently represent.
@@ -8963,19 +8981,19 @@ sources:
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 122
+      line: 121
   - label: message_compression_and_transfer_encoding_consistency (3)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 101
+      line: 100
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
       line: 55
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 207
+      line: 215
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 291
+      line: 299
     - file: lint-http-rules/src/rules/message_transfer_encoding_chunked_final.rs
       line: 76
   - label: message_compression_and_transfer_encoding_consistency (4)
@@ -8983,13 +9001,13 @@ sources:
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 132
+      line: 131
   - label: message_compression_and_transfer_encoding_consistency (5)
     section: § 7.3
     snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
     cited_by:
     - file: lint-http-rules/src/rules/message_compression_and_transfer_encoding_consistency.rs
-      line: 131
+      line: 130
   - label: message_content_length_vs_transfer_encoding
     section: § 6.2
     snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
@@ -9151,7 +9169,7 @@ sources:
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 48
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 362
+      line: 373
   - label: message_te_header_constraints (3)
     section: § 7.4
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
@@ -9165,43 +9183,43 @@ sources:
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 273
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 258
+      line: 266
   - label: message_transfer_coding_iana_registered
     section: § 6.1
     snippet: A server that receives a request message with a transfer coding it does not understand SHOULD respond with 501 (Not Implemented).
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 279
+      line: 287
   - label: message_transfer_coding_iana_registered (2)
     section: § 6.1
     snippet: 'Transfer-Encoding = #transfer-coding'
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 339
+      line: 350
   - label: message_transfer_coding_iana_registered (3)
     section: § 7.1
     snippet: The chunked coding does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 231
+      line: 239
   - label: message_transfer_coding_iana_registered (4)
     section: § 7.1
     snippet: Their presence SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 232
+      line: 240
   - label: message_transfer_coding_iana_registered (5)
     section: § 7.2
     snippet: The compression codings do not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 222
+      line: 230
   - label: message_transfer_coding_iana_registered (6)
     section: § 7.2
     snippet: The presence of parameters with any of these compression codings SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 223
+      line: 231
   - label: message_transfer_coding_iana_registered (7)
     section: § 7.3
     snippet: The "HTTP Transfer Coding Registry" defines the namespace for transfer coding names.
@@ -9213,13 +9231,13 @@ sources:
     snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 204
+      line: 212
   - label: message_transfer_coding_iana_registered (9)
     section: § 7.4
     snippet: The keyword "trailers" indicates that the sender will not discard trailer fields, as described in Section 6.5 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/message_transfer_coding_iana_registered.rs
-      line: 158
+      line: 166
   - label: message_transfer_encoding_chunked_final
     section: § 6.1
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).


### PR DESCRIPTION
`helpers::headers::field_line_as_written` reads one field line one `char` per octet, and `as_written_octets` reads it back out. Eleven rules were using `String::from_utf8_lossy(hv.as_bytes())` where they wanted the first.

Every one of those sites carries a comment saying it decodes the raw octets deliberately, so that `obs-text` reaches the check instead of taking `to_str`'s "no such field here". The intent was right and the instrument was not. `from_utf8_lossy` reads the octets as UTF-8 and hands back the text they spell: a sender's %xC3 %xA9 — two `obs-text` octets — arrives as the single `char` U+00E9, and an octet that begins no valid sequence arrives as U+FFFD, which no sender can write and no `field-content` admits. The correct decode was already in the tree, in the form a *list* field wants: `combined_field_value_as_written` joins the lines first. A field whose grammar is not a list is read line by line and had nowhere to go.

The verdict defect is in the multipart body rule, and it needed the second helper rather than the first. `message_multipart_content_type_and_body_consistency` took the boundary out of a lossily-decoded `Content-Type` and compared it against the raw body octets — so `boundary="x<%xA0>y"` was hunted for as `x<%xEF %xBF %xBD>y` and a conforming body carrying its own delimiter lines was reported as not containing them. `obs-text` is legal in the `quoted-string` alternative a boundary may be written in, so this is a value a conforming sender produces. `str::as_bytes` is not the way back either — it re-encodes U+00A0 into the two octets it is not — so `scan_delimiter_lines` takes `&[u8]` and the boundary reaches it through `as_written_octets`.

Review round, and it found the hazard the helper's own doc had failed to enumerate. That doc named counting octets and naming one as the two things a conversion perturbs; the third is trimming, and it is the one that moved verdicts. U+FFFD is not whitespace and U+00A0 is, so a `str::trim` that left a lossy value alone strips an as-written one. Three sites had that trim: `Transfer-Encoding: gzip<%xA0>` and `Accept: text/html<%xA0>` stopped being reported, and `message_media_type_suffix_validity` ran a second `str::trim` on a subtype `parse_media_type` had already trimmed, so it judged the suffix of a name that is not a name — the finding its own `description()` promises to leave alone. All three are `trim_ows` or removed now, each with a case that fails without it.

The same round found seven rstest cases from the last iteration silently gutted: their fixtures spelled the octet %xC2 %xA0, which was one `char` under the lossy decode and is two under this one, so `str::trim` no longer reached the branch they pin. They are bare %xA0 now and all seven kill the mutation again. Six comments and two doc blocks describing the lossy reader are corrected, including two written in the P17 and P18 commits.

One `from_utf8_lossy` stays, in `shown_alpn_name`, where an ASCII guard above it makes the decode exact — with the reason at the site.

Cites 2206 → 2211.
