### PR TITLE
The set is HTML's six, not Fetch's twenty, and the header path refuse…

### DIFF
--- a/docs/rules/message_link_header_validity.md
+++ b/docs/rules/message_link_header_validity.md
@@ -20,14 +20,15 @@ Parses the `Link` field of a request and of a response — every field line of o
 
 **Commas inside a member are data.** A `URI-Reference` admits `,` as a `sub-delim` and a `quoted-string` admits it as `qdtext`; §3.3 says so in as many words when it requires an extension relation type to be quoted if it holds one. The members are therefore cut at the commas outside both `<>` and `""`, and `Link: </a,b>; rel=next` is one link and not two malformed ones.
 
-**What §3.4.1's `as` finding rests on, and where.** No RFC requires an `as` parameter of anything: `preload` and `as` are HTML's, and the sentence that makes their pairing observable is in the HTML Standard's *Processing `Link` headers* algorithm, which runs over a **response**'s header list and returns early when `attribs["as"]` does not exist. So the member is not malformed — it is discarded by the recipient it was written for, and the finding says that rather than inventing a requirement. On a request it is not reported at all, because that algorithm never sees one.
+**What §3.4.1's `as` findings rest on, and where.** No RFC requires an `as` parameter of anything: `preload` and `as` are HTML's, and the sentences that make their pairing observable are in the HTML Standard's *Processing `Link` headers* algorithm, which runs over a **response**'s header list and returns early when `attribs["as"]` does not exist — or when its value translates to null. So the member is not malformed — it is discarded by the recipient it was written for, and both findings say that rather than inventing a requirement. On a request neither is reported at all, because that algorithm never sees one.
+
+**An `as` value is measured against HTML's six preload destinations, not Fetch's table.** *Translate a preload destination* refuses membership before Fetch's *translate a potential destination* is ever consulted, so the set is `fetch`, `font`, `image`, `script`, `style`, `track` — and `as=document`, a Fetch destination, is discarded like any other non-member, while `as=fetch` conforms. The match keeps case, and deliberately: the neighbouring steps of the same algorithm say *"an ASCII case-insensitive match"* about `crossorigin` and `fetchpriority` in as many words and this step says nothing of the kind, so `as=Font` is a string the set does not hold. A repeated `as` is not reported and only the first is judged: RFC 8288's parsing algorithm deduplicates only the four attributes §3.4.1 bounds, and the map read HTML performs takes the first entry.
 
 **RFC 8297 requires nothing of a `Link` in a 103.** Its five modals are two MUST NOTs and a SHOULD NOT addressed to the client about what it does with fields it received, plus two MAYs handed to the server; none of them is about this field's content. The status-gated check this replaces asked a 103's members for a `rel` and let every other response omit it — a narrower rendering of §3.3's MUST, which is stated once for every link-value there is.
 
 **What this rule does not decide.**
 
 - **What a `media` value holds.** §1.1 imports its production — `media-query-list` — from the dated 2012 CSS3 Media Queries Recommendation: a grammar in CSS's formalism rather than ABNF, from a document this catalogue does not read, whose own error handling folds a query it cannot parse to `not all` rather than refusing it. Measuring a value against the pinned 2012 grammar would adjudicate a drift this catalogue has not audited — the Media Queries syntax senders write today derives range forms the 2012 document does not print — and a floor loose enough to sidestep the drift would measure nothing. §3.4.1's one MUST about the value (quote it if it holds a `;` or `,`) needs no rule, because the serialisation enforces it itself: unquoted, those characters are this field's own delimiters, so the value never arrives as one value to ask about.
-- **Whether an `as` value names a preload destination.** The same HTML algorithm drops the member when `as` translates to nothing, but the set of destinations lives in Fetch and would have to be transcribed and kept in step here. Being wrong about it costs a false report on an otherwise conforming member, so the question is carried rather than guessed at.
 - **Where a relative `URI-Reference` resolves.** §3.1 and §3.2 make that a parser's MUST and it needs a base the field does not carry.
 - **`rev`.** §3.3 deprecates it in a sentence holding no BCP 14 keyword at all, so nothing there makes writing it a defect.
 - **Whether the target exists, or the relation type is registered.** §2.1.1.2 registers relation types under Specification Required and §2.1.2 hands every unregistered name to the URI form, so an unrecognised lowercase name is an extension the registry has not been asked about — not a finding.
