### PR TITLE
The alphabet had one reader and its two ingredients had nine

### DIFF
--- a/lint-http-rules/src/helpers/mod.rs
+++ b/lint-http-rules/src/helpers/mod.rs
@@ -28,6 +28,15 @@
 //! unchanged and is what decides it: a shared answer moves on the second caller,
 //! and that caller has to be asking the same question, not merely reading the
 //! same publisher.**
+//!
+//! **And the second caller can be a caller of one *ingredient* rather than of
+//! the function.** `first_non_pchar` in `message_well_known_uri_format` had one
+//! caller and stayed there, while the two sets it is composed of —
+//! `uri::is_unreserved` and `uri::is_sub_delim` — had five readers and four,
+//! written out character for character each time. A grammar that builds its component rules
+//! by naming one set and adding to it will produce that shape every time, so the
+//! count that decides the move is the count of the *smallest thing two sites
+//! share*, not of the function one of them happens to have wrapped it in.
 
 pub mod accept_ranges;
 pub mod auth;

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -80,19 +80,52 @@ pub fn find_non_uri_char(s: &str) -> Option<char> {
     s.chars().find(|&c| !is_uri_char(c))
 }
 
-/// Whether `c` is one of the characters a URI is composed from.
+/// Whether `c` is in RFC 3986's `unreserved` set.
+///
+/// One of the two character sets RFC 3986 builds its general component
+/// alphabets out of. Five of its productions name the pair and then add
+/// something different beside it — `userinfo`, `IPvFuture`, `reg-name`,
+/// `segment-nz-nc`, `pchar` — which is why this is a predicate and not a
+/// transcription per site: the set is the shared answer and the divergence is
+/// each caller's own line. Five sites in this crate read it (`reg-name`,
+/// `pchar`, `IPvFuture`, the URI-wide alphabet, and [`decode_unreserved`], which
+/// asks it of a decoded octet rather than of a written character).
 // cite(RFC 3986 § 2.3): "unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~""
-// cite(RFC 3986 § 2.2): "gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@""
+pub fn is_unreserved(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~')
+}
+
+/// Whether `c` is in RFC 3986's `sub-delims` set.
+///
+/// The other of the two, and it never travels alone: every component rule of
+/// the generic syntax that names this set names [`is_unreserved`]'s beside it.
+/// The one place `sub-delims` appears without it is `reserved = gen-delims /
+/// sub-delims`, which is a set definition rather than a component's alphabet —
+/// and §2.2 says a component rule never names *that* one at all. Four sites in
+/// this crate read it, one fewer than its partner, because a decoder asks which
+/// octets it may write out and no `sub-delims` octet is one of them.
 // cite(RFC 3986 § 2.2): "sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=""
+pub fn is_sub_delim(c: char) -> bool {
+    matches!(
+        c,
+        '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '='
+    )
+}
+
+/// Whether `c` is one of the characters a URI is composed from.
+///
+/// `gen-delims` stays written out here because this is the only reading in the
+/// tree that wants it: §2.2 says a component rule never names the set directly,
+/// so a *component* alphabet borrows characters from it one at a time — `pchar`
+/// takes `:` and `@`, `IPvFuture` takes `:` — and only a question asked of the
+/// whole URI takes all seven.
+// cite(RFC 3986 § 2.2): "gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@""
+// cite(RFC 3986 § 2.2): "A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component."
 // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
 fn is_uri_char(c: char) -> bool {
-    c.is_ascii_alphanumeric()
-        || matches!(c, '-' | '.' | '_' | '~')
+    is_unreserved(c)
+        || is_sub_delim(c)
         || matches!(c, ':' | '/' | '?' | '#' | '[' | ']' | '@')
-        || matches!(
-            c,
-            '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '='
-        )
         || c == '%'
 }
 
