### PR TITLE
Seven arrays read against their registries, and one held a name from …

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -510,7 +510,14 @@ allowed = ["text/plain", "text/html", "application/json", "image/*", "+json"]
 [rules.message_media_type_suffix_validity]
 enabled = true
 severity = "warn"
-allowed = ["json", "xml", "ber", "der", "fastinfoset", "wbxml", "exi"]
+# Six names from IANA's Structured Syntax Suffix registry. The list used to
+# hold "exi" as a seventh -- a name that registry has never held: "exi" is a
+# registered HTTP *content coding* (W3C EXI), and it had been copied here from
+# the neighbouring registry, silencing exactly the finding this rule exists to
+# make for "+exi". As with every allowed list, the registry is not consulted
+# at lint time; this array stands in for it, so its contents have to be read
+# against the registry they name.
+allowed = ["json", "xml", "ber", "der", "fastinfoset", "wbxml"]
 
 [rules.message_charset_iana_registered]
 enabled = true

--- a/docs/rules/message_media_type_suffix_validity.md
+++ b/docs/rules/message_media_type_suffix_validity.md
@@ -27,7 +27,14 @@ Flags media types — in `Content-Type` on either side of a transaction, or in a
 [rules.message_media_type_suffix_validity]
 enabled = true
 severity = "warn"
-allowed = ["json", "xml", "ber", "der", "fastinfoset", "wbxml", "exi"]
+# Six names from IANA's Structured Syntax Suffix registry. The list used to
+# hold "exi" as a seventh -- a name that registry has never held: "exi" is a
+# registered HTTP *content coding* (W3C EXI), and it had been copied here from
+# the neighbouring registry, silencing exactly the finding this rule exists to
+# make for "+exi". As with every allowed list, the registry is not consulted
+# at lint time; this array stands in for it, so its contents have to be read
+# against the registry they name.
+allowed = ["json", "xml", "ber", "der", "fastinfoset", "wbxml"]
 ```
 
 ## Examples


### PR DESCRIPTION
…the registry next door

A shipped example config is a claim, and no ratchet reaches it. The eighth allowed array was read in F14 8/9 (ws/wss in an ALPN list); the other seven had never been read against the registries their rules name. Fetched and diffed today:

- content codings: all 13 shipped names registered (the list is the full registry, exactly)
- transfer codings: chunked, compress, gzip, deflate - all registered
- auth schemes: Basic, Bearer, Digest - all registered
- charsets: UTF-8, ISO-8859-1, US-ASCII - all registered (preferred MIME names)
- media types: text/plain, text/html, application/json registered; image/* and +json are the rule's own pattern forms
- extension headers: disclaimed as a deployment illustration in its own comment, ships disabled - honest by construction
- structured syntax suffixes: json, xml, ber, der, fastinfoset, wbxml registered - and "exi" is not. "+exi" has never been in that registry; "exi" is a registered HTTP content coding (W3C EXI), copied into the suffix list from the registry next door. The example config was silencing exactly the finding message_media_type_suffix_validity exists to make. Removed, with the reason in the config comment.

The F14 8/9 shape recurred with a sharper tell: not an unregistered name invented, but a registered name from the wrong registry - the same class as the campaign's neighbouring-production imports, one shelf up.
