### PR TITLE
Add an xtask crate that owns the documentation generator

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,3 +12,7 @@ coverage = "tarpaulin --workspace --engine llvm --out Xml --skip-clean --fail-un
 # Run clippy with all features and targets across every workspace crate,
 # treating warnings as errors
 lint = "clippy --workspace --all-features --all-targets -- -D warnings"
+# Repository maintenance tasks (`cargo xtask gendocs`). The tasks live in their
+# own unpublished crate so the delivered binary carries none of them; `--package`
+# is explicit so the alias works from any subdirectory.
+xtask = "run --package xtask --"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ Actionable guidance for AI coding agents working in `lint-http` (TLS-terminating
 - Format: `cargo fmt`
 - Lint: `cargo lint` (alias for strict clippy with `-D warnings`)
 - Tests: `cargo test`
-- Coverage: `cargo coverage` (tarpaulin alias, currently `--fail-under 96` in `.cargo/config.toml`)
+- Coverage: `cargo coverage` (tarpaulin alias, currently `--fail-under 95` in `.cargo/config.toml`)
 - Treat `.cargo/config.toml` as source of truth for lint/coverage aliases and thresholds.
 
 ## Rule implementation workflow (required)
@@ -27,7 +27,7 @@ Actionable guidance for AI coding agents working in `lint-http` (TLS-terminating
 2. Implement `Rule` in `src/rules/mod.rs` style; set `scope()` (`Client`, `Server`, or `Both`). `scope()` is what places the rule in the generated index, so it is metadata and not a comment.
 3. Nothing to register: `build.rs` discovers the file and a `linkme::distributed_slice(REGISTERED_RULES)` static at the bottom of the file adds it to the catalogue.
 4. If custom config is needed, override `validate` and fail fast on invalid config.
-5. Put docs prose in `description()` / `specifications()` / `examples()` and run `cargo run -p lint-http-proxy -- gendocs`. `docs/rules/<rule_id>.md` and `docs/rules.md` are generated; editing them by hand fails `docs_match_generated`.
+5. Put docs prose in `description()` / `specifications()` / `examples()` and run `cargo xtask gendocs`. `docs/rules/<rule_id>.md` and `docs/rules.md` are generated; editing them by hand fails `docs_match_generated`.
 6. Add example config in `config_example.toml` (tests assert rule/doc example coverage).
 7. Add tests with `src/test_helpers.rs` helpers (`enable_rule`, `enable_rule_with_paths`, `make_test_transaction_with_response`, `make_test_engine`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "lint-http-rules",
+ "uuid",
+]
+
+[[package]]
 name = "yasna"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [workspace]
 resolver = "2"
-members = ["lint-http-core", "lint-http-rules", "lint-http-proxy"]
+members = ["lint-http-core", "lint-http-rules", "lint-http-proxy", "xtask"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The CI gates are mirrored locally with [`just`](https://just.systems). Run bare
 ```bash
 just check          # everything CI rejects a PR for: fmt, citations, lint, test
 just fmt            # format the whole tree, including the rule modules cargo fmt can't reach
+just gendocs        # regenerate docs/rules/ and docs/rules.md from rule metadata
 just install-hooks  # enable the pre-commit guard (fmt + citations, once per clone)
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -169,7 +169,7 @@ not write them by hand. Put the prose on the rule itself, in `description()`,
 Then regenerate:
 
 ```bash
-cargo run -p lint-http-proxy -- gendocs
+cargo xtask gendocs
 ```
 
 The `docs_match_generated` test diffs the checked-in tree against freshly

--- a/justfile
+++ b/justfile
@@ -42,6 +42,11 @@ citations:
     "$apy" extract --frozen
     "$apy" ratchet
 
+# Regenerate docs/rules/ and docs/rules.md from rule metadata — the fixer for the
+# `docs_match_generated` gate. Not part of `check`: it writes into the tree.
+gendocs:
+    cargo xtask gendocs
+
 # Third-party licensing + advisories (needs `reuse` and `cargo-deny` installed).
 supply-chain:
     reuse lint

--- a/lint-http-rules/src/gendocs.rs
+++ b/lint-http-rules/src/gendocs.rs
@@ -537,8 +537,7 @@ mod tests {
     /// #11d drift gate: the committed `docs/rules/` files must equal what
     /// `gendocs` regenerates from rule metadata. This makes the docs a verified
     /// generated artifact — editing a rule (or `config_example.toml`) without
-    /// regenerating fails CI. Run `cargo run -p lint-http-proxy -- gendocs` to
-    /// fix drift.
+    /// regenerating fails CI. Run `cargo xtask gendocs` to fix drift.
     #[test]
     fn docs_match_generated() {
         let root = repo_root();
@@ -550,7 +549,7 @@ mod tests {
                 .unwrap_or_else(|e| panic!("cannot read {}: {}", path.display(), e));
             assert!(
                 on_disk == expected,
-                "docs/rules/{}.md is out of date — run `cargo run -p lint-http-proxy -- gendocs`",
+                "docs/rules/{}.md is out of date — run `cargo xtask gendocs`",
                 id
             );
         };
@@ -584,7 +583,7 @@ mod tests {
         let on_disk = std::fs::read_to_string(root.join("docs/rules.md")).expect("docs/rules.md");
         assert!(
             on_disk == index,
-            "docs/rules.md is out of date — run `cargo run -p lint-http-proxy -- gendocs`"
+            "docs/rules.md is out of date — run `cargo xtask gendocs`"
         );
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+#
+# SPDX-License-Identifier: ISC
+
+[package]
+name = "xtask"
+description = "Repository maintenance tasks for lint-http. Not shipped, not published."
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+# The point of this crate: the dev tooling cannot reach a user. Nothing here is
+# built by `cargo install --path lint-http-proxy`, and `publish = false` makes
+# that a fact about the manifest rather than a convention.
+publish = false
+
+[dependencies]
+lint-http-rules = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+# Test-only: unique temp directory names for the write_all round-trip.
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Repository maintenance tasks, kept out of the delivered `lint-http` binary.
+//!
+//! `gendocs` regenerates `docs/rules/<id>.md` and the `docs/rules.md` index from
+//! rule metadata. It is a repo tool and not a user tool: it reads
+//! `config_example.toml` and writes into the working tree, both resolved from
+//! the workspace root that this crate's manifest dir points at. An installed
+//! binary has no such tree, which is why this lives here and not in the CLI.
+//!
+//! Run it as `cargo xtask gendocs` (the alias is in `.cargo/config.toml`) or
+//! `just gendocs`.
+
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(name = "xtask", about = "Repository maintenance tasks for lint-http")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Regenerate the rule documentation under <out>/ from rule metadata.
+    Gendocs(GendocsArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct GendocsArgs {
+    /// Output directory; `rules.md` and `rules/<id>.md` are written under it.
+    #[arg(long, default_value = "docs")]
+    out: PathBuf,
+}
+
+/// The whole tool, minus argument parsing, so the work is reachable from a test
+/// and `main` stays a line the coverage gate does not have to care about.
+fn run(cli: Cli) -> anyhow::Result<()> {
+    match cli.command {
+        Command::Gendocs(args) => {
+            lint_http_rules::gendocs::write_all(&args.out)?;
+            eprintln!("Wrote rule docs to {}", args.out.display());
+            Ok(())
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    run(Cli::parse())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lint_http_rules::rules::{
+        PROTOCOL_RULES, REGISTERED_PROTOCOL_RULES, REGISTERED_RULES, RULES,
+    };
+
+    /// Cross-crate linkme guard, in this binary's link configuration.
+    ///
+    /// The rule catalogue self-registers into `linkme` distributed slices over in
+    /// `lint-http-rules`; here it arrives across an rlib boundary, where dead-code
+    /// elimination or a missing reference could leave the slices empty. That
+    /// matters more than it looks: every documentation gate iterates `RULES`, so
+    /// an empty catalogue would make them all pass over nothing at all rather
+    /// than fail. This test is what stands between that and a green build. The
+    /// shipped binary has the same guard in
+    /// `lint-http-proxy/tests/linkme_catalogue.rs`.
+    #[test]
+    fn catalogue_collected_in_xtask_link_config() {
+        assert!(
+            !REGISTERED_RULES.is_empty(),
+            "no transaction rules were collected by linkme in the xtask link config",
+        );
+        assert!(
+            !REGISTERED_PROTOCOL_RULES.is_empty(),
+            "no protocol rules were collected by linkme in the xtask link config",
+        );
+
+        // Sorted views must agree with the raw registrations.
+        assert_eq!(RULES.len(), REGISTERED_RULES.len());
+        assert_eq!(PROTOCOL_RULES.len(), REGISTERED_PROTOCOL_RULES.len());
+
+        // Spot-check a known transaction rule and a known protocol rule.
+        assert!(RULES.iter().any(|r| r.id() == "host_header"));
+        assert!(PROTOCOL_RULES
+            .iter()
+            .any(|r| r.id() == "quic_transport_parameters_valid"));
+    }
+
+    #[test]
+    fn cli_gendocs_defaults_out_to_docs() {
+        let cli = Cli::parse_from(["xtask", "gendocs"]);
+        let Command::Gendocs(args) = cli.command;
+        assert_eq!(args.out, PathBuf::from("docs"));
+    }
+
+    #[test]
+    fn cli_gendocs_parses_out() {
+        let cli = Cli::parse_from(["xtask", "gendocs", "--out", "/tmp/docs-out"]);
+        let Command::Gendocs(args) = cli.command;
+        assert_eq!(args.out, PathBuf::from("/tmp/docs-out"));
+    }
+
+    #[test]
+    fn run_gendocs_writes_the_index_and_a_rule_page() {
+        let dir = std::env::temp_dir().join(format!("xtask_gendocs_{}", uuid::Uuid::new_v4()));
+        run(Cli::parse_from([
+            "xtask",
+            "gendocs",
+            "--out",
+            dir.to_str().expect("temp path is utf-8"),
+        ]))
+        .expect("gendocs should succeed");
+
+        assert!(dir.join("rules.md").is_file());
+        let first = RULES.first().expect("catalogue is non-empty");
+        assert!(dir
+            .join("rules")
+            .join(format!("{}.md", first.id()))
+            .is_file());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
`gendocs` is repo maintenance, not a user command: it reads `config_example.toml` and writes into the working tree, both resolved from the manifest dir at compile time. An installed binary has no such tree, so the subcommand cannot work anywhere it is actually delivered.

Give the dev tooling its own unpublished workspace member. This commit only adds it — `xtask` delegates to `lint_http_rules::gendocs::write_all`, the proxy subcommand still works, and every documented way to regenerate the docs is repointed at `cargo xtask gendocs` now that both spellings run. The crate keeps the generator away from `cargo install` by construction rather than by convention: `publish = false`, and nothing in the shipped graph depends on it.

The catalogue guard is the load-bearing part. Rules self-register through linkme in `lint-http-rules`, and here they arrive across an rlib boundary; every documentation gate iterates `RULES`, so an empty catalogue would make them all pass over nothing rather than fail. `lint-http-proxy` already carries that guard for the shipped link config, and xtask now carries its own for the one the gates are about to move into.
