### PR TITLE
The row was three days dead and its sentence was two thirds alive

### DIFF
--- a/docs/rules/message_access_control_allow_origin_valid.md
+++ b/docs/rules/message_access_control_allow_origin_valid.md
@@ -14,7 +14,7 @@ This rule checks that the `Access-Control-Allow-Origin` response header is synta
 
 - [MDN Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): Access-Control-Allow-Origin
 - [Fetch §3.3.3](https://fetch.spec.whatwg.org/#http-access-control-allow-origin): `Access-Control-Allow-Origin` carries one value: an echoed origin, `null`, or `*`
-- [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): Governing origin syntax: `serialized-origin` has no path component (not even a trailing slash), and `origin-or-null`'s `null` is case-sensitive
+- [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it, and `origin-or-null`'s `null` is case-sensitive
 - [RFC 6454 §7.1](https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1): Historical origin syntax the non-`*` value is validated against — `serialized-origin = scheme "://" host [ ":" port ]`, and `null` via origin-list-or-null; Fetch §3.2 supplants it
 
 ## Configuration

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -2316,6 +2316,16 @@ pub fn media_type_subtype_suffix(subtype: &str) -> Option<&str> {
 /// even a bare trailing slash, which a byte-for-byte origin comparison rejects.
 /// This is a conservative validator: it ensures scheme chars, presence of host,
 /// and numeric port (if present). It does not attempt full IDNA or host label validation.
+///
+/// **"Nothing may follow the authority" is § 3.2's sentence, and it names three
+/// characters.** This function used to enumerate one of them — a
+/// `rest.contains('/')` — so `https://example.com?x=1` and
+/// `https://example.com#f` were serialized origins to every caller. The
+/// terminators are not re-enumerated here now:
+/// [`crate::helpers::uri::authority_component`] is where that sentence is read
+/// and cited, and what this function adds is the *grammar's* half — a
+/// serialized-origin ends where its authority does, so any character that
+/// function stopped at is a character the production does not generate.
 // Both callers (Timing-Allow-Origin, Access-Control-Allow-Origin) take their value
 // grammar from Fetch, whose production supplants RFC 6454's. The two agree on the
 // shape checked here — an authority and nothing after it — so both are quoted.
@@ -2332,31 +2342,43 @@ pub fn is_valid_serialized_origin(val: &str) -> bool {
         return false;
     }
 
-    // Split scheme://rest
-    let parts: Vec<&str> = s.splitn(2, "://").collect();
-    if parts.len() != 2 {
+    // The `://` is located rather than split on, because a `://` further along
+    // is data rather than a delimiter: `scheme_authority_marker` is that
+    // question's one answer and argues at its own site why `find("://")` is not.
+    let Some(marker) = crate::helpers::uri::scheme_authority_marker(s) else {
+        return false;
+    };
+    let scheme = &s[..marker];
+
+    // `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` was written out here
+    // a third time, and `validate_scheme_name`'s own doc comment already counts
+    // the two copies it was extracted from. This one was missed because it sits
+    // in `helpers::headers`, on the shelf keyed by the field rather than by the
+    // question — the same reason the sixteen-bit port predicate was missed.
+    if crate::helpers::uri::validate_scheme_name(scheme).is_err() {
         return false;
     }
-    let scheme = parts[0];
-    let rest = parts[1];
 
-    // Scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) per RFC3986
-    let mut chars = scheme.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() => (),
-        _ => return false,
-    }
-    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+    // Where the authority ends is § 3.2's sentence and not this function's; the
+    // grammar above is what makes stopping short of the value's end a defect,
+    // since a serialized-origin is a scheme, a `://` and an authority and
+    // nothing else. Enumerating the terminators here instead is how `?` and `#`
+    // stayed acceptable for as long as `/` did not.
+    let Some(rest) = crate::helpers::uri::authority_component(s) else {
+        return false;
+    };
+    if rest != &s[marker + "://".len()..] {
         return false;
     }
 
-    // rest should be host[:port] and must not contain '/', whitespace or userinfo '@'
-    if rest.is_empty()
-        || rest.contains('/')
-        || rest.contains('\t')
-        || rest.contains(' ')
-        || rest.contains('@')
-    {
+    // An empty authority names no host. Whitespace is not one of § 3.2's
+    // terminators, so it arrives here *inside* the authority and is rejected on
+    // its own; the userinfo is rejected because neither grammar quoted above has
+    // one — `authority = [ userinfo "@" ] host [ ":" port ]` writes the
+    // subcomponent that `serialized-origin = scheme "://" host [ ":" port ]`
+    // leaves out, and the at-sign is the whole difference between them.
+    // cite(RFC 3986 § 3.2, label: authority grammar): "authority   = [ userinfo "@" ] host [ ":" port ]"
+    if rest.is_empty() || rest.contains('\t') || rest.contains(' ') || rest.contains('@') {
         return false;
     }
 
@@ -2657,6 +2679,18 @@ mod tests {
         assert!(!is_valid_serialized_origin("https://example.com/path"));
         assert!(!is_valid_serialized_origin("https://example.com:8080/"));
         assert!(!is_valid_serialized_origin("https://[::1]/path"));
+
+        // § 3.2 ends the authority at three characters and the slash is one of
+        // them. The other two were accepted here until the terminator sentence
+        // stopped being enumerated by hand — and only in the shape below,
+        // because a port or a bracketed literal put the trailing junk in front
+        // of a reader that was already strict about it.
+        assert!(!is_valid_serialized_origin("https://example.com?x=1"));
+        assert!(!is_valid_serialized_origin("https://example.com#frag"));
+        assert!(!is_valid_serialized_origin("https://example.com?"));
+        assert!(!is_valid_serialized_origin("https://example.com#"));
+        assert!(!is_valid_serialized_origin("https://example.com:8080?x=1"));
+        assert!(!is_valid_serialized_origin("https://[::1]#frag"));
 
         assert!(!is_valid_serialized_origin("example.com"));
         assert!(!is_valid_serialized_origin("https:///foo"));

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -1847,6 +1847,22 @@ mod tests {
         // invalid scheme in Origin
         let m = validate_origin_value("1http://example.com").unwrap();
         assert!(m.contains("Invalid scheme"));
+
+        // This function names the path itself, because § 3.2's *first*
+        // terminator is the one an `Origin` sender most plausibly wrote by
+        // accident. The other two are the shared predicate's answer and get its
+        // generic reason — which is what the comment at the delegation says
+        // callers may rely on, and the two messages are asserted here so the
+        // split between them is a decision and not a coincidence.
+        let path = validate_origin_value("https://example.com/p").unwrap();
+        assert_eq!(path, "Origin must not include a path");
+        for after in ["https://example.com?x=1", "https://example.com#frag"] {
+            assert_eq!(
+                validate_origin_value(after).unwrap(),
+                "Origin is not a valid serialized origin",
+                "for {after}"
+            );
+        }
     }
 
     #[test]

--- a/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -120,7 +120,7 @@ impl Rule for MessageAccessControlAllowOriginValid {
                 spec: "Fetch",
                 section: Some("3.2"),
                 url: "https://fetch.spec.whatwg.org/#origin-header",
-                note: "Governing origin syntax: `serialized-origin` has no path component (not even a trailing slash), and `origin-or-null`'s `null` is case-sensitive",
+                note: "Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it, and `origin-or-null`'s `null` is case-sensitive",
             },
             crate::rules::SpecRef {
                 spec: "RFC 6454",
@@ -241,10 +241,15 @@ mod tests {
         );
     }
 
+    // § 3.2 terminates an authority at "/", "?" or "#", and a serialized origin
+    // ends where its authority does. Only the first of the three reached this
+    // rule until the shared validator stopped enumerating them by hand.
     #[rstest]
     #[case("https://example.com/")]
     #[case("https://example.com/path")]
-    fn origin_with_path_or_trailing_slash_is_violation(#[case] val: &str) {
+    #[case("https://example.com?x=1")]
+    #[case("https://example.com#frag")]
+    fn origin_with_anything_after_the_authority_is_violation(#[case] val: &str) {
         let rule = MessageAccessControlAllowOriginValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(
             200,

--- a/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+++ b/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
@@ -344,11 +344,17 @@ mod tests {
         assert!(v.is_none());
     }
 
+    // § 3.2 terminates an authority at "/", "?" or "#", and a serialized origin
+    // ends where its authority does. Only the first of the three reached this
+    // rule until the shared validator stopped enumerating them by hand.
     #[rstest]
     #[case("https://a/")]
     #[case("https://a/path")]
     #[case("https://ok.example, https://b/path")]
-    fn member_with_path_or_trailing_slash_is_violation(#[case] val: &str) {
+    #[case("https://a?x=1")]
+    #[case("https://a#frag")]
+    #[case("https://ok.example, https://b#frag")]
+    fn member_with_anything_after_the_authority_is_violation(#[case] val: &str) {
         let rule = MessageTimingAllowOriginValidity;
         let tx = crate::test_helpers::make_test_transaction_with_response(
             200,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2328
+      line: 2338
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2323
+      line: 2333
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2322
+      line: 2332
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -264,7 +264,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2387
+      line: 2409
   - label: message_refresh_header_syntax_valid
     snippet: A code point is found that is not a URL unit.
     cited_by:
@@ -1011,6 +1011,14 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/forwarded_node.rs
       line: 157
+  - label: authority grammar
+    section: § 3.2
+    snippet: authority   = [ userinfo "@" ] host [ ":" port ]
+    cited_by:
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 2380
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 175
   - label: lint-http-rules/src/helpers/ipv6.rs
     section: § 3.2.2
     snippet: A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]").
@@ -1175,12 +1183,6 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 210
-  - label: authority grammar
-    section: § 3.2
-    snippet: authority   = [ userinfo "@" ] host [ ":" port ]
-    cited_by:
-    - file: lint-http-rules/src/helpers/uri.rs
-      line: 175
   - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
@@ -2072,7 +2074,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2324
+      line: 2334
     - file: lint-http-rules/src/helpers/uri.rs
       line: 292
   - label: lint-http-rules/src/helpers/uri.rs


### PR DESCRIPTION
§6's P23 said `is_valid_serialized_origin` strips everything after `/`, so `https://a/path` passes as an origin, and queued the flagging as a user call. That strip was deleted on 2026-08-01 by e6d8763, three days before §6 was opened, and the RFC 7034 `ALLOW-FROM` caller whose leniency licensed it no longer exists. The row deferred to the user, so nobody re-derived it.

What was live is the rest of the sentence. RFC 3986 §3.2 terminates an authority at "/", "?" **or** "#"; the function enumerated the first, so `https://example.com?x=1` and `https://example.com#frag` were serialized origins to Timing-Allow-Origin, Access-Control-Allow-Origin and `validate_origin_value` alike. The gap was shape-dependent, which is how one third of a sentence hid behind the other two: with a port the tail reached a port reader that rejected it, and inside brackets the IPv6 parser did — only a reg-name host with no port let it through.

The terminators are not enumerated a second time. `authority_component` reads and cites that sentence already; what this function adds is the grammar's half — a serialized-origin is a scheme, a `://` and an authority and nothing else — so the check is that the authority is the whole of what follows the marker.

Two more copies came out of the same twenty-five lines: `splitn(2, "://")` was the `find("://")` that `scheme_authority_marker` exists to replace, and the scheme character loop was a third transcription of `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, missed by that extraction because the caller sits in `helpers::headers` rather than `helpers::uri`. The `@` rejection had been prose only and now cites `authority = [ userinfo "@" ] host [ ":" port ]`, whose difference from the origin grammar is exactly that at-sign.

The authority's contents are still unmeasured — `https://exa|mple.com` is accepted — and that is queued as its own iteration, overlapping one already open.

2214 -> 2215 cites, 1481/1481 PASS, ratchet 0 of 201, 5620 -> 5625 tests.
