### PR TITLE
The H3 client binds a socket that can reach both families, and the or…

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -49,8 +49,11 @@ captures_include_body = false
 # discovered endpoint is still only used once its cert validates for the origin
 # authority. Set false to route H3 solely from h3_upstream_authorities. Default: true.
 # h3_upstream_trust_alt_svc = true
-# UDP bind address for the H3 upstream client. Default: "0.0.0.0:0".
-# h3_upstream_bind = "0.0.0.0:0"
+# UDP bind address for the H3 upstream client. Default: "[::]:0" -- the IPv6
+# wildcard, which quinn makes dual-stack (it clears only_v6 and v4-maps an IPv4
+# peer), so both families are reachable. Setting this to an IPv4 address makes
+# origins that resolve to IPv6 unreachable over H3; they fall back to H1/H2.
+# h3_upstream_bind = "[::]:0"
 # Extra CA PEM files to trust for origin H3 endpoint certificates (private CAs),
 # in addition to the platform trust store.
 # h3_upstream_extra_ca_certs = ["/etc/lint-http/origin-ca.pem"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,7 +142,7 @@ h3_upstream_enabled = false                       # Master switch. Default: fals
 h3_upstream_authorities = ["origin.example:443"]  # Origins always tried over H3 (pre-seeds discovery)
 h3_upstream_denylist = ["legacy.example:443"]     # Origins that must never use H3
 h3_upstream_trust_alt_svc = true                  # Learn H3 endpoints from origin Alt-Svc headers. Default: true
-h3_upstream_bind = "0.0.0.0:0"                    # UDP bind address for the H3 client. Default: "0.0.0.0:0"
+h3_upstream_bind = "[::]:0"                       # UDP bind address for the H3 client. Default: "[::]:0" (dual-stack)
 h3_upstream_extra_ca_certs = []                   # Extra CA PEM files to trust for origin H3 endpoint certs
 h3_upstream_connect_timeout_ms = 5000             # Connect + QUIC handshake budget. Default: 5000
 h3_upstream_response_timeout_ms = 30000           # Response-head (first byte) budget. Default: 30000
@@ -155,7 +155,7 @@ h3_upstream_pool_max = 256                        # Max pooled H3 connections (o
 - **h3_upstream_authorities**: Origin authorities (`host:port`) always attempted over HTTP/3. This pre-seeds selection — the *first* request to an origin cannot have learned `Alt-Svc` yet, so without an allowlist entry HTTP/3 is inherently second-connection-onward. The port is optional and defaults to `443`, and matching is case-insensitive, so `example.com` and `example.com:443` are equivalent.
 - **h3_upstream_denylist**: Origin authorities that must **never** use HTTP/3, overriding both the allowlist and `Alt-Svc` discovery. Same `host[:port]` normalization as the allowlist.
 - **h3_upstream_trust_alt_svc**: When `true` (default), an origin's `Alt-Svc: h3=...` response header adds an HTTP/3 route for that origin at runtime (honoring `ma`/`clear`). A discovered endpoint is only *used* once its certificate validates **for the origin authority** (RFC 7838 §2.1 / RFC 9114 §3.3) — a mismatched cert fails the handshake and the proxy falls back. Set `false` to route HTTP/3 solely from `h3_upstream_authorities`.
-- **h3_upstream_bind**: The local UDP socket the HTTP/3 client binds. Default `"0.0.0.0:0"` (any interface, ephemeral port).
+- **h3_upstream_bind**: The local UDP socket the HTTP/3 client binds. Default `"[::]:0"` — the IPv6 wildcard on an ephemeral port, which quinn makes dual-stack (it clears `only_v6` and maps an IPv4 peer to a v4-mapped address), so origins of either family are reachable. Pinning this to an IPv4 address makes IPv6-only origins unreachable over HTTP/3 — they fall back to HTTP/1.1/HTTP/2. Hosts without IPv6 fall back to the IPv4 wildcard automatically.
 - **h3_upstream_extra_ca_certs**: Extra CA PEM files (private CAs) to trust when validating origin HTTP/3 endpoint certificates, layered on top of the system roots. Useful for an internal origin under test.
 - **h3_upstream_connect_timeout_ms**: How long to wait for the QUIC connect + handshake before treating the attempt as failed and falling back to HTTP/1.1/HTTP/2 (default: 5000).
 - **h3_upstream_response_timeout_ms**: How long to wait for the origin's **response head** (first byte) once the request has been sent (default: 30000). This is origin think-time, bounded separately from — and far more generously than — the connect timeout so a slow-but-healthy origin is not dropped. An idempotent, bodyless request that hits this timeout is retried on HTTP/1.1/HTTP/2 (RFC 9110 §9.2.2); anything else returns `502`.

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -27,7 +27,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::poll_fn;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
 use std::task::{Context, Poll};
