### PR TITLE
A userinfo finding was printing the password, and the elision is now …

### DIFF
--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -177,6 +177,32 @@ pub fn split_userinfo(authority: &str) -> (Option<&str>, &str) {
     }
 }
 
+/// `Some(authority with the password elided)`, or `None` when there is nothing
+/// to elide.
+///
+/// The point of a userinfo finding is that credentials arrived somewhere a
+/// server logs, and a lint report is one more place they would be written down
+/// in clear. The sentence asking for this names the *first* colon and exempts
+/// an empty tail, so `user:@host` has nothing to elide and `user:s3cret@host`
+/// becomes `user:...@host`.
+///
+/// Shared on its second caller: `message_referer_uri_valid` wrote this for the
+/// field whose MUST NOT names the component, and the two pseudo-header rules
+/// print an authority rather than a whole reference — the elision is the same
+/// decision in both shapes, so the authority form lives here and the
+/// whole-value caller substitutes the result back into its value.
+// cite(RFC 3986 § 3.2.1): "Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password)."
+pub fn userinfo_password_withheld(authority: &str) -> Option<String> {
+    let (Some(userinfo), host_and_port) = split_userinfo(authority) else {
+        return None;
+    };
+    let (user, secret) = userinfo.split_once(':')?;
+    if secret.is_empty() {
+        return None;
+    }
+    Some(format!("{user}:...@{host_and_port}"))
+}
+
 /// The `authority` a URI reference carries, or `None` when it carries none.
 ///
 /// § 3.2's sentence is the whole of this function, in both directions: the
