### PR TITLE
The alphabet was one of three, and a helper lost its last caller

### DIFF
--- a/docs/rules/message_access_control_allow_origin_valid.md
+++ b/docs/rules/message_access_control_allow_origin_valid.md
@@ -14,7 +14,7 @@ This rule checks that the `Access-Control-Allow-Origin` response header is synta
 
 - [MDN Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): Access-Control-Allow-Origin
 - [Fetch §3.3.3](https://fetch.spec.whatwg.org/#http-access-control-allow-origin): `Access-Control-Allow-Origin` carries one value: an echoed origin, `null`, or `*`
-- [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it, and `origin-or-null`'s `null` is case-sensitive
+- [Fetch §3.2](https://fetch.spec.whatwg.org/#origin-header): Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it; the host inside it is a `reg-name` or a bracketed `IP-literal`, so a character outside those productions or a malformed percent-encoding disqualifies it too; and `origin-or-null`'s `null` is case-sensitive
 - [RFC 6454 §7.1](https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1): Historical origin syntax the non-`*` value is validated against — `serialized-origin = scheme "://" host [ ":" port ]`, and `null` via origin-list-or-null; Fetch §3.2 supplants it
 
 ## Configuration

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -2323,8 +2323,29 @@ pub fn media_type_subtype_suffix(subtype: &str) -> Option<&str> {
 /// Validate a serialized-origin as defined by RFC 6454: scheme "://" host [":" port]
 /// The grammar has no path component, so nothing may follow the authority — not
 /// even a bare trailing slash, which a byte-for-byte origin comparison rejects.
-/// This is a conservative validator: it ensures scheme chars, presence of host,
-/// and numeric port (if present). It does not attempt full IDNA or host label validation.
+///
+/// **Each of the three parts is read by the function that owns its production**,
+/// and none of them is transcribed here: [`crate::helpers::uri::validate_scheme_name`]
+/// for `scheme`, [`crate::helpers::uri::validate_uri_host`] for `host`, and
+/// [`crate::helpers::uri::port_number`] for `port`. What is left is the
+/// composition — the `://` between the first two, and that the authority is the
+/// whole of what follows it.
+///
+/// **It measured where the authority ended and nothing about what it held.** The
+/// host was checked for emptiness, a space, a tab and an at-sign, so
+/// `https://exa|mple.com`, `https://a<b>c` and `https://a^b` were serialized
+/// origins — none of `|`, `<`, `>`, `^`, `` ` ``, `\`, `"`, `{`, `}` or any octet
+/// at or above %x80 is in `unreserved`, `sub-delims` or a `pct-encoded`, so none
+/// is in any `reg-name`. Two more went with it: `%zz` and `%4` passed because
+/// nothing asked `check_percent_encoding`, and `https://[foo]` passed because
+/// `helpers::ipv6::parse_bracketed_ipv6` handed its bracketed content back
+/// unexamined — which its own doc comment said in as many words, and which was
+/// what condemned it: this was its last caller and the function is gone.
+///
+/// **The conservatism that remains is about IDNA and label syntax**, which is a
+/// different question from the alphabet: a `reg-name` is a character set and no
+/// more, so `a..b` and a 300-character label are registered names here and are
+/// not domains anywhere.
 ///
 /// **"Nothing may follow the authority" is § 3.2's sentence, and it names three
 /// characters.** This function used to enumerate one of them — a
@@ -2380,47 +2401,35 @@ pub fn is_valid_serialized_origin(val: &str) -> bool {
         return false;
     }
 
-    // An empty authority names no host. Whitespace is not one of § 3.2's
-    // terminators, so it arrives here *inside* the authority and is rejected on
-    // its own; the userinfo is rejected because neither grammar quoted above has
-    // one — `authority = [ userinfo "@" ] host [ ":" port ]` writes the
-    // subcomponent that `serialized-origin = scheme "://" host [ ":" port ]`
-    // leaves out, and the at-sign is the whole difference between them.
+    // `authority = [ userinfo "@" ] host [ ":" port ]` is the production this
+    // one is *not*: the origin grammars above write `host [ ":" port ]` and no
+    // userinfo, so the at-sign that would delimit one is a character no
+    // `reg-name` holds and `validate_uri_host` refuses it as such. The split is
+    // at the first colon and bracket-aware, which is why an `IP-literal`'s own
+    // colons do not become a port.
     // cite(RFC 3986 § 3.2, label: authority grammar): "authority   = [ userinfo "@" ] host [ ":" port ]"
-    if rest.is_empty() || rest.contains('\t') || rest.contains(' ') || rest.contains('@') {
+    let (host, port) = crate::helpers::uri::split_host_and_port(rest);
+
+    // `reg-name = *( unreserved / pct-encoded / sub-delims )` derives the empty
+    // string, so this is not the grammar's line. An origin naming no host names
+    // nothing to compare against, and every caller here is comparing origins.
+    if host.is_empty() {
+        return false;
+    }
+    if crate::helpers::uri::validate_uri_host(host).is_err() {
         return false;
     }
 
-    if let Some(colon_pos) = rest.rfind(':') {
-        // If colon exists, treat as host:port candidate. But IPv6 address may contain ':' and be bracketed.
-        if rest.starts_with('[') {
-            // Use the ipv6 helper to parse bracketed IPv6 and optional port
-            if let Some((_, port_opt)) = crate::helpers::ipv6::parse_bracketed_ipv6(rest) {
-                if let Some(port_str) = port_opt {
-                    return crate::helpers::uri::port_number(port_str).is_some();
-                }
-                return true;
-            } else {
-                return false; // malformed or unmatched '['
-            }
-        }
-
-        let host = &rest[..colon_pos];
-        let port = &rest[colon_pos + 1..];
-        if host.is_empty() || port.is_empty() {
-            return false;
-        }
-        // Sixteen bits, and the licence to ask that of *this* value is the URL
-        // Standard's rather than a transport's: an origin's port is not a run of
-        // digits that happens to reach a TCP port, it is declared to be an
-        // integer of that width. `0` is one of them, so an origin naming it is a
-        // serialized origin; the shared reader rejected it until this was read.
-        // cite(URL): "A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port."
-        return crate::helpers::uri::port_number(port).is_some();
+    // Sixteen bits, and the licence to ask that of *this* value is the URL
+    // Standard's rather than a transport's: an origin's port is not a run of
+    // digits that happens to reach a TCP port, it is declared to be an integer
+    // of that width. `0` is one of them, so an origin naming it is a serialized
+    // origin; the shared reader rejected it until this was read.
+    // cite(URL): "A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port."
+    match port {
+        Some(port) => crate::helpers::uri::port_number(port).is_some(),
+        None => true,
     }
-
-    // No port: ensure host is non-empty
-    !rest.is_empty()
 }
 
 #[cfg(test)]
@@ -2708,6 +2717,58 @@ mod tests {
         assert!(!is_valid_serialized_origin("https://user@example.com"));
         assert!(!is_valid_serialized_origin("https://[::1"));
         assert!(!is_valid_serialized_origin(""));
+    }
+
+    /// **The authority's contents, which this predicate measured nothing of.**
+    /// It asked the host for emptiness, a space, a tab and an at-sign; the host
+    /// has a production, and each of these values fails it.
+    #[test]
+    fn an_origins_host_is_measured_against_its_own_production() {
+        // **The host's own alphabet, which nothing here used to ask.** None of
+        // these is in `unreserved`, `sub-delims` or a `pct-encoded`, so none is
+        // in any `reg-name` — and each was a serialized origin to all three
+        // callers while the host was checked for emptiness, a space, a tab and
+        // an at-sign and for nothing else.
+        for c in [
+            '|', '<', '>', '"', '{', '}', '\\', '^', '`', '\u{80}', '\u{ff}',
+        ] {
+            assert!(
+                !is_valid_serialized_origin(&format!("https://exa{c}mple.com")),
+                "for {c:?}"
+            );
+            assert!(
+                !is_valid_serialized_origin(&format!("https://exa{c}mple.com:8080")),
+                "for {c:?} with a port"
+            );
+        }
+
+        // A `pct-encoded` is three characters and the last two are `HEXDIG`. The
+        // alphabet walk alone would admit these, which is why `validate_uri_host`
+        // asks `check_percent_encoding` before it.
+        assert!(!is_valid_serialized_origin("https://a%zzb.example"));
+        assert!(!is_valid_serialized_origin("https://a%4"));
+        assert!(is_valid_serialized_origin("https://a%41b.example"));
+
+        // `IP-literal = "[" ( IPv6address / IPvFuture ) "]"`, and the inner text
+        // used to be handed back unexamined — so a bracketed anything was a
+        // host. `[v7.abc]` passed then for no reason and passes now for the
+        // production's.
+        assert!(!is_valid_serialized_origin("https://[foo]"));
+        assert!(!is_valid_serialized_origin("https://[]"));
+        assert!(is_valid_serialized_origin("https://[v7.abc]"));
+
+        // A `reg-name` holds no colon, so the second one is not a port
+        // delimiter; the split is at the first colon and this used to be read
+        // right to left, which made `a:b` a host and `80` its port.
+        assert!(!is_valid_serialized_origin("https://a:b:80"));
+
+        // The explicit space and tab checks went with the host's own production,
+        // which admits neither -- and `port_number` refuses a non-digit, so the
+        // other half of the authority is covered by the reader that owns it.
+        assert!(!is_valid_serialized_origin("https://exa mple.com"));
+        assert!(!is_valid_serialized_origin("https://exa\tmple.com"));
+        assert!(!is_valid_serialized_origin("https://example.com: 80"));
+        assert!(!is_valid_serialized_origin("https://example.com:8 0"));
     }
 
     use rstest::rstest;

--- a/lint-http-rules/src/helpers/ipv6.rs
+++ b/lint-http-rules/src/helpers/ipv6.rs
@@ -2,51 +2,32 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! Utilities for parsing and validating IPv6 bracketed literals used in headers.
+//! One heuristic about an IPv6 literal written without its brackets.
 //!
-//! These helpers focus on safely handling syntax like "[::1]" and "[::1]:443" and
-//! small utilities to detect problematic unbracketed IPv6+port patterns.
+//! **What is left here is not a shelf, it is a remainder.** The module held three
+//! functions and two have gone to `helpers::uri`, each because the question it
+//! answered was about a URI component and not about an address family: a port's
+//! namespace (`parse_port_str` -> `port_number`) and where a bracketed host ends
+//! (`parse_bracketed_ipv6` -> `split_host_and_port` + `validate_uri_host`). The
+//! one below stays because its question really is about the brackets --
+//! *what does a value that has none but looks like it wants them mean* -- which
+//! no component rule asks, because no component rule generates such a value.
 
-/// Given a string starting at an IPv6 bracket '[', parse the bracketed content and
-/// optional trailing port.
-///
-/// Returns `Some((inner, port_opt))` when the bracketed section is syntactically valid
-/// and the trailing part is either empty or a `:port` sequence (port as a &str) —
-/// it does not validate the numeric range of the port.
-///
-/// Returns `None` when the bracket is unmatched, the inner part is empty, or the
-/// trailing part is present but not in the form `:digits`.
-///
-/// The sentence cited below is about the brackets and nothing else, which is all
-/// this function decides. `IP-literal = "[" ( IPv6address / IPvFuture ) "]"` is
-/// deliberately *not* quoted here: the inner text is handed back unexamined, so
-/// quoting a production that constrains it would claim a check that happens --
-/// when it happens at all -- in the caller.
-pub fn parse_bracketed_ipv6(s: &str) -> Option<(&str, Option<&str>)> {
-    // cite(RFC 3986 § 3.2.2): "A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]")."
-    if !s.starts_with('[') {
-        return None;
-    }
-    let closing = s.find(']')?;
-    // require at least one char inside the brackets
-    if closing <= 1 {
-        return None;
-    }
-    let inner = &s[1..closing];
-    let tail = &s[closing + 1..];
-    if tail.is_empty() {
-        return Some((inner, None));
-    }
-    // tail must start with ':' followed by at least one digit
-    if !tail.starts_with(':') {
-        return None;
-    }
-    let port = &tail[1..];
-    if port.is_empty() || !port.chars().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    Some((inner, Some(port)))
-}
+// `parse_bracketed_ipv6` was here, and its own doc comment is what condemned it:
+// *"the inner text is handed back unexamined, so quoting a production that
+// constrains it would claim a check that happens -- when it happens at all -- in
+// the caller."* It happened in no caller. Its last one,
+// `helpers::headers::is_valid_serialized_origin`, therefore read `https://[foo]`
+// as an origin, and the two halves it answered are `helpers::uri`'s:
+// `split_host_and_port` finds the port past the `]`, and `validate_uri_host`
+// quotes `IP-literal = "[" ( IPv6address / IPvFuture ) "]"` and measures the
+// inner text against it.
+//
+// Second function to leave this module for `helpers::uri`, after `parse_port_str`
+// below, and for the same reason both times: **the shelf is keyed by a construct
+// of the document rather than by a question**, so a function about *where a host
+// ends* and a function about *what a port is* were filed under the address family
+// that happens to need brackets.
 
 // `parse_port_str` was here. It answered "is this a port in the sixteen-bit
 // namespace", which is a question about a URI component and not about an IPv6
@@ -93,43 +74,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_bracketed_ipv6_ok_without_port() {
-        assert_eq!(parse_bracketed_ipv6("[::1]"), Some(("::1", None)));
-        assert_eq!(parse_bracketed_ipv6("[::1]:"), None);
-    }
-
-    #[test]
-    fn parse_bracketed_ipv6_ok_with_port() {
-        assert_eq!(
-            parse_bracketed_ipv6("[::1]:443"),
-            Some(("::1", Some("443")))
-        );
-        assert_eq!(
-            parse_bracketed_ipv6("[fe80::1]:80"),
-            Some(("fe80::1", Some("80")))
-        );
-    }
-
-    #[test]
-    fn parse_bracketed_ipv6_rejects_malformed() {
-        assert_eq!(parse_bracketed_ipv6("[::1"), None);
-        assert_eq!(parse_bracketed_ipv6("[]"), None);
-        assert_eq!(parse_bracketed_ipv6("[::1]extra"), None);
-        assert_eq!(parse_bracketed_ipv6("[::1]:notnum"), None);
-    }
-
-    #[test]
     fn looks_like_unbracketed_ipv6_with_port_cases() {
         assert!(looks_like_unbracketed_ipv6_with_port("fe80::1:80"));
         assert!(!looks_like_unbracketed_ipv6_with_port("example.com:80"));
         assert!(!looks_like_unbracketed_ipv6_with_port("::1"));
-    }
-
-    #[test]
-    fn parse_bracketed_ipv6_rejects_non_bracket_input() {
-        // Input not starting with '[' should return None
-        assert_eq!(parse_bracketed_ipv6("example.com:80"), None);
-        // Unbracketed IPv6-like string should also be rejected by this helper
-        assert_eq!(parse_bracketed_ipv6("::1:80"), None);
     }
 }

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -1254,6 +1254,34 @@ mod tests {
         }
     }
 
+    /// What `helpers::ipv6::parse_bracketed_ipv6` used to assert, asked of the
+    /// pair that replaced it — and the case it could not answer, which is why it
+    /// went: it handed the bracketed content back unexamined, so `[foo]` was a
+    /// host to every caller that did not re-examine it, and no caller did.
+    #[test]
+    fn a_bracketed_host_is_split_and_then_measured() {
+        assert_eq!(split_host_and_port("[::1]"), ("[::1]", None));
+        assert_eq!(split_host_and_port("[::1]:443"), ("[::1]", Some("443")));
+        assert_eq!(
+            split_host_and_port("[fe80::1]:80"),
+            ("[fe80::1]", Some("80"))
+        );
+        // The colon belongs to the address, not to a port, and the bracket is
+        // what says so.
+        assert_eq!(split_host_and_port("[::1]:"), ("[::1]", Some("")));
+
+        assert!(validate_uri_host("[::1]").is_ok());
+        assert!(validate_uri_host("[fe80::1]").is_ok());
+        // `IPvFuture` is the other alternative of `IP-literal`, and it used to
+        // pass here by accident rather than by the production.
+        assert!(validate_uri_host("[v7.abc]").is_ok());
+
+        assert!(validate_uri_host("[foo]").is_err());
+        assert!(validate_uri_host("[]").is_err());
+        assert!(validate_uri_host("[::1").is_err());
+        assert!(validate_uri_host("[::1]extra").is_err());
+    }
+
     #[test]
     fn scheme_validation() {
         assert!(validate_scheme_if_present("1http://ex").is_some());

--- a/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -120,7 +120,7 @@ impl Rule for MessageAccessControlAllowOriginValid {
                 spec: "Fetch",
                 section: Some("3.2"),
                 url: "https://fetch.spec.whatwg.org/#origin-header",
-                note: "Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it, and `origin-or-null`'s `null` is case-sensitive",
+                note: "Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it; the host inside it is a `reg-name` or a bracketed `IP-literal`, so a character outside those productions or a malformed percent-encoding disqualifies it too; and `origin-or-null`'s `null` is case-sensitive",
             },
             crate::rules::SpecRef {
                 spec: "RFC 6454",
@@ -249,6 +249,13 @@ mod tests {
     #[case("https://example.com/path")]
     #[case("https://example.com?x=1")]
     #[case("https://example.com#frag")]
+    // The authority's *contents*, which the check measured nothing of: none of
+    // these characters is in any `reg-name`, and a `%zz` is no `pct-encoded`.
+    #[case("https://exa|mple.com")]
+    #[case("https://a<b>c")]
+    #[case("https://a^b")]
+    #[case("https://a%zzb")]
+    #[case("https://[foo]")]
     fn origin_with_anything_after_the_authority_is_violation(#[case] val: &str) {
         let rule = MessageAccessControlAllowOriginValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(

--- a/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+++ b/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
@@ -354,6 +354,12 @@ mod tests {
     #[case("https://a?x=1")]
     #[case("https://a#frag")]
     #[case("https://ok.example, https://b#frag")]
+    // The authority's *contents*, unmeasured until the host was asked its own
+    // production rather than asked for a space, a tab and an at-sign.
+    #[case("https://exa|mple.com")]
+    #[case("https://ok.example, https://a<b>c")]
+    #[case("https://a%zzb")]
+    #[case("https://[foo]")]
     fn member_with_anything_after_the_authority_is_violation(#[case] val: &str) {
         let rule = MessageTimingAllowOriginValidity;
         let tx = crate::test_helpers::make_test_transaction_with_response(

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -17,17 +17,17 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2347
+      line: 2368
   - label: lint-http-rules/src/helpers/headers.rs (2)
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2342
+      line: 2363
   - label: lint-http-rules/src/helpers/headers.rs (3)
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2341
+      line: 2362
   - label: message_access_control_allow_credentials_when_origin
     snippet: If credentials is `true`, then return success.
     cited_by:
@@ -264,7 +264,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2418
+      line: 2428
   - label: message_refresh_header_syntax_valid
     snippet: A code point is found that is not a URL unit.
     cited_by:
@@ -1016,7 +1016,7 @@ sources:
     snippet: authority   = [ userinfo "@" ] host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2389
+      line: 2410
     - file: lint-http-rules/src/helpers/uri.rs
       line: 170
   - label: lint-http-rules/src/helpers/ipv6.rs
@@ -1024,9 +1024,7 @@ sources:
     snippet: A host identified by an Internet Protocol literal address, version 6 [RFC3513] or later, is distinguished by enclosing the IP literal within square brackets ("[" and "]").
     cited_by:
     - file: lint-http-rules/src/helpers/ipv6.rs
-      line: 26
-    - file: lint-http-rules/src/helpers/ipv6.rs
-      line: 68
+      line: 49
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1019
     - file: lint-http-rules/src/rules/client_host_header.rs
@@ -1036,7 +1034,7 @@ sources:
     snippet: This is the only place where square bracket characters are allowed in the URI syntax.
     cited_by:
     - file: lint-http-rules/src/helpers/ipv6.rs
-      line: 69
+      line: 50
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1020
   - label: lint-http-rules/src/helpers/uri.rs
@@ -2074,7 +2072,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2343
+      line: 2364
     - file: lint-http-rules/src/helpers/uri.rs
       line: 294
   - label: lint-http-rules/src/helpers/uri.rs


### PR DESCRIPTION
§6's P45 said `is_valid_serialized_origin` measures where the authority ends and nothing about what it holds. Running the predicate found three classes, not one: the host alphabet, a `%zz` that no `check_percent_encoding` was asked about, and `https://[foo]` -- which passed because `parse_bracketed_ipv6` handed its bracketed content back unexamined, as its own doc comment said. It happened in no caller.

All three go by asking `validate_uri_host`, which owns the production. The function now composes three readers and transcribes none: `validate_scheme_name` for the scheme, `validate_uri_host` for the host, `port_number` for the port.

P41 had already settled this row's stated question -- the URI-wide alphabet is the floor every URI-shaped value gets, and `reg-name`'s narrower set belongs where an authority is validated -- so the two rows that "want deciding together" were decided in sequence.

`parse_bracketed_ipv6` lost its last caller and is gone. Both halves it answered belong to `helpers::uri`: `split_host_and_port` finds the port past the `]`, and `validate_uri_host` quotes `IP-literal` and measures the inner text. Second function to leave `helpers::ipv6` after `parse_port_str`, for the same reason both times.

The colon was found with `rfind`, so `https://a:b:80` was the host `a:b` and the port `80`; the split takes the first colon outside brackets, and no `reg-name` holds one.

2229 -> 2228 cites, 1482/1482 PASS, ratchet 0 of 201, 5663 -> 5670 tests.