@@ -229,14 +229,33 @@ impl H3UpstreamClient {
         ));
         client_config.transport_config(Arc::new(transport));
 
-        let bind: SocketAddr = cfg
-            .general
-            .h3_upstream_bind
-            .as_deref()
-            .unwrap_or("0.0.0.0:0")
-            .parse()
-            .map_err(|e| anyhow::anyhow!("h3_upstream_bind: {e}"))?;
-        let mut endpoint = quinn::Endpoint::client(bind)?;
+        // The default binds the IPv6 wildcard, not the IPv4 one, because quinn
+        // makes a v6 endpoint dual-stack on purpose: it clears `only_v6` on the
+        // socket, and maps an IPv4 peer to a v4-mapped address before dialing.
+        // A v4 endpoint has no such reverse path -- it *rejects* a v6 peer
+        // outright -- so binding v4 silently loses every origin whose first
+        // resolved address is AAAA, which on a dual-stack host is most of the
+        // ones worth speaking H3 to.
+        //
+        // A host with IPv6 compiled out cannot bind `[::]` at all, so that case
+        // falls back to the v4 wildcard and `lookup_endpoint` then filters the
+        // resolved addresses to what this endpoint can actually reach.
+        let mut endpoint = match cfg.general.h3_upstream_bind.as_deref() {
+            Some(configured) => {
+                let bind: SocketAddr = configured
+                    .parse()
+                    .map_err(|e| anyhow::anyhow!("h3_upstream_bind: {e}"))?;
+                quinn::Endpoint::client(bind)?
+            }
+            None => match quinn::Endpoint::client(SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))) {
+                Ok(ep) => ep,
+                Err(e) => {
+                    warn!(error = %e, "h3 upstream: no IPv6 socket; binding IPv4 only, \
+                          IPv6-only origins will not be reachable over H3");
+                    quinn::Endpoint::client(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))?
+                }
+            },
+        };
         endpoint.set_default_client_config(client_config);
 
         // Canonicalize the configured authorities so an operator's intent matches
@@ -408,7 +427,12 @@ impl H3UpstreamClient {
     /// `server_quic_transport_parameters` activation would need a different
     /// source than this path.
     async fn connect(&self, route: &H3Route, shared: &Arc<Shared>) -> anyhow::Result<PooledConn> {
-        let addr = lookup_endpoint(&route.dial_host, route.dial_port).await?;
+        let local_is_ipv6 = self
+            .endpoint
+            .local_addr()
+            .map(|a| a.is_ipv6())
+            .unwrap_or(false);
+        let addr = lookup_endpoint(&route.dial_host, route.dial_port, local_is_ipv6).await?;
         let connection_id = crate::connection::ConnectionMetadata::new_quic(addr).id;
 
         let weak = Arc::downgrade(shared);
@@ -738,12 +762,47 @@ fn pre_request(error: anyhow::Error, request: Request<ClientBody>) -> H3Failure 
     }
 }
 
-/// Resolve `host:port` to a socket address for dialing the QUIC endpoint.
-async fn lookup_endpoint(host: &str, port: u16) -> anyhow::Result<SocketAddr> {
-    tokio::net::lookup_host((host, port))
-        .await?
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("h3 upstream: could not resolve {host}:{port}"))
+/// Resolve `host:port` to a socket address this endpoint can actually dial.
+///
+/// `local_is_ipv6` is the family of the bound QUIC endpoint. A v6 endpoint is
+/// dual-stack (quinn clears `only_v6` and v4-maps the peer), so it can reach
+/// every resolved address and the first one wins. A v4 endpoint cannot reach a
+/// v6 peer at all -- quinn rejects it with `InvalidRemoteAddress` -- so the v6
+/// results are skipped rather than dialed and failed.
+///
+/// Taking the first address unconditionally is what made the whole H3 upstream
+/// leg unusable on a dual-stack host: resolution routinely returns AAAA first,
+/// and every such origin fell back to H1/H2 with only a warning to show for it.
+fn select_endpoint_addr<I>(
+    addrs: I,
+    local_is_ipv6: bool,
+    host: &str,
+    port: u16,
+) -> anyhow::Result<SocketAddr>
+where
+    I: IntoIterator<Item = SocketAddr>,
+{
+    let mut saw_unreachable = false;
+    for addr in addrs {
+        if local_is_ipv6 || addr.is_ipv4() {
+            return Ok(addr);
+        }
+        saw_unreachable = true;
+    }
+    if saw_unreachable {
+        anyhow::bail!(
+            "h3 upstream: {host}:{port} resolves only to IPv6 addresses, \
+             which the IPv4 h3_upstream_bind cannot reach"
+        );
+    }
+    anyhow::bail!("h3 upstream: could not resolve {host}:{port}")
+}
+
+/// Resolve `host:port` to a socket address for dialing the QUIC endpoint,
+/// filtered to what `local_is_ipv6` can reach (see [`select_endpoint_addr`]).
+async fn lookup_endpoint(host: &str, port: u16, local_is_ipv6: bool) -> anyhow::Result<SocketAddr> {
+    let addrs = tokio::net::lookup_host((host, port)).await?;
+    select_endpoint_addr(addrs, local_is_ipv6, host, port)
 }
 
 /// Split an `host[:port]` authority into its bracket-stripped host and port,