@@ -620,9 +653,11 @@ pub fn decode_unreserved(component: &str) -> String {
             .flatten();
 
         match octet {
-            Some(octet)
-                if octet.is_ascii_alphanumeric() || matches!(octet, b'-' | b'.' | b'_' | b'~') =>
-            {
+            // The set is ASCII-only and `u8 as char` is the identity there, so
+            // asking [`is_unreserved`] of the decoded octet answers exactly what
+            // a byte-wise copy of it would — this is the same set as the other
+            // four sites, read at the one place it arrives as an octet.
+            Some(octet) if is_unreserved(octet as char) => {
                 out.push(octet as char);
                 i += 3;
             }
@@ -887,10 +922,12 @@ pub fn validate_scheme_name(scheme: &str) -> Result<(), String> {
 /// `unreserved` — so a dotted quad that is out of range is a perfectly good
 /// registered name and is not a syntax finding here. What separates the
 /// alternatives is the brackets, which appear in no other host form.
+///
+/// The two sets `reg-name` is written out of are [`is_unreserved`] and
+/// [`is_sub_delim`], and their productions are quoted there rather than here:
+/// this function composes them, it does not transcribe them.
 // cite(RFC 3986 § 3.2.2): "host        = IP-literal / IPv4address / reg-name"
 // cite(RFC 3986 § 3.2.2): "reg-name    = *( unreserved / pct-encoded / sub-delims )"
-// cite(RFC 3986 § 2.3): "unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~""
-// cite(RFC 3986 § 2.2): "sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=""
 pub fn validate_uri_host(host: &str) -> Result<(), String> {
     if let Some(rest) = host.strip_prefix('[') {
         // cite(RFC 3986 § 3.2.2): "IP-literal = "[" ( IPv6address / IPvFuture  ) "]""
@@ -916,15 +953,11 @@ pub fn validate_uri_host(host: &str) -> Result<(), String> {
     if let Some(msg) = check_percent_encoding(host) {
         return Err(msg);
     }
+    // The production read left to right: `unreserved`, the `%` that opens a
+    // `pct-encoded`, `sub-delims`, and nothing else — no `:` and no `@`, which
+    // is the whole of the difference between this alphabet and `pchar`'s.
     for c in host.chars() {
-        if !(c.is_ascii_alphanumeric()
-            || c == '%'
-            || matches!(c, '-' | '.' | '_' | '~')
-            || matches!(
-                c,
-                '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '='
-            ))
-        {
+        if !(is_unreserved(c) || c == '%' || is_sub_delim(c)) {
             return Err(format!("invalid character '{}' in host '{}'", c, host));
         }
     }
@@ -950,14 +983,9 @@ fn is_ipvfuture(s: &str) -> bool {
         return false;
     }
     !tail.is_empty()
-        && tail.chars().all(|c| {
-            c.is_ascii_alphanumeric()
-                || matches!(c, '-' | '.' | '_' | '~' | ':')
-                || matches!(
-                    c,
-                    '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '='
-                )
-        })
+        && tail
+            .chars()
+            .all(|c| is_unreserved(c) || is_sub_delim(c) || c == ':')
 }
 
 /// Where the `uri-host` ends and `":" port` begins, with neither half examined.
@@ -1058,6 +1086,86 @@ pub fn validate_host_and_optional_port(value: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Both sets, spelled out from the productions rather than composed from the
+    /// predicates, and asserted over the whole US-ASCII range — four component
+    /// alphabets and one decoder now rest on these two functions, so a character
+    /// added or dropped here is added or dropped in all five.
+    #[test]
+    fn the_two_character_sets_are_what_their_productions_print() {
+        // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        let unreserved: Vec<char> = ('a'..='z')
+            .chain('A'..='Z')
+            .chain('0'..='9')
+            .chain("-._~".chars())
+            .collect();
+        // sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+        let sub_delims: Vec<char> = "!$&'()*+,;=".chars().collect();
+        assert_eq!(sub_delims.len(), 11);
+
+        for c in (0u8..=0x7F).map(char::from) {
+            assert_eq!(
+                is_unreserved(c),
+                unreserved.contains(&c),
+                "unreserved disagrees about {c:?}"
+            );
+            assert_eq!(
+                is_sub_delim(c),
+                sub_delims.contains(&c),
+                "sub-delims disagrees about {c:?}"
+            );
+        }
+
+        // Neither set reaches past US-ASCII: every octet at or above %x80 has to
+        // be percent-encoded before the URI is formed.
+        for c in (0x80u8..=0xFF).map(char::from) {
+            assert!(!is_unreserved(c) && !is_sub_delim(c), "{c:?}");
+        }
+    }
+
+    /// The four alphabets built on those sets differ exactly where their
+    /// productions differ, and nowhere else. This is the property the extraction
+    /// was for: the divergence is one line per caller, and it is this one.
+    #[test]
+    fn the_component_alphabets_differ_only_by_what_their_productions_add() {
+        for c in (0u8..=0x7F).map(char::from) {
+            let shared = is_unreserved(c) || is_sub_delim(c);
+
+            // reg-name = *( unreserved / pct-encoded / sub-delims ). Asked of a
+            // character standing between two others, and with `%` left out of
+            // the sweep: a lone `%` is not the alphabet's answer but
+            // `pct-encoded`'s, which `validate_uri_host` asks separately and
+            // first. The two assertions below the loop are that half.
+            let reg_name = c == '%' || validate_uri_host(&format!("a{c}b")).is_ok();
+            assert_eq!(reg_name, shared || c == '%', "reg-name: {c:?}");
+
+            // pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+            let pchar = is_unreserved(c) || is_sub_delim(c) || matches!(c, ':' | '@' | '%');
+            assert_eq!(pchar, reg_name || matches!(c, ':' | '@'), "pchar: {c:?}");
+
+            // IPvFuture's tail = 1*( unreserved / sub-delims / ":" ) — the one
+            // of the four that admits no `pct-encoded`, so no `%`.
+            assert_eq!(
+                is_ipvfuture(&format!("v1.{c}")),
+                shared || c == ':',
+                "IPvFuture: {c:?}"
+            );
+
+            // The URI-wide alphabet adds all seven `gen-delims` at once, which
+            // §2.2 says no component rule does.
+            assert_eq!(
+                is_uri_char(c),
+                shared || c == '%' || matches!(c, ':' | '/' | '?' | '#' | '[' | ']' | '@'),
+                "URI alphabet: {c:?}"
+            );
+        }
+
+        // `pct-encoded` is the triplet and not the `%`, and it is a separate
+        // question from the alphabet at every one of the four sites.
+        assert!(validate_uri_host("a%41b").is_ok());
+        assert!(validate_uri_host("a%zzb").is_err());
+        assert!(validate_uri_host("a%4").is_err());
+    }
 
     /// The two normalizations § 6.2.2 asks for on percent-encoding, and the one
     /// § 2.4 forbids.

--- a/lint-http-rules/src/rules/message_well_known_uri_format.rs
+++ b/lint-http-rules/src/rules/message_well_known_uri_format.rs
@@ -4,7 +4,8 @@
 
 use crate::helpers::headers::{describe_char, shown_in_finding};
 use crate::helpers::uri::{
-    extract_path_from_request_target, remove_dot_segments, scheme_authority_marker,
+    extract_path_from_request_target, is_sub_delim, is_unreserved, remove_dot_segments,
+    scheme_authority_marker,
 };
 use crate::lint::Violation;
 use crate::rules::Rule;
@@ -32,22 +33,23 @@ const WELL_KNOWN_SEGMENT: &str = ".well-known";
 /// segments and the other two terminate the path. So the two checks are the
 /// same question asked at two widths, and the neighbour owns the wider one.
 ///
-/// Written privately: nothing else in the tree asks for a `segment-nz` yet, and
-/// the shared answer moves to `helpers::uri` on the second caller.
+/// Still written privately, and the reason has moved: `pchar` has one reader in
+/// the tree, but the two sets it is built out of had five and four, so what went
+/// to `helpers::uri` is [`is_unreserved`] and [`is_sub_delim`] rather than this
+/// function. The line below is now `pchar`'s own alternation and nothing else —
+/// the two shared sets, then the two characters this production adds to them,
+/// then the `%`. A second reader of the whole alphabet moves *this* to the
+/// helper module; a fifth reader of either set changes nothing, because the sets
+/// are already there.
+///
+/// The cardinality is the caller's: `segment-nz = 1*pchar`, and a character-set
+/// predicate is never a floor — the empty name is reported one branch above,
+/// against that `1*`.
 // cite(RFC 3986 § 3.3, label: pchar): "pchar         = unreserved / pct-encoded / sub-delims / ":" / "@""
-// cite(RFC 3986 § 2.3, label: unreserved): "unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~""
-// cite(RFC 3986 § 2.2, label: sub-delims): "sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "=""
 // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
 fn first_non_pchar(name: &str) -> Option<char> {
-    name.chars().find(|c| {
-        !(c.is_ascii_alphanumeric()
-            || matches!(c, '-' | '.' | '_' | '~')
-            || matches!(
-                c,
-                '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '='
-            )
-            || matches!(c, ':' | '@' | '%'))
-    })
+    name.chars()
+        .find(|&c| !(is_unreserved(c) || is_sub_delim(c) || matches!(c, ':' | '@' | '%')))
 }
 
 /// Whether one path segment *is* the reserved segment.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1020,7 +1020,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 68
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 975
+      line: 1003
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 142
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
@@ -1030,7 +1030,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 69
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 976
+      line: 1004
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 2
     snippet: A URI is composed from a limited set of characters consisting of digits, letters, and a few graphic symbols.
@@ -1074,9 +1074,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 13
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 87
+      line: 124
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 40
+      line: 49
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 57
     - file: lint-http-rules/src/rules/server_alt_svc_protocol_iana_registered.rs
@@ -1087,20 +1087,20 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 78
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 123
   - label: lint-http-rules/src/helpers/uri.rs (8)
     section: § 2.2
     snippet: gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 85
+      line: 122
   - label: sub-delims
     section: § 2.2
     snippet: sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 86
-    - file: lint-http-rules/src/helpers/uri.rs
-      line: 893
+      line: 107
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 55
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -1109,124 +1109,118 @@ sources:
       line: 457
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 108
-    - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 39
   - label: lint-http-rules/src/helpers/uri.rs (9)
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 602
+      line: 635
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 70
+      line: 72
   - label: lint-http-rules/src/helpers/uri.rs (10)
     section: § 2.3
     snippet: percent-encoded octets in the ranges of ALPHA (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers and, when found in a URI, should be decoded to their corresponding unreserved characters by URI normalizers
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 687
-  - label: unreserved
+      line: 722
+  - label: lint-http-rules/src/helpers/uri.rs (11)
     section: § 2.3
     snippet: unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 84
+      line: 93
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 601
-    - file: lint-http-rules/src/helpers/uri.rs
-      line: 892
-    - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 38
-  - label: lint-http-rules/src/helpers/uri.rs (11)
+      line: 634
+  - label: lint-http-rules/src/helpers/uri.rs (12)
     section: § 2.4
     snippet: The only exception is for percent-encoded octets corresponding to characters in the unreserved set, which can be decoded at any time.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 686
-  - label: lint-http-rules/src/helpers/uri.rs (12)
+      line: 721
+  - label: lint-http-rules/src/helpers/uri.rs (13)
     section: § 2.4
     snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 605
+      line: 638
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 60
-  - label: lint-http-rules/src/helpers/uri.rs (13)
+  - label: lint-http-rules/src/helpers/uri.rs (14)
     section: § 3
     snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 175
-  - label: lint-http-rules/src/helpers/uri.rs (14)
+      line: 208
+  - label: lint-http-rules/src/helpers/uri.rs (15)
     section: § 3.1
     snippet: Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 866
-  - label: lint-http-rules/src/helpers/uri.rs (15)
+      line: 901
+  - label: lint-http-rules/src/helpers/uri.rs (16)
     section: § 3.1
     snippet: scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 206
+      line: 239
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 865
+      line: 900
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 738
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 220
-  - label: lint-http-rules/src/helpers/uri.rs (16)
+  - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 177
+      line: 210
   - label: authority grammar
     section: § 3.2
     snippet: authority   = [ userinfo "@" ] host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 142
-  - label: lint-http-rules/src/helpers/uri.rs (17)
+      line: 175
+  - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 144
-  - label: lint-http-rules/src/helpers/uri.rs (18)
+      line: 177
+  - label: lint-http-rules/src/helpers/uri.rs (19)
     section: § 3.2.1
     snippet: userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 143
-  - label: lint-http-rules/src/helpers/uri.rs (19)
+      line: 176
+  - label: lint-http-rules/src/helpers/uri.rs (20)
     section: § 3.2.2
     snippet: IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 896
-  - label: lint-http-rules/src/helpers/uri.rs (20)
+      line: 933
+  - label: lint-http-rules/src/helpers/uri.rs (21)
     section: § 3.2.2
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 940
+      line: 973
   - label: host grammar
     section: § 3.2.2
     snippet: host        = IP-literal / IPv4address / reg-name
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 390
+      line: 423
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 890
+      line: 929
   - label: reg-name
     section: § 3.2.2
     snippet: reg-name    = *( unreserved / pct-encoded / sub-delims )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 178
+      line: 211
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 891
+      line: 930
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 107
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -1235,148 +1229,148 @@ sources:
       line: 479
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 139
-  - label: lint-http-rules/src/helpers/uri.rs (21)
+  - label: lint-http-rules/src/helpers/uri.rs (22)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 977
+      line: 1005
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1018
+      line: 1046
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1044
+      line: 1072
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 51
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
       line: 393
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 151
-  - label: lint-http-rules/src/helpers/uri.rs (22)
+  - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1045
+      line: 1073
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 110
+      line: 143
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 105
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 37
-  - label: lint-http-rules/src/helpers/uri.rs (23)
+      line: 48
+  - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 4.2
     snippet: A path segment that contains a colon character (e.g., "this:that") cannot be used as the first segment of a relative-path reference, as it would be mistaken for a scheme name.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 111
+      line: 144
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 91
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 221
-  - label: lint-http-rules/src/helpers/uri.rs (24)
+  - label: lint-http-rules/src/helpers/uri.rs (25)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 731
+      line: 766
   - label: relative-part
     section: § 4.2
     snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 176
+      line: 209
   - label: absolute-URI
     section: § 4.3
     snippet: absolute-URI  = scheme ":" hier-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 174
+      line: 207
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 65
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 94
-  - label: lint-http-rules/src/helpers/uri.rs (25)
+  - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 5.2.3
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 703
-  - label: lint-http-rules/src/helpers/uri.rs (26)
+      line: 738
+  - label: lint-http-rules/src/helpers/uri.rs (27)
     section: § 5.2.3
     snippet: return a string consisting of the reference's path component appended to all but the last segment of the base URI's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 707
-  - label: lint-http-rules/src/helpers/uri.rs (27)
+      line: 742
+  - label: lint-http-rules/src/helpers/uri.rs (28)
     section: § 5.2.4
     snippet: This is done after the path is extracted from a reference, whether or not the path was relative, in order to remove any invalid or extraneous dot-segments prior to forming the target URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 521
-  - label: lint-http-rules/src/helpers/uri.rs (28)
+      line: 554
+  - label: lint-http-rules/src/helpers/uri.rs (29)
     section: § 5.4.2
     snippet: Some applications fail to separate the reference's query and/or fragment components from the path component before merging it with the base path and removing dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 685
-  - label: lint-http-rules/src/helpers/uri.rs (29)
+      line: 720
+  - label: lint-http-rules/src/helpers/uri.rs (30)
     section: § 5.4.2
     snippet: parsers must remove the dot-segments "." and ".." when they are complete components of a path, but not when they are only part of a segment.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 689
-  - label: lint-http-rules/src/helpers/uri.rs (30)
+      line: 724
+  - label: lint-http-rules/src/helpers/uri.rs (31)
     section: § 6.2.2
     snippet: Syntax-based normalization includes such techniques as case normalization, percent-encoding normalization, and removal of dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 684
-  - label: lint-http-rules/src/helpers/uri.rs (31)
+      line: 719
+  - label: lint-http-rules/src/helpers/uri.rs (32)
     section: § 6.2.2.1
     snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 604
+      line: 637
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 91
-  - label: lint-http-rules/src/helpers/uri.rs (32)
+  - label: lint-http-rules/src/helpers/uri.rs (33)
     section: § 6.2.2.1
     snippet: The other generic syntax components are assumed to be case-sensitive unless specifically defined otherwise by the scheme (see Section 6.2.3).
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 690
+      line: 725
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 194
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 149
-  - label: lint-http-rules/src/helpers/uri.rs (33)
+      line: 151
+  - label: lint-http-rules/src/helpers/uri.rs (34)
     section: § 6.2.2.1
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 391
+      line: 424
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 193
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 196
-  - label: lint-http-rules/src/helpers/uri.rs (34)
+  - label: lint-http-rules/src/helpers/uri.rs (35)
     section: § 6.2.2.2
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 603
-  - label: lint-http-rules/src/helpers/uri.rs (35)
+      line: 636
+  - label: lint-http-rules/src/helpers/uri.rs (36)
     section: § 6.2.2.3
     snippet: URI normalizers should remove dot-segments by applying the remove_dot_segments algorithm to the path, as described in Section 5.2.4.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 688
+      line: 723
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 159
+      line: 161
   - label: message_host_and_authority_consistency
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1420,19 +1414,19 @@ sources:
     snippet: The path is terminated by the first question mark ("?") or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 135
+      line: 137
   - label: path-absolute
     section: § 3.3
     snippet: path-absolute = "/" [ segment-nz *( "/" segment ) ]
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 148
+      line: 150
   - label: segment-nz
     section: § 3.3
     snippet: segment-nz    = 1*pchar
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 234
+      line: 236
   - label: server_location_header_uri_valid
     section: § 4.1
     snippet: URI-reference = URI / relative-ref
@@ -2054,7 +2048,7 @@ sources:
     snippet: Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1020
+      line: 1048
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 93
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -2064,7 +2058,7 @@ sources:
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1019
+      line: 1047
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 92
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
@@ -2080,13 +2074,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2324
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 259
+      line: 292
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 252
+      line: 285
 - label: RFC 6455
   url: https://www.rfc-editor.org/rfc/rfc6455.txt
   type: text/plain
@@ -3983,79 +3977,79 @@ sources:
     snippet: Furthermore, defining well-known locations usurps the origin's control over its own URI space [RFC7320].
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 204
+      line: 206
   - label: message_well_known_uri_format (2)
     section: § 1
     snippet: To address these uses, this memo reserves a path prefix in HTTP, HTTPS, WebSocket (WS), and Secure WebSocket (WSS) URIs for these "well-known locations", "/.well-known/".
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 216
+      line: 218
   - label: message_well_known_uri_format (3)
     section: § 1
     snippet: Well-known URIs can also be used with other URI schemes, but only when those schemes' definitions explicitly allow it.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 120
+      line: 122
   - label: message_well_known_uri_format (4)
     section: § 3
     snippet: A well-known URI is a URI [RFC3986] whose path component begins with the characters "/.well-known/", provided that the scheme is explicitly defined to support well-known URIs.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 118
+      line: 120
   - label: message_well_known_uri_format (5)
     section: § 3
     snippet: Also, this specification does not define a format or media type for the resource located at "/.well-known/", and clients should not expect a resource to exist at that location.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 235
+      line: 237
   - label: message_well_known_uri_format (6)
     section: § 3
     snippet: Applications that wish to mint new well-known URIs MUST register them, following the procedures in Section 5.1, subject to the following requirements.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 91
+      line: 93
   - label: message_well_known_uri_format (7)
     section: § 3
     snippet: For example, "/.well-known/example" is a well-known URI, whereas "/foo/.well-known/example" is not.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 203
+      line: 205
   - label: message_well_known_uri_format (8)
     section: § 3
     snippet: Registered names MUST conform to the "segment-nz" production in [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 233
+      line: 235
   - label: message_well_known_uri_format (9)
     section: § 3
     snippet: Registrations MAY also contain additional information, such as the syntax of additional path components, query strings, and/or fragment identifiers to be appended to the well-known URI
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 249
+      line: 251
   - label: message_well_known_uri_format (10)
     section: § 3
     snippet: This means they cannot contain the "/" character.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 248
+      line: 250
   - label: message_well_known_uri_format (11)
     section: § 3
     snippet: This specification updates the "http" [RFC7230] and "https" [RFC7230] schemes to support well-known URIs.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 119
+      line: 121
   - label: message_well_known_uri_format (12)
     section: § 3
     snippet: Well-known URIs are rooted in the top of the path's hierarchy; they are not well-known by definition in other parts of the path.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 202
+      line: 204
   - label: message_well_known_uri_format (13)
     section: § 5.2
     snippet: If a URI scheme explicitly has been specified to use well-known URIs as per Section 3, the value changes to a reference to that specification.
     cited_by:
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 121
+      line: 123
 - label: RFC 9000
   url: https://www.rfc-editor.org/rfc/rfc9000.txt
   type: text/plain
@@ -5959,7 +5953,7 @@ sources:
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 306
+      line: 339
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 111
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
@@ -5969,7 +5963,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1043
+      line: 1071
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 161
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -5981,7 +5975,7 @@ sources:
     snippet: In HTTP/2 [HTTP/2] and HTTP/3 [HTTP/3], the Host header field is, in some cases, supplanted by the ":authority" pseudo-header field of a request's control data.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 308
+      line: 341
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -5993,7 +5987,7 @@ sources:
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 307
+      line: 340
   - label: message_accept_and_content_type_negotiation
     section: § 12.1
     snippet: A user agent cannot rely on proactive negotiation preferences being consistently honored, since the origin server might not implement proactive negotiation for the requested resource or might decide that sending a response that doesn't conform to the user agent's preferences is better than sending a 406 (Not Acceptable) response.
@@ -8963,7 +8957,7 @@ sources:
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 312
+      line: 345
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 77
   - label: request-target forms
@@ -8971,31 +8965,31 @@ sources:
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 344
+      line: 377
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 417
+      line: 450
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 13
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
-      line: 134
+      line: 136
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 3.3
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 310
+      line: 343
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.3
     snippet: If there is no Host header field or if its field value is empty or invalid, the target URI's authority component is empty.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 311
+      line: 344
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 3.3
     snippet: The target URI is the request-target when the request-target is in absolute-form.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 309
+      line: 342
     - file: lint-http-rules/src/rules/semantic_post_creates_resource.rs
       line: 86
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs


### PR DESCRIPTION
`first_non_pchar` stays private in `message_well_known_uri_format`: `pchar` has one reader in the tree. What did not have one reader is what `pchar` is built out of. RFC 3986 names `unreserved` and `sub-delims` together in five component productions — `userinfo`, `IPvFuture`, `reg-name`, `segment-nz-nc`, `pchar` — each adding something different beside them, and this crate had written the two sets out character for character at five sites and four.

`helpers::uri::is_unreserved` and `is_sub_delim` are those two sets. The four component alphabets that read them — `reg-name` in `validate_uri_host`, `pchar` in the rule, `IPvFuture`'s tail, and the URI-wide alphabet in `is_uri_char` — are now one line each, and the line is what its production adds: `:` and `@` for `pchar`, `:` for `IPvFuture`, the seven `gen-delims` for the URI-wide one, nothing for `reg-name`. `decode_unreserved` is the fifth reader of the first set, asking it of a decoded octet.

The four renderings agreed before this, so no verdict moves. What they did not have was anything holding them to that: two tests now pin the sets against the productions over the whole US-ASCII range, and pin that the four alphabets differ exactly where their productions differ. Dropping `=` from `sub-delims` fails 13 tests across seven modules; swapping `IPvFuture`'s `:` for an `@` fails three.

The `unreserved` and `sub-delims` quotes move off the three sites that no longer transcribe them, which is why the store shrinks by three while the code gets one more sentence: §2.2's "A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly", at `is_uri_char`, where taking all seven at once is the thing that needs a reason.
