### PR TITLE
The negotiation stops at the relay, because the relay reads every frame

### DIFF
--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -250,9 +250,15 @@ where
             // Preserve hop-by-hop headers for the upstream handshake: the
             // WebSocket upgrade depends on `Connection`/`Upgrade` reaching the
             // origin (the request-side analog of the 101 carve-out in
-            // `filter_response_headers`).
+            // `filter_response_headers`). The one field removed is the
+            // extension negotiation, which stops at the relay — the frames of
+            // an accepted extension would be unreadable in the middle, and a
+            // session tungstenite cannot read is a session it kills. The
+            // capture records `req_headers` as received, offer included; see
+            // `websocket::without_extension_negotiation`.
+            let upstream_headers = super::websocket::without_extension_negotiation(&req_headers);
             let upstream_req =
-                match upstream_request_builder(&method, &uri, &req_headers, &shared, false)
+                match upstream_request_builder(&method, &uri, &upstream_headers, &shared, false)
                     .body(Full::new(body_bytes.clone()))
                 {
                     Ok(r) => r,

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -168,9 +168,12 @@ pub(super) async fn handle_websocket_upgrade(
 
         // Build the 101 response to send back to the client.
         // Forward ALL headers including upgrade-related ones (Connection, Upgrade,
-        // Sec-WebSocket-Accept) — do NOT strip hop-by-hop headers for 101.
+        // Sec-WebSocket-Accept) — do NOT strip hop-by-hop headers for 101. The one
+        // exception is the extension negotiation, which stops at the relay:
+        // see `without_extension_negotiation`. The capture above already
+        // recorded the 101 as received.
         let mut resp_builder = Response::builder().status(101);
-        for (name, value) in headers.iter() {
+        for (name, value) in without_extension_negotiation(&headers).iter() {
             resp_builder = resp_builder.header(name, value);
         }
         let resp = resp_builder
@@ -327,6 +330,33 @@ async fn connect_upstream_for_upgrade(
         let handle = tokio::spawn(conn.with_upgrades());
         Ok((sender, handle))
     }
+}
+
+/// The message minus its `Sec-WebSocket-Extensions` field: the extension
+/// negotiation stops at the relay, in both directions.
+///
+/// **The relay is a WebSocket endpoint on each leg, not a tunnel.** Every frame
+/// passes through tungstenite, which implements no extension and returns
+/// `ProtocolError::NonZeroReservedBits` for any frame that sets one — so a
+/// negotiation relayed end-to-end authorises frames the middle cannot read.
+/// That was live: the client's `permessage-deflate` offer reached the origin,
+/// the origin's acceptance reached the client, and the first compressed frame
+/// killed the session (RULECITES P48). An intermediary that cannot read an
+/// extension's frames must not relay its negotiation, so the offer is removed
+/// from the upstream handshake request and the acceptance — which a conforming
+/// origin then never sends, but a broken one still might — from the `101`
+/// forwarded to the client.
+///
+/// **Captures are untouched.** Both the request and the `101` are recorded as
+/// received, offer and acceptance included, before this runs — the rules read
+/// what each party wrote, not what the relay could live with.
+// cite(RFC 6455 § 9.1): "Note that like other HTTP header fields, this header field MAY be split or combined across multiple lines."
+pub(super) fn without_extension_negotiation(headers: &hyper::HeaderMap) -> hyper::HeaderMap {
+    let mut out = headers.clone();
+    // `HeaderMap::remove` takes every value of the name, so a field split
+    // across lines — which § 9.1 permits in as many words — leaves nothing.
+    out.remove("sec-websocket-extensions");
+    out
 }
 
 /// What a `101` settled about extensions, read from the response and not from
@@ -623,6 +653,35 @@ mod tests {
             MessageDirection::Client,
         );
         assert_eq!(unmasked.masked, Some(false));
+    }
+
+    /// The negotiation stops at the relay: the field is removed however many
+    /// lines carried it, and nothing else moves. The frames of an accepted
+    /// extension would be unreadable to tungstenite in the middle, so relaying
+    /// the offer or the acceptance authorised sessions the relay then killed
+    /// (RULECITES P48).
+    #[test]
+    fn extension_negotiation_is_stripped_and_nothing_else_is() {
+        use hyper::header::{HeaderName, HeaderValue};
+        let name = HeaderName::from_static("sec-websocket-extensions");
+
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(
+            hyper::header::UPGRADE,
+            HeaderValue::from_static("websocket"),
+        );
+        headers.insert(
+            HeaderName::from_static("sec-websocket-key"),
+            HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
+        );
+        headers.append(name.clone(), HeaderValue::from_static("permessage-deflate"));
+        headers.append(name.clone(), HeaderValue::from_static("bbf-usp-protocol"));
+
+        let out = without_extension_negotiation(&headers);
+        assert!(!out.contains_key(&name), "both field lines are gone");
+        assert_eq!(out.len(), 2, "everything else survives");
+        assert!(out.contains_key(hyper::header::UPGRADE));
+        assert!(out.contains_key("sec-websocket-key"));
     }
 
     /// The one line that turns a `101` into the fact a frame rule reads.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2249,7 +2249,7 @@ sources:
     - file: lint-http-core/src/protocol_event.rs
       line: 71
     - file: lint-http-proxy/src/proxy/websocket.rs
-      line: 354
+      line: 384
     - file: lint-http-rules/src/rules/stateful_websocket_handshake_validity.rs
       line: 250
   - label: lint-http-proxy/src/proxy/websocket.rs
@@ -2273,7 +2273,13 @@ sources:
     snippet: '%x0 denotes a continuation frame * %x1 denotes a text frame * %x2 denotes a binary frame * %x3-7 are reserved for further non-control frames * %x8 denotes a connection close * %x9 denotes a ping * %xA denotes a pong'
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket.rs
-      line: 528
+      line: 558
+  - label: lint-http-proxy/src/proxy/websocket.rs (4)
+    section: § 9.1
+    snippet: Note that like other HTTP header fields, this header field MAY be split or combined across multiple lines.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/websocket.rs
+      line: 353
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 4.1
     snippet: (as a string, not base64-decoded) with the string


### PR DESCRIPTION
The proxy's WebSocket relay is an endpoint on each leg, not a tunnel: every frame passes through tungstenite, which implements no extension and returns ProtocolError::NonZeroReservedBits for any frame that sets a reserved bit. Sec-WebSocket-Extensions was not in HOP_BY_HOP_HEADERS and the upgrade path forwards headers unfiltered in both directions — so the client's permessage-deflate offer reached the origin, the origin's acceptance reached the client, and the first compressed frame the handshake authorised killed the session. Found by the P30a audit, which gave the frame rules the negotiation to read and found the relay could not survive one.

An intermediary that cannot read an extension's frames must not relay its negotiation: websocket::without_extension_negotiation removes the field from the upstream handshake request (a conforming origin then never accepts) and from the 101 forwarded to the client (a broken origin still might). Captures are untouched — both messages are recorded as received, offer and acceptance included, before the strip runs, so the rules read what each party wrote.

Closing the live-defect group for the second time. Cites 2355 → 2356.