@@ -1102,6 +1128,27 @@ pub fn validate_host_and_optional_port(value: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// § 3.2.1's sentence names the *first* colon and exempts an empty tail:
+    /// only a nonempty secret is elided, and everything else comes back `None`
+    /// so the caller shows the value as written.
+    #[test]
+    fn userinfo_password_withheld_elides_only_a_nonempty_secret() {
+        use super::userinfo_password_withheld;
+        assert_eq!(
+            userinfo_password_withheld("user:s3cret@h:1"),
+            Some("user:...@h:1".into())
+        );
+        // The first colon decides; later ones are part of the secret and go
+        // with it.
+        assert_eq!(
+            userinfo_password_withheld("user:a:b@h"),
+            Some("user:...@h".into())
+        );
+        assert_eq!(userinfo_password_withheld("user:@h"), None);
+        assert_eq!(userinfo_password_withheld("user@h"), None);
+        assert_eq!(userinfo_password_withheld("h:1"), None);
+    }
 
     /// Both sets, spelled out from the productions rather than composed from the
     /// predicates, and asserted over the whole US-ASCII range — four component

--- a/lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
+++ b/lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
@@ -37,7 +37,15 @@ fn connect_authority_finding(authority: &str) -> Option<String> {
     // makes the host look like a port to any reader splitting on the colon.
     // The form is a `uri-host` and a `port` and has no third component, and the
     // sentence naming the two is one paragraph above the grammar.
+    //
+    // What is shown is the elided form: a userinfo is where credentials
+    // travel, and a report printing the password would be one more place they
+    // are written down in clear. The elision is the shared helper's, with
+    // RFC 3986 § 3.2.1's sentence on it.
     if authority.contains('@') {
+        let shown = crate::helpers::uri::userinfo_password_withheld(authority)
+            .map(|redacted| crate::helpers::headers::shown_in_finding(&redacted))
+            .unwrap_or(shown);
         return Some(format!(
             "CONNECT ':authority' '{shown}' carries a userinfo subcomponent and its '@' \
              delimiter: the field is only the host and port number of the tunnel destination"
@@ -307,17 +315,22 @@ impl Rule for MessageHttp2PseudoHeadersValidity {
             // The MUST NOT names the two schemes it is about, and the scheme is
             // the left half of the value being read -- so a userinfo under some
             // other scheme is outside it and is not reported.
+            //
+            // The password half is withheld from the finding: the elision is
+            // the shared helper's, with RFC 3986 § 3.2.1's sentence on it.
             // cite(RFC 9113 § 8.3.1): "":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs."
             if authority.contains('@')
                 && (scheme.eq_ignore_ascii_case("http") || scheme.eq_ignore_ascii_case("https"))
             {
+                let shown = crate::helpers::uri::userinfo_password_withheld(&authority)
+                    .unwrap_or_else(|| authority.to_string());
                 return Some(Violation {
                     rule: self.id().into(),
                     severity: config.severity,
                     message: format!(
                         "Authority '{}' of an '{scheme}' target carries the deprecated userinfo \
                          subcomponent and its '@' delimiter",
-                        crate::helpers::headers::shown_in_finding(&authority)
+                        crate::helpers::headers::shown_in_finding(&shown)
                     ),
                 });
             }
@@ -782,6 +795,25 @@ mod tests {
             reported,
             "{target}: {message:?}"
         );
+    }
+
+    /// Both userinfo findings withhold the password: the finding is about
+    /// credentials arriving where a server logs, and a lint report must not be
+    /// one more place they are written down in clear (RFC 3986 § 3.2.1). A
+    /// userinfo with no secret is shown as written — the same sentence exempts
+    /// an empty tail.
+    #[test]
+    fn userinfo_findings_withhold_the_password() {
+        let msg = judge_request("CONNECT", "user:s3cret@example.com:443").expect("reported");
+        assert!(msg.contains("'user:...@example.com:443'"), "{msg}");
+        assert!(!msg.contains("s3cret"), "{msg}");
+
+        let msg = judge_request("GET", "http://user:s3cret@example.com/p").expect("reported");
+        assert!(msg.contains("'user:...@example.com'"), "{msg}");
+        assert!(!msg.contains("s3cret"), "{msg}");
+
+        let msg = judge_request("GET", "https://user@example.com/p").expect("reported");
+        assert!(msg.contains("'user@example.com'"), "{msg}");
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/message_referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/message_referer_uri_valid.rs
@@ -31,16 +31,14 @@ fn shown_referer(value: &str) -> String {
 
 /// `Some(value with the password elided)`, or `None` when there is nothing to
 /// elide. Separate from [`shown_referer`] so the userinfo finding can say which
-/// of the two it is showing.
+/// of the two it is showing. The elision itself is
+/// [`crate::helpers::uri::userinfo_password_withheld`]'s, shared with the two
+/// pseudo-header rules that print an authority; what stays here is putting the
+/// redacted authority back into the whole reference this rule shows.
 fn redacted_userinfo(value: &str) -> Option<String> {
-    let (Some(userinfo), _) = split_userinfo(authority_component(value)?) else {
-        return None;
-    };
-    let (user, secret) = userinfo.split_once(':')?;
-    if secret.is_empty() {
-        return None;
-    }
-    Some(value.replacen(&format!("{userinfo}@"), &format!("{user}:...@"), 1))
+    let authority = authority_component(value)?;
+    let redacted = crate::helpers::uri::userinfo_password_withheld(authority)?;
+    Some(value.replacen(authority, &redacted, 1))
 }
 
 impl Rule for MessageRefererUriValid {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1081,7 +1081,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 49
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1019
+      line: 1045
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 142
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
@@ -1091,7 +1091,7 @@ sources:
     - file: lint-http-rules/src/helpers/ipv6.rs
       line: 50
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1020
+      line: 1046
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 2
     snippet: A URI is composed from a limited set of characters consisting of digits, letters, and a few graphic symbols.
@@ -1099,7 +1099,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 71
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 313
+      line: 339
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 109
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
@@ -1171,13 +1171,13 @@ sources:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 544
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 108
+      line: 106
   - label: lint-http-rules/src/helpers/uri.rs (9)
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 651
+      line: 677
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 72
   - label: lint-http-rules/src/helpers/uri.rs (10)
@@ -1185,7 +1185,7 @@ sources:
     snippet: percent-encoded octets in the ranges of ALPHA (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers and, when found in a URI, should be decoded to their corresponding unreserved characters by URI normalizers
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 738
+      line: 764
   - label: lint-http-rules/src/helpers/uri.rs (11)
     section: § 2.3
     snippet: unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
@@ -1193,19 +1193,19 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 88
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 650
+      line: 676
   - label: lint-http-rules/src/helpers/uri.rs (12)
     section: § 2.4
     snippet: The only exception is for percent-encoded octets corresponding to characters in the unreserved set, which can be decoded at any time.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 737
+      line: 763
   - label: lint-http-rules/src/helpers/uri.rs (13)
     section: § 2.4
     snippet: When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 654
+      line: 680
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 60
   - label: lint-http-rules/src/helpers/uri.rs (14)
@@ -1213,71 +1213,79 @@ sources:
     snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 203
+      line: 229
   - label: lint-http-rules/src/helpers/uri.rs (15)
     section: § 3.1
     snippet: Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 917
+      line: 943
   - label: lint-http-rules/src/helpers/uri.rs (16)
     section: § 3.1
     snippet: scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 234
+      line: 260
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 916
+      line: 942
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 928
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 220
+      line: 218
   - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 205
+      line: 231
   - label: lint-http-rules/src/helpers/uri.rs (18)
+    section: § 3.2.1
+    snippet: Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password).
+    cited_by:
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 194
+    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
+      line: 26
+  - label: lint-http-rules/src/helpers/uri.rs (19)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 172
-  - label: lint-http-rules/src/helpers/uri.rs (19)
+  - label: lint-http-rules/src/helpers/uri.rs (20)
     section: § 3.2.1
     snippet: userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 171
-  - label: lint-http-rules/src/helpers/uri.rs (20)
+  - label: lint-http-rules/src/helpers/uri.rs (21)
     section: § 3.2.2
     snippet: IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 949
-  - label: lint-http-rules/src/helpers/uri.rs (21)
+      line: 975
+  - label: lint-http-rules/src/helpers/uri.rs (22)
     section: § 3.2.2
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 989
+      line: 1015
   - label: host grammar
     section: § 3.2.2
     snippet: host        = IP-literal / IPv4address / reg-name
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 439
+      line: 465
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 945
+      line: 971
   - label: reg-name
     section: § 3.2.2
     snippet: reg-name    = *( unreserved / pct-encoded / sub-delims )
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 206
+      line: 232
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 946
+      line: 972
     - file: lint-http-rules/src/rules/client_request_uri_percent_encoding_valid.rs
       line: 107
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
@@ -1286,28 +1294,28 @@ sources:
       line: 479
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 139
-  - label: lint-http-rules/src/helpers/uri.rs (22)
+  - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1021
-    - file: lint-http-rules/src/helpers/uri.rs
-      line: 1062
+      line: 1047
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1088
+    - file: lint-http-rules/src/helpers/uri.rs
+      line: 1114
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 51
     - file: lint-http-rules/src/rules/message_via_header_syntax_valid.rs
       line: 393
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 151
-  - label: lint-http-rules/src/helpers/uri.rs (23)
+  - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1089
+      line: 1115
   - label: pchar
     section: § 3.3
     snippet: pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
@@ -1318,7 +1326,7 @@ sources:
       line: 105
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 48
-  - label: lint-http-rules/src/helpers/uri.rs (24)
+  - label: lint-http-rules/src/helpers/uri.rs (25)
     section: § 4.2
     snippet: A path segment that contains a colon character (e.g., "this:that") cannot be used as the first segment of a relative-path reference, as it would be mistaken for a scheme name.
     cited_by:
@@ -1327,105 +1335,105 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 91
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 221
-  - label: lint-http-rules/src/helpers/uri.rs (25)
+      line: 219
+  - label: lint-http-rules/src/helpers/uri.rs (26)
     section: § 4.2
     snippet: A relative reference that begins with two slash characters is termed a network-path reference; such references are rarely used.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 782
+      line: 808
   - label: relative-part
     section: § 4.2
     snippet: relative-part = "//" authority path-abempty / path-absolute / path-noscheme / path-empty
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 204
+      line: 230
   - label: absolute-URI
     section: § 4.3
     snippet: absolute-URI  = scheme ":" hier-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 202
+      line: 228
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 65
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 94
-  - label: lint-http-rules/src/helpers/uri.rs (26)
+  - label: lint-http-rules/src/helpers/uri.rs (27)
     section: § 5.2.3
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 754
-  - label: lint-http-rules/src/helpers/uri.rs (27)
+      line: 780
+  - label: lint-http-rules/src/helpers/uri.rs (28)
     section: § 5.2.3
     snippet: return a string consisting of the reference's path component appended to all but the last segment of the base URI's path
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 758
-  - label: lint-http-rules/src/helpers/uri.rs (28)
+      line: 784
+  - label: lint-http-rules/src/helpers/uri.rs (29)
     section: § 5.2.4
     snippet: This is done after the path is extracted from a reference, whether or not the path was relative, in order to remove any invalid or extraneous dot-segments prior to forming the target URI.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 570
-  - label: lint-http-rules/src/helpers/uri.rs (29)
+      line: 596
+  - label: lint-http-rules/src/helpers/uri.rs (30)
     section: § 5.4.2
     snippet: Some applications fail to separate the reference's query and/or fragment components from the path component before merging it with the base path and removing dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 736
-  - label: lint-http-rules/src/helpers/uri.rs (30)
+      line: 762
+  - label: lint-http-rules/src/helpers/uri.rs (31)
     section: § 5.4.2
     snippet: parsers must remove the dot-segments "." and ".." when they are complete components of a path, but not when they are only part of a segment.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 740
-  - label: lint-http-rules/src/helpers/uri.rs (31)
+      line: 766
+  - label: lint-http-rules/src/helpers/uri.rs (32)
     section: § 6.2.2
     snippet: Syntax-based normalization includes such techniques as case normalization, percent-encoding normalization, and removal of dot-segments.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 735
-  - label: lint-http-rules/src/helpers/uri.rs (32)
+      line: 761
+  - label: lint-http-rules/src/helpers/uri.rs (33)
     section: § 6.2.2.1
     snippet: For all URIs, the hexadecimal digits within a percent-encoding triplet (e.g., "%3a" versus "%3A") are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 653
+      line: 679
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 91
-  - label: lint-http-rules/src/helpers/uri.rs (33)
+  - label: lint-http-rules/src/helpers/uri.rs (34)
     section: § 6.2.2.1
     snippet: The other generic syntax components are assumed to be case-sensitive unless specifically defined otherwise by the scheme (see Section 6.2.3).
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 741
+      line: 767
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 241
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
       line: 154
-  - label: lint-http-rules/src/helpers/uri.rs (34)
+  - label: lint-http-rules/src/helpers/uri.rs (35)
     section: § 6.2.2.1
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 440
+      line: 466
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 240
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
       line: 196
-  - label: lint-http-rules/src/helpers/uri.rs (35)
+  - label: lint-http-rules/src/helpers/uri.rs (36)
     section: § 6.2.2.2
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 652
-  - label: lint-http-rules/src/helpers/uri.rs (36)
+      line: 678
+  - label: lint-http-rules/src/helpers/uri.rs (37)
     section: § 6.2.2.3
     snippet: URI normalizers should remove dot-segments by applying the remove_dot_segments algorithm to the path, as described in Section 5.2.4.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 739
+      line: 765
   - label: message_content_location_and_uri_consistency
     section: § 4.3
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
@@ -1433,7 +1441,7 @@ sources:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 169
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 202
+      line: 200
   - label: message_host_and_authority_consistency
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1442,28 +1450,22 @@ sources:
       line: 54
   - label: message_referer_uri_valid
     section: § 3.2.1
-    snippet: Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password).
-    cited_by:
-    - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 26
-  - label: message_referer_uri_valid (2)
-    section: § 3.2.1
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 252
-  - label: message_referer_uri_valid (3)
+      line: 250
+  - label: message_referer_uri_valid (2)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 203
-  - label: message_referer_uri_valid (4)
+      line: 201
+  - label: message_referer_uri_valid (3)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 147
+      line: 145
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
       line: 128
   - label: message_well_known_uri_format
@@ -2107,9 +2109,9 @@ sources:
     snippet: Reserved port numbers include values at the edges of each range, e.g., 0, 1023, 1024, etc., which may be used to extend these ranges or the overall port number space in the future.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1064
+      line: 1090
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 93
+      line: 101
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 184
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -2117,9 +2119,9 @@ sources:
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1063
+      line: 1089
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 92
+      line: 100
     - file: lint-http-rules/src/rules/server_alt_svc_header_syntax.rs
       line: 183
 - label: RFC 6454
@@ -2133,13 +2135,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2364
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 294
+      line: 320
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: origin-list-or-null = %x6E %x75 %x6C %x6C / origin-list
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 287
+      line: 313
 - label: RFC 6455
   url: https://www.rfc-editor.org/rfc/rfc6455.txt
   type: text/plain
@@ -4100,13 +4102,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 194
+      line: 202
   - label: message_http2_pseudo_headers_validity (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 195
+      line: 203
 - label: RFC 8447
   url: https://www.rfc-editor.org/rfc/rfc8447.txt
   type: text/plain
@@ -4498,7 +4500,7 @@ sources:
     - file: lint-http-rules/src/rules/message_from_header_email_syntax.rs
       line: 22
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 57
+      line: 55
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 395
   - label: client_expect_header_valid (2)
@@ -4594,7 +4596,7 @@ sources:
     - file: lint-http-rules/src/rules/message_prefer_header_valid.rs
       line: 229
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 167
+      line: 165
     - file: lint-http-rules/src/rules/message_warning_header_syntax.rs
       line: 303
     - file: lint-http-rules/src/rules/server_location_header_uri_valid.rs
@@ -4716,7 +4718,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 203
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 178
+      line: 186
     - file: lint-http-rules/src/rules/semantic_head_response_headers_match_get.rs
       line: 208
     - file: lint-http-rules/src/rules/semantic_options_method_capabilities.rs
@@ -4922,7 +4924,7 @@ sources:
     - file: lint-http-rules/src/rules/message_allow_header_method_tokens.rs
       line: 115
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 156
+      line: 164
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
@@ -4942,7 +4944,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 259
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 233
+      line: 241
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
       line: 97
   - label: client_request_target_form_checks (3)
@@ -4968,7 +4970,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 230
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 234
+      line: 242
     - file: lint-http-rules/src/rules/message_http3_pseudo_headers_validity.rs
       line: 98
   - label: client_request_target_form_checks (6)
@@ -5656,7 +5658,7 @@ sources:
     - file: lint-http-rules/src/rules/message_max_forwards_numeric.rs
       line: 88
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 124
+      line: 122
     - file: lint-http-rules/src/rules/message_te_header_constraints.rs
       line: 49
     - file: lint-http-rules/src/rules/message_upgrade_header_syntax_valid.rs
@@ -6234,7 +6236,7 @@ sources:
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 355
+      line: 381
     - file: lint-http-rules/src/rules/client_request_target_no_fragment.rs
       line: 111
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
@@ -6244,7 +6246,7 @@ sources:
     snippet: Host = uri-host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1087
+      line: 1113
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 161
     - file: lint-http-rules/src/rules/message_forwarded_header_validity.rs
@@ -6256,19 +6258,19 @@ sources:
     snippet: In HTTP/2 [HTTP/2] and HTTP/3 [HTTP/3], the Host header field is, in some cases, supplanted by the ":authority" pseudo-header field of a request's control data.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 357
+      line: 383
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 164
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 208
+      line: 216
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 356
+      line: 382
   - label: message_accept_and_content_type_negotiation
     section: § 12.1
     snippet: A user agent cannot rely on proactive negotiation preferences being consistently honored, since the origin server might not implement proactive negotiation for the requested resource or might decide that sending a response that doesn't conform to the user agent's preferences is better than sending a 406 (Not Acceptable) response.
@@ -6820,7 +6822,7 @@ sources:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 167
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 200
+      line: 198
   - label: message_content_location_and_uri_consistency (2)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
@@ -6828,7 +6830,7 @@ sources:
     - file: lint-http-rules/src/rules/message_content_location_and_uri_consistency.rs
       line: 168
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 201
+      line: 199
   - label: message_content_location_and_uri_consistency (3)
     section: § 8.7
     snippet: Content-Location = absolute-URI / partial-URI
@@ -7020,7 +7022,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 49
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 276
+      line: 274
   - label: message_http2_pseudo_headers_validity
     section: § 9.3.6
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
@@ -7410,79 +7412,79 @@ sources:
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 199
+      line: 197
   - label: message_referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 328
+      line: 326
   - label: message_referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 148
+      line: 146
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 86
+      line: 84
   - label: message_referer_uri_valid (4)
     section: § 10.1.3
     snippet: The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled).
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 85
+      line: 83
   - label: message_referer_uri_valid (5)
     section: § 17.9
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 333
+      line: 331
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 146
+      line: 144
   - label: message_referer_uri_valid (6)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 274
+      line: 272
   - label: message_referer_uri_valid (7)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 331
+      line: 329
   - label: message_referer_uri_valid (8)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 330
+      line: 328
   - label: message_referer_uri_valid (9)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 275
+      line: 273
   - label: message_referer_uri_valid (10)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 332
+      line: 330
   - label: message_referer_uri_valid (11)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/message_referer_uri_valid.rs
-      line: 329
+      line: 327
   - label: message_response_body_length_accuracy
     section: § 8.6
     snippet: A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 15.4.5); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a 200 (OK) response to the same request.
@@ -9316,7 +9318,7 @@ sources:
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 361
+      line: 387
     - file: lint-http-rules/src/rules/client_host_header.rs
       line: 77
   - label: request-target forms
@@ -9324,9 +9326,9 @@ sources:
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 393
+      line: 419
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 466
+      line: 492
     - file: lint-http-rules/src/rules/client_request_target_form_checks.rs
       line: 13
     - file: lint-http-rules/src/rules/message_well_known_uri_format.rs
@@ -9336,19 +9338,19 @@ sources:
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 359
+      line: 385
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.3
     snippet: If there is no Host header field or if its field value is empty or invalid, the target URI's authority component is empty.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 360
+      line: 386
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 3.3
     snippet: The target URI is the request-target when the request-target is in absolute-form.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 358
+      line: 384
     - file: lint-http-rules/src/rules/semantic_post_creates_resource.rs
       line: 86
     - file: lint-http-rules/src/rules/stateful_redirect_chain_validity.rs
@@ -9710,7 +9712,7 @@ sources:
     - file: lint-http-rules/src/rules/client_request_method_token_valid.rs
       line: 136
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 152
+      line: 160
   - label: client_request_target_form_checks
     section: § 8.3.1
     snippet: A request in asterisk form (for OPTIONS) includes the value '*' for the ":path" pseudo-header field.
@@ -9720,7 +9722,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 202
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 232
+      line: 240
   - label: client_request_target_form_checks (2)
     section: § 8.3.1
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
@@ -9816,7 +9818,7 @@ sources:
     - file: lint-http-rules/src/rules/message_host_and_authority_consistency.rs
       line: 185
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 272
+      line: 280
   - label: message_host_and_authority_consistency (5)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -9828,67 +9830,67 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 168
+      line: 176
   - label: message_http2_pseudo_headers_validity (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 157
+      line: 165
   - label: message_http2_pseudo_headers_validity (3)
     section: § 8.3.1
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 310
+      line: 321
   - label: message_http2_pseudo_headers_validity (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 277
+      line: 285
   - label: message_http2_pseudo_headers_validity (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 248
+      line: 256
   - label: message_http2_pseudo_headers_validity (6)
     section: § 8.3.1
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 271
+      line: 279
   - label: message_http2_pseudo_headers_validity (7)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 247
+      line: 255
   - label: message_http2_pseudo_headers_validity (8)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 358
+      line: 371
   - label: message_http2_pseudo_headers_validity (9)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 359
+      line: 372
   - label: message_http2_pseudo_headers_validity (10)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 200
+      line: 208
   - label: message_http2_pseudo_headers_validity (11)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 91
+      line: 99
   - label: message_http2_pseudo_headers_validity (12)
     section: § 8.5
     snippet: The ":authority" pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 3.2.3 of [HTTP/1.1]).
@@ -9896,13 +9898,13 @@ sources:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
       line: 20
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 199
+      line: 207
   - label: message_http2_pseudo_headers_validity (13)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/message_http2_pseudo_headers_validity.rs
-      line: 179
+      line: 187
   - label: message_no_connection_specific_fields
     section: § 8.2.2
     snippet: An intermediary transforming an HTTP/1.x message to HTTP/2 MUST remove connection-specific header fields as discussed in Section 7.6.1 of [HTTP], or their messages will be treated by other HTTP/2 endpoints as malformed (Section 8.1.1).


### PR DESCRIPTION
…shared

The Referer audit established the shape: a userinfo is where credentials travel, RFC 3986 § 3.2.1 asks an application rendering a URI not to show what follows the first colon (exempting an empty tail), and a lint report is one more place a password would be written down in clear.

`message_http2_pseudo_headers_validity` had the same finding in two places — the CONNECT ':authority' check and the absolute-form http/https check — and both printed the authority as written, password included. The elision moves to `helpers::uri::userinfo_password_withheld` on its second caller; the Referer rule now composes it (substituting the redacted authority back into the whole reference it shows), and both HTTP/2 findings use it.

Found while preparing the same checks for the HTTP/3 rule (the next commit), which would otherwise have been the third copy — or the third disclosure.
