### PR TITLE
A rule can now answer its configuration once, when the engine is built

### DIFF
--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -16,6 +16,14 @@ use crate::config::Config;
 use crate::lint::Violation;
 use crate::rules::{ProtocolRule, Rule};
 
+/// One enabled rule with everything the engine resolved about it at
+/// construction. `query` is the [`crate::rules::STATEFUL_RULES`] lookup,
+/// answered once here instead of hashing the rule id on every transaction.
+struct PreparedRule {
+    rule: &'static dyn Rule,
+    query: Option<crate::queries::QueryType>,
+}
+
 /// The enabled rule set for one [`Config`], precomputed once so per-transaction
 /// dispatch cost is proportional to the *enabled* rules rather than the full
 /// catalogue. `is_enabled` is a pure function of the (immutable) config, so the
@@ -23,9 +31,9 @@ use crate::rules::{ProtocolRule, Rule};
 /// transaction. Build once and reuse for the lifetime of the config.
 pub struct PreparedEngine {
     /// Enabled rules for a full transaction (response collected).
-    enabled_full: Vec<&'static dyn Rule>,
+    enabled_full: Vec<PreparedRule>,
     /// Enabled rules for a request-only transaction (Server-scoped excluded).
-    enabled_request_only: Vec<&'static dyn Rule>,
+    enabled_request_only: Vec<PreparedRule>,
     /// Enabled protocol-event rules (consumed by `lint_protocol_event`).
     pub(crate) enabled_protocol: Vec<&'static dyn ProtocolRule>,
 }
