### PR TITLE
The grammars can name their section now, and nine were filed under th…

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -2404,13 +2404,13 @@ pub fn media_type_subtype_suffix(subtype: &str) -> Option<&str> {
 // Both callers (Timing-Allow-Origin, Access-Control-Allow-Origin) take their value
 // grammar from Fetch, whose production supplants RFC 6454's. The two agree on the
 // shape checked here — an authority and nothing after it — so both are quoted.
-// cite(Fetch): "serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]"
-// cite(Fetch): "This supplants the definition in The Web Origin Concept"
+// cite(Fetch § 3.2): "serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]"
+// cite(Fetch § 3.2): "This supplants the definition in The Web Origin Concept"
 // cite(RFC 6454 § 7.1): "serialized-origin = scheme "://" host [ ":" port ]"
 // Where they differ, Fetch is the stricter of the two, which is the direction this
 // validator is deliberately permissive in: it accepts host shapes (IDNA, label
 // syntax) that Fetch's serialization would reject.
-// cite(Fetch): "The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways."
+// cite(Fetch § 3.2): "The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways."
 pub fn is_valid_serialized_origin(val: &str) -> bool {
     let s = val.trim();
     if s.is_empty() {
@@ -2470,7 +2470,7 @@ pub fn is_valid_serialized_origin(val: &str) -> bool {
     // digits that happens to reach a TCP port, it is declared to be an integer
     // of that width. `0` is one of them, so an origin naming it is a serialized
     // origin; the shared reader rejected it until this was read.
-    // cite(URL): "A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port."
+    // cite(URL § 4.1): "A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port."
     match port {
         Some(port) => crate::helpers::uri::port_number(port).is_some(),
         None => true,

--- a/lint-http-rules/src/rules/client_request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/client_request_origin_header_present_for_cors.rs
@@ -29,7 +29,7 @@ impl Rule for ClientRequestOriginHeaderPresentForCors {
         // If this looks like a CORS preflight (OPTIONS with Access-Control-Request-Method)
         // then Origin header MUST be present and syntactically valid. A preflight is an
         // `OPTIONS` — neither GET nor HEAD — so it falls in the sentence below twice over.
-        // cite(Fetch): "It is used for all HTTP fetches whose request’s response tainting is "cors", as well as those where request’s method is neither `GET` nor `HEAD`."
+        // cite(Fetch § 3.2): "It is used for all HTTP fetches whose request’s response tainting is "cors", as well as those where request’s method is neither `GET` nor `HEAD`."
         if req.method == "OPTIONS"
             && (headers.get("access-control-request-method").is_some()
                 || headers.get("access-control-request-headers").is_some())
@@ -66,7 +66,7 @@ impl Rule for ClientRequestOriginHeaderPresentForCors {
                     let target_authority = &target_origin[delimiter_pos + 3..];
                     if !target_authority.eq_ignore_ascii_case(host_authority) {
                         // they differ; require Origin header
-                        // cite(Fetch): "The `Origin` request header indicates where a fetch originates from."
+                        // cite(Fetch § 3.2): "The `Origin` request header indicates where a fetch originates from."
                         if crate::helpers::headers::get_header_str(headers, "origin").is_none() {
                             return Some(Violation {
                                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
@@ -84,8 +84,8 @@ impl Rule for MessageAccessControlAllowCredentialsWhenOrigin {
         // returns success on `*` for a request whose credentials mode is *not* "include",
         // and a credentialed request must instead match the byte-serialized origin — which
         // `*` is not. A server sending both is advertising a sharing it will never get.
-        // cite(Fetch): "If request’s credentials mode is not "include" and origin is `*`, then return success."
-        // cite(Fetch): "If credentials is `true`, then return success."
+        // cite(Fetch § 4.10): "If request’s credentials mode is not "include" and origin is `*`, then return success."
+        // cite(Fetch § 4.10): "If credentials is `true`, then return success."
         if acc_val.eq_ignore_ascii_case("true") && acao_has_star {
             return Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -37,7 +37,7 @@ impl Rule for MessageAccessControlAllowOriginValid {
 
         // Multiple header fields are not allowed for Access-Control-Allow-Origin: the
         // header carries one value — an echoed origin, `null`, or `*` — not a list.
-        // cite(Fetch): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
+        // cite(Fetch § 3.3.3): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
         if acao_count > 1 {
             return Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
+++ b/lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
@@ -95,9 +95,9 @@ impl Rule for MessageContentSecurityPolicyAndFrameOptionsConsistency {
         // disagree, one of them is a statement of intent that nothing enforces. That
         // precedence (and why only enforced CSP counts, so report-only is skipped above)
         // is §6.4.2.2's; the two purpose cites give each header's own scope.
-        // cite(CSP3): "the frame-ancestors directive overrides the ``X-Frame-Options`` header."
-        // cite(CSP3): "The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed."
-        // cite(HTML Speculative Loading): "The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable."
+        // cite(CSP3 § 6.4.2.2): "the frame-ancestors directive overrides the ``X-Frame-Options`` header."
+        // cite(CSP3 § 6.4.2): "The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed."
+        // cite(HTML Speculative Loading § 7.7): "The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable."
         let xfo_count = resp.headers.get_all("x-frame-options").iter().count();
         if xfo_count == 0 {
             return None;

--- a/lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
+++ b/lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
@@ -122,7 +122,7 @@ impl Rule for MessageCookieAttributeConsistency {
                         }
                     };
                     // Accept Strict, Lax, None (case-insensitive)
-                    // cite(draft-ietf-httpbis-rfc6265bis): "samesite-value = "Strict" / "Lax" / "None""
+                    // cite(draft-ietf-httpbis-rfc6265bis § 4.1.1): "samesite-value = "Strict" / "Lax" / "None""
                     let vnorm = v.trim().to_ascii_lowercase();
                     if vnorm != "strict" && vnorm != "lax" && vnorm != "none" {
                         return Some(Violation {
@@ -259,7 +259,7 @@ impl Rule for MessageCookieAttributeConsistency {
             // `SameSite=None` without `Secure` is not a cookie with a weaker policy — it is
             // a cookie the user agent throws away. That is why this is a violation and not
             // a suggestion.
-            // cite(draft-ietf-httpbis-rfc6265bis): "If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true."
+            // cite(draft-ietf-httpbis-rfc6265bis § 5.7): "If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true."
             if let Some(sv) = samesite_value {
                 if sv == "none" && !secure_present {
                     return Some(Violation {

--- a/lint-http-rules/src/rules/message_cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/message_cross_origin_embedder_policy_valid.rs
@@ -75,7 +75,7 @@ impl Rule for MessageCrossOriginEmbedderPolicyValid {
         // why: it is a *valid* value, and it is the one that turns the protection off. This
         // rule is stricter than the grammar by choice, which is a thing a linter may be —
         // as long as it says so, which is what this cite makes it do.
-        // cite(HTML): "An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners."
+        // cite(HTML § 7.1.4): "An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners."
         if val.eq_ignore_ascii_case("require-corp") || val.eq_ignore_ascii_case("credentialless") {
             return None;
         }

--- a/lint-http-rules/src/rules/message_cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/message_cross_origin_opener_policy_valid.rs
@@ -72,7 +72,7 @@ impl Rule for MessageCrossOriginOpenerPolicyValid {
         // token combined with a compatible COEP, never from a token of its own, so a response
         // literally carrying `same-origin-plus-COEP` *is* wrong. The header value is a single
         // structured-field item (token), which is also why the list check above applies.
-        // cite(HTML): "Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list."
+        // cite(HTML § 7.1.3.1): "Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list."
         if val.eq_ignore_ascii_case("same-origin")
             || val.eq_ignore_ascii_case("same-origin-allow-popups")
             || val.eq_ignore_ascii_case("noopener-allow-popups")

--- a/lint-http-rules/src/rules/message_cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/message_cross_origin_resource_policy_valid.rs
@@ -75,8 +75,8 @@ impl Rule for MessageCrossOriginResourcePolicyValid {
         // called `SAME-ORIGIN` valid; a user agent does not. It sets an unrecognized policy
         // to null and fetches the resource as if the header were never sent, so accepting
         // the miscased form told the operator a protection was on while it was off.
-        // cite(Fetch): "Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive"
-        // cite(Fetch): "If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null."
+        // cite(Fetch § 3.7): "Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive"
+        // cite(Fetch § 3.7): "If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null."
         if val == "same-site" || val == "same-origin" || val == "cross-origin" {
             return None;
         }

--- a/lint-http-rules/src/rules/message_link_header_validity.rs
+++ b/lint-http-rules/src/rules/message_link_header_validity.rs
@@ -806,9 +806,9 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), String> {
     // one, and HTML's own `must` about `as` is authoring conformance for a
     // `link` element rather than for a field.
     //
-    // cite(HTML Semantics): "To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase"
-    // cite(HTML Semantics): "Apply link options from parsed header attributes to options given attribs"
-    // cite(HTML Semantics): "If attribs["as"] does not exist, then return false."
+    // cite(HTML Semantics § 4.2.4.4): "To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase"
+    // cite(HTML Semantics § 4.2.4.4): "Apply link options from parsed header attributes to options given attribs"
+    // cite(HTML Semantics § 4.2.4.4): "If attribs["as"] does not exist, then return false."
     if is_response && preloads {
         let Some(as_value) = as_value else {
             return Err(format!(
@@ -826,9 +826,9 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), String> {
         // `crossorigin` and `fetchpriority` in as many words, and this step
         // says nothing of the kind — so `Font` is a string the set does not
         // hold.
-        // cite(HTML Semantics): "Let destination be the result of translating attribs["as"]."
-        // cite(HTML Semantics): "If destination is null, then return false."
-        // cite(HTML Semantics): "If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords"
+        // cite(HTML Semantics § 4.2.4.4): "Let destination be the result of translating attribs["as"]."
+        // cite(HTML Semantics § 4.2.4.4): "If destination is null, then return false."
+        // cite(HTML Semantics § 4.2.4.4): "If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords"
         if !PRELOAD_DESTINATIONS.contains(&as_value.as_str()) {
             return Err(format!(
                 "'{}' asks for a preload whose as='{}' names no preload destination (fetch, font, image, script, style, track, matched case-sensitively), so the HTML processing model for a response's Link headers stops before fetching anything",
@@ -851,8 +851,8 @@ fn validate_link_value(member: &str, is_response: bool) -> Result<(), String> {
 /// destination and is discarded all the same. `fetch` is in the set — it
 /// translates to the empty string one call later — which is why it is not the
 /// odd one out it looks like.
-// cite(HTML Links): "A preload destination is "fetch", "font", "image", "script", "style", or "track"."
-// cite(HTML Links): "If destination is not a preload destination, then return null."
+// cite(HTML Links § 4.6.8.20): "A preload destination is "fetch", "font", "image", "script", "style", or "track"."
+// cite(HTML Links § 4.6.8.20): "If destination is not a preload destination, then return null."
 const PRELOAD_DESTINATIONS: &[&str] = &["fetch", "font", "image", "script", "style", "track"];
 
 /// The `rel` requirement, written once for the two branches that reach it — a

--- a/lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
+++ b/lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
@@ -57,7 +57,7 @@ impl Rule for MessageOriginIsolatedHeaderValidity {
             };
 
         // Must not be a comma-separated list
-        // cite(HTML): "This header is a structured header whose value must be a boolean."
+        // cite(HTML § 7.1.2): "This header is a structured header whose value must be a boolean."
         if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
@@ -70,7 +70,7 @@ impl Rule for MessageOriginIsolatedHeaderValidity {
         // origin-keyed agent cluster. The spec *ignores* any other value; this
         // rule is deliberately stricter and reports it, since a non-`?1` value
         // (`?0`, `unsafe-none`, …) is almost always a server misconfiguration.
-        // cite(HTML): "values that are not the structured header boolean true value (i.e., `?1`) will be ignored."
+        // cite(HTML § 7.1.2): "values that are not the structured header boolean true value (i.e., `?1`) will be ignored."
         if val.eq("?1") {
             return None;
         }

--- a/lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
@@ -96,7 +96,7 @@ impl Rule for MessagePermissionsPolicyDirectivesValid {
             //
             // Either way the finding is that something the server wrote will
             // not be enforced, which is what the message says now.
-            // cite(Permissions Policy): "The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client."
+            // cite(Permissions Policy § 6.1): "The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client."
             if let Some(msg) = validate_permissions_policy(s) {
                 return Some(Violation {
                     rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
+++ b/lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -33,7 +33,7 @@ pub struct MessageRefreshHeaderSyntaxValid;
 /// here: the caller's input is isomorphic-decoded field octets, so every code
 /// point is U+0000 to U+00FF.
 fn is_url_code_point(c: char) -> bool {
-    // cite(URL): "The URL code points are ASCII alphanumeric, U+0021 (!), U+0024 ($), U+0026 (&), U+0027 ('), U+0028 LEFT PARENTHESIS, U+0029 RIGHT PARENTHESIS, U+002A (*), U+002B (+), U+002C (,), U+002D (-), U+002E (.), U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+003F (?), U+0040 (@), U+005F (_), U+007E (~), and code points in the range U+00A0 to U+10FFFD, inclusive, excluding surrogates and noncharacters."
+    // cite(URL § 4.3): "The URL code points are ASCII alphanumeric, U+0021 (!), U+0024 ($), U+0026 (&), U+0027 ('), U+0028 LEFT PARENTHESIS, U+0029 RIGHT PARENTHESIS, U+002A (*), U+002B (+), U+002C (,), U+002D (-), U+002E (.), U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+003F (?), U+0040 (@), U+005F (_), U+007E (~), and code points in the range U+00A0 to U+10FFFD, inclusive, excluding surrogates and noncharacters."
     c.is_ascii_alphanumeric()
         || matches!(
             c,
@@ -72,7 +72,7 @@ fn is_url_code_point(c: char) -> bool {
 fn find_invalid_url_unit(s: &str) -> Option<String> {
     for (i, c) in s.char_indices() {
         if c == '%' {
-            // cite(URL): "URL units are URL code points and percent-encoded bytes."
+            // cite(URL § 4.3): "URL units are URL code points and percent-encoded bytes."
             // A percent-encoded byte is `%` and exactly two hex digits, so a `%`
             // that does not open one is the code point itself, unescaped.
             let mut rest = s[i + 1..].chars();
@@ -86,13 +86,13 @@ fn find_invalid_url_unit(s: &str) -> Option<String> {
             }
             continue;
         }
-        // cite(URL): "An absolute-URL-with-fragment string must be an absolute-URL string, optionally followed by U+0023 (#) and a URL-fragment string."
-        // cite(URL): "A valid host string must be a valid domain string, a valid IPv4-address string, or: U+005B ([), followed by a valid IPv6-address string, followed by U+005D (])."
+        // cite(URL § 4.3): "An absolute-URL-with-fragment string must be an absolute-URL string, optionally followed by U+0023 (#) and a URL-fragment string."
+        // cite(URL § 3.4): "A valid host string must be a valid domain string, a valid IPv4-address string, or: U+005B ([), followed by a valid IPv6-address string, followed by U+005D (])."
         // `#`, `[` and `]` are named by the grammar as the delimiters they are.
         if is_url_code_point(c) || matches!(c, '#' | '[' | ']') {
             continue;
         }
-        // cite(URL): "A code point is found that is not a URL unit."
+        // cite(URL § 1.1): "A code point is found that is not a URL unit."
         return Some(format!("contains {c:?}, which is not a URL unit"));
     }
     None
@@ -105,7 +105,7 @@ fn find_invalid_url_unit(s: &str) -> Option<String> {
 /// sentence has to have somewhere to attach: a call to std carries no
 /// transcription, so there would be nothing for the cite to sit on.
 fn is_ascii_whitespace(c: char) -> bool {
-    // cite(Infra): "ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE."
+    // cite(Infra § 4.6): "ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE."
     matches!(c, '\t' | '\n' | '\u{C}' | '\r' | ' ')
 }
 
@@ -116,9 +116,9 @@ fn is_ascii_whitespace(c: char) -> bool {
 /// conformance requirement for the `meta` pragma, which § 7.8 makes this field's
 /// too — two forms, and everything else is a finding.
 fn refresh_value_error(s: &str) -> Option<String> {
-    // cite(HTML Semantics): "For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:"
-    // cite(HTML Semantics): "just a valid non-negative integer, or"
-    // cite(HTML Semantics): "a valid non-negative integer, followed by a U+003B SEMICOLON character (;), followed by one or more ASCII whitespace, followed by a substring that is an ASCII case-insensitive match for the string "URL", followed by a U+003D EQUALS SIGN character (=), followed by a valid URL string"
+    // cite(HTML Semantics § 4.2.5.3): "For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:"
+    // cite(HTML Semantics § 4.2.5.3): "just a valid non-negative integer, or"
+    // cite(HTML Semantics § 4.2.5.3): "a valid non-negative integer, followed by a U+003B SEMICOLON character (;), followed by one or more ASCII whitespace, followed by a substring that is an ASCII case-insensitive match for the string "URL", followed by a U+003D EQUALS SIGN character (=), followed by a valid URL string"
     // The sentence runs on into the quote clause, which is cited at the check
     // that enforces it below: the trailing `(")` leaves this fragment's
     // quotation marks unpaired, and the cite grammar has no escape for that.
@@ -132,7 +132,7 @@ fn refresh_value_error(s: &str) -> Option<String> {
         None => (s, None),
     };
 
-    // cite(HTML Common Microsyntaxes): "A string is a valid non-negative integer if it consists of one or more ASCII digits."
+    // cite(HTML Common Microsyntaxes § 2.3.4.2): "A string is a valid non-negative integer if it consists of one or more ASCII digits."
     // One or more ASCII digits and nothing else — no sign, no radix point. This
     // is why the check is not `parse::<u64>()`, which accepts a leading `+`.
     if time.is_empty() || !time.chars().all(|c| c.is_ascii_digit()) {
@@ -173,18 +173,18 @@ fn refresh_value_error(s: &str) -> Option<String> {
     if url.is_empty() {
         return Some("`URL=` carries no URL".into());
     }
-    // cite(HTML Semantics): "that does not start with a literal U+0027 APOSTROPHE (') or U+0022 QUOTATION MARK"
+    // cite(HTML Semantics § 4.2.5.3): "that does not start with a literal U+0027 APOSTROPHE (') or U+0022 QUOTATION MARK"
     // The rest of the second form's sentence, above. A quoted URL is not a
     // conforming value even though the processing model reads one, and the
     // reading is why: the closing quote and everything after it are discarded,
     // so a sender who quotes a URL loses whatever followed the second mark.
-    // cite(HTML Semantics): "If quote is not the empty string, and there is a code point in urlString equal to quote, then truncate urlString at that code point, so that it and all subsequent code points are removed."
+    // cite(HTML Semantics § 4.2.5.3): "If quote is not the empty string, and there is a code point in urlString equal to quote, then truncate urlString at that code point, so that it and all subsequent code points are removed."
     if url.starts_with('\'') || url.starts_with('"') {
         return Some(format!(
             "the URL {url:?} starts with a quote character, which the value may not do"
         ));
     }
-    // cite(URL): "A valid URL string must be either a relative-URL-with-fragment string or an absolute-URL-with-fragment string."
+    // cite(URL § 4.3): "A valid URL string must be either a relative-URL-with-fragment string or an absolute-URL-with-fragment string."
     // Relative is a conforming form, which is why nothing here asks for a
     // scheme: `1http://example/` names none and is an ordinary relative path,
     // not a malformed absolute URL.
@@ -197,7 +197,7 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
     }
 
     fn scope(&self) -> crate::rules::RuleScope {
-        // cite(HTML Speculative Loading): "The `Refresh` HTTP response header is the HTTP-equivalent to a meta element with an http-equiv attribute in the Refresh state."
+        // cite(HTML Speculative Loading § 7.8): "The `Refresh` HTTP response header is the HTTP-equivalent to a meta element with an http-equiv attribute in the Refresh state."
         crate::rules::RuleScope::Server
     }
 
@@ -216,8 +216,8 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
             return None;
         }
 
-        // cite(HTML Document Lifecycle): "We do not currently have a spec for how to handle multiple `Refresh` headers."
-        // cite(Fetch): "Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20"
+        // cite(HTML Document Lifecycle § 7.5.1): "We do not currently have a spec for how to handle multiple `Refresh` headers."
+        // cite(Fetch § 2.2.2): "Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20"
         // The processing model is handed one string, and that string is the
         // combination of every field line — so HTML's note is not about a choice
         // between the lines, it is about a value none of them carries. Nothing is
@@ -236,8 +236,8 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
         }
 
         let raw = lines.iter().next()?.as_bytes();
-        // cite(HTML Document Lifecycle): "Let value be the isomorphic decoding of the value of the header."
-        // cite(Infra): "To isomorphic decode a byte sequence input, return a string whose code point length is equal to input’s length and whose code points have the same values as the values of input’s bytes, in the same order."
+        // cite(HTML Document Lifecycle § 7.5.1): "Let value be the isomorphic decoding of the value of the header."
+        // cite(Infra § 4.5): "To isomorphic decode a byte sequence input, return a string whose code point length is equal to input’s length and whose code points have the same values as the values of input’s bytes, in the same order."
         // Not `to_str()`. Every octet becomes the code point of the same value,
         // so an `obs-text` byte reaches the check that owns it — `%xE9` is a URL
         // code point and `%x85` is not, and a UTF-8 decode cannot tell them
@@ -250,7 +250,7 @@ impl Rule for MessageRefreshHeaderSyntaxValid {
         // and belongs to the value.
         let value = decoded.trim_matches(|c| c == ' ' || c == '\t');
 
-        // cite(HTML Speculative Loading): "It takes the same value and works largely the same."
+        // cite(HTML Speculative Loading § 7.8): "It takes the same value and works largely the same."
         // The conformance requirement `refresh_value_error` implements is written
         // for the `meta` pragma's content attribute; this is the sentence that
         // makes it this field's requirement too.

--- a/lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
+++ b/lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
@@ -31,7 +31,7 @@ impl Rule for MessageSecFetchDestValueValid {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
-        // cite(Fetch Metadata): "HTTP request header exposes a request’s destination to a server"
+        // cite(Fetch Metadata § 2.1): "HTTP request header exposes a request’s destination to a server"
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-dest").iter().count();
         if count == 0 {
@@ -63,7 +63,7 @@ impl Rule for MessageSecFetchDestValueValid {
         };
 
         // An empty value cannot be a token.
-        // cite(Fetch Metadata): "It is a Structured Field whose value MUST be a token."
+        // cite(Fetch Metadata § 2.1): "It is a Structured Field whose value MUST be a token."
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
@@ -76,7 +76,7 @@ impl Rule for MessageSecFetchDestValueValid {
         // grammar, slightly looser than sf-token; the closed value match below is
         // what actually gates acceptance, so the difference only picks which
         // message a bad value gets.
-        // cite(Fetch Metadata): "It is a Structured Field whose value MUST be a token."
+        // cite(Fetch Metadata § 2.1): "It is a Structured Field whose value MUST be a token."
         if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
             return Some(Violation {
                 rule: self.id().into(),
@@ -94,12 +94,12 @@ impl Rule for MessageSecFetchDestValueValid {
         // why the spec tells servers to ignore unknown values; this rule lints the
         // *sender*, where an unknown value means a non-conforming (or non-browser)
         // origin of the header, so it flags instead.
-        // cite(Fetch Metadata): "In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value."
-        // cite(Fetch Metadata): "Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch]."
-        // cite(Fetch): "A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt"."
+        // cite(Fetch Metadata § 2.1): "In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value."
+        // cite(Fetch Metadata § 2.1): "Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch]."
+        // cite(Fetch § 2.2.5): "A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt"."
         // Fetch's "the empty string" destination is carried as the literal token
         // `empty`, which is why the arm below accepts it.
-        // cite(Fetch Metadata): "If r’s destination is the empty string, set header’s value to the string "empty""
+        // cite(Fetch Metadata § 2.1): "If r’s destination is the empty string, set header’s value to the string "empty""
         match val {
             "empty" | "audio" | "audioworklet" | "document" | "embed" | "font" | "frame"
             | "iframe" | "image" | "json" | "manifest" | "object" | "paintworklet" | "report"

--- a/lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
+++ b/lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
@@ -28,7 +28,7 @@ impl Rule for MessageSecFetchModeValueValid {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
-        // cite(Fetch Metadata): "HTTP request header exposes a request’s mode to a server"
+        // cite(Fetch Metadata § 2.2): "HTTP request header exposes a request’s mode to a server"
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-mode").iter().count();
         if count == 0 {
@@ -60,7 +60,7 @@ impl Rule for MessageSecFetchModeValueValid {
         };
 
         // An empty value cannot be a token.
-        // cite(Fetch Metadata): "It is a Structured Field whose value MUST be a token."
+        // cite(Fetch Metadata § 2.1): "It is a Structured Field whose value MUST be a token."
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
@@ -73,7 +73,7 @@ impl Rule for MessageSecFetchModeValueValid {
         // grammar, slightly looser than sf-token; the closed value match below is
         // what actually gates acceptance, so the difference only picks which
         // message a bad value gets.
-        // cite(Fetch Metadata): "It is a Structured Field whose value MUST be a token."
+        // cite(Fetch Metadata § 2.1): "It is a Structured Field whose value MUST be a token."
         if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
             return Some(Violation {
                 rule: self.id().into(),
@@ -88,8 +88,8 @@ impl Rule for MessageSecFetchModeValueValid {
         // The spec tells servers to ignore unknown values for forward compatibility;
         // this rule lints the sender, where an unknown value means a non-conforming
         // (or non-browser) origin of the header, so it flags instead.
-        // cite(Fetch Metadata): "In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value."
-        // cite(Fetch Metadata): "Valid Sec-Fetch-Mode values include "cors", "navigate", "no-cors", "same-origin", and "websocket"."
+        // cite(Fetch Metadata § 2.1): "In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value."
+        // cite(Fetch Metadata § 2.2): "Valid Sec-Fetch-Mode values include "cors", "navigate", "no-cors", "same-origin", and "websocket"."
         match val {
             "cors" | "no-cors" | "same-origin" | "navigate" | "websocket" => None,
             _ => Some(Violation {

--- a/lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
+++ b/lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
@@ -28,7 +28,7 @@ impl Rule for MessageSecFetchSiteValueValid {
     ) -> Option<Violation> {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
-        // cite(Fetch Metadata): "HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin"
+        // cite(Fetch Metadata § 2.3): "HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin"
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-site").iter().count();
         if count == 0 {
@@ -61,7 +61,7 @@ impl Rule for MessageSecFetchSiteValueValid {
 
         // An empty value cannot be a token (§2.3 words it without the MUST its
         // sibling sections carry, but the constraint is the same).
-        // cite(Fetch Metadata): "It is a Structured Field whose value is a token."
+        // cite(Fetch Metadata § 2.3): "It is a Structured Field whose value is a token."
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
@@ -74,7 +74,7 @@ impl Rule for MessageSecFetchSiteValueValid {
         // grammar, slightly looser than sf-token; the closed value match below is
         // what actually gates acceptance, so the difference only picks which
         // message a bad value gets.
-        // cite(Fetch Metadata): "It is a Structured Field whose value is a token."
+        // cite(Fetch Metadata § 2.3): "It is a Structured Field whose value is a token."
         if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
             return Some(Violation {
                 rule: self.id().into(),
@@ -89,8 +89,8 @@ impl Rule for MessageSecFetchSiteValueValid {
         // The spec tells servers to ignore unknown values for forward compatibility;
         // this rule lints the sender, where an unknown value means a non-conforming
         // (or non-browser) origin of the header, so it flags instead.
-        // cite(Fetch Metadata): "In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value."
-        // cite(Fetch Metadata): "Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none"."
+        // cite(Fetch Metadata § 2.1): "In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value."
+        // cite(Fetch Metadata § 2.3): "Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none"."
         match val {
             "cross-site" | "same-origin" | "same-site" | "none" => None,
             _ => Some(Violation {

--- a/lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
+++ b/lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
@@ -28,7 +28,7 @@ impl Rule for MessageSecFetchUserValueValid {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // A request header; absence is the normal case (it rides only user-activated
         // navigations).
-        // cite(Fetch Metadata): "HTTP request header exposes whether or not a navigation request was triggered by user activation."
+        // cite(Fetch Metadata § 2.4): "HTTP request header exposes whether or not a navigation request was triggered by user activation."
         let headers = &tx.request.headers;
         let count = headers.get_all("sec-fetch-user").iter().count();
         if count == 0 {
@@ -60,7 +60,7 @@ impl Rule for MessageSecFetchUserValueValid {
         };
 
         // An empty value cannot be an sf-boolean.
-        // cite(Fetch Metadata): "It is a Structured Field whose value is a boolean."
+        // cite(Fetch Metadata § 2.4): "It is a Structured Field whose value is a boolean."
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+++ b/lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
@@ -25,7 +25,7 @@ impl Rule for MessageTimingAllowOriginValidity {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The header is server-sent: it rides responses, so only the response side is
         // inspected.
-        // cite(Resource Timing): "Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions."
+        // cite(Resource Timing § 3.5.2): "Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions."
         let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
@@ -38,8 +38,8 @@ impl Rule for MessageTimingAllowOriginValidity {
         // Combine members across multiple header fields; list_members handles commas & whitespace.
         // Several header fields are explicitly allowed, so this rule checks the members,
         // not the field count — unlike Access-Control-Allow-Origin, which carries one value.
-        // cite(Resource Timing): "The sender MAY generate multiple Timing-Allow-Origin header fields."
-        // cite(Resource Timing): "The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma."
+        // cite(Resource Timing § 3.5.2): "The sender MAY generate multiple Timing-Allow-Origin header fields."
+        // cite(Resource Timing § 3.5.2): "The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma."
         for hv in headers.get_all("timing-allow-origin").iter() {
             // cite(RFC 9110 § 5.5): "newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB"
             let s =
@@ -68,7 +68,7 @@ impl Rule for MessageTimingAllowOriginValidity {
             // Detect empty list members caused by consecutive commas or leading empty
             // members. The header's ABNF uses RFC 9110's list construct, so its
             // empty-element rules apply.
-            // cite(Resource Timing): "The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):"
+            // cite(Resource Timing § 3.5.2): "The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):"
             let parts: Vec<&str> = s.split(',').collect();
             for (i, raw_member) in parts.iter().enumerate() {
                 if raw_member.trim().is_empty() {
@@ -91,7 +91,7 @@ impl Rule for MessageTimingAllowOriginValidity {
                 // `wildcard` and the case-sensitive lowercase `null` are the two
                 // non-origin members the grammar admits (both productions resolve
                 // into Fetch).
-                // cite(Fetch): "origin-or-null = serialized-origin / %s"null" ; case-sensitive"
+                // cite(Fetch § 3.2): "origin-or-null = serialized-origin / %s"null" ; case-sensitive"
                 if m == "*" || m == "null" {
                     continue;
                 }

--- a/lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
@@ -59,7 +59,7 @@ impl Rule for SemanticOriginMatchingForCors {
         }
 
         // Multiple header fields are not permitted; treat as violation early
-        // cite(Fetch): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
+        // cite(Fetch § 3.3.3): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
         if acao_values.len() > 1 {
             return Some(Violation {
                 rule: self.id().into(),
@@ -88,7 +88,7 @@ impl Rule for SemanticOriginMatchingForCors {
         // circuits on `*` *only* for a request that does not carry credentials; a
         // credentialed one falls through to the byte-serialized comparison below, which
         // `*` can never satisfy.
-        // cite(Fetch): "If request’s credentials mode is not "include" and origin is `*`, then return success."
+        // cite(Fetch § 4.10): "If request’s credentials mode is not "include" and origin is `*`, then return success."
         if acao_val == "*" {
             if let Some(cred) = crate::helpers::headers::get_header_str(
                 &resp.headers,
@@ -108,7 +108,7 @@ impl Rule for SemanticOriginMatchingForCors {
         // For any other value, it must match the request's Origin header byte-for-byte.
         // Byte-serializing an opaque origin yields the lowercase literal `null`, so no
         // case normalisation is applied on either side.
-        // cite(Fetch): "If the result of byte-serializing a request origin with request is not origin, then return failure."
+        // cite(Fetch § 4.10): "If the result of byte-serializing a request origin with request is not origin, then return failure."
         if acao_val != origin {
             return Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/server_clear_site_data.rs
+++ b/lint-http-rules/src/rules/server_clear_site_data.rs
@@ -126,7 +126,7 @@ impl Rule for ServerClearSiteData {
         // cite(Clear-Site-Data): "A user signs out of Super Secret Social Network via a CSRF-protected POST to https://supersecretsocialnetwork.example.com/logout, and the site author wishes to ensure that locally stored data is removed as a result"
         // What the specification supplies is what the header is for, and the reason a
         // sign-out that omits it leaves the session's data behind.
-        // cite(Clear-Site-Data): "The Clear-Site-Data HTTP response header field sends a signal to the user agent that it ought to remove all data of a certain set of types."
+        // cite(Clear-Site-Data § 3.1): "The Clear-Site-Data HTTP response header field sends a signal to the user agent that it ought to remove all data of a certain set of types."
         if is_logout_path && !resp.headers.contains_key("clear-site-data") {
             Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/server_content_security_policy_validity.rs
+++ b/lint-http-rules/src/rules/server_content_security_policy_validity.rs
@@ -78,7 +78,7 @@ impl Rule for ServerContentSecurityPolicyValidity {
                 // A CSP directive-name is narrower than the HTTP `token`: only
                 // letters, digits and `-`. Enforcing `token` here let typos like
                 // `default_src` (underscore is a legal tchar) pass unflagged.
-                // cite(CSP3): "directive-name = 1*( ALPHA / DIGIT / "-" )"
+                // cite(CSP3 § 2.3): "directive-name = 1*( ALPHA / DIGIT / "-" )"
                 if let Some(c) = name
                     .chars()
                     .find(|c| !(c.is_ascii_alphanumeric() || *c == '-'))

--- a/lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_server_timing_header_syntax.rs
@@ -332,7 +332,7 @@ fn check_field_value(value: &str) -> Option<String> {
         return None;
     }
 
-    // cite(Server Timing, label: Server-Timing grammar): "Server-Timing = #server-timing-metric"
+    // cite(Server Timing § 2, label: Server-Timing grammar): "Server-Timing = #server-timing-metric"
     // cite(Server Timing § 2): "See [RFC7230] for definitions of #, *, OWS, token, and quoted-string."
     // The empty-preserving walk, because the empty member *is* the finding below
     // -- and the `OWS` trim in it is `trim_ows` rather than `str::trim`, because
@@ -361,8 +361,8 @@ fn check_field_value(value: &str) -> Option<String> {
 }
 
 /// One `server-timing-metric`.
-// cite(Server Timing, label: server-timing-metric grammar): "server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )"
-// cite(Server Timing, label: metric-name grammar): "*( OWS ";" OWS server-timing-param ) metric-name = token"
+// cite(Server Timing § 2, label: server-timing-metric grammar): "server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )"
+// cite(Server Timing § 2, label: metric-name grammar): "*( OWS ";" OWS server-timing-param ) metric-name = token"
 fn check_metric(metric: &str) -> Option<String> {
     // Quote-aware, and the segments come back `OWS`-trimmed: the semicolon
     // splitter trims where the comma splitter does not. A bare `split(';')`
@@ -434,8 +434,8 @@ fn check_metric(metric: &str) -> Option<String> {
 /// `message_keep_alive_header_validity::validate_param_value`'s list of five and
 /// added one, and the list had not been extended when Alt-Svc's audit wrote the
 /// sixth. **A copy count quoted from a neighbour is a copy count one short.**
-// cite(Server Timing, label: server-timing-param grammar): "server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value"
-// cite(Server Timing, label: server-timing-param-name grammar): "server-timing-param-name = token"
+// cite(Server Timing § 2, label: server-timing-param grammar): "server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value"
+// cite(Server Timing § 2, label: server-timing-param-name grammar): "server-timing-param-name = token"
 fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Option<String> {
     // The repetition is `*( OWS ";" OWS server-timing-param )`: every semicolon
     // it generates owes a parameter behind it, so a trailing `;` and a `; ;`
@@ -539,7 +539,7 @@ fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Opt
     // rule that decided it by omission would be one capture format away from
     // being wrong.
     //
-    // cite(Server Timing, label: server-timing-param-value grammar): "server-timing-param-value = token / quoted-string"
+    // cite(Server Timing § 2, label: server-timing-param-value grammar): "server-timing-param-value = token / quoted-string"
     let text = match token_or_quoted_string(value) {
         Ok(content) => content,
         // Neither alternative derives the empty string: `token = 1*tchar`, and

--- a/lint-http-rules/src/rules/server_x_content_type_options.rs
+++ b/lint-http-rules/src/rules/server_x_content_type_options.rs
@@ -91,8 +91,8 @@ impl Rule for ServerXContentTypeOptions {
         // first list element case-insensitively, so anything else means sniffing
         // stays on while the sender believes otherwise. A conforming extra element
         // after a valid first one is tolerated (the processing model ignores it).
-        // cite(Fetch): "X-Content-Type-Options = "nosniff" ; case-insensitive"
-        // cite(Fetch): "If values[0] is an ASCII case-insensitive match for "nosniff", then return true."
+        // cite(Fetch § 3.6): "X-Content-Type-Options = "nosniff" ; case-insensitive"
+        // cite(Fetch § 3.6): "If values[0] is an ASCII case-insensitive match for "nosniff", then return true."
         if let Some(xcto) =
             crate::helpers::headers::get_header_str(&resp.headers, "x-content-type-options")
         {
@@ -118,13 +118,13 @@ impl Rule for ServerXContentTypeOptions {
             });
 
         if let Some(content_type) = content_type_header {
-            // cite(Fetch): "The `X-Content-Type-Options` response header can be used to require checking of a response’s `Content-Type` header against the destination of a request."
+            // cite(Fetch § 3.6): "The `X-Content-Type-Options` response header can be used to require checking of a response’s `Content-Type` header against the destination of a request."
             // The 2xx gate is the rule's own tolerance (no sentence scopes the header
             // to successful responses). The configured content-type list stands in for
             // the request destination, which a proxy cannot know: the spec only blocks
             // for script-like and style destinations, so the config names the types a
             // deployment serves to those destinations.
-            // cite(Fetch): "Only request destinations that are script-like or "style" are considered as any exploits pertain to them."
+            // cite(Fetch § 3.6.1): "Only request destinations that are script-like or "style" are considered as any exploits pertain to them."
             if (200..300).contains(&resp.status)
                 && config.content_types.contains(&content_type)
                 && !resp.headers.contains_key("x-content-type-options")

--- a/lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
@@ -25,8 +25,8 @@ impl Rule for ServerXFrameOptionsValueValid {
         let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // It is a response header, so only the response side is inspected. RFC 7034
         // originally defined it; the HTML Standard's §7.7 definition governs now.
-        // cite(HTML Speculative Loading): "It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document."
-        // cite(HTML Speculative Loading): "HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable"
+        // cite(HTML Speculative Loading § 7.7): "It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document."
+        // cite(HTML Speculative Loading § 7.7): "HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable"
         let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
@@ -62,8 +62,8 @@ impl Rule for ServerXFrameOptionsValueValid {
 
         // The two conforming values; the match is case-insensitive because the
         // processing model lowercases each value before comparing.
-        // cite(HTML Speculative Loading): "X-Frame-Options = "DENY" / "SAMEORIGIN""
-        // cite(HTML Speculative Loading): "For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions."
+        // cite(HTML Speculative Loading § 7.7): "X-Frame-Options = "DENY" / "SAMEORIGIN""
+        // cite(HTML Speculative Loading § 7.7): "For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions."
         if val.eq_ignore_ascii_case("DENY") || val.eq_ignore_ascii_case("SAMEORIGIN") {
             return None;
         }
@@ -73,7 +73,7 @@ impl Rule for ServerXFrameOptionsValueValid {
         // it as an unrecognized value, leaving the resource unprotected while the
         // sender believes otherwise. Flag it with a targeted message rather than
         // the generic unsupported-value one.
-        // cite(HTML Speculative Loading): "In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented."
+        // cite(HTML Speculative Loading § 7.7): "In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented."
         if val.len() >= 10 && val[..10].eq_ignore_ascii_case("ALLOW-FROM") {
             return Some(Violation {
                 rule: self.id().into(),

--- a/lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
+++ b/lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
@@ -122,7 +122,7 @@ impl Rule for StatefulCookieSameSiteEnforcement {
                     // same paragraph as the Strict/Lax cites gives it a default
                     // enforcement equivalent to Lax, which is why this rule holds
                     // such cookies to the Lax cross-site rule below.
-                    // cite(draft-ietf-httpbis-rfc6265bis): "If the "SameSite" attribute's value is something other than these three known keywords, the attribute's value will be subject to a default enforcement mode that is equivalent to "Lax"."
+                    // cite(draft-ietf-httpbis-rfc6265bis § 4.1.2.7): "If the "SameSite" attribute's value is something other than these three known keywords, the attribute's value will be subject to a default enforcement mode that is equivalent to "Lax"."
                     crate::helpers::cookie::SameSite::Unspecified => {
                         crate::helpers::cookie::SameSite::Lax
                     }
@@ -130,7 +130,7 @@ impl Rule for StatefulCookieSameSiteEnforcement {
 
                 if is_cross {
                     match effective {
-                        // cite(draft-ietf-httpbis-rfc6265bis): "If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests."
+                        // cite(draft-ietf-httpbis-rfc6265bis § 4.1.2.7): "If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests."
                         crate::helpers::cookie::SameSite::Strict => {
                             return Some(Violation {
                                 rule: self.id().into(),
@@ -144,7 +144,7 @@ impl Rule for StatefulCookieSameSiteEnforcement {
                         // `allow_lax` is the carve-out named in the second half of this
                         // sentence: a top-level navigation is where a Lax cookie legitimately
                         // crosses sites, which is why this arm only fires when it is not one.
-                        // cite(draft-ietf-httpbis-rfc6265bis): "If the value is "Lax", the cookie will be sent with same-site requests, and with "cross-site" top-level navigations, as described in Section 5.6.7.1."
+                        // cite(draft-ietf-httpbis-rfc6265bis § 4.1.2.7): "If the value is "Lax", the cookie will be sent with same-site requests, and with "cross-site" top-level navigations, as described in Section 5.6.7.1."
                         crate::helpers::cookie::SameSite::Lax if !allow_lax => {
                             return Some(Violation {
                                 rule: self.id().into(),

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4,36 +4,43 @@ sources:
   type: text/html
   fragments:
   - label: client_request_origin_header_present_for_cors
+    section: § 3.2
     snippet: It is used for all HTTP fetches whose request’s response tainting is "cors", as well as those where request’s method is neither `GET` nor `HEAD`.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_origin_header_present_for_cors.rs
       line: 32
   - label: client_request_origin_header_present_for_cors (2)
+    section: § 3.2
     snippet: The `Origin` request header indicates where a fetch originates from.
     cited_by:
     - file: lint-http-rules/src/rules/client_request_origin_header_present_for_cors.rs
       line: 69
   - label: lint-http-rules/src/helpers/headers.rs
+    section: § 3.2
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2413
   - label: lint-http-rules/src/helpers/headers.rs (2)
+    section: § 3.2
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2408
   - label: lint-http-rules/src/helpers/headers.rs (3)
+    section: § 3.2
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2407
   - label: message_access_control_allow_credentials_when_origin
+    section: § 4.10
     snippet: If credentials is `true`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
       line: 88
   - label: message_access_control_allow_credentials_when_origin (2)
+    section: § 4.10
     snippet: If request’s credentials mode is not "include" and origin is `*`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/message_access_control_allow_credentials_when_origin.rs
@@ -41,6 +48,7 @@ sources:
     - file: lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
       line: 91
   - label: message_access_control_allow_origin_valid
+    section: § 3.3.3
     snippet: Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response.
     cited_by:
     - file: lint-http-rules/src/rules/message_access_control_allow_origin_valid.rs
@@ -48,75 +56,89 @@ sources:
     - file: lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
       line: 62
   - label: message_cross_origin_resource_policy_valid
+    section: § 3.7
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/message_cross_origin_resource_policy_valid.rs
       line: 78
   - label: message_cross_origin_resource_policy_valid (2)
+    section: § 3.7
     snippet: If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null.
     cited_by:
     - file: lint-http-rules/src/rules/message_cross_origin_resource_policy_valid.rs
       line: 79
   - label: message_refresh_header_syntax_valid
+    section: § 2.2.2
     snippet: Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 220
   - label: message_sec_fetch_dest_value_valid
+    section: § 2.2.5
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
       line: 99
   - label: message_timing_allow_origin_validity
+    section: § 3.2
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
       line: 94
   - label: semantic_origin_matching_for_cors
+    section: § 4.10
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
     - file: lint-http-rules/src/rules/semantic_origin_matching_for_cors.rs
       line: 111
   - label: server_x_content_type_options
+    section: § 3.6
     snippet: If values[0] is an ASCII case-insensitive match for "nosniff", then return true.
     cited_by:
     - file: lint-http-rules/src/rules/server_x_content_type_options.rs
       line: 95
   - label: server_x_content_type_options (2)
-    snippet: Only request destinations that are script-like or "style" are considered as any exploits pertain to them.
-    cited_by:
-    - file: lint-http-rules/src/rules/server_x_content_type_options.rs
-      line: 127
-  - label: server_x_content_type_options (3)
+    section: § 3.6
     snippet: The `X-Content-Type-Options` response header can be used to require checking of a response’s `Content-Type` header against the destination of a request.
     cited_by:
     - file: lint-http-rules/src/rules/server_x_content_type_options.rs
       line: 121
-  - label: server_x_content_type_options (4)
+  - label: server_x_content_type_options (3)
+    section: § 3.6
     snippet: X-Content-Type-Options = "nosniff" ; case-insensitive
     cited_by:
     - file: lint-http-rules/src/rules/server_x_content_type_options.rs
       line: 94
+  - label: server_x_content_type_options (4)
+    section: § 3.6.1
+    snippet: Only request destinations that are script-like or "style" are considered as any exploits pertain to them.
+    cited_by:
+    - file: lint-http-rules/src/rules/server_x_content_type_options.rs
+      line: 127
 - label: HTML
   url: https://html.spec.whatwg.org/multipage/browsers.html
   type: text/html
   fragments:
   - label: message_cross_origin_embedder_policy_valid
+    section: § 7.1.4
     snippet: An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners.
     cited_by:
     - file: lint-http-rules/src/rules/message_cross_origin_embedder_policy_valid.rs
       line: 78
   - label: message_cross_origin_opener_policy_valid
+    section: § 7.1.3.1
     snippet: Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
     cited_by:
     - file: lint-http-rules/src/rules/message_cross_origin_opener_policy_valid.rs
       line: 75
   - label: message_origin_isolated_header_validity
+    section: § 7.1.2
     snippet: This header is a structured header whose value must be a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
       line: 60
   - label: message_origin_isolated_header_validity (2)
+    section: § 7.1.2
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/message_origin_isolated_header_validity.rs
@@ -126,11 +148,13 @@ sources:
   type: text/html
   fragments:
   - label: message_link_header_validity
+    section: § 4.6.8.20
     snippet: A preload destination is "fetch", "font", "image", "script", "style", or "track".
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 854
   - label: message_link_header_validity (2)
+    section: § 4.6.8.20
     snippet: If destination is not a preload destination, then return null.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
@@ -140,41 +164,49 @@ sources:
   type: text/html
   fragments:
   - label: message_content_security_policy_and_frame_options_consistency
+    section: § 7.7
     snippet: The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
       line: 100
   - label: message_refresh_header_syntax_valid
+    section: § 7.8
     snippet: It takes the same value and works largely the same.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 253
   - label: message_refresh_header_syntax_valid (2)
+    section: § 7.8
     snippet: The `Refresh` HTTP response header is the HTTP-equivalent to a meta element with an http-equiv attribute in the Refresh state.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 200
   - label: server_x_frame_options_value_valid
+    section: § 7.7
     snippet: For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
     cited_by:
     - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
       line: 66
   - label: server_x_frame_options_value_valid (2)
+    section: § 7.7
     snippet: HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable
     cited_by:
     - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
       line: 29
   - label: server_x_frame_options_value_valid (3)
+    section: § 7.7
     snippet: In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented.
     cited_by:
     - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
       line: 76
   - label: server_x_frame_options_value_valid (4)
+    section: § 7.7
     snippet: It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document.
     cited_by:
     - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
       line: 28
   - label: server_x_frame_options_value_valid (5)
+    section: § 7.7
     snippet: X-Frame-Options = "DENY" / "SAMEORIGIN"
     cited_by:
     - file: lint-http-rules/src/rules/server_x_frame_options_value_valid.rs
@@ -184,56 +216,67 @@ sources:
   type: text/html
   fragments:
   - label: message_link_header_validity
+    section: § 4.2.4.4
     snippet: Apply link options from parsed header attributes to options given attribs
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 810
   - label: message_link_header_validity (2)
+    section: § 4.2.4.4
     snippet: If attribs["as"] does not exist, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 811
   - label: message_link_header_validity (3)
+    section: § 4.2.4.4
     snippet: If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 831
   - label: message_link_header_validity (4)
+    section: § 4.2.4.4
     snippet: If destination is null, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 830
   - label: message_link_header_validity (5)
+    section: § 4.2.4.4
     snippet: Let destination be the result of translating attribs["as"].
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 829
   - label: message_link_header_validity (6)
+    section: § 4.2.4.4
     snippet: To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase
     cited_by:
     - file: lint-http-rules/src/rules/message_link_header_validity.rs
       line: 809
   - label: message_refresh_header_syntax_valid
+    section: § 4.2.5.3
     snippet: 'For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:'
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 119
   - label: message_refresh_header_syntax_valid (2)
+    section: § 4.2.5.3
     snippet: If quote is not the empty string, and there is a code point in urlString equal to quote, then truncate urlString at that code point, so that it and all subsequent code points are removed.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 181
   - label: message_refresh_header_syntax_valid (3)
+    section: § 4.2.5.3
     snippet: a valid non-negative integer, followed by a U+003B SEMICOLON character (;), followed by one or more ASCII whitespace, followed by a substring that is an ASCII case-insensitive match for the string "URL", followed by a U+003D EQUALS SIGN character (=), followed by a valid URL string
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 121
   - label: message_refresh_header_syntax_valid (4)
+    section: § 4.2.5.3
     snippet: just a valid non-negative integer, or
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 120
   - label: message_refresh_header_syntax_valid (5)
+    section: § 4.2.5.3
     snippet: that does not start with a literal U+0027 APOSTROPHE (') or U+0022 QUOTATION MARK
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -243,6 +286,7 @@ sources:
   type: text/html
   fragments:
   - label: message_refresh_header_syntax_valid
+    section: § 2.3.4.2
     snippet: A string is a valid non-negative integer if it consists of one or more ASCII digits.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -276,11 +320,13 @@ sources:
   type: text/html
   fragments:
   - label: message_refresh_header_syntax_valid
+    section: § 7.5.1
     snippet: Let value be the isomorphic decoding of the value of the header.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 239
   - label: message_refresh_header_syntax_valid (2)
+    section: § 7.5.1
     snippet: We do not currently have a spec for how to handle multiple `Refresh` headers.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -290,36 +336,43 @@ sources:
   type: text/html
   fragments:
   - label: lint-http-rules/src/helpers/headers.rs
+    section: § 4.1
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2473
   - label: message_refresh_header_syntax_valid
+    section: § 1.1
     snippet: A code point is found that is not a URL unit.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 95
   - label: message_refresh_header_syntax_valid (2)
-    snippet: A valid URL string must be either a relative-URL-with-fragment string or an absolute-URL-with-fragment string.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
-      line: 187
-  - label: message_refresh_header_syntax_valid (3)
+    section: § 3.4
     snippet: 'A valid host string must be a valid domain string, a valid IPv4-address string, or: U+005B ([), followed by a valid IPv6-address string, followed by U+005D (]).'
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 90
+  - label: message_refresh_header_syntax_valid (3)
+    section: § 4.3
+    snippet: A valid URL string must be either a relative-URL-with-fragment string or an absolute-URL-with-fragment string.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
+      line: 187
   - label: message_refresh_header_syntax_valid (4)
+    section: § 4.3
     snippet: An absolute-URL-with-fragment string must be an absolute-URL string, optionally followed by U+0023 (#) and a URL-fragment string.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 89
   - label: message_refresh_header_syntax_valid (5)
+    section: § 4.3
     snippet: The URL code points are ASCII alphanumeric, U+0021 (!), U+0024 ($), U+0026 (&), U+0027 ('), U+0028 LEFT PARENTHESIS, U+0029 RIGHT PARENTHESIS, U+002A (*), U+002B (+), U+002C (,), U+002D (-), U+002E (.), U+002F (/), U+003A (:), U+003B (;), U+003D (=), U+003F (?), U+0040 (@), U+005F (_), U+007E (~), and code points in the range U+00A0 to U+10FFFD, inclusive, excluding surrogates and noncharacters.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 36
   - label: message_refresh_header_syntax_valid (6)
+    section: § 4.3
     snippet: URL units are URL code points and percent-encoded bytes.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
@@ -329,30 +382,35 @@ sources:
   type: text/html
   fragments:
   - label: message_refresh_header_syntax_valid
-    snippet: ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
-      line: 108
-  - label: message_refresh_header_syntax_valid (2)
+    section: § 4.5
     snippet: To isomorphic decode a byte sequence input, return a string whose code point length is equal to input’s length and whose code points have the same values as the values of input’s bytes, in the same order.
     cited_by:
     - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
       line: 240
+  - label: message_refresh_header_syntax_valid (2)
+    section: § 4.6
+    snippet: ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_refresh_header_syntax_valid.rs
+      line: 108
 - label: CSP3
   url: https://www.w3.org/TR/CSP3/
   type: text/html
   fragments:
   - label: message_content_security_policy_and_frame_options_consistency
+    section: § 6.4.2
     snippet: The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
       line: 99
   - label: message_content_security_policy_and_frame_options_consistency (2)
+    section: § 6.4.2.2
     snippet: the frame-ancestors directive overrides the ``X-Frame-Options`` header.
     cited_by:
     - file: lint-http-rules/src/rules/message_content_security_policy_and_frame_options_consistency.rs
       line: 98
   - label: server_content_security_policy_validity
+    section: § 2.3
     snippet: directive-name = 1*( ALPHA / DIGIT / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/server_content_security_policy_validity.rs
@@ -367,6 +425,7 @@ sources:
     - file: lint-http-rules/src/rules/server_clear_site_data.rs
       line: 126
   - label: server_clear_site_data (2)
+    section: § 3.1
     snippet: The Clear-Site-Data HTTP response header field sends a signal to the user agent that it ought to remove all data of a certain set of types.
     cited_by:
     - file: lint-http-rules/src/rules/server_clear_site_data.rs
@@ -376,16 +435,19 @@ sources:
   type: text/html
   fragments:
   - label: message_sec_fetch_dest_value_valid
+    section: § 2.1
     snippet: HTTP request header exposes a request’s destination to a server
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
       line: 34
   - label: message_sec_fetch_dest_value_valid (2)
+    section: § 2.1
     snippet: If r’s destination is the empty string, set header’s value to the string "empty"
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
       line: 102
   - label: message_sec_fetch_dest_value_valid (3)
+    section: § 2.1
     snippet: In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value.
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
@@ -395,6 +457,7 @@ sources:
     - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
       line: 92
   - label: message_sec_fetch_dest_value_valid (4)
+    section: § 2.1
     snippet: It is a Structured Field whose value MUST be a token.
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
@@ -406,26 +469,31 @@ sources:
     - file: lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
       line: 76
   - label: message_sec_fetch_dest_value_valid (5)
+    section: § 2.1
     snippet: Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch].
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_dest_value_valid.rs
       line: 98
   - label: message_sec_fetch_mode_value_valid
+    section: § 2.2
     snippet: HTTP request header exposes a request’s mode to a server
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
       line: 31
   - label: message_sec_fetch_mode_value_valid (2)
+    section: § 2.2
     snippet: Valid Sec-Fetch-Mode values include "cors", "navigate", "no-cors", "same-origin", and "websocket".
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_mode_value_valid.rs
       line: 92
   - label: message_sec_fetch_site_value_valid
+    section: § 2.3
     snippet: HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
       line: 31
   - label: message_sec_fetch_site_value_valid (2)
+    section: § 2.3
     snippet: It is a Structured Field whose value is a token.
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
@@ -433,88 +501,71 @@ sources:
     - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
       line: 77
   - label: message_sec_fetch_site_value_valid (3)
+    section: § 2.3
     snippet: Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none".
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_site_value_valid.rs
       line: 93
   - label: message_sec_fetch_user_value_valid
-    snippet: HTTP request header exposes whether or not a navigation request was triggered by user activation.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
-      line: 31
-  - label: message_sec_fetch_user_value_valid (2)
-    snippet: It is a Structured Field whose value is a boolean.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
-      line: 63
-  - label: message_sec_fetch_user_value_valid (3)
     snippet: 'Sec-Fetch-User = sf-boolean Note: The header is delivered only for navigation requests, and only when its value is true.'
     cited_by:
     - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
       line: 75
+  - label: message_sec_fetch_user_value_valid (2)
+    section: § 2.4
+    snippet: HTTP request header exposes whether or not a navigation request was triggered by user activation.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
+      line: 31
+  - label: message_sec_fetch_user_value_valid (3)
+    section: § 2.4
+    snippet: It is a Structured Field whose value is a boolean.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_sec_fetch_user_value_valid.rs
+      line: 63
 - label: Resource Timing
   url: https://www.w3.org/TR/resource-timing/
   type: text/html
   fragments:
   - label: message_timing_allow_origin_validity
-    snippet: Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
-      line: 28
-  - label: message_timing_allow_origin_validity (2)
-    snippet: 'The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):'
-    cited_by:
-    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
-      line: 71
-  - label: message_timing_allow_origin_validity (3)
-    snippet: The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
-      line: 42
-  - label: message_timing_allow_origin_validity (4)
-    snippet: The sender MAY generate multiple Timing-Allow-Origin header fields.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
-      line: 41
-  - label: message_timing_allow_origin_validity (5)
     snippet: Timing-Allow-Origin = 1#( origin-or-null / wildcard )
     cited_by:
     - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
       line: 59
+  - label: message_timing_allow_origin_validity (2)
+    section: § 3.5.2
+    snippet: Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+      line: 28
+  - label: message_timing_allow_origin_validity (3)
+    section: § 3.5.2
+    snippet: 'The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):'
+    cited_by:
+    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+      line: 71
+  - label: message_timing_allow_origin_validity (4)
+    section: § 3.5.2
+    snippet: The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+      line: 42
+  - label: message_timing_allow_origin_validity (5)
+    section: § 3.5.2
+    snippet: The sender MAY generate multiple Timing-Allow-Origin header fields.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_timing_allow_origin_validity.rs
+      line: 41
 - label: Server Timing
   url: https://www.w3.org/TR/server-timing/
   type: text/html
   fragments:
   - label: metric-name grammar
+    section: § 2
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 365
-  - label: Server-Timing grammar
-    snippet: 'Server-Timing = #server-timing-metric'
-    cited_by:
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 335
-  - label: server-timing-metric grammar
-    snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
-    cited_by:
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 364
-  - label: server-timing-param grammar
-    snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
-    cited_by:
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 437
-  - label: server-timing-param-name grammar
-    snippet: server-timing-param-name = token
-    cited_by:
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 438
-  - label: server-timing-param-value grammar
-    snippet: server-timing-param-value = token / quoted-string
-    cited_by:
-    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
-      line: 542
   - label: server_server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
@@ -539,6 +590,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 336
+  - label: Server-Timing grammar
+    section: § 2
+    snippet: 'Server-Timing = #server-timing-metric'
+    cited_by:
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 335
   - label: server_server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
@@ -563,6 +620,30 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
       line: 512
+  - label: server-timing-metric grammar
+    section: § 2
+    snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
+    cited_by:
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 364
+  - label: server-timing-param grammar
+    section: § 2
+    snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
+    cited_by:
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 437
+  - label: server-timing-param-name grammar
+    section: § 2
+    snippet: server-timing-param-name = token
+    cited_by:
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 438
+  - label: server-timing-param-value grammar
+    section: § 2
+    snippet: server-timing-param-value = token / quoted-string
+    cited_by:
+    - file: lint-http-rules/src/rules/server_server_timing_header_syntax.rs
+      line: 542
   - label: server_server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
@@ -586,17 +667,12 @@ sources:
   type: text/html
   fragments:
   - label: message_permissions_policy_directives_valid
-    snippet: The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
-      line: 99
-  - label: message_permissions_policy_directives_valid (2)
     section: § 5.2
     snippet: Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present.
     cited_by:
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 331
-  - label: message_permissions_policy_directives_valid (3)
+  - label: message_permissions_policy_directives_valid (2)
     section: § 5.2
     snippet: Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps.
     cited_by:
@@ -604,43 +680,54 @@ sources:
       line: 95
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 315
-  - label: message_permissions_policy_directives_valid (4)
+  - label: message_permissions_policy_directives_valid (3)
     section: § 5.2
     snippet: The Member Names must be Tokens.
     cited_by:
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 423
-  - label: message_permissions_policy_directives_valid (5)
+  - label: message_permissions_policy_directives_valid (4)
     section: § 5.2
     snippet: 'The Member Values represent allowlists, and must be one of:'
     cited_by:
     - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
       line: 314
+  - label: message_permissions_policy_directives_valid (5)
+    section: § 6.1
+    snippet: The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_permissions_policy_directives_valid.rs
+      line: 99
 - label: draft-ietf-httpbis-rfc6265bis
   url: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis
   type: text/html
   fragments:
   - label: message_cookie_attribute_consistency
-    snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
-    cited_by:
-    - file: lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
-      line: 262
-  - label: message_cookie_attribute_consistency (2)
+    section: § 4.1.1
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
       line: 125
+  - label: message_cookie_attribute_consistency (2)
+    section: § 5.7
+    snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
+    cited_by:
+    - file: lint-http-rules/src/rules/message_cookie_attribute_consistency.rs
+      line: 262
   - label: stateful_cookie_same_site_enforcement
+    section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
       line: 133
   - label: stateful_cookie_same_site_enforcement (2)
+    section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is something other than these three known keywords, the attribute's value will be subject to a default enforcement mode that is equivalent to "Lax".
     cited_by:
     - file: lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs
       line: 125
   - label: stateful_cookie_same_site_enforcement (3)
+    section: § 4.1.2.7
     snippet: If the value is "Lax", the cookie will be sent with same-site requests, and with "cross-site" top-level navigations, as described in Section 5.6.7.1.
     cited_by:
     - file: lint-http-rules/src/rules/stateful_cookie_same_site_enforcement.rs


### PR DESCRIPTION
…e heading above them

apysource 0.8.1 is installed (0.7.0 before), so the hazard these cites were written around is gone: a snippet inside a `<pre>` was unreachable under a `§ N` cite and reachable only document-scoped, which is why every ABNF production on a non-RFC source carried the bare source name.

Re-measured rather than taken from the note -- `locate_section` over all 90 document-scoped cites on HTML sources under 0.7.0 and under 0.8.1, and diffed. Twelve gained a section, nine changed, none were lost. **All twelve that gained one are ABNF productions**: `serialized-origin`, `origin-or-null`, `Cross-Origin-Resource-Policy`, `X-Content-Type-Options`, `directive-name`, `samesite-value`, and the six Server-Timing grammar rules. That is the bug's own shape, read back off the corpus.

The nine that changed are prose, and 0.7.0's answer for them was wrong rather than absent -- it filed each under the heading that preceded an unclosed `<p>`. The `Refresh` field's five sentences move from "4.2.4 The link element" to "4.2.5.3 Pragma directives", its HTTP-header pair from "7.7 The `X-Frame-Options` header" to "7.8 The `Refresh` header", and the two preload cites from "4.6.1 Introduction" to "4.6.8.20 Link type `preload`".

Sectioning stops where the document stops. Eleven cites keep the bare source name: three whose snippet no section can be proved to contain, and eight on MDN, whose pages have no numbered sections at all -- `locate_section` answers those with a title selector (`lit-node 1Directives`), and writing that after a `§` would be a label no reader could follow.

The store is unchanged at 1542 fragments and 1531 of them now carry a section, up from 1444. `apycite verify` is the check that matters here and it is 1542/1542: extraction is section-scoped, so a wrong section fails it -- which is exactly how the original hazard announced itself.
