### PR TITLE
Move the documentation generator into xtask

### DIFF
--- a/apycite.toml
+++ b/apycite.toml
@@ -7,6 +7,13 @@
 # prototype carries it in a docstring — apycite is right to refuse to call those
 # files clean, so they are simply not in scope. Nothing outside these roots
 # enforces a normative sentence.
+#
+# `xtask/` is the same claim in its stronger form. The documentation generator
+# lived under `lint-http-rules/src` and needed an exclude line to say "it
+# enforces nothing; it prints" — a claim a reviewer had to re-check on every
+# pass. It renders whatever `SpecRef` a rule declares and formats the URL; the
+# spec strings in it are test fixtures. Out of scope, that claim is the status
+# quo instead of an assertion to maintain.
 roots = [
     "lint-http-rules/src",
     "lint-http-core/src",
@@ -44,12 +51,12 @@ label = "{path}"
 # reason this widening is allowed to happen. Widening to a non-empty baseline
 # would have traded "every file in scope is cited" for "every file in scope is
 # cited eventually", and there is no second mechanism to hold the difference.
-# 208 files, 196 cited, 12 excluded below, 0 to migrate.
+# 221 files, 210 cited, 11 excluded below, 0 to migrate.
 #
 # `lint-http-core` and `lint-http-proxy` are deliberately still out of scope, and
 # not because their cites do not work — they do, and both crates carry some. It is
-# that 10 of 11 core files and 18 of 22 proxy files are uncited, and excluding
-# them would mean making 28 claims of "no normative content" about files nobody
+# that 9 of 12 core files and 18 of 23 proxy files are uncited, and excluding
+# them would mean making 27 claims of "no normative content" about files nobody
 # has read for one. Two of those claims would already be false: `protocol_event.rs`
 # holds the WebSocket opcode table as prose and is citable the day it becomes an
 # enum. An exclude list is a set of assertions, so it may only ever contain
@@ -71,10 +78,6 @@ baseline = "specs/ratchet.txt"
 # entry point: both decide *which* rule runs, never what any rule means.
 # `test_helpers.rs` builds fixtures. `lib.rs` is declarations.
 #
-# `gendocs.rs` mentions RFC 9110 and is still plumbing: it renders whatever
-# `SpecRef` a rule declares and formats the URL. The spec strings in it are test
-# fixtures. It enforces nothing; it prints.
-#
 # `queries/` groups stored transactions — by connection, origin, resource. The
 # one to look at twice is `by_origin.rs`, whose doc comment names RFC 6454. It
 # does not implement it: the origin arrives as a caller-supplied string and the
@@ -86,7 +89,6 @@ exclude = [
     "lint-http-rules/src/helpers/mod.rs",
     "lint-http-rules/src/queries/*.rs",
     "lint-http-rules/src/engine.rs",
-    "lint-http-rules/src/gendocs.rs",
     "lint-http-rules/src/lib.rs",
     "lint-http-rules/src/lint_protocol.rs",
     "lint-http-rules/src/test_helpers.rs",

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,6 +176,11 @@ The `docs_match_generated` test diffs the checked-in tree against freshly
 rendered output, so a rule whose metadata changed without a regeneration fails
 CI. The index places the rule by its `scope()`, so there is no link to add.
 
+That test lives in `xtask` alongside the generator, so `cargo test -p
+lint-http-rules` will not run it: a targeted run can come back green on a rule
+whose docs are stale. `just test` and a bare `cargo test` are workspace-wide and
+do run it, as does CI.
+
 ### 6. Configurable Rules Guidelines
 
 - Do not use hardcoded defaults in rule implementations. If a rule requires configuration, it should require an explicit TOML table under `[rules.<rule_id>]` and parse its numeric/string values from that table.

--- a/lint-http-rules/src/lib.rs
+++ b/lint-http-rules/src/lib.rs
@@ -20,7 +20,6 @@ pub use lint_http_core::{
 };
 
 pub mod engine;
-pub mod gendocs;
 pub mod helpers;
 pub mod lint_protocol;
 pub mod queries;

--- a/xtask/src/gendocs.rs
+++ b/xtask/src/gendocs.rs
@@ -4,23 +4,25 @@
 
 //! Documentation generator: renders `docs/rules/<id>.md` and the
 //! `docs/rules.md` index from rule metadata
-//! ([`Rule::description`](crate::rules::Rule::description),
-//! [`specifications`](crate::rules::Rule::specifications),
-//! [`examples`](crate::rules::Rule::examples),
-//! [`title`](crate::rules::Rule::title)) plus the per-rule `[rules.<id>]`
-//! section pulled from `config_example.toml`.
+//! ([`Rule::description`](lint_http_rules::rules::Rule::description),
+//! [`specifications`](lint_http_rules::rules::Rule::specifications),
+//! [`examples`](lint_http_rules::rules::Rule::examples),
+//! [`title`](lint_http_rules::rules::Rule::title)) plus the per-rule
+//! `[rules.<id>]` section pulled from `config_example.toml`.
 //!
 //! The render functions are pure and deterministic so the #11d CI gate
 //! (`docs_match_generated` test) can diff regenerated output against the
 //! checked-in docs.
 
-use crate::rules::{Compliance, Example, ProtocolRule, Rule, RuleScope, SpecRef};
+use lint_http_rules::rules::{
+    Compliance, Example, ProtocolRule, Rule, RuleScope, SpecRef, PROTOCOL_RULES, RULES,
+};
 use std::path::{Path, PathBuf};
 
 /// The workspace root, derived from this crate's manifest dir. `config_example.toml`
 /// and the `docs/` tree live there, so reads are anchored here rather than to the
 /// process CWD (which varies between `cargo run` at the root and `cargo test -p`).
-fn repo_root() -> PathBuf {
+pub fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("crate manifest dir has a parent (the workspace root)")
@@ -228,15 +230,15 @@ pub fn config_block_for(id: &str, config_toml: &str) -> Option<String> {
 
 /// Render every rule to disk under `out_dir`: `<out_dir>/rules/<id>.md` per
 /// rule plus `<out_dir>/rules.md`. Configuration sections are sourced from
-/// `config_example.toml` (read from the current working directory — the repo
-/// root). Creates directories as needed.
+/// [`repo_root`]`/config_example.toml`, never from the working directory.
+/// Creates directories as needed.
 pub fn write_all(out_dir: &Path) -> anyhow::Result<()> {
     let rules_dir = out_dir.join("rules");
     std::fs::create_dir_all(&rules_dir)?;
 
     let config_toml = std::fs::read_to_string(repo_root().join("config_example.toml"))?;
 
-    for rule in crate::rules::RULES.iter() {
+    for rule in RULES.iter() {
         let doc = render_doc(
             rule.id(),
             rule.title(),
@@ -247,7 +249,7 @@ pub fn write_all(out_dir: &Path) -> anyhow::Result<()> {
         );
         std::fs::write(rules_dir.join(format!("{}.md", rule.id())), doc)?;
     }
-    for rule in crate::rules::PROTOCOL_RULES.iter() {
+    for rule in PROTOCOL_RULES.iter() {
         let doc = render_doc(
             rule.id(),
             rule.title(),
@@ -259,7 +261,7 @@ pub fn write_all(out_dir: &Path) -> anyhow::Result<()> {
         std::fs::write(rules_dir.join(format!("{}.md", rule.id())), doc)?;
     }
 
-    let index = render_index(&crate::rules::RULES, &crate::rules::PROTOCOL_RULES);
+    let index = render_index(&RULES, &PROTOCOL_RULES);
     std::fs::write(out_dir.join("rules.md"), index)?;
     Ok(())
 }
@@ -267,6 +269,7 @@ pub fn write_all(out_dir: &Path) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lint_http_rules::rules::REGISTERED_RULES;
 
     #[test]
     fn title_from_id_capitalizes_each_word() {
@@ -360,7 +363,7 @@ mod tests {
                 config_block_for(id, &config_toml).as_deref(),
             )
         };
-        for rule in crate::rules::RULES.iter() {
+        for rule in RULES.iter() {
             let doc = render(
                 rule.id(),
                 rule.title(),
@@ -379,7 +382,7 @@ mod tests {
                 rule.id()
             );
         }
-        for rule in crate::rules::PROTOCOL_RULES.iter() {
+        for rule in PROTOCOL_RULES.iter() {
             let doc = render(
                 rule.id(),
                 rule.title(),
@@ -416,9 +419,9 @@ mod tests {
     /// both, which a `contains` check on its own would not.
     #[test]
     fn render_index_mentions_every_rule() {
-        let index = render_index(&crate::rules::RULES, &crate::rules::PROTOCOL_RULES);
+        let index = render_index(&RULES, &PROTOCOL_RULES);
         assert!(index.contains("# Lint Rules"));
-        for rule in crate::rules::RULES.iter() {
+        for rule in RULES.iter() {
             assert_eq!(
                 index
                     .matches(&format!("[{0}](rules/{0}.md)", rule.id()))
@@ -428,7 +431,7 @@ mod tests {
                 rule.id()
             );
         }
-        for rule in crate::rules::PROTOCOL_RULES.iter() {
+        for rule in PROTOCOL_RULES.iter() {
             assert!(
                 index.contains(&format!("[{0}](rules/{0}.md)", rule.id())),
                 "index missing protocol rule {}",
@@ -443,7 +446,7 @@ mod tests {
         write_all(&dir).expect("write_all should succeed");
 
         assert!(dir.join("rules.md").is_file());
-        let first = crate::rules::RULES.first().expect("catalogue is non-empty");
+        let first = RULES.first().expect("catalogue is non-empty");
         assert!(dir
             .join("rules")
             .join(format!("{}.md", first.id()))
@@ -526,10 +529,10 @@ mod tests {
                 }
             }
         };
-        for rule in crate::rules::RULES.iter() {
+        for rule in RULES.iter() {
             check(rule.id(), rule.specifications());
         }
-        for rule in crate::rules::PROTOCOL_RULES.iter() {
+        for rule in PROTOCOL_RULES.iter() {
             check(rule.id(), rule.specifications());
         }
     }
@@ -538,8 +541,21 @@ mod tests {
     /// `gendocs` regenerates from rule metadata. This makes the docs a verified
     /// generated artifact — editing a rule (or `config_example.toml`) without
     /// regenerating fails CI. Run `cargo xtask gendocs` to fix drift.
+    ///
+    /// The gate is a loop over `RULES`, so an empty catalogue would satisfy it
+    /// over nothing at all — and the catalogue reaches this crate across an rlib
+    /// boundary, which is exactly where linkme can come up empty. The floor
+    /// assertion is what keeps a link failure from reading as 194 files in
+    /// agreement; `catalogue_collected_in_xtask_link_config` in `main.rs` says
+    /// the same thing where a reader will look for it.
     #[test]
     fn docs_match_generated() {
+        assert_eq!(RULES.len(), REGISTERED_RULES.len());
+        assert!(
+            !RULES.is_empty(),
+            "catalogue did not collect in the xtask link config — this gate would pass vacuously",
+        );
+
         let root = repo_root();
         let config_toml =
             std::fs::read_to_string(root.join("config_example.toml")).expect("config_example.toml");
@@ -553,7 +569,7 @@ mod tests {
                 id
             );
         };
-        for rule in crate::rules::RULES.iter() {
+        for rule in RULES.iter() {
             check(
                 rule.id(),
                 render_doc(
@@ -566,7 +582,7 @@ mod tests {
                 ),
             );
         }
-        for rule in crate::rules::PROTOCOL_RULES.iter() {
+        for rule in PROTOCOL_RULES.iter() {
             check(
                 rule.id(),
                 render_doc(
@@ -579,7 +595,7 @@ mod tests {
                 ),
             );
         }
-        let index = render_index(&crate::rules::RULES, &crate::rules::PROTOCOL_RULES);
+        let index = render_index(&RULES, &PROTOCOL_RULES);
         let on_disk = std::fs::read_to_string(root.join("docs/rules.md")).expect("docs/rules.md");
         assert!(
             on_disk == index,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,8 @@
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
+mod gendocs;
+
 #[derive(Parser, Debug)]
 #[command(name = "xtask", about = "Repository maintenance tasks for lint-http")]
 struct Cli {
@@ -32,8 +34,22 @@ enum Command {
 #[derive(clap::Args, Debug)]
 struct GendocsArgs {
     /// Output directory; `rules.md` and `rules/<id>.md` are written under it.
-    #[arg(long, default_value = "docs")]
-    out: PathBuf,
+    /// Defaults to `docs/` at the workspace root.
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+/// Where the docs go when `--out` is not given: the workspace root's `docs/`,
+/// not `./docs`.
+///
+/// The alias passes `--package`, so `cargo xtask gendocs` runs from any
+/// subdirectory — and the drift gate's failure message tells people to run
+/// exactly that. A relative default would let the suggested fix write 194 files
+/// into `lint-http-rules/docs/` and leave the gate red, which is a bad way to
+/// find out what your working directory was. The inputs are already anchored to
+/// the repo root; the output now agrees with them.
+fn resolve_out(out: Option<PathBuf>) -> PathBuf {
+    out.unwrap_or_else(|| gendocs::repo_root().join("docs"))
 }
 
 /// The whole tool, minus argument parsing, so the work is reachable from a test
@@ -41,8 +57,9 @@ struct GendocsArgs {
 fn run(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Command::Gendocs(args) => {
-            lint_http_rules::gendocs::write_all(&args.out)?;
-            eprintln!("Wrote rule docs to {}", args.out.display());
+            let out = resolve_out(args.out);
+            gendocs::write_all(&out)?;
+            eprintln!("Wrote rule docs to {}", out.display());
             Ok(())
         }
     }
@@ -91,18 +108,23 @@ mod tests {
             .any(|r| r.id() == "quic_transport_parameters_valid"));
     }
 
+    /// The default is absolute, and it is the tree the drift gate reads — not
+    /// `./docs`, which is only the same thing when you happen to be standing at
+    /// the workspace root.
     #[test]
-    fn cli_gendocs_defaults_out_to_docs() {
+    fn out_defaults_to_the_workspace_docs_tree() {
         let cli = Cli::parse_from(["xtask", "gendocs"]);
         let Command::Gendocs(args) = cli.command;
-        assert_eq!(args.out, PathBuf::from("docs"));
+        let out = resolve_out(args.out);
+        assert!(out.is_absolute());
+        assert_eq!(out, gendocs::repo_root().join("docs"));
     }
 
     #[test]
     fn cli_gendocs_parses_out() {
         let cli = Cli::parse_from(["xtask", "gendocs", "--out", "/tmp/docs-out"]);
         let Command::Gendocs(args) = cli.command;
-        assert_eq!(args.out, PathBuf::from("/tmp/docs-out"));
+        assert_eq!(resolve_out(args.out), PathBuf::from("/tmp/docs-out"));
     }
 
     #[test]


### PR DESCRIPTION
The generator is now where it is run from. `lint-http-rules` stops compiling 265 lines of markdown formatting into every consumer of the rule catalogue, and the module reaches the metadata the way any other dependent would — across the crate boundary, through the public `Rule` surface it was already using.

The drift gate comes with it, and that is the part with teeth. It is a loop over `RULES`; in this crate the catalogue arrives across an rlib boundary, where linkme can come up empty. An empty catalogue would not fail the gate, it would satisfy it over nothing — 194 files declared in agreement because none were compared. The floor assertion refuses that reading, and both failure modes were checked by hand: inverted, it fires; with one generated file perturbed, the gate still catches the drift.

`--out` loses its relative default. The alias runs from any subdirectory and the gate's message tells people to run it, so the old `docs` would have written 194 files into `lint-http-rules/docs/` and left the gate red — the inputs were anchored to the workspace root all along, and the output now agrees with them.

apycite loses an exclude line and keeps the claim behind it: "it enforces nothing; it prints" was an assertion a reviewer re-checked on every pass, and out of scope it is simply the status quo. The counts in the two comments were already stale before this change (208/196/12, and 10-of-11 core files); recounted, they are 221/210/11 and 9-of-12.