@@ -994,6 +1053,101 @@ mod tests {
         H3UpstreamClient::build(&cfg, &roots)
             .expect("build h3 client")
             .expect("h3 client is Some when enabled")
+    }
+
+    const V4: SocketAddr =
+        SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443);
+    const V6: SocketAddr = SocketAddr::new(
+        std::net::IpAddr::V6(Ipv6Addr::new(0x2606, 0x4700, 0, 0, 0, 0, 0x6810, 0x7c60)),
+        443,
+    );
+
+    /// The regression this whole family-awareness exists for: resolution puts an
+    /// AAAA first for most H3-capable origins, and the dual-stack endpoint must
+    /// dial it rather than skip past it.
+    #[test]
+    fn ipv6_endpoint_dials_an_ipv6_first_result() {
+        let got = select_endpoint_addr([V6, V4], true, "origin.example", 443)
+            .expect("dual-stack endpoint reaches a v6 origin");
+        assert_eq!(got, V6);
+    }
+
+    #[test]
+    fn ipv6_endpoint_also_dials_ipv4_only_origins() {
+        let got = select_endpoint_addr([V4], true, "origin.example", 443)
+            .expect("quinn v4-maps an IPv4 peer on a dual-stack endpoint");
+        assert_eq!(got, V4);
+    }
+
+    /// A v4 endpoint cannot reach a v6 peer -- quinn rejects it outright -- so
+    /// the v6 result is skipped instead of dialed and failed.
+    #[test]
+    fn ipv4_endpoint_skips_ipv6_results() {
+        let got = select_endpoint_addr([V6, V4], false, "origin.example", 443)
+            .expect("v4 endpoint falls through to the A record");
+        assert_eq!(got, V4);
+    }
+
+    /// And when skipping leaves nothing, the error names the real cause rather
+    /// than surfacing quinn's opaque "invalid remote address".
+    #[test]
+    fn ipv4_endpoint_reports_an_ipv6_only_origin_clearly() {
+        let err = select_endpoint_addr([V6], false, "origin.example", 443)
+            .expect_err("v4 endpoint cannot reach a v6-only origin");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("resolves only to IPv6"),
+            "error should name the address-family mismatch, got: {msg}"
+        );
+        assert!(
+            msg.contains("origin.example"),
+            "error should name the origin"
+        );
+    }
+
+    #[test]
+    fn empty_resolution_is_distinct_from_a_family_mismatch() {
+        let err =
+            select_endpoint_addr([], false, "origin.example", 443).expect_err("nothing resolved");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("could not resolve"),
+            "empty resolution keeps its own message, got: {msg}"
+        );
+    }
+
+    /// The default bind must be the IPv6 wildcard: quinn makes a v6 endpoint
+    /// dual-stack, while a v4 one rejects every v6 peer. Binding v4 by default
+    /// is what made the upstream leg unusable on a dual-stack host.
+    #[tokio::test]
+    async fn default_bind_is_dual_stack() {
+        let client = test_client(30);
+        let local = client
+            .endpoint
+            .local_addr()
+            .expect("client endpoint is bound");
+        assert!(
+            local.is_ipv6(),
+            "default h3_upstream_bind should be the IPv6 wildcard, got {local}"
+        );
+    }
+
+    /// An explicit bind is still honoured verbatim, so an operator can pin the
+    /// leg to a v4 source address.
+    #[tokio::test]
+    async fn configured_bind_is_honoured() {
+        let mut cfg = Config::default();
+        cfg.general.h3_upstream_enabled = true;
+        cfg.general.h3_upstream_bind = Some("127.0.0.1:0".to_string());
+        let roots = rustls::RootCertStore::empty();
+        let client = H3UpstreamClient::build(&cfg, &roots)
+            .expect("build h3 client")
+            .expect("h3 client is Some when enabled");
+        let local = client.endpoint.local_addr().expect("bound");
+        assert!(
+            local.is_ipv4(),
+            "configured v4 bind should win, got {local}"
+        );
     }
 
     #[tokio::test]

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -12,7 +12,7 @@
 //! field discipline (a connection-specific field is stripped before it reaches
 //! the origin).
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -411,6 +411,63 @@ async fn upstream_h3_connect_failure_falls_back_to_h1() -> anyhow::Result<()> {
 
     proxy_handle.abort();
     let _ = tokio::fs::remove_file(&captures_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn upstream_h3_reaches_an_ipv6_origin() -> anyhow::Result<()> {
+    // An origin reachable only over IPv6 is the ordinary case on the real web:
+    // resolution usually sorts AAAA first, so the address the leg dials is a v6
+    // one. A QUIC endpoint bound to the IPv4 wildcard *rejects* such a peer
+    // outright, and the leg then falls back to H1/H2 with only a warning — which
+    // made the whole H3 upstream path unusable on a dual-stack host. Binding the
+    // IPv6 wildcard by default is what fixes it, and this asserts the end-to-end
+    // consequence rather than the binding.
+    use rcgen::SanType;
+
+    let Ok(udp) = std::net::UdpSocket::bind("[::1]:0") else {
+        eprintln!("skipping: host has no IPv6 loopback");
+        return Ok(());
+    };
+
+    let pki = gen_test_pki_san(SanType::IpAddress(IpAddr::V6(Ipv6Addr::LOCALHOST)))?;
+    let ca_pem_path =
+        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
+
+    let (origin_addr, _captured, origin_task) = start_h3_origin(&pki, udp)?;
+    let authority = format!("[::1]:{}", origin_addr.port());
+
+    let mut cfg = Config::default();
+    cfg.general.h3_upstream_enabled = true;
+    cfg.general.h3_upstream_authorities = vec![authority.clone()];
+    cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
+    cfg.general.h3_upstream_connect_timeout_ms = 3000;
+    // Left as None on purpose: this asserts the *default* bind is dual-stack.
+    assert!(cfg.general.h3_upstream_bind.is_none());
+
+    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let (status, headers, body) = proxy_get(proxy_addr, &authority, "/v6", &[]).await?;
+    assert_eq!(status, 200, "the v6 origin should be reached over H3");
+    assert_eq!(body, b"world");
+    assert!(
+        headers.iter().any(|(k, v)| k == "x-origin" && v == "h3"),
+        "the response should come from the H3 origin, not a fall-back"
+    );
+
+    let caps = read_captures(&captures_path).await?;
+    assert_eq!(
+        caps[0]["response"]["version"].as_str(),
+        Some("HTTP/3.0"),
+        "the capture must record the origin leg as H3; HTTP/1.1 here means the \
+         v6 peer was rejected and the request silently fell back"
+    );
+
+    proxy_handle.abort();
+    origin_task.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 


### PR DESCRIPTION
…igins answering on AAAA stop falling back

The upstream QUIC endpoint bound the IPv4 wildcard, and `lookup_endpoint` took the first address resolution returned without asking whether it was one this endpoint could dial. Resolution routinely puts an AAAA first, and quinn rejects an IPv6 peer on a v4 endpoint outright, so every such origin failed with `invalid remote address` and fell back to H1/H2 -- at `warn`, with a working response to show for it, which is why nothing noticed. On a dual-stack host that was most of the origins worth speaking H3 to at all, so the leg was effectively dead and the three control-stream rules behind it could not fire.

The default is now the IPv6 wildcard, which quinn makes dual-stack on purpose: it clears `only_v6` and maps an IPv4 peer to a v4-mapped address, so one socket reaches both. A host with no IPv6 falls back to the v4 wildcard and says so.

An explicitly configured bind is still honoured verbatim, so that case keeps a v4 endpoint that genuinely cannot reach a v6 peer. `select_endpoint_addr` skips the v6 results there instead of dialing one and failing, and when skipping leaves nothing it names the address-family mismatch rather than passing quinn's `invalid remote address` up to an operator who has no way to read it.

The end-to-end test runs an H3 origin on the IPv6 loopback against the default bind and asserts the capture records the origin leg as H3: an HTTP/1.1 there is exactly the silent fall-back this fixes. It skips itself on a host without IPv6 loopback rather than failing for the wrong reason.