@@ -52,6 +53,7 @@ Parses the `Link` field of a request and of a response — every field line of o
 - [RFC 6838 §4.2](https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2): Naming Requirements: `restricted-name`, the production behind both halves of a `type` value. It opens on a letter or digit and closes at 127 characters, and §3.4.1's ABNF for the value ends at the subtype-name, so there is no parameters group and no wildcard here
 - [HTML Semantics §4.2.4.4](https://html.spec.whatwg.org/multipage/semantics.html#processing-link-headers): *Processing `Link` headers* — the algorithm that reads this field out of a **response** and, for `rel=preload`, returns early when `as` does not exist. The only published sentence pairing the two, and the reason that finding is worded as a member being discarded rather than as a MUST
 - [HTML Links §4.6.8.20](https://html.spec.whatwg.org/multipage/links.html#link-type-preload): Where the `preload` keyword itself is defined, and where it says the resource is fetched *according to the preload destination given by the `as` attribute*. The old reference here named a retired W3C Preload specification in its note while pointing at this page
+- [HTML Links §4.6.8.20](https://html.spec.whatwg.org/multipage/links.html#preload-destination): *Preload destination* — the six strings the header path admits — and *translate a preload destination*, which returns null for anything else before Fetch's own translation is consulted. The reason the table here holds six values and not Fetch's twenty
 - [RFC 8297 §2](https://www.rfc-editor.org/rfc/rfc8297.html#section-2): Early Hints. Named because a check here used to be gated on the 103 status and rest on this document: it states nothing about a `Link` member's content, and its modals are addressed to the client
 
 ## Configuration
@@ -141,6 +143,13 @@ Link: <https://example.com/>; rel = next
 ```http
 HTTP/1.1 103 Early Hints
 Link: <https://example.com/script.js>; rel=preload
+```
+
+### ❌ Bad (as=document is a Fetch destination, but not one of HTML's six preload destinations)
+
+```http
+HTTP/1.1 200 OK
+Link: <https://example.com/next>; rel=preload; as=document
 ```
 
 ### ❌ Bad (an invalid character in a parameter name)

--- a/lint-http-rules/src/rules/message_link_header_validity.rs
+++ b/lint-http-rules/src/rules/message_link_header_validity.rs
@@ -116,13 +116,26 @@ impl Rule for MessageLinkHeaderValidity {
          the commas outside both `<>` and `\"\"`, and `Link: </a,b>; rel=next` is one link and not \
          two malformed ones.\
          \n\n\
-         **What §3.4.1's `as` finding rests on, and where.** No RFC requires an `as` parameter of \
-         anything: `preload` and `as` are HTML's, and the sentence that makes their pairing \
-         observable is in the HTML Standard's *Processing `Link` headers* algorithm, which runs \
+         **What §3.4.1's `as` findings rest on, and where.** No RFC requires an `as` parameter of \
+         anything: `preload` and `as` are HTML's, and the sentences that make their pairing \
+         observable are in the HTML Standard's *Processing `Link` headers* algorithm, which runs \
          over a **response**'s header list and returns early when `attribs[\"as\"]` does not \
-         exist. So the member is not malformed — it is discarded by the recipient it was written \
-         for, and the finding says that rather than inventing a requirement. On a request it is \
-         not reported at all, because that algorithm never sees one.\
+         exist — or when its value translates to null. So the member is not malformed — it is \
+         discarded by the recipient it was written for, and both findings say that rather than \
+         inventing a requirement. On a request neither is reported at all, because that \
+         algorithm never sees one.\
+         \n\n\
+         **An `as` value is measured against HTML's six preload destinations, not Fetch's \
+         table.** *Translate a preload destination* refuses membership before Fetch's *translate \
+         a potential destination* is ever consulted, so the set is `fetch`, `font`, `image`, \
+         `script`, `style`, `track` — and `as=document`, a Fetch destination, is discarded like \
+         any other non-member, while `as=fetch` conforms. The match keeps case, and deliberately: \
+         the neighbouring steps of the same algorithm say *\"an ASCII case-insensitive match\"* \
+         about `crossorigin` and `fetchpriority` in as many words and this step says nothing of \
+         the kind, so `as=Font` is a string the set does not hold. A repeated `as` is not \
+         reported and only the first is judged: RFC 8288's parsing algorithm deduplicates only \
+         the four attributes §3.4.1 bounds, and the map read HTML performs takes the first \
+         entry.\
          \n\n\
          **RFC 8297 requires nothing of a `Link` in a 103.** Its five modals are two MUST NOTs \
          and a SHOULD NOT addressed to the client about what it does with fields it received, \
@@ -143,12 +156,6 @@ impl Rule for MessageLinkHeaderValidity {
          nothing. §3.4.1's one MUST about the value (quote it if it holds a `;` or `,`) needs no \
          rule, because the serialisation enforces it itself: unquoted, those characters are this \
          field's own delimiters, so the value never arrives as one value to ask about.\
-         \n\
-         - **Whether an `as` value names a preload destination.** The same HTML algorithm drops \
-         the member when `as` translates to nothing, but the set of destinations lives in Fetch \
-         and would have to be transcribed and kept in step here. Being wrong about it costs a \
-         false report on an otherwise conforming member, so the question is carried rather than \
-         guessed at.\
          \n\
          - **Where a relative `URI-Reference` resolves.** §3.1 and §3.2 make that a parser's MUST \
          and it needs a base the field does not carry.\
@@ -329,6 +336,15 @@ impl Rule for MessageLinkHeaderValidity {
                        specification in its note while pointing at this page",
             },
             crate::rules::SpecRef {
+                spec: "HTML Links",
+                section: Some("4.6.8.20"),
+                url: "https://html.spec.whatwg.org/multipage/links.html#preload-destination",
+                note: "*Preload destination* — the six strings the header path admits — and \
+                       *translate a preload destination*, which returns null for anything else \
+                       before Fetch's own translation is consulted. The reason the table here \
+                       holds six values and not Fetch's twenty",
+            },
+            crate::rules::SpecRef {
                 spec: "RFC 8297",
                 section: Some("2"),
                 url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-2",
@@ -396,6 +412,11 @@ impl Rule for MessageLinkHeaderValidity {
                 compliance: Compliance::NonCompliant,
                 label: Some("(the HTML processing model drops a preload with no as)"),
                 snippet: "HTTP/1.1 103 Early Hints\nLink: <https://example.com/script.js>; rel=preload",
+            },
+            Example {
+                compliance: Compliance::NonCompliant,
+                label: Some("(as=document is a Fetch destination, but not one of HTML's six preload destinations)"),
+                snippet: "HTTP/1.1 200 OK\nLink: <https://example.com/next>; rel=preload; as=document",
             },
             Example {
                 compliance: Compliance::NonCompliant,
@@ -636,6 +657,7 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), String> {
 
     let mut seen: Vec<String> = Vec::new();
     let mut rel_value: Option<String> = None;
+    let mut as_value: Option<String> = None;
 
     for segment in split_semicolons_respecting_quotes(params_src) {
         if segment.is_empty() {
@@ -687,6 +709,18 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), String> {
                 // `link-param`, and §3.3's own ABNF for the value then asks it
                 // for a `relation-type` that neither of them has.
                 rel_value = Some(parsed.value.unwrap_or_default());
+            }
+            // Kept for the preload check after the loop. The first occurrence
+            // is the one judged: HTML's header extraction defers to RFC 8288's
+            // own parsing algorithm, whose Appendix B.3 deduplicates only
+            // `media`, `title`, `title*` and `type` — a repeated `as` survives
+            // into the attribute map, and the map read the algorithm performs
+            // takes the first. Repetition itself is bounded by nothing, so it
+            // is not a finding.
+            "as" => {
+                if as_value.is_none() {
+                    as_value = Some(parsed.value.unwrap_or_default());
+                }
             }
             // §3.4.1 prints `Language-Tag` as the whole of this value's ABNF.
             // §1.1's second import list is where the production comes from,
@@ -775,15 +809,51 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), String> {
     // cite(HTML Semantics): "To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase"
     // cite(HTML Semantics): "Apply link options from parsed header attributes to options given attribs"
     // cite(HTML Semantics): "If attribs["as"] does not exist, then return false."
-    if is_response && preloads && !seen.iter().any(|n| n == "as") {
-        return Err(format!(
-            "'{}' asks for a preload with no 'as' parameter, so the HTML processing model for a response's Link headers stops before fetching anything",
-            shown_in_finding(member)
-        ));
+    if is_response && preloads {
+        let Some(as_value) = as_value else {
+            return Err(format!(
+                "'{}' asks for a preload with no 'as' parameter, so the HTML processing model for a response's Link headers stops before fetching anything",
+                shown_in_finding(member)
+            ));
+        };
+
+        // The value takes the same early return the absent parameter does,
+        // one step later: translation refuses anything outside the six-string
+        // set, the refusal is null, and null is `return false`.
+        //
+        // The match keeps case, and that is the algorithm's own contrast: the
+        // steps beside this one say *"an ASCII case-insensitive match"* about
+        // `crossorigin` and `fetchpriority` in as many words, and this step
+        // says nothing of the kind — so `Font` is a string the set does not
+        // hold.
+        // cite(HTML Semantics): "Let destination be the result of translating attribs["as"]."
+        // cite(HTML Semantics): "If destination is null, then return false."
+        // cite(HTML Semantics): "If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords"
+        if !PRELOAD_DESTINATIONS.contains(&as_value.as_str()) {
+            return Err(format!(
+                "'{}' asks for a preload whose as='{}' names no preload destination (fetch, font, image, script, style, track, matched case-sensitively), so the HTML processing model for a response's Link headers stops before fetching anything",
+                shown_in_finding(member),
+                shown_in_finding(&as_value)
+            ));
+        }
     }
 
     Ok(())
 }
+
+/// The six strings a response's `Link: rel=preload` survives HTML's
+/// *translate a preload destination* with.
+///
+/// **This is HTML's set and not Fetch's, and the difference decides
+/// findings.** The header path refuses membership here before Fetch's
+/// *translate a potential destination* is ever consulted, so Fetch's twenty-odd
+/// `destination` values are the wrong table: `as=document` names a Fetch
+/// destination and is discarded all the same. `fetch` is in the set — it
+/// translates to the empty string one call later — which is why it is not the
+/// odd one out it looks like.
+// cite(HTML Links): "A preload destination is "fetch", "font", "image", "script", "style", or "track"."
+// cite(HTML Links): "If destination is not a preload destination, then return null."
+const PRELOAD_DESTINATIONS: &[&str] = &["fetch", "font", "image", "script", "style", "track"];
 
 /// The `rel` requirement, written once for the two branches that reach it — a
 /// member with no parameters at all, and a member whose parameters do not
@@ -1037,6 +1107,14 @@ mod tests {
     // `.` and `+` are restricted-name-chars; what they mean is the suffix
     // rule's question, not this one's.
     #[case(b"<https://example.com/>; rel=alternate; type=\"application/vnd.api+json\"")]
+    // `fetch` is a preload destination (it translates to the empty string one
+    // call later), and `track` is the set's least-travelled member.
+    #[case(b"<https://example.com/data.json>; rel=preload; as=fetch")]
+    #[case(b"<https://example.com/cap.vtt>; rel=preload; as=track")]
+    // A repeated `as` is judged on its first entry only: RFC 8288's parser
+    // deduplicates only the four bounded attributes, and HTML's map read
+    // takes the first.
+    #[case(b"<https://example.com/a.css>; rel=preload; as=style; as=nonsense")]
     // %xE9 inside a quoted-string is `qdtext`, and reading the field through
     // `to_str` used to report the whole message for it.
     #[case(b"<https://example.com/>; rel=next; title=\"caf\xe9\"")]
@@ -1154,6 +1232,28 @@ mod tests {
         b"</a>; rel=alternate; type=\"text/\"",
         "member 1 writes type='text/', which does not derive from type-name \"/\" subtype-name: its subtype-name is empty"
     )]
+    // `document` is a Fetch destination and not a preload destination — the
+    // header path refuses membership before Fetch's table is consulted.
+    #[case(
+        b"</a>; rel=preload; as=document",
+        "member 1 '</a>; rel=preload; as=document' asks for a preload whose as='document' names no preload destination (fetch, font, image, script, style, track, matched case-sensitively), so the HTML processing model for a response's Link headers stops before fetching anything"
+    )]
+    // The neighbouring steps fold case in as many words; this one does not.
+    #[case(
+        b"</a>; rel=preload; as=Font",
+        "member 1 '</a>; rel=preload; as=Font' asks for a preload whose as='Font' names no preload destination (fetch, font, image, script, style, track, matched case-sensitively), so the HTML processing model for a response's Link headers stops before fetching anything"
+    )]
+    // A valueless `as` and an `as=""` both translate the empty string, which
+    // is not in the set.
+    #[case(
+        b"</a>; rel=preload; as",
+        "member 1 '</a>; rel=preload; as' asks for a preload whose as='' names no preload destination (fetch, font, image, script, style, track, matched case-sensitively), so the HTML processing model for a response's Link headers stops before fetching anything"
+    )]
+    // First entry wins, so the conforming second cannot rescue the first.
+    #[case(
+        b"</a>; rel=preload; as=nonsense; as=style",
+        "member 1 '</a>; rel=preload; as=nonsense; as=style' asks for a preload whose as='nonsense' names no preload destination (fetch, font, image, script, style, track, matched case-sensitively), so the HTML processing model for a response's Link headers stops before fetching anything"
+    )]
     fn every_branch_states_its_own_finding(#[case] value: &[u8], #[case] expected: &str) {
         assert_eq!(
             judge_response(200, value),
@@ -1200,6 +1300,14 @@ mod tests {
         );
 
         assert_eq!(judge_request(value), None);
+
+        // The value finding is gated the same way: HTML's algorithm reads a
+        // response's header list, so a request's non-destination `as` is not
+        // reported either.
+        assert_eq!(
+            judge_request(b"<https://example.com/x>; rel=preload; as=document"),
+            None
+        );
 
         // The same member with `as` is clean, and the status is not the gate:
         // a 200 carrying the field is read exactly as the 103 is.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -121,6 +121,20 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
       line: 73
+- label: HTML Links
+  url: https://html.spec.whatwg.org/multipage/links.html
+  type: text/html
+  fragments:
+  - label: message_link_header_validity
+    snippet: A preload destination is "fetch", "font", "image", "script", "style", or "track".
+    cited_by:
+    - file: lint-http-rules/src/rules/message_link_header_validity.rs
+      line: 854
+  - label: message_link_header_validity (2)
+    snippet: If destination is not a preload destination, then return null.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_link_header_validity.rs
+      line: 855
 - label: HTML Speculative Loading
   url: https://html.spec.whatwg.org/multipage/speculative-loading.html
   type: text/html
@@ -173,17 +187,32 @@ sources:
     snippet: Apply link options from parsed header attributes to options given attribs
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 776
+      line: 810
   - label: message_link_header_validity (2)
     snippet: If attribs["as"] does not exist, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 777
+      line: 811
   - label: message_link_header_validity (3)
+    snippet: If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords
+    cited_by:
+    - file: lint-http-rules/src/rules/message_link_header_validity.rs
+      line: 831
+  - label: message_link_header_validity (4)
+    snippet: If destination is null, then return false.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_link_header_validity.rs
+      line: 830
+  - label: message_link_header_validity (5)
+    snippet: Let destination be the result of translating attribs["as"].
+    cited_by:
+    - file: lint-http-rules/src/rules/message_link_header_validity.rs
+      line: 829
+  - label: message_link_header_validity (6)
     snippet: To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 775
+      line: 809
   - label: message_refresh_header_syntax_valid
     snippet: 'For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:'
     cited_by:
@@ -1140,7 +1169,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 205
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 523
+      line: 544
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 108
   - label: lint-http-rules/src/helpers/uri.rs (9)
@@ -1200,7 +1229,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 916
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 858
+      line: 928
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
       line: 220
   - label: lint-http-rules/src/helpers/uri.rs (17)
@@ -2814,7 +2843,7 @@ sources:
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 937
+      line: 1007
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
       line: 123
   - label: message_link_header_validity (2)
@@ -2822,7 +2851,7 @@ sources:
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 938
+      line: 1008
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
       line: 136
   - label: message_link_header_validity (3)
@@ -2830,13 +2859,13 @@ sources:
     snippet: restricted-name-chars = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "-" / "^" / "_"
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 939
+      line: 1009
   - label: message_link_header_validity (4)
     section: § 4.2
     snippet: restricted-name-chars =/ "+" ; Characters after last plus always ; specify a structured syntax suffix
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 941
+      line: 1011
     - file: lint-http-rules/src/rules/message_media_type_suffix_validity.rs
       line: 131
   - label: message_link_header_validity (5)
@@ -2844,13 +2873,13 @@ sources:
     snippet: restricted-name-chars =/ "." ; Characters before first dot always ; specify a facet name
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 940
+      line: 1010
   - label: message_link_header_validity (6)
     section: § 4.2
     snippet: type-name = restricted-name subtype-name = restricted-name
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 914
+      line: 984
   - label: message_media_type_suffix_validity
     section: § 4.2.8
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
@@ -3815,49 +3844,49 @@ sources:
     snippet: 'This document uses the Augmented Backus-Naur Form (ABNF) [RFC5234] notation of [RFC7230], including the #rule, and explicitly includes the following rules from it'
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 651
+      line: 673
   - label: message_link_header_validity (2)
     section: § 1.2
     snippet: The requirements regarding conformance and error handling highlighted in [RFC7230], Section 2.5 apply to this document.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 452
+      line: 473
   - label: message_link_header_validity (3)
     section: § 2.1.1
     snippet: Registered relation type names MUST conform to the reg-rel-type rule (see Section 3.3) and MUST be compared character by character in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 762
+      line: 796
   - label: message_link_header_validity (4)
     section: § 2.1.2
     snippet: When extension relation types are compared, they MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion, character by character.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 848
+      line: 918
   - label: message_link_header_validity (5)
     section: § 2.2
     snippet: The names of target attributes SHOULD conform to the token rule, but SHOULD NOT include any of the characters "%", "'", or "*", for portability across serialisations and MUST be compared in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 674
+      line: 696
   - label: message_link_header_validity (6)
     section: § 3
     snippet: Individual link-params specify their syntax in terms of the value after any necessary unquoting
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 650
+      line: 672
   - label: message_link_header_validity (7)
     section: § 3
     snippet: 'Link       = #link-value link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )'
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 454
+      line: 475
   - label: message_link_header_validity (8)
     section: § 3
     snippet: Note that any link-param can be generated with values using either the token or the quoted-string syntax; therefore, recipients MUST be able to parse both forms.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 649
+      line: 671
   - label: message_link_header_validity (9)
     section: § 3
     snippet: The Link header field provides a means for serialising one or more links into HTTP headers.
@@ -3869,121 +3898,121 @@ sources:
     snippet: link-param = token BWS [ "=" BWS ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 648
+      line: 670
   - label: message_link_header_validity (11)
     section: § 3
     snippet: link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 522
+      line: 543
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 583
+      line: 604
   - label: message_link_header_validity (12)
     section: § 3.1
     snippet: Each link-value conveys one target IRI as a URI-Reference (after conversion to one, if necessary; see [RFC3987], Section 3.1) inside angle brackets ("<>").
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 611
+      line: 632
   - label: message_link_header_validity (13)
     section: § 3.3
     snippet: Note that extension relation types are REQUIRED to be absolute URIs in Link header fields and MUST be quoted when they contain characters not allowed in tokens
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 847
+      line: 917
   - label: message_link_header_validity (14)
     section: § 3.3
     snippet: The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 575
+      line: 596
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 793
+      line: 863
   - label: message_link_header_validity (15)
     section: § 3.3
     snippet: The rel parameter can, however, contain multiple link relation types.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 809
+      line: 879
   - label: message_link_header_validity (16)
     section: § 3.3
     snippet: The relation type of a link conveyed in the Link header field is conveyed in the "rel" parameter's value.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 792
+      line: 862
   - label: message_link_header_validity (17)
     section: § 3.3
     snippet: ext-rel-type   = URI ; Section 3 of [RFC3986]
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 846
+      line: 916
   - label: message_link_header_validity (18)
     section: § 3.3
     snippet: reg-rel-type   = LOALPHA *( LOALPHA / DIGIT / "." / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 845
+      line: 915
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 891
+      line: 961
   - label: message_link_header_validity (19)
     section: § 3.3
     snippet: relation-type  = reg-rel-type / ext-rel-type
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 844
+      line: 914
   - label: message_link_header_validity (20)
     section: § 3.3
     snippet: relation-type *( 1*SP relation-type )
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 808
+      line: 878
   - label: message_link_header_validity (21)
     section: § 3.4.1
     snippet: Its value MUST be quoted if it contains a semicolon (";") or comma (",").
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 740
+      line: 774
   - label: message_link_header_validity (22)
     section: § 3.4.1
     snippet: 'The ABNF for the hreflang parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 708
+      line: 742
   - label: message_link_header_validity (23)
     section: § 3.4.1
     snippet: 'The ABNF for the media parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 739
+      line: 773
   - label: message_link_header_validity (24)
     section: § 3.4.1
     snippet: 'The ABNF for the type parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 719
+      line: 753
   - label: message_link_header_validity (25)
     section: § 3.4.1
     snippet: The title attribute MUST NOT appear more than once in a given link; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 577
+      line: 598
   - label: message_link_header_validity (26)
     section: § 3.4.1
     snippet: The title* link-param MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 578
+      line: 599
   - label: message_link_header_validity (27)
     section: § 3.4.1
     snippet: The type attribute MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 579
+      line: 600
   - label: message_link_header_validity (28)
     section: § 3.4.1
     snippet: There MUST NOT be more than one media attribute in a link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 576
+      line: 597
 - label: RFC 8297
   url: https://www.rfc-editor.org/rfc/rfc8297.txt
   type: text/plain
@@ -4557,7 +4586,7 @@ sources:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
       line: 430
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 453
+      line: 474
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 229
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
@@ -5439,7 +5468,7 @@ sources:
     - file: lint-http-rules/src/rules/message_keep_alive_header_validity.rs
       line: 433
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 456
+      line: 477
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 247
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
@@ -5711,7 +5740,7 @@ sources:
     - file: lint-http-rules/src/rules/message_if_none_match_etag_syntax.rs
       line: 83
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 472
+      line: 493
     - file: lint-http-rules/src/rules/message_pragma_token_valid.rs
       line: 134
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -5753,7 +5782,7 @@ sources:
     - file: lint-http-rules/src/rules/message_accept_language_weight_validity.rs
       line: 43
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 464
+      line: 485
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 432
   - label: lint-http-rules/src/helpers/headers.rs (18)
@@ -5885,7 +5914,7 @@ sources:
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
       line: 421
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 543
+      line: 564
   - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
@@ -7069,7 +7098,7 @@ sources:
     snippet: A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 666
+      line: 688
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 204
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
@@ -7081,7 +7110,7 @@ sources:
     snippet: A sender MUST NOT generate BWS in messages.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
-      line: 665
+      line: 687
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs


### PR DESCRIPTION
…s first

The old decline said an `as` value could not be checked because "the set of destinations lives in Fetch and would have to be transcribed and kept in step". Re-deriving found the premise wrong in the direction that matters: HTML's *translate a preload destination* refuses membership against its own six-string set — fetch, font, image, script, style, track — before Fetch's *translate a potential destination* is ever consulted. Transcribing Fetch's table would have passed `as=document`, which the algorithm discards.

`message_link_header_validity` now reports a response preload whose `as` names no preload destination, worded as the member being discarded — the same early return the absent parameter takes, one step later. The match keeps case, and that is the algorithm's own contrast: the neighbouring steps say "an ASCII case-insensitive match" about `crossorigin` and `fetchpriority` in as many words, and this step says nothing of the kind. A repeated `as` is judged on its first entry only: RFC 8288's parser deduplicates only the four attributes § 3.4.1 bounds, and HTML's map read takes the first.

Cites 2302 → 2307, all verified; rule tests 61 → 68.
