### PR TITLE
The version gate was three of seven and the read was two lookups

### DIFF
--- a/lint-http-rules/src/rules/message_http3_no_connection_header.rs
+++ b/lint-http-rules/src/rules/message_http3_no_connection_header.rs
@@ -39,7 +39,6 @@ impl Rule for MessageHttp3NoConnectionHeader {
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions. Scoping cite: HTTP/3's field model
         // is why this rule exists. (The previous cite here — the *intermediary*
         // MUST-remove sentence — did not govern this request version gate; it is
@@ -50,6 +49,11 @@ impl Rule for MessageHttp3NoConnectionHeader {
         if !crate::http_version::is_major(&tx.request.version, 3) {
             return None;
         }
+
+        // Read after the gate, not before it: one digit comparison ends the rule
+        // for every message that is not HTTP/3, and `parse_rule_config` looks the
+        // rule id up twice (its doc comment costs it).
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // Check request headers.
         if let Some(msg) = check_forbidden_headers(&tx.request.headers) {

--- a/lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
+++ b/lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
@@ -22,7 +22,6 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 transactions. The version gate is scoping, not a
         // normative check, so it carries no cite; each requirement below cites the
         // sentence it enforces. What it reads is the major digit and not a string:
@@ -31,6 +30,11 @@ impl Rule for MessageHttp3PseudoHeadersValidity {
         if !crate::http_version::is_major(&tx.request.version, 3) {
             return None;
         }
+
+        // Read after the gate, not before it: one digit comparison ends the rule
+        // for every request that is not HTTP/3, and `parse_rule_config` looks the
+        // rule id up twice (its doc comment costs it).
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // :method is required. (The :scheme half of the same sentence is not
         // checked — the canonical model does not retain scheme for origin-form

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -17,6 +17,27 @@ pub struct RuleConfig {
 
 /// Parse severity from config for a given rule.
 /// Returns RuleConfig with parsed severity. Fails if severity is not explicitly configured.
+///
+/// **What it costs, exactly.** Two independent lookups of the same rule id:
+/// [`get_rule_severity_required`] and [`get_rule_enabled_required`] each hash
+/// `rule_id` against `Config::rules`, take the value as a table and probe that
+/// table for their own key. Thirteen rules that read this after their gates say
+/// why in the comment placing the call, and word it "several map probes plus a
+/// hash over the rule id" — the hash is two. That is why the call belongs
+/// **after** whatever gate ends the rule: a version comparison or an event-kind
+/// discriminant is a few instructions against this.
+///
+/// **And half of it is answered before the rule runs.** Nothing at lint time
+/// reads [`RuleConfig::enabled`]: `PreparedEngine` partitions the catalogue with
+/// `Config::is_enabled` when it is built, so a disabled rule is never dispatched
+/// and the flag this function returns is discarded at all 174 of its
+/// `check_transaction` / `check_event` call sites. The second lookup is not
+/// dead, though — it is the *presence* check that makes a rule table without
+/// `enabled` an error rather than a default, which is what the two
+/// `validate` defaults want at startup, and they are this function's only other
+/// callers. Splitting the two readings apart would change what an unvalidated
+/// config does at lint time, so it is carried in RULECITES §6 rather than done
+/// here.
 pub fn parse_rule_config(cfg: &crate::config::Config, rule_id: &str) -> anyhow::Result<RuleConfig> {
     let severity = get_rule_severity_required(cfg, rule_id)?;
     let enabled = get_rule_enabled_required(cfg, rule_id)?;

--- a/lint-http-rules/src/rules/server_http3_status_code_validity.rs
+++ b/lint-http-rules/src/rules/server_http3_status_code_validity.rs
@@ -22,7 +22,6 @@ impl Rule for ServerHttp3StatusCodeValidity {
         _history: &crate::transaction_history::TransactionHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to HTTP/3 connections. Scoping, not a normative check — no cite.
         // Both gates read the major digit rather than a string: neither direction
         // of this version carries a version field, so both values are ones a
@@ -38,6 +37,12 @@ impl Rule for ServerHttp3StatusCodeValidity {
         if !crate::http_version::is_major(&resp.version, 3) {
             return None;
         }
+
+        // Read after all three gates: only an exchange that is HTTP/3 on both
+        // sides can be reported here, reaching that verdict costs two digit
+        // comparisons and a borrow, and `parse_rule_config` looks the rule id up
+        // twice (its doc comment costs it).
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // § 4.5 is the only place RFC 9114 mentions 101 at all.
         // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."

--- a/lint-http-rules/src/rules/server_quic_transport_parameters.rs
+++ b/lint-http-rules/src/rules/server_quic_transport_parameters.rs
@@ -52,7 +52,6 @@ impl ProtocolRule for ServerQuicTransportParameters {
         _history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The event carries the contents of the quic_transport_parameters TLS
         // extension (this cite was re-homed here from the bidi check below, where
         // it did not belong — it describes the extension, not a stream rule).
@@ -61,6 +60,13 @@ impl ProtocolRule for ServerQuicTransportParameters {
             ProtocolEventKind::QuicTransportParams { params, .. } => params,
             _ => return None,
         };
+
+        // Read after the match, not before it: every protocol rule sees every
+        // event on the connection, and this extension arrives once per
+        // connection, so the discriminant ends the rule for very nearly all of
+        // them; `parse_rule_config` looks the rule id up twice (its doc comment
+        // costs it).
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // "number of permitted streams" half of §6.1's SHOULD. §18.2: a 0 (or
         // absent) grant only defers stream opening until a MAX_STREAMS frame, so

--- a/lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
+++ b/lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
@@ -29,7 +29,25 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
+        // The configuration is read when a finding is built, not on entry. The
+        // other six rules of this family have one gate apiece and read it after
+        // that gate; this one dispatches on the event kind into two arms, and
+        // inside each the finding is a comparison against the history — so the
+        // last point at which nothing is decided yet is the branch that reports.
+        // Every enabled protocol rule sees every event on the connection, and
+        // `parse_rule_config` looks the rule id up twice (its doc comment costs
+        // it). Written once here rather than at both report sites: `?` inside the
+        // closure ends the closure, and returning its `None` is what the two
+        // sites do with it.
+        let report = |message: String| -> Option<Violation> {
+            Some(Violation {
+                rule: self.id().into(),
+                severity: crate::rules::parse_rule_config(cfg, self.id())
+                    .ok()?
+                    .severity,
+                message,
+            })
+        };
         // cite(RFC 9114 § 7.2.6): "The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint."
         match &event.kind {
             // RFC 9114 §5.2: the identifier in a GOAWAY frame MUST NOT
@@ -57,15 +75,11 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
                         // cite(RFC 9114 § 5.2): "Receiving a GOAWAY containing a larger identifier than previously received MUST be treated as a connection error of type H3_ID_ERROR."
                         if let (Some(curr), Some(prev)) = (current_id, prev_id) {
                             if curr > prev {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "HTTP/3 GOAWAY identifier {} increased from previous {} \
-                                         (RFC 9114 §5.2)",
-                                        curr, prev
-                                    ),
-                                });
+                                return report(format!(
+                                    "HTTP/3 GOAWAY identifier {} increased from previous {} \
+                                     (RFC 9114 §5.2)",
+                                    curr, prev
+                                ));
                             }
                         }
                         break; // Only check the most recent prior same-sender GOAWAY
@@ -96,15 +110,11 @@ impl ProtocolRule for StatefulHttp3GoawaySemantics {
                         // cite(RFC 9114 § 5.2): "Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer."
                         if let Some(goaway_id) = goaway_id {
                             if stream_id > goaway_id {
-                                return Some(Violation {
-                                    rule: self.id().into(),
-                                    severity: config.severity,
-                                    message: format!(
-                                        "HTTP/3 stream {} opened after server GOAWAY with last \
-                                         stream ID {} (RFC 9114 §5.2)",
-                                        stream_id, goaway_id
-                                    ),
-                                });
+                                return report(format!(
+                                    "HTTP/3 stream {} opened after server GOAWAY with last \
+                                     stream ID {} (RFC 9114 §5.2)",
+                                    stream_id, goaway_id
+                                ));
                             }
                         }
                         break; // Only the most recent server GOAWAY sets the limit
@@ -217,6 +227,54 @@ mod tests {
 
     fn make_stream_opened(conn: Uuid, stream_id: u64) -> ProtocolEvent {
         make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id })
+    }
+
+    /// A rule table carrying `enabled` and no `severity`: `parse_rule_config`
+    /// fails on it, and the two report sites turn that into silence.
+    fn make_config_without_severity() -> crate::config::Config {
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        cfg.rules.insert(
+            "stateful_http3_goaway_semantics".to_string(),
+            toml::Value::Table(table),
+        );
+        cfg
+    }
+
+    /// The configuration is read where the finding is built, not on entry — the
+    /// only one of this family's seven rules where that is a closure rather than
+    /// a moved statement, so it is the only one whose ordering a test can see.
+    /// The other six are held by the borrow checker: the binding has to precede
+    /// its uses. What this pins is the `?`, which is what keeps an unreadable
+    /// configuration silencing the rule rather than defaulting a severity for
+    /// it.
+    #[rstest::rstest]
+    #[case::the_goaway_arm(Some(4), 10, None)]
+    #[case::the_stream_opened_arm(Some(4), 0, Some(10))]
+    fn an_unreadable_configuration_silences_both_arms(
+        #[case] prior_id: Option<u64>,
+        #[case] goaway_id: u64,
+        #[case] opened_stream: Option<u64>,
+    ) {
+        let rule = StatefulHttp3GoawaySemantics;
+        let conn = Uuid::new_v4();
+        let (history, evt) = match opened_stream {
+            None => (
+                ProtocolEventHistory::new(vec![make_goaway(conn, prior_id)]),
+                make_goaway(conn, Some(goaway_id)),
+            ),
+            Some(stream_id) => (
+                ProtocolEventHistory::new(vec![make_server_goaway(conn, Some(goaway_id))]),
+                make_stream_opened(conn, stream_id),
+            ),
+        };
+
+        // The same traffic under a readable configuration is a finding.
+        assert!(rule.check_event(&evt, &history, &make_config()).is_some());
+        assert!(rule
+            .check_event(&evt, &history, &make_config_without_severity())
+            .is_none());
     }
 
     // ── GOAWAY stream ID must not increase ──────────────────────────────

--- a/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/stateful_http3_max_push_id.rs
@@ -29,8 +29,6 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The event this rule recognizes is the MAX_PUSH_ID frame itself; every
         // other protocol event is out of scope.
         // cite(RFC 9114 § 7.2.7): "The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate."
@@ -38,6 +36,12 @@ impl ProtocolRule for StatefulHttp3MaxPushId {
             ProtocolEventKind::H3MaxPushId { push_id, direction } => (*push_id, *direction),
             _ => return None,
         };
+
+        // Read after the match, not before it: every protocol rule sees every
+        // event on the connection, so this discriminant ends the rule for all but
+        // one frame type, and `parse_rule_config` looks the rule id up twice (its
+        // doc comment costs it).
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // MAX_PUSH_ID is a client-only frame: a server sending one at all is the
         // violation, whatever its value. This became checkable once the upstream

--- a/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/stateful_http3_settings_frame.rs
@@ -44,8 +44,6 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
         history: &ProtocolEventHistory,
         cfg: &crate::config::Config,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The event this rule recognizes is the SETTINGS frame itself; every
         // other protocol event is out of scope.
         // cite(RFC 9114 § 7.2.4): "The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints communicate"
@@ -56,6 +54,13 @@ impl ProtocolRule for StatefulHttp3SettingsFrame {
             } => (settings, *direction),
             _ => return None,
         };
+
+        // Read after the match, not before it. `lint_protocol_event` hands every
+        // enabled protocol rule every event on the connection, so this
+        // discriminant is the rule's whole scope and it ends the rule for all but
+        // one frame type; `parse_rule_config` looks the rule id up twice (its doc
+        // comment costs it).
+        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // Scanning the whole connection history — rather than a single stream —
         // is what makes a second SETTINGS visible at all.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4077,25 +4077,25 @@ sources:
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 59
+      line: 58
   - label: server_quic_transport_parameters (2)
     section: § 18.2
     snippet: Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0.
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 141
+      line: 147
   - label: server_quic_transport_parameters (3)
     section: § 18.2
     snippet: the initial flow control limit for locally initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 99
+      line: 105
   - label: server_quic_transport_parameters (4)
     section: § 18.2
     snippet: the initial value for the maximum amount of data that can be sent on the connection
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 84
+      line: 90
 - label: RFC 9110
   url: https://www.rfc-editor.org/rfc/rfc9110.txt
   type: text/plain
@@ -4703,7 +4703,7 @@ sources:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 233
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 93
+      line: 97
   - label: client_request_target_form_checks (3)
     section: § 7.1
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
@@ -4729,7 +4729,7 @@ sources:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 234
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 94
+      line: 98
   - label: client_request_target_form_checks (6)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
@@ -4981,7 +4981,7 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket.rs
       line: 144
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
-      line: 58
+      line: 63
     - file: lint-http-rules/src/rules/server_no_body_for_1xx_204_304.rs
       line: 54
   - label: lint-http-rules/src/helpers/accept_ranges.rs
@@ -9605,7 +9605,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 125
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 51
+      line: 49
   - label: lint-http-proxy/src/h3_instrument.rs (3)
     section: § 7.2.6
     snippet: The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint.
@@ -9613,7 +9613,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 131
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 33
+      line: 51
   - label: lint-http-proxy/src/h3_instrument.rs (4)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
@@ -9621,7 +9621,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 128
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 36
+      line: 34
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 4.3.2
     snippet: HTTP/3 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.
@@ -9641,7 +9641,7 @@ sources:
     - file: lint-http-rules/src/rules/message_connection_upgrade.rs
       line: 63
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 178
+      line: 182
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 162
   - label: message_extension_headers_registered
@@ -9675,7 +9675,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 269
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 122
+      line: 126
   - label: message_host_and_authority_consistency (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
@@ -9687,51 +9687,51 @@ sources:
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/3 endpoints as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 78
+      line: 82
   - label: message_http3_no_connection_header (2)
     section: § 4.2
     snippet: HTTP/3 does not use the Connection header field to indicate connection-specific fields; in this protocol, connection-specific metadata is conveyed by other means.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 48
+      line: 47
   - label: message_http3_no_connection_header (3)
     section: § 4.2
     snippet: The only exception to this is the TE header field, which MAY be present in an HTTP/3 request header; when it is, it MUST NOT contain any value other than "trailers".
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 95
+      line: 99
     - file: lint-http-rules/src/rules/message_http3_no_connection_header.rs
-      line: 196
+      line: 200
   - label: message_http3_pseudo_headers_validity
     section: § 4.3.1
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 38
+      line: 42
   - label: message_http3_pseudo_headers_validity (2)
     section: § 4.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 107
+      line: 111
   - label: message_http3_pseudo_headers_validity (3)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 153
+      line: 157
   - label: message_http3_pseudo_headers_validity (4)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 154
+      line: 158
   - label: message_http3_pseudo_headers_validity (5)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
-      line: 54
+      line: 58
   - label: server_alt_svc_h3_advertisement_valid
     section: § 3.1.1
     snippet: An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token.
@@ -9743,7 +9743,7 @@ sources:
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/server_http3_status_code_validity.rs
-      line: 43
+      line: 48
     - file: lint-http-rules/src/rules/stateful_101_switching_protocols.rs
       line: 115
   - label: server_no_body_for_1xx_204_304
@@ -9763,59 +9763,59 @@ sources:
     snippet: HTTP/3 does not use server-initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 100
+      line: 106
   - label: server_quic_transport_parameters (2)
     section: § 6.1
     snippet: In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window.
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 69
+      line: 75
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 114
+      line: 120
   - label: server_quic_transport_parameters (3)
     section: § 6.2
     snippet: Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked.
     cited_by:
     - file: lint-http-rules/src/rules/server_quic_transport_parameters.rs
-      line: 127
+      line: 133
   - label: stateful_http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 96
+      line: 110
   - label: stateful_http3_goaway_semantics (2)
     section: § 5.2
     snippet: Receiving a GOAWAY containing a larger identifier than previously received MUST be treated as a connection error of type H3_ID_ERROR.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 57
+      line: 75
   - label: stateful_http3_goaway_semantics (3)
     section: § 5.2
     snippet: The server sends a client-initiated bidirectional stream ID; the client sends a push ID.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 50
+      line: 68
     - file: lint-http-rules/src/rules/stateful_http3_goaway_semantics.rs
-      line: 89
+      line: 103
   - label: stateful_http3_max_push_id
     section: § 7.2.7
     snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 62
+      line: 66
   - label: stateful_http3_max_push_id (2)
     section: § 7.2.7
     snippet: A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 46
+      line: 50
   - label: stateful_http3_max_push_id (3)
     section: § 7.2.7
     snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_max_push_id.rs
-      line: 93
+      line: 97
   - label: stateful_http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document
@@ -9827,31 +9827,31 @@ sources:
     snippet: A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 68
+      line: 73
   - label: stateful_http3_settings_frame (3)
     section: § 7.2.4
     snippet: An implementation MUST ignore any parameter with an identifier it does not understand
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 127
+      line: 132
   - label: stateful_http3_settings_frame (4)
     section: § 7.2.4
     snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 62
+      line: 67
   - label: stateful_http3_settings_frame (5)
     section: § 7.2.4
     snippet: The same setting identifier MUST NOT occur more than once in the SETTINGS frame
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 110
+      line: 115
   - label: stateful_http3_settings_frame (6)
     section: § 7.2.4.1
     snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/stateful_http3_settings_frame.rs
-      line: 91
+      line: 96
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.txt
   type: text/plain


### PR DESCRIPTION
`parse_rule_config` now runs after the gate that ends the rule in the seven HTTP/3-family rules that were reading it on entry, not the three §6's P22 named.

The row names three transaction rules and *the version gate*. The version gate is one shape of the family's scoping gate: the other four rules are `ProtocolRule`s gated on an event-kind discriminant, and `lint_protocol_event` hands every enabled protocol rule every event on the connection, so that discriminant is more selective than any version comparison in the catalogue. The fifth protocol rule, `stateful_websocket_frame_opcode_sequence`, already destructured its event kind first — the convention existed inside the group that was missing it.

Six are a moved statement. `stateful_http3_goaway_semantics` dispatches into two arms with no single gate under them, so its read moved into the finding as a `report` closure, and there the `?` is testable: a rule table carrying `enabled` and no `severity` silences traffic the same fixtures report under a readable one. Two cases, checked by mutation.

Two facts recorded at `parse_rule_config` itself rather than in thirteen already-audited comments: it hashes the rule id *twice*, once per required field, where those comments say "a hash"; and nothing at lint time reads the `enabled` it returns, because `PreparedEngine` partitioned the catalogue with `Config::is_enabled` before dispatch. Splitting that second reading out changes what an unvalidated config does at 174 call sites, so it is queued separately rather than part of this.

No cite added, moved or deleted: 2214, 1481/1481 PASS, ratchet 0 of 201.