@@ -49,18 +57,19 @@ impl PreparedEngine {
     /// is dispatched.
     pub fn new(cfg: &Config) -> anyhow::Result<Self> {
         crate::rules::validate_rules(cfg)?;
-        let enabled = |r: &&'static dyn Rule| cfg.is_enabled(r.id());
+        let prepare_enabled = |rules: &[&'static dyn Rule]| {
+            rules
+                .iter()
+                .filter(|r| cfg.is_enabled(r.id()))
+                .map(|&rule| PreparedRule {
+                    rule,
+                    query: crate::rules::query_type_for(rule.id()),
+                })
+                .collect()
+        };
         Ok(Self {
-            enabled_full: crate::rules::RULES
-                .iter()
-                .copied()
-                .filter(enabled)
-                .collect(),
-            enabled_request_only: crate::rules::REQUEST_ONLY_RULES
-                .iter()
-                .copied()
-                .filter(enabled)
-                .collect(),
+            enabled_full: prepare_enabled(&crate::rules::RULES),
+            enabled_request_only: prepare_enabled(&crate::rules::REQUEST_ONLY_RULES),
             enabled_protocol: crate::rules::PROTOCOL_RULES
                 .iter()
                 .copied()
@@ -105,8 +114,9 @@ impl PreparedEngine {
         } else {
             &self.enabled_request_only
         };
-        for rule in scoped {
-            let history = match crate::rules::query_type_for(rule.id()) {
+        for prepared in scoped {
+            let rule = prepared.rule;
+            let history = match prepared.query {
                 Some(crate::queries::QueryType::ByResource) => history_by_resource
                     .get_or_insert_with(|| {
                         crate::queries::by_resource::by_resource(state, &tx.client, &tx.request.uri)
@@ -186,14 +196,17 @@ mod tests {
         let engine = PreparedEngine::new(&cfg).unwrap();
 
         assert_eq!(engine.enabled_full.len(), 3);
-        assert!(engine.enabled_full.iter().all(|r| cfg.is_enabled(r.id())));
+        assert!(engine
+            .enabled_full
+            .iter()
+            .all(|p| cfg.is_enabled(p.rule.id())));
         // Only the non-Server rule survives into the request-only set; the
         // assertion is non-vacuous because that set is non-empty here.
         assert_eq!(engine.enabled_request_only.len(), 1);
         assert!(engine
             .enabled_request_only
             .iter()
-            .all(|r| !matches!(r.scope(), crate::rules::RuleScope::Server)));
+            .all(|p| !matches!(p.rule.scope(), crate::rules::RuleScope::Server)));
 
         // An empty config enables nothing.
         let empty = PreparedEngine::new(&Config::default()).unwrap();

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -77,6 +77,50 @@ pub fn validate_rule_table(cfg: &crate::config::Config, rule_id: &str) -> anyhow
     Ok(())
 }
 
+/// Everything a rule derives from its configuration, resolved once when the
+/// engine is built. What [`Rule::prepare`] returns.
+///
+/// `state` is the rule's own resolved shape — an allowed-list, a set of
+/// header names — behind `dyn Any` so the trait stays object-safe (the
+/// catalogue is dispatched through `&'static dyn Rule`, which rules out an
+/// associated type). Rules that read only their severity return `Box::new(())`.
+pub struct ResolvedRule {
+    pub severity: crate::lint::Severity,
+    pub state: Box<dyn std::any::Any + Send + Sync>,
+}
+
+/// One rule's resolved configuration, borrowed for one dispatch.
+///
+/// This is what replaces `cfg: &Config` at the check sites: two words on the
+/// stack, no hashing, no TOML, no allocation. The severity is read directly;
+/// rule-specific state comes back out through [`RuleContext::state`], typed
+/// by the rule that put it in.
+pub struct RuleContext<'a> {
+    pub severity: crate::lint::Severity,
+    state: &'a (dyn std::any::Any + Send + Sync),
+}
+
+impl<'a> RuleContext<'a> {
+    /// Borrow a prepared rule's resolved configuration for one dispatch.
+    pub fn new(resolved: &'a ResolvedRule) -> Self {
+        Self {
+            severity: resolved.severity,
+            state: &*resolved.state,
+        }
+    }
+
+    /// The rule-specific state this rule's own `prepare` returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a type mismatch. The engine builds each context from the
+    /// same rule's [`ResolvedRule`], so a mismatch means a rule asked for a
+    /// type its `prepare` does not produce — a wiring bug, not a config one.
+    pub fn state<T: 'static>(&self) -> &T {
+        self.state.downcast_ref().expect("rule state wiring")
+    }
+}
+
 /// The `Rule` trait defines a single hook that runs on the canonical
 /// `HttpTransaction`. All rules must implement `check_transaction`.
 /// Scope of a rule: whether it applies to client-only traffic (requests),
@@ -172,6 +216,22 @@ pub trait Rule: Send + Sync {
     /// a custom config section override this to validate their own fields.
     fn validate(&self, cfg: &crate::config::Config) -> anyhow::Result<()> {
         validate_rule_table(cfg, self.id())
+    }
+
+    /// Resolve this rule's configuration once, when the engine is built.
+    ///
+    /// Validation *is* successful preparation: what `validate` answers with
+    /// `Ok(())`, this answers with the resolved values themselves, so the
+    /// same parse cannot run again — typed or untyped — on the lint path.
+    /// The default resolves what every rule needs (the table's two required
+    /// keys, of which severity is the one carried forward); a rule with a
+    /// custom config section overrides this to parse it into its own `state`.
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<ResolvedRule> {
+        validate_rule_table(cfg, self.id())?;
+        Ok(ResolvedRule {
+            severity: get_rule_severity_required(cfg, self.id())?,
+            state: Box::new(()),
+        })
     }
 
     /// The scope where the rule should be executed. Default is `Both`;
@@ -430,6 +490,16 @@ pub trait ProtocolRule: Send + Sync {
     /// [`Rule::validate`] for the contract.
     fn validate(&self, cfg: &crate::config::Config) -> anyhow::Result<()> {
         validate_rule_table(cfg, self.id())
+    }
+
+    /// Resolve this rule's configuration once, when the engine is built. See
+    /// [`Rule::prepare`] for the contract.
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<ResolvedRule> {
+        validate_rule_table(cfg, self.id())?;
+        Ok(ResolvedRule {
+            severity: get_rule_severity_required(cfg, self.id())?,
+            state: Box::new(()),
+        })
     }
 
     /// Evaluate a single protocol event against this rule. Rules parse
@@ -1234,6 +1304,70 @@ severity = "warn"
         // Also verify through a trait object (now object-safe).
         let v: &dyn Rule = &r;
         assert_eq!(v.scope(), RuleScope::Both);
+    }
+
+    #[test]
+    fn default_prepare_resolves_severity_and_unit_state() -> anyhow::Result<()> {
+        let cfg = crate::test_helpers::make_test_config_with_severity("host_header", "error");
+        let rule = RULES
+            .iter()
+            .find(|r| r.id() == "host_header")
+            .expect("host_header registered");
+        let resolved = rule.prepare(&cfg)?;
+        assert_eq!(resolved.severity, crate::lint::Severity::Error);
+        let ctx = RuleContext::new(&resolved);
+        assert_eq!(ctx.severity, crate::lint::Severity::Error);
+        // The default prepare carries no rule-specific state.
+        let _: &() = ctx.state::<()>();
+        Ok(())
+    }
+
+    #[test]
+    fn default_prepare_rejects_missing_severity() {
+        let mut cfg = crate::config::Config::default();
+        let mut table = toml::map::Map::new();
+        table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        cfg.rules
+            .insert("host_header".to_string(), toml::Value::Table(table));
+        let rule = RULES
+            .iter()
+            .find(|r| r.id() == "host_header")
+            .expect("host_header registered");
+        assert!(rule.prepare(&cfg).is_err());
+    }
+
+    #[test]
+    fn rule_context_state_roundtrips_the_prepared_type() {
+        let resolved = ResolvedRule {
+            severity: crate::lint::Severity::Info,
+            state: Box::new(vec!["utf-8".to_string()]),
+        };
+        let ctx = RuleContext::new(&resolved);
+        assert_eq!(ctx.state::<Vec<String>>(), &vec!["utf-8".to_string()]);
+    }
+
+    #[test]
+    #[should_panic(expected = "rule state wiring")]
+    fn rule_context_state_mismatch_panics() {
+        let resolved = ResolvedRule {
+            severity: crate::lint::Severity::Warn,
+            state: Box::new(()),
+        };
+        let ctx = RuleContext::new(&resolved);
+        let _ = ctx.state::<Vec<String>>();
+    }
+
+    #[test]
+    fn protocol_rule_default_prepare_resolves_severity() -> anyhow::Result<()> {
+        let cfg =
+            crate::test_helpers::make_test_config_with_severity("websocket_frame_masking", "warn");
+        let rule = PROTOCOL_RULES
+            .iter()
+            .find(|r| r.id() == "websocket_frame_masking")
+            .expect("websocket_frame_masking registered");
+        let resolved = rule.prepare(&cfg)?;
+        assert_eq!(resolved.severity, crate::lint::Severity::Warn);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Both traits gain prepare: resolve the table's severity — and, for rules that override it, their own parsed shape behind dyn Any — into a ResolvedRule at construction time. RuleContext is the dispatch-time view of one: two words on the stack, no hashing, no TOML. Validation is successful preparation, so the same parse cannot run again, typed or untyped, on the lint path.

Nothing dispatches through it yet — the rules still take the config and parse per transaction — but the engine already stops asking one question per transaction that was answered at build time: each enabled rule's state query is resolved into its PreparedRule instead of hashed out of STATEFUL_RULES on every dispatch.
