### PR TITLE
Nothing in the tree teaches the prefix any more, and the error that c…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,11 +23,11 @@ Actionable guidance for AI coding agents working in `lint-http` (TLS-terminating
 - Treat `.cargo/config.toml` as source of truth for lint/coverage aliases and thresholds.
 
 ## Rule implementation workflow (required)
-1. Add `src/rules/<client|server|message|semantic>_<name>.rs`.
-2. Implement `Rule` in `src/rules/mod.rs` style; set `scope()` (`Client`, `Server`, or `Both`).
-3. Register module and add rule to `RULES` in `src/rules/mod.rs`.
-4. If custom config is needed, override `validate_and_box` and fail fast on invalid config.
-5. Add docs in `docs/rules/<rule_id>.md` and link in `docs/rules.md`.
+1. Add `lint-http-rules/src/rules/<subject>_<predicate>.rs`. Ids carry **no** category prefix; see `docs/development.md` for the predicate vocabulary (`_syntax`, `_valid`, `_registered`, `_present`, `_consistent`, `_enforced`). The file stem, the `id()` literal, and the `PascalCase` struct name must be the same name.
+2. Implement `Rule` in `src/rules/mod.rs` style; set `scope()` (`Client`, `Server`, or `Both`). `scope()` is what places the rule in the generated index, so it is metadata and not a comment.
+3. Nothing to register: `build.rs` discovers the file and a `linkme::distributed_slice(REGISTERED_RULES)` static at the bottom of the file adds it to the catalogue.
+4. If custom config is needed, override `validate` and fail fast on invalid config.
+5. Put docs prose in `description()` / `specifications()` / `examples()` and run `cargo run -p lint-http-proxy -- gendocs`. `docs/rules/<rule_id>.md` and `docs/rules.md` are generated; editing them by hand fails `docs_match_generated`.
 6. Add example config in `config_example.toml` (tests assert rule/doc example coverage).
 7. Add tests with `src/test_helpers.rs` helpers (`enable_rule`, `enable_rule_with_paths`, `make_test_transaction_with_response`, `make_test_engine`).
 
@@ -36,7 +36,8 @@ Actionable guidance for AI coding agents working in `lint-http` (TLS-terminating
 - Rules are disabled by default; enabling requires `[rules.<id>] enabled = <bool>` and `severity = "info|warn|error"`.
 - Config validation happens before runtime in `Config::load_from_path` via `validate_rules`; missing `enabled`/`severity` is a startup error.
 - `RuleConfigEngine::get_cached` panics if an enabled rule wasn’t validated/cached; always rely on validated engine instances.
-- `config_example.toml` is canonical; keep it synchronized with `RULES`.
+- `config_example.toml` is canonical; every registered rule must have a `[rules.<id>]` section there, which `config_example_includes_all_rules` asserts.
+- Rule ids are breaking to change and are never aliased: `validate_rules` rejects an unknown `[rules.<id>]` at startup and points at `docs/rules.md`.
 - Prefer existing helpers/utilities (`src/test_helpers.rs`, `src/token.rs`) over custom parsing/fixture code.
 
 ## Integration points to understand before editing

--- a/config_example.toml
+++ b/config_example.toml
@@ -89,7 +89,6 @@ passthrough_domains = ["example.com"]
 suppress_headers = ["X-Sensitive-Header"]
 
 
-# Client Rules
 [rules.accept_encoding_present]
 enabled = true
 severity = "info"
@@ -126,7 +125,6 @@ severity = "info"
 enabled = true
 severity = "warn"
 
-# Server Rules
 [rules.cache_control_present]
 enabled = true
 severity = "warn"

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,11 +51,44 @@ Adding a new lint rule involves several steps.
 
 ### 1. Naming Convention
 
-Rules should be named using `snake_case` and prefixed with their category:
-- Client rules: `client_<name>`
-- Server rules: `server_<name>`
+Rule ids are `snake_case` and carry no category prefix. The file stem, the id
+returned by `id()`, and the `PascalCase` struct name are the same name in three
+spellings — `cache_control_present.rs`, `"cache_control_present"`,
+`CacheControlPresent` — and `build.rs` and the citation store both derive from
+the stem, so they must agree.
 
-Example: `cache_control_present`
+The shape is `<subject>[_<qualifier>]_<predicate>`: name the thing being read,
+then the property asserted about it.
+
+| Meaning | Ending | Example |
+| --- | --- | --- |
+| Conforms to the field's ABNF grammar | `_syntax` | `etag_syntax` |
+| Value acceptable beyond grammar (in range, well-formed, permitted) | `_valid` | `link_header_valid` |
+| Value appears in an IANA registry | `_registered` | `charset_registered` |
+| Field or value must be present | `_present` | `cache_control_present` |
+| Two things must agree | `_consistent` | `conditional_headers_consistent` |
+| A directive must be honoured | `_enforced` | `no_store_enforced` |
+
+`_syntax` and `_valid` are not alternatives to pick between: `_syntax` is
+conformance to the grammar, `_valid` is acceptability past it. A rule checking
+only the grammar takes `_syntax`, never `_syntax_valid`.
+
+Do not bolt a predicate onto an id that names a relation, an event, or a subject
+area rather than a claim — `status_3xx_vs_request_method`, `cookie_lifecycle`,
+`websocket_frame_rsv_bits`, `retry_after_date_or_delay` are correct as they
+stand.
+
+Include `_header` only where the subject is also a common noun and would read as
+one without it (`host_header`, `prefer_header_valid`); leave it out where the
+field name is already unmistakable (`etag_syntax`, `content_type_registered`).
+
+An id must be a valid Rust identifier, because `build.rs` emits `pub mod
+<stem>;`. A rule keyed on a status code therefore takes a `status_` subject
+rather than leading with the number: `status_426_upgrade_valid`.
+
+Renaming an existing rule is a breaking change for every configuration naming
+it, and this catalogue does not alias: `validate_rules` fails at startup on an
+id it does not recognise, pointing the operator at `docs/rules.md`.
 
 ### 2. Implementation
 
@@ -69,7 +102,7 @@ pub struct MyRule;
 
 impl Rule for MyRule {
     fn id(&self) -> &'static str {
-        "category_my_rule_name"
+        "my_rule_name"
     }
 
     fn check_transaction(&self, tx: &crate::http_transaction::HttpTransaction, previous: Option<&crate::http_transaction::HttpTransaction>, config: &crate::config::Config) -> Option<Violation> {
@@ -104,7 +137,18 @@ Being explicit prevents accidental evaluation on the wrong side and improves rea
 
 ### 3. Registration
 
-Register the new rule in `src/rules/mod.rs` by adding it to the `RULES` list.
+Nothing to edit. `build.rs` lists `src/rules/*.rs` and emits a `pub mod` for each
+stem, and the rule registers itself into the catalogue with a `linkme`
+distributed slice at the bottom of its own file:
+
+```rust
+#[linkme::distributed_slice(crate::rules::REGISTERED_RULES)]
+static REGISTRATION: &dyn crate::rules::Rule = &MyRule;
+```
+
+Use `REGISTERED_PROTOCOL_RULES` and `&dyn ProtocolRule` for a rule that reads
+protocol events rather than transactions. Creating the file is the whole of the
+registration.
 
 ### 4. Testing
 
@@ -114,12 +158,23 @@ You must include unit tests in your rule file covering:
 
 ### 5. Documentation
 
-Create a markdown file in `docs/rules/<rule_name>.md` explaining:
+`docs/rules/<rule_name>.md` and the `docs/rules.md` index are **generated** — do
+not write them by hand. Put the prose on the rule itself, in `description()`,
+`specifications()` and `examples()`, covering:
+
 - What the rule checks.
 - Why it is important (best practice justification).
 - Examples of compliant and non-compliant headers/behavior.
 
-Finally, add a link to your new rule in `docs/rules.md`.
+Then regenerate:
+
+```bash
+cargo run -p lint-http-proxy -- gendocs
+```
+
+The `docs_match_generated` test diffs the checked-in tree against freshly
+rendered output, so a rule whose metadata changed without a regeneration fails
+CI. The index places the rule by its `scope()`, so there is no link to add.
 
 ### 6. Configurable Rules Guidelines
 

--- a/docs/rules/upgrade_and_connection_consistent.md
+++ b/docs/rules/upgrade_and_connection_consistent.md
@@ -35,8 +35,6 @@ Scope: this rule reads header sections — a request's and a response's, each ag
 [rules.upgrade_and_connection_consistent]
 enabled = true
 severity = "warn"
-
-# Server Rules
 ```
 
 ## Examples

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -369,17 +369,22 @@ pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
     // section under an unknown name used to validate fine and configure
     // nothing — which is a rule the operator believes is on and is not. Both
     // ways of arriving here deserve the error: a typo, and a configuration
-    // that predates a rule rename (this catalogue has had three breaking
-    // renames, decided each time against silent aliasing).
+    // written against ids this catalogue no longer uses. Renames here are
+    // breaking by decision, never aliased, so this is the only place a
+    // configuration hears about one.
+    //
+    // The message names `docs/rules.md` rather than any particular old id. It
+    // used to carry the most recent rename as a worked example, which is a
+    // shape that only survives while renames arrive one at a time; every id in
+    // the catalogue was rewritten at once, and a hint listing 193 pairs is a
+    // document, not an error message.
     for rule_name in config.rules.keys() {
         let known = RULES.iter().any(|r| r.id() == rule_name)
             || PROTOCOL_RULES.iter().any(|r| r.id() == rule_name);
         if !known {
             return Err(anyhow::anyhow!(
-                "Configuration names a rule '{}' that does not exist. Rule ids are listed in \
-                 docs/rules.md; if this configuration predates a rename, update the id \
-                 (most recently, 'client_prefer_header_and_preference_applied' became \
-                 'prefer_header_and_preference_applied')",
+                "Configuration names a rule '{}' that does not exist. Every rule id is listed \
+                 in docs/rules.md",
                 rule_name
             ));
         }
@@ -966,27 +971,30 @@ severity = "warn"
         }
     }
 
-    /// A configured name matching no registered rule fails validation, and the
-    /// error points at the rename that most recently made an id stale. The
-    /// stale id used here is the real one: the rule whose prefix contradicted
-    /// its scope was renamed without an alias (RULECITES P39, the user's
-    /// call), and a deployment carrying the old section must hear about it at
-    /// startup rather than run with the rule silently unconfigured.
+    /// A configured name matching no registered rule fails validation, so a
+    /// deployment carrying a stale section hears about it at startup rather
+    /// than running with the rule silently unconfigured. Renames in this
+    /// catalogue are breaking by decision and never aliased, which is what
+    /// makes this the load-bearing check rather than a courtesy.
+    ///
+    /// Both ids below are invented. The test used to assert on a real id the
+    /// catalogue had just retired, and on the error naming its replacement —
+    /// which tied it to one rename and made it a record of catalogue history.
+    /// What is being tested is that an unregistered name fails, and a name that
+    /// never existed says that without dating the test.
     #[test]
     fn validate_rules_rejects_a_rule_id_that_does_not_exist() {
         let mut cfg = crate::config::Config::default();
-        enable_rule(&mut cfg, "client_prefer_header_and_preference_applied");
+        enable_rule(&mut cfg, "no_such_rule_was_ever_registered");
         let err = validate_rules(&cfg).expect_err("an unknown rule id must fail validation");
         let msg = err.to_string();
         assert!(msg.contains("does not exist"), "{msg}");
-        assert!(
-            msg.contains("'prefer_header_and_preference_applied'"),
-            "{msg}"
-        );
+        assert!(msg.contains("no_such_rule_was_ever_registered"), "{msg}");
+        assert!(msg.contains("docs/rules.md"), "{msg}");
 
-        // A typo is the same failure.
+        // A typo in a real id is the same failure.
         let mut cfg = crate::config::Config::default();
-        enable_rule(&mut cfg, "server_cache_control_presnet");
+        enable_rule(&mut cfg, "cache_control_presnet");
         assert!(validate_rules(&cfg).is_err());
     }
 


### PR DESCRIPTION
…arried one rename stops carrying any

The rename is done; this removes what still described the scheme it replaced.

`validate_rules` named the most recent rename inside its error string as a worked example. That shape only survives while renames arrive one at a time — every id in the catalogue moved at once, and a hint listing 193 pairs is a document. The error now names `docs/rules.md` and nothing else, and the comment above it drops the running count of breaking renames while keeping the decision it recorded: never aliased, so this check is the only place a stale configuration hears about one.

The test guarding that check asserted on a real id the catalogue had just retired, and on the error naming its replacement — a test that was a record of catalogue history and had to be rewritten by whoever next renamed anything. Both ids in it are invented now. What it tests is that an unregistered name fails, and a name that never existed says so without dating the test.

`docs/development.md`'s naming section listed two of the five prefixes and told authors to register a rule in a `RULES` list deleted some time ago; it now carries the predicate vocabulary, says why `_syntax` and `_valid` are not alternatives, says which ids should *not* take a predicate, and says that `build.rs` plus `linkme` make registration the act of creating the file. Its documentation step said to write `docs/rules/<id>.md` by hand, which `docs_match_generated` has been rejecting.

`config_example.toml` carried `# Client Rules` and `# Server Rules` headings over a list that interleaved all five categories from its second entry — untrue before this campaign and unmoored after it. `config_block_for` reads to the next `[`, so the second heading was also being rendered into `upgrade_and_connection_consistent`'s Configuration block, documenting a grouping that rule is not in.
