### PR TITLE
The media-type list learns what a browser asks for, and keeps reporti…

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -522,21 +522,30 @@ severity = "warn"
 # `application/octet-stream` is the type RFC 9110 § 8.3 names for content whose
 # type is unknown, so a default that rejects it rejects the specified fallback.
 #
-# The rest are the ordinary shapes of a request body and a non-JSON API. A
-# deployment whose clients are browsers needs the subresource types too --
-# text/css, text/javascript, font/woff2, application/wasm, image/svg+xml -- but
-# those are not added here, because this list is the one a deployment is
-# expected to narrow to what it actually serves.
+# The rest are the ordinary shapes of a request body, a non-JSON API, and the
+# subresources a browser fetches for any page it renders. The stylesheet, script
+# and font types are registered and are served by essentially every deployment
+# with a web front end, so leaving them out reported conformant traffic on any
+# corpus a browser produced -- the same defect as rejecting `message/http`, one
+# step further out.
+#
+# A deployment is still expected to narrow this to what it actually serves.
 allowed = [
   "text/plain",
   "text/html",
+  "text/css",
+  "text/javascript",
+  "application/javascript",
   "application/json",
   "application/xml",
+  "application/wasm",
   "application/octet-stream",
   "application/x-www-form-urlencoded",
   "multipart/byteranges",
   "multipart/form-data",
   "message/http",
+  "font/woff",
+  "font/woff2",
   "image/*",
   "+json",
 ]

--- a/docs/rules/message_content_type_iana_registered.md
+++ b/docs/rules/message_content_type_iana_registered.md
@@ -33,21 +33,30 @@ severity = "warn"
 # `application/octet-stream` is the type RFC 9110 § 8.3 names for content whose
 # type is unknown, so a default that rejects it rejects the specified fallback.
 #
-# The rest are the ordinary shapes of a request body and a non-JSON API. A
-# deployment whose clients are browsers needs the subresource types too --
-# text/css, text/javascript, font/woff2, application/wasm, image/svg+xml -- but
-# those are not added here, because this list is the one a deployment is
-# expected to narrow to what it actually serves.
+# The rest are the ordinary shapes of a request body, a non-JSON API, and the
+# subresources a browser fetches for any page it renders. The stylesheet, script
+# and font types are registered and are served by essentially every deployment
+# with a web front end, so leaving them out reported conformant traffic on any
+# corpus a browser produced -- the same defect as rejecting `message/http`, one
+# step further out.
+#
+# A deployment is still expected to narrow this to what it actually serves.
 allowed = [
   "text/plain",
   "text/html",
+  "text/css",
+  "text/javascript",
+  "application/javascript",
   "application/json",
   "application/xml",
+  "application/wasm",
   "application/octet-stream",
   "application/x-www-form-urlencoded",
   "multipart/byteranges",
   "multipart/form-data",
   "message/http",
+  "font/woff",
+  "font/woff2",
   "image/*",
   "+json",
 ]


### PR DESCRIPTION
…ng the two types nobody registered

Driving a real browser through the proxy produced the evidence the previous comment could only assert: over a 59-origin corpus the list rejected `text/javascript` 42 times, `text/css` 34, `application/javascript` 14, `font/woff2` 9 and `font/woff` 5. Those are registered types, and they arrive for any page a browser renders, so the default was reporting a deployment serving a stylesheet. That is the same defect as rejecting `message/http`, one step further out from the protocol, and the earlier reasoning for leaving them to the operator does not survive it -- a starting point that flags every CSS file is not one. `application/wasm` joins them on the same footing.

What stayed out is the part worth keeping: the same corpus rejected `application/binary` six times and `application/x-protobuf` five, and neither is registered. They are reported now for the reason the rule exists, without a hundred stylesheets around them to hide in.
