### PR TITLE
The seven protocol rules stop reading configuration at lint time

### DIFF
--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -377,7 +377,7 @@ fn lint_websocket_session(
             session.id,
             &session.extensions,
         );
-        violations.extend(engine.lint_protocol_event(&event, cfg, &event_store));
+        violations.extend(engine.lint_protocol_event(&event, &event_store));
         event_store.record_event(&event);
     }
     violations

--- a/lint-http-proxy/src/proxy/pipeline.rs
+++ b/lint-http-proxy/src/proxy/pipeline.rs
@@ -57,29 +57,24 @@ impl TransactionPipeline {
 }
 
 /// Orchestrates the per-protocol-event cycle: lint, then record to the event
-/// store. Cloneable so concurrent relay tasks can each own one.
+/// store. Cloneable so concurrent relay tasks can each own one. No config
+/// here: the protocol rules' configuration was resolved into the engine when
+/// it was built.
 #[derive(Clone)]
 pub(super) struct ProtocolEventPipeline {
     engine: Arc<PreparedEngine>,
-    cfg: Arc<Config>,
     store: Arc<ProtocolEventStore>,
 }
 
 impl ProtocolEventPipeline {
-    pub(super) fn new(
-        engine: Arc<PreparedEngine>,
-        cfg: Arc<Config>,
-        store: Arc<ProtocolEventStore>,
-    ) -> Self {
-        Self { engine, cfg, store }
+    pub(super) fn new(engine: Arc<PreparedEngine>, store: Arc<ProtocolEventStore>) -> Self {
+        Self { engine, store }
     }
 
     /// Lint `event`, then record it — in that order. Returns the violations
     /// so callers can log or collect them.
     pub(super) fn commit(&self, event: &ProtocolEvent) -> Vec<Violation> {
-        let violations = self
-            .engine
-            .lint_protocol_event(event, &self.cfg, &self.store);
+        let violations = self.engine.lint_protocol_event(event, &self.store);
         self.store.record_event(event);
         violations
     }
@@ -96,11 +91,7 @@ impl Shared {
     }
 
     pub(super) fn protocol_event_pipeline(&self) -> ProtocolEventPipeline {
-        ProtocolEventPipeline::new(
-            self.engine.clone(),
-            self.cfg.clone(),
-            self.protocol_event_store.clone(),
-        )
+        ProtocolEventPipeline::new(self.engine.clone(), self.protocol_event_store.clone())
     }
 }
 

--- a/lint-http-proxy/src/proxy/websocket.rs
+++ b/lint-http-proxy/src/proxy/websocket.rs
@@ -736,11 +736,10 @@ mod tests {
     }
 
     fn test_pe_pipeline() -> ProtocolEventPipeline {
-        let cfg = StdArc::new(crate::config::Config::default());
+        let cfg = crate::config::Config::default();
         let engine = StdArc::new(crate::engine::PreparedEngine::new(&cfg).unwrap());
         ProtocolEventPipeline::new(
             engine,
-            cfg,
             StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
                 300, 100,
             )),

--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -24,6 +24,14 @@ struct PreparedRule {
     query: Option<crate::queries::QueryType>,
 }
 
+/// One enabled protocol rule with its configuration resolved by its own
+/// `prepare` at construction. Dispatch borrows `resolved` into a
+/// [`crate::rules::RuleContext`] per event — no per-event config reads.
+pub(crate) struct PreparedProtocolRule {
+    pub(crate) rule: &'static dyn ProtocolRule,
+    pub(crate) resolved: crate::rules::ResolvedRule,
+}
+
 /// The enabled rule set for one [`Config`], precomputed once so per-transaction
 /// dispatch cost is proportional to the *enabled* rules rather than the full
 /// catalogue. `is_enabled` is a pure function of the (immutable) config, so the
@@ -35,7 +43,7 @@ pub struct PreparedEngine {
     /// Enabled rules for a request-only transaction (Server-scoped excluded).
     enabled_request_only: Vec<PreparedRule>,
     /// Enabled protocol-event rules (consumed by `lint_protocol_event`).
-    pub(crate) enabled_protocol: Vec<&'static dyn ProtocolRule>,
+    pub(crate) enabled_protocol: Vec<PreparedProtocolRule>,
 }
 
 impl PreparedEngine {
@@ -74,7 +82,13 @@ impl PreparedEngine {
                 .iter()
                 .copied()
                 .filter(|r| cfg.is_enabled(r.id()))
-                .collect(),
+                .map(|rule| {
+                    Ok(PreparedProtocolRule {
+                        rule,
+                        resolved: rule.prepare(cfg)?,
+                    })
+                })
+                .collect::<anyhow::Result<_>>()?,
         })
     }
 

--- a/lint-http-rules/src/lint_protocol.rs
+++ b/lint-http-rules/src/lint_protocol.rs
@@ -16,11 +16,13 @@ use crate::protocol_event_store::ProtocolEventStore;
 
 impl PreparedEngine {
     /// Lint a single protocol event against the enabled protocol rules
-    /// (disabled rules were filtered out when the engine was built).
+    /// (disabled rules were filtered out when the engine was built; each
+    /// rule's configuration was resolved by its own `prepare` there too, so
+    /// dispatch hands out borrowed [`crate::rules::RuleContext`]s and reads
+    /// no config).
     pub fn lint_protocol_event(
         &self,
         event: &ProtocolEvent,
-        cfg: &Config,
         event_store: &ProtocolEventStore,
     ) -> Vec<Violation> {
         let mut out = Vec::new();
@@ -28,13 +30,14 @@ impl PreparedEngine {
         // Lazily computed history for this connection.
         let mut history_by_connection: Option<ProtocolEventHistory> = None;
 
-        for rule in &self.enabled_protocol {
+        for prepared in &self.enabled_protocol {
             let history = history_by_connection.get_or_insert_with(|| {
                 let entries = event_store.get_history_for_connection(event.connection_id);
                 ProtocolEventHistory::new(entries)
             });
 
-            out.extend(rule.check_event(event, history, cfg));
+            let ctx = crate::rules::RuleContext::new(&prepared.resolved);
+            out.extend(prepared.rule.check_event(event, history, &ctx));
         }
 
         out
@@ -56,7 +59,7 @@ pub fn lint_protocol_event(
 ) -> Vec<Violation> {
     PreparedEngine::new(cfg)
         .expect("config failed rule validation")
-        .lint_protocol_event(event, cfg, event_store)
+        .lint_protocol_event(event, event_store)
 }
 
 #[cfg(test)]

--- a/lint-http-rules/src/rules/http3_goaway_semantics.rs
+++ b/lint-http-rules/src/rules/http3_goaway_semantics.rs
@@ -27,24 +27,16 @@ impl ProtocolRule for Http3GoawaySemantics {
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        // The configuration is read when a finding is built, not on entry. The
-        // other six rules of this family have one gate apiece and read it after
-        // that gate; this one dispatches on the event kind into two arms, and
-        // inside each the finding is a comparison against the history — so the
-        // last point at which nothing is decided yet is the branch that reports.
-        // Every enabled protocol rule sees every event on the connection, and
-        // `parse_rule_config` looks the rule id up twice (its doc comment costs
-        // it). Written once here rather than at both report sites: `?` inside the
-        // closure ends the closure, and returning its `None` is what the two
-        // sites do with it.
+        // Written once here rather than at both report sites: this rule
+        // dispatches on the event kind into two arms, and inside each the
+        // finding is a comparison against the history, so the two sites share
+        // one builder.
         let report = |message: String| -> Option<Violation> {
             Some(Violation {
                 rule: self.id().into(),
-                severity: crate::rules::parse_rule_config(cfg, self.id())
-                    .ok()?
-                    .severity,
+                severity: ctx.severity,
                 message,
             })
         };
@@ -227,8 +219,8 @@ mod tests {
         make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id })
     }
 
-    /// A rule table carrying `enabled` and no `severity`: `parse_rule_config`
-    /// fails on it, and the two report sites turn that into silence.
+    /// A rule table carrying `enabled` and no `severity`: `prepare` fails on
+    /// it, and the dispatch helper turns that into silence.
     fn make_config_without_severity() -> crate::config::Config {
         let mut cfg = crate::config::Config::default();
         let mut table = toml::map::Map::new();
@@ -269,10 +261,16 @@ mod tests {
         };
 
         // The same traffic under a readable configuration is a finding.
-        assert!(rule.check_event(&evt, &history, &make_config()).is_some());
-        assert!(rule
-            .check_event(&evt, &history, &make_config_without_severity())
-            .is_none());
+        assert!(
+            crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config()).is_some()
+        );
+        assert!(crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &history,
+            &make_config_without_severity()
+        )
+        .is_none());
     }
 
     // ── GOAWAY stream ID must not increase ──────────────────────────────
@@ -282,7 +280,12 @@ mod tests {
         let rule = Http3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -293,7 +296,7 @@ mod tests {
         let prev = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -304,7 +307,7 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -315,7 +318,7 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(10));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("increased from previous"));
@@ -332,7 +335,7 @@ mod tests {
         let prev = make_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, None);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -343,7 +346,7 @@ mod tests {
         let prev = make_goaway(conn, None);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(4));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -354,7 +357,12 @@ mod tests {
         let rule = Http3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -365,7 +373,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 8);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -376,7 +384,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(10));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 10);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -387,7 +395,7 @@ mod tests {
         let goaway = make_server_goaway(conn, Some(4));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 5);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("stream 5"));
@@ -404,7 +412,9 @@ mod tests {
         let goaway = make_goaway(conn, Some(4)); // client GOAWAY (push id 4)
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 5);
-        assert!(rule.check_event(&evt, &history, &make_config()).is_none());
+        assert!(
+            crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config()).is_none()
+        );
     }
 
     #[test]
@@ -417,7 +427,7 @@ mod tests {
         let goaway = make_goaway(conn, None);
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -430,7 +440,12 @@ mod tests {
             Uuid::new_v4(),
             ProtocolEventKind::H3StreamClosed { stream_id: 0 },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -450,7 +465,12 @@ mod tests {
                 payload_length: 10,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -484,7 +504,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![goaway, stream]);
         // New GOAWAY with id=12 > 10 should fail
         let evt = make_goaway(conn, Some(12));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -511,7 +531,7 @@ mod tests {
         // Stream 3 > goaway id 2 — first event is H3StreamClosed which
         // should be skipped; the goaway at index 1 triggers violation.
         let evt = make_stream_opened(conn, 3);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -540,7 +560,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![g1, g2]);
         // New GOAWAY with id=8: compared to most recent (6), 8 > 6 → fail
         let evt = make_goaway(conn, Some(8));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -552,7 +572,12 @@ mod tests {
         let rule = Http3GoawaySemantics;
         let conn = Uuid::new_v4();
         let evt = make_goaway(conn, Some(0));
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -564,7 +589,7 @@ mod tests {
         let goaway = make_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -576,7 +601,7 @@ mod tests {
         let goaway = make_server_goaway(conn, Some(0));
         let history = ProtocolEventHistory::new(vec![goaway]);
         let evt = make_stream_opened(conn, 1);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -588,7 +613,7 @@ mod tests {
         let prev = make_goaway(conn, Some(100));
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_goaway(conn, Some(0));
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 }

--- a/lint-http-rules/src/rules/http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/http3_max_push_id.rs
@@ -27,7 +27,7 @@ impl ProtocolRule for Http3MaxPushId {
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The event this rule recognizes is the MAX_PUSH_ID frame itself; every
         // other protocol event is out of scope.
@@ -37,12 +37,6 @@ impl ProtocolRule for Http3MaxPushId {
             _ => return None,
         };
 
-        // Read after the match, not before it: every protocol rule sees every
-        // event on the connection, so this discriminant ends the rule for all but
-        // one frame type, and `parse_rule_config` looks the rule id up twice (its
-        // doc comment costs it).
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // MAX_PUSH_ID is a client-only frame: a server sending one at all is the
         // violation, whatever its value. This became checkable once the upstream
         // leg is observed with a sender direction — a `Server` MAX_PUSH_ID is one
@@ -51,7 +45,7 @@ impl ProtocolRule for Http3MaxPushId {
         if direction == MessageDirection::Server {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "HTTP/3 MAX_PUSH_ID (push_id {}) sent by a server; a server MUST NOT \
                      send MAX_PUSH_ID (RFC 9114 §7.2.7, H3_FRAME_UNEXPECTED)",
@@ -72,7 +66,7 @@ impl ProtocolRule for Http3MaxPushId {
                 if current < *prev_id {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "HTTP/3 MAX_PUSH_ID {} decreased from previous {} \
                              (RFC 9114 §7.2.7, H3_ID_ERROR)",
@@ -202,9 +196,13 @@ mod tests {
                 direction: MessageDirection::Server,
             },
         );
-        let v = rule
-            .check_event(&evt, &ProtocolEventHistory::empty(), &make_config())
-            .expect("a server-sent MAX_PUSH_ID must be flagged");
+        let v = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        )
+        .expect("a server-sent MAX_PUSH_ID must be flagged");
         assert!(v.message.contains("server"));
         assert!(v.message.contains("H3_FRAME_UNEXPECTED"));
     }
@@ -215,9 +213,13 @@ mod tests {
         let rule = Http3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 5);
-        assert!(rule
-            .check_event(&evt, &ProtocolEventHistory::empty(), &make_config())
-            .is_none());
+        assert!(crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config()
+        )
+        .is_none());
     }
 
     // ── First MAX_PUSH_ID on a connection: any value is valid ────────────
@@ -227,7 +229,12 @@ mod tests {
         let rule = Http3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -236,7 +243,12 @@ mod tests {
         let rule = Http3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, 100);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -246,7 +258,12 @@ mod tests {
         let rule = Http3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_max_push_id(conn, (1u64 << 62) - 1);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -259,7 +276,7 @@ mod tests {
         let prev = make_max_push_id(conn, 5);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 10);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -271,7 +288,7 @@ mod tests {
         let prev = make_max_push_id(conn, 7);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 7);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -284,7 +301,7 @@ mod tests {
         let prev = make_max_push_id(conn, 10);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 4);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert_eq!(v.rule, "http3_max_push_id");
         assert!(v.message.contains("MAX_PUSH_ID 4"));
@@ -299,7 +316,7 @@ mod tests {
         let prev = make_max_push_id(conn, 1);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 0"));
         assert!(v.message.contains("previous 1"));
@@ -312,7 +329,7 @@ mod tests {
         let prev = make_max_push_id(conn, 100);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 99);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -351,7 +368,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![g1, g2, g3]);
         // 20 (most recent) == 20 -> OK
         let evt = make_max_push_id(conn, 20);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -383,7 +400,7 @@ mod tests {
         );
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 8);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -411,7 +428,7 @@ mod tests {
         );
         let history = ProtocolEventHistory::new(vec![newer, older]);
         let evt = make_max_push_id(conn, 10);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 10"));
         assert!(v.message.contains("previous 20"));
@@ -446,7 +463,7 @@ mod tests {
 
         // New MAX_PUSH_ID = 5 < 10 → violation; settings should be skipped.
         let evt = make_max_push_id(conn, 5);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -467,7 +484,7 @@ mod tests {
         let history = ProtocolEventHistory::new(vec![settings, stream]);
         // No prior MAX_PUSH_ID → first one is accepted at any value.
         let evt = make_max_push_id(conn, 0);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -484,7 +501,12 @@ mod tests {
                 direction: MessageDirection::Client,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -499,7 +521,12 @@ mod tests {
                 direction: MessageDirection::Client,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -508,7 +535,12 @@ mod tests {
         let rule = Http3MaxPushId;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 });
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -529,7 +561,12 @@ mod tests {
                 payload_length: 10,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -550,8 +587,7 @@ mod tests {
         ] {
             let cfg =
                 crate::test_helpers::make_test_config_with_severity("http3_max_push_id", sev_str);
-            let v = rule
-                .check_event(&evt, &history, &cfg)
+            let v = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &cfg)
                 .expect("expected violation");
             assert_eq!(v.severity, sev);
             assert_eq!(v.rule, "http3_max_push_id");
@@ -579,7 +615,7 @@ mod tests {
         }
         let history = ProtocolEventHistory::new(history_vec);
         let evt = make_max_push_id(conn, 6);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         let v = result.expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 6"));
         assert!(v.message.contains("previous 7"));
@@ -623,8 +659,7 @@ mod tests {
         ));
         let history = ProtocolEventHistory::new(history_vec);
         let evt = make_max_push_id(conn, 14);
-        let v = rule
-            .check_event(&evt, &history, &make_config())
+        let v = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config())
             .expect("expected violation");
         assert!(v.message.contains("MAX_PUSH_ID 14"));
         assert!(v.message.contains("previous 15"));
@@ -639,8 +674,7 @@ mod tests {
         let prev = make_max_push_id(conn, 3);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_max_push_id(conn, 0);
-        let v = rule
-            .check_event(&evt, &history, &make_config())
+        let v = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config())
             .expect("expected violation");
         // The message should reference RFC 9114 §7.2.7 and the H3_ID_ERROR
         // connection error code so operators can map it to the spec.

--- a/lint-http-rules/src/rules/http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/http3_settings_frame.rs
@@ -42,7 +42,7 @@ impl ProtocolRule for Http3SettingsFrame {
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The event this rule recognizes is the SETTINGS frame itself; every
         // other protocol event is out of scope.
@@ -54,13 +54,6 @@ impl ProtocolRule for Http3SettingsFrame {
             } => (settings, *direction),
             _ => return None,
         };
-
-        // Read after the match, not before it. `lint_protocol_event` hands every
-        // enabled protocol rule every event on the connection, so this
-        // discriminant is the rule's whole scope and it ends the rule for all but
-        // one frame type; `parse_rule_config` looks the rule id up twice (its doc
-        // comment costs it).
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // Scanning the whole connection history — rather than a single stream —
         // is what makes a second SETTINGS visible at all.
@@ -82,7 +75,7 @@ impl ProtocolRule for Http3SettingsFrame {
                 }
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "HTTP/3 duplicate SETTINGS frame from the same peer on one connection \
                          (RFC 9114 §7.2.4)"
@@ -98,7 +91,7 @@ impl ProtocolRule for Http3SettingsFrame {
             if RESERVED_SETTING_IDS.contains(&id) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "HTTP/3 SETTINGS contains reserved HTTP/2 setting identifier \
                          0x{:02X} (RFC 9114 §7.2.4.1)",
@@ -117,7 +110,7 @@ impl ProtocolRule for Http3SettingsFrame {
             if settings[..i].iter().any(|&(prev_id, _)| prev_id == id) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "HTTP/3 SETTINGS contains setting identifier 0x{:02X} more \
                          than once (RFC 9114 §7.2.4)",
@@ -255,7 +248,9 @@ mod tests {
         let prior_client = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prior_client]);
         let evt = make_server_settings(conn, vec![(0x06, 8192)]);
-        assert!(rule.check_event(&evt, &history, &make_config()).is_none());
+        assert!(
+            crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config()).is_none()
+        );
     }
 
     // ── First SETTINGS on a connection: valid cases ──────────────────
@@ -272,7 +267,12 @@ mod tests {
                 (0x07, 100),  // SETTINGS_QPACK_BLOCKED_STREAMS
             ],
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -281,7 +281,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -291,7 +296,12 @@ mod tests {
         let conn = Uuid::new_v4();
         // Extension/unknown setting identifiers are allowed.
         let evt = make_settings(conn, vec![(0x33, 1), (0xFF00, 42)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -304,7 +314,7 @@ mod tests {
         let prev = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -316,7 +326,7 @@ mod tests {
         let prev = make_settings(conn, vec![]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }
@@ -335,7 +345,7 @@ mod tests {
         let closed = make_event_at(conn, ProtocolEventKind::H3StreamClosed { stream_id: 0 }, t);
         let history = ProtocolEventHistory::new(vec![opened, closed]);
         let evt = make_settings(conn, vec![(0x06, 4096)]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_none());
     }
 
@@ -375,7 +385,7 @@ mod tests {
         );
         let history = ProtocolEventHistory::new(vec![opened, prev_settings, transport]);
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
     }
 
@@ -386,7 +396,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x00, 0)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x00"));
     }
@@ -396,7 +411,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x02, 1)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x02"));
     }
@@ -406,7 +426,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x03, 100)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
     }
@@ -416,7 +441,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x04, 65535)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x04"));
     }
@@ -426,7 +456,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x05, 16384)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x05"));
     }
@@ -437,7 +472,12 @@ mod tests {
         let conn = Uuid::new_v4();
         // Mix valid settings with one reserved.
         let evt = make_settings(conn, vec![(0x06, 8192), (0x03, 100), (0x07, 50)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x03"));
     }
@@ -449,7 +489,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x06, 8192), (0x06, 4096)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("more than once"));
@@ -462,7 +507,12 @@ mod tests {
         let conn = Uuid::new_v4();
         // Same identifier repeated with an unrelated one between.
         let evt = make_settings(conn, vec![(0x01, 4096), (0x07, 100), (0x01, 2048)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("0x01"));
     }
@@ -473,7 +523,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x06, 100), (0x01, 100), (0x07, 100)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -484,7 +539,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x03, 1), (0x03, 2)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("reserved"));
@@ -499,7 +559,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x01, 4096)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -508,7 +573,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x06, 8192)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -517,7 +587,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x07, 200)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -527,7 +602,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x08, 1)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -537,7 +617,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_settings(conn, vec![(0x33, 1)]);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -548,7 +633,12 @@ mod tests {
         let rule = Http3SettingsFrame;
         let conn = Uuid::new_v4();
         let evt = make_event(conn, ProtocolEventKind::H3StreamOpened { stream_id: 0 });
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -563,7 +653,12 @@ mod tests {
                 direction: MessageDirection::Client,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -578,7 +673,12 @@ mod tests {
                 direction: MessageDirection::Client,
             },
         );
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -592,7 +692,7 @@ mod tests {
         let prev = make_settings(conn, vec![(0x06, 4096)]);
         let history = ProtocolEventHistory::new(vec![prev]);
         let evt = make_settings(conn, vec![(0x02, 1)]); // reserved + duplicate
-        let result = rule.check_event(&evt, &history, &make_config());
+        let result = crate::test_helpers::run_protocol_rule(&rule, &evt, &history, &make_config());
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("duplicate SETTINGS"));
     }

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -502,13 +502,14 @@ pub trait ProtocolRule: Send + Sync {
         })
     }
 
-    /// Evaluate a single protocol event against this rule. Rules parse
-    /// whatever configuration they need directly from `cfg: &Config`.
+    /// Evaluate a single protocol event against this rule. Everything the
+    /// rule derived from its configuration arrives resolved in `ctx` — its
+    /// own `prepare` ran when the engine was built.
     fn check_event(
         &self,
         event: &crate::protocol_event::ProtocolEvent,
         history: &crate::protocol_event::ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &RuleContext<'_>,
     ) -> Option<Violation>;
 
     /// Doc title override (the `# ` heading of the generated per-rule doc).

--- a/lint-http-rules/src/rules/quic_transport_parameters_valid.rs
+++ b/lint-http-rules/src/rules/quic_transport_parameters_valid.rs
@@ -50,7 +50,7 @@ impl ProtocolRule for QuicTransportParametersValid {
         &self,
         event: &ProtocolEvent,
         _history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The event carries the contents of the quic_transport_parameters TLS
         // extension (this cite was re-homed here from the bidi check below, where
@@ -61,13 +61,6 @@ impl ProtocolRule for QuicTransportParametersValid {
             _ => return None,
         };
 
-        // Read after the match, not before it: every protocol rule sees every
-        // event on the connection, and this extension arrives once per
-        // connection, so the discriminant ends the rule for very nearly all of
-        // them; `parse_rule_config` looks the rule id up twice (its doc comment
-        // costs it).
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // "number of permitted streams" half of §6.1's SHOULD. §18.2: a 0 (or
         // absent) grant only defers stream opening until a MAX_STREAMS frame, so
         // this is a SHOULD-level reasonableness check, not a hard requirement; it
@@ -76,7 +69,7 @@ impl ProtocolRule for QuicTransportParametersValid {
         if params.initial_max_streams_bidi == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "QUIC initial_max_streams_bidi is 0; HTTP/3 requires at least one \
                      bidirectional stream for request/response exchange (RFC 9114 §6.1)"
                     .into(),
@@ -91,7 +84,7 @@ impl ProtocolRule for QuicTransportParametersValid {
         if params.initial_max_data == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "QUIC initial_max_data is 0; no data can be transferred on this \
                      connection (RFC 9000 §18.2)"
                     .into(),
@@ -107,7 +100,7 @@ impl ProtocolRule for QuicTransportParametersValid {
         if params.initial_max_stream_data_bidi_local == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "QUIC initial_max_stream_data_bidi_local is 0; bidirectional streams \
                      cannot carry data (RFC 9000 §18.2)"
                     .into(),
@@ -121,7 +114,7 @@ impl ProtocolRule for QuicTransportParametersValid {
         if params.initial_max_stream_data_bidi_remote == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "QUIC initial_max_stream_data_bidi_remote is 0; request streams \
                      cannot carry data (RFC 9114 §6.1)"
                     .into(),
@@ -134,7 +127,7 @@ impl ProtocolRule for QuicTransportParametersValid {
         if params.initial_max_stream_data_uni == Some(0) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "QUIC initial_max_stream_data_uni is 0; HTTP/3 unidirectional streams \
                      (control, QPACK) cannot carry data (RFC 9114 §6.2)"
                     .into(),
@@ -149,7 +142,7 @@ impl ProtocolRule for QuicTransportParametersValid {
             Some(0) | None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "QUIC max_idle_timeout is 0 or absent; connections may remain \
                          idle indefinitely, consuming server resources (RFC 9000 §18.2)"
                         .into(),
@@ -158,7 +151,7 @@ impl ProtocolRule for QuicTransportParametersValid {
             Some(ms) if ms > MAX_REASONABLE_IDLE_TIMEOUT_MS => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "QUIC max_idle_timeout is {}ms (>{} ms); excessively large idle \
                          timeouts waste server resources (RFC 9000 §18.2)",
@@ -284,7 +277,12 @@ mod tests {
     fn reasonable_params_pass() {
         let rule = QuicTransportParametersValid;
         let evt = make_event(reasonable_params());
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -296,7 +294,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("initial_max_streams_bidi"));
     }
@@ -307,7 +310,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = Some(1);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -317,7 +325,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_streams_bidi = None;
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -329,7 +342,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_data = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("initial_max_data"));
     }
@@ -340,7 +358,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_data = None;
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -352,7 +375,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_bidi_local = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -368,7 +396,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_bidi_remote = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -384,7 +417,12 @@ mod tests {
         let mut p = reasonable_params();
         p.initial_max_stream_data_uni = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result
             .unwrap()
@@ -400,7 +438,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(0);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
     }
@@ -411,7 +454,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = None;
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
     }
@@ -422,7 +470,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(MAX_REASONABLE_IDLE_TIMEOUT_MS + 1);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         let msg = result.unwrap().message;
         assert!(msg.contains("excessively large"));
@@ -434,7 +487,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(MAX_REASONABLE_IDLE_TIMEOUT_MS);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -444,7 +502,12 @@ mod tests {
         let mut p = reasonable_params();
         p.max_idle_timeout_ms = Some(1);
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -458,7 +521,12 @@ mod tests {
             connection_id: Uuid::new_v4(),
             kind: ProtocolEventKind::H3StreamOpened { stream_id: 0 },
         };
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -479,7 +547,12 @@ mod tests {
                 payload_length: 10,
             },
         };
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_none());
     }
 
@@ -507,7 +580,12 @@ mod tests {
             initial_max_stream_data_uni: None,
         };
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         // Only max_idle_timeout triggers because None means no timeout
         assert!(result.is_some());
         assert!(result.unwrap().message.contains("max_idle_timeout"));
@@ -527,7 +605,12 @@ mod tests {
             initial_max_stream_data_uni: Some(0),
         };
         let evt = make_event(p);
-        let result = rule.check_event(&evt, &ProtocolEventHistory::empty(), &make_config());
+        let result = crate::test_helpers::run_protocol_rule(
+            &rule,
+            &evt,
+            &ProtocolEventHistory::empty(),
+            &make_config(),
+        );
         assert!(result.is_some());
         // First check is initial_max_streams_bidi
         assert!(result.unwrap().message.contains("initial_max_streams_bidi"));

--- a/lint-http-rules/src/rules/websocket_frame_masking.rs
+++ b/lint-http-rules/src/rules/websocket_frame_masking.rs
@@ -28,7 +28,7 @@ impl ProtocolRule for WebsocketFrameMasking {
         &self,
         event: &ProtocolEvent,
         _history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let ProtocolEventKind::WebSocketFrame {
             direction, masked, ..
@@ -79,12 +79,9 @@ impl ProtocolRule for WebsocketFrameMasking {
             _ => return None,
         };
 
-        // Read last: both gates above end the rule for every conforming frame,
-        // and `parse_rule_config` is two lookups of the rule id.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("A WebSocket frame where {defect}"),
         })
     }
@@ -183,7 +180,8 @@ mod tests {
     }
 
     fn judge(event: &ProtocolEvent) -> Option<Violation> {
-        RULE.check_event(
+        crate::test_helpers::run_protocol_rule(
+            &RULE,
             event,
             &ProtocolEventHistory::new(Vec::new()),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[RULE.id()]),

--- a/lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
+++ b/lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
@@ -329,7 +329,7 @@ impl ProtocolRule for WebsocketFrameOpcodeSequence {
         &self,
         event: &ProtocolEvent,
         history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let ProtocolEventKind::WebSocketFrame {
             session_id,
@@ -364,11 +364,10 @@ impl ProtocolRule for WebsocketFrameOpcodeSequence {
         // Every gate above ends the rule, and reading the configuration is
         // several map probes and a hash of the id — so only a frame about to be
         // reported pays for it.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("A WebSocket frame the {} sent {}", frame.sender(), defect),
         })
     }
@@ -545,9 +544,13 @@ mod tests {
     }
 
     fn judge(event: &ProtocolEvent, history: &ProtocolEventHistory) -> Option<String> {
-        WebsocketFrameOpcodeSequence
-            .check_event(event, history, &make_config())
-            .map(|v| v.message)
+        crate::test_helpers::run_protocol_rule(
+            &WebsocketFrameOpcodeSequence,
+            event,
+            history,
+            &make_config(),
+        )
+        .map(|v| v.message)
     }
 
     #[test]

--- a/lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
+++ b/lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
@@ -47,7 +47,7 @@ impl ProtocolRule for WebsocketFrameRsvBits {
         &self,
         event: &ProtocolEvent,
         _history: &ProtocolEventHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let ProtocolEventKind::WebSocketFrame {
             direction,
@@ -71,9 +71,6 @@ impl ProtocolRule for WebsocketFrameRsvBits {
             return None;
         }
 
-        // Read once, after the branch that ends the rule for every conforming
-        // frame: `parse_rule_config` is two lookups of the rule id.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let sender = match direction {
             MessageDirection::Client => "client",
             MessageDirection::Server => "server",
@@ -90,7 +87,7 @@ impl ProtocolRule for WebsocketFrameRsvBits {
         if *rsv > 0b111 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "A WebSocket frame the {sender} sent records the reserved bits as {rsv:#05b}, \
                      and the frame header holds three of them — one bit each — so no frame on any \
@@ -127,7 +124,7 @@ impl ProtocolRule for WebsocketFrameRsvBits {
         // catalogue does.
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "A WebSocket frame the {sender} sent has {} set, and the 101 that opened this \
                  session accepted no extension: RFC 6455 §5.2 makes a reserved bit non-zero only \
@@ -238,7 +235,8 @@ mod tests {
     }
 
     fn judge(event: &ProtocolEvent) -> Option<Violation> {
-        RULE.check_event(
+        crate::test_helpers::run_protocol_rule(
+            &RULE,
             event,
             &ProtocolEventHistory::new(Vec::new()),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[RULE.id()]),

--- a/lint-http-rules/src/test_helpers.rs
+++ b/lint-http-rules/src/test_helpers.rs
@@ -20,3 +20,20 @@ pub fn make_test_rule_config() -> crate::rules::RuleConfig {
         severity: crate::lint::Severity::Warn,
     }
 }
+
+/// Prepare `rule` under `cfg`, then dispatch one event through it — the way
+/// the engine does, collapsed to one call for tests.
+///
+/// Returns `None` when `prepare` rejects the config, which preserves what a
+/// direct `check_event` call answered when its own parse failed: the rule
+/// yields nothing. Tests asserting *why* preparation fails call `prepare`
+/// directly.
+pub fn run_protocol_rule(
+    rule: &dyn crate::rules::ProtocolRule,
+    event: &crate::protocol_event::ProtocolEvent,
+    history: &crate::protocol_event::ProtocolEventHistory,
+    cfg: &crate::config::Config,
+) -> Option<crate::lint::Violation> {
+    let resolved = rule.prepare(cfg).ok()?;
+    rule.check_event(event, history, &crate::rules::RuleContext::new(&resolved))
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2642,25 +2642,25 @@ sources:
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 121
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 120
+      line: 117
   - label: websocket_frame_rsv_bits
     section: § 5.2
     snippet: If a nonzero value is received and none of the negotiated extensions defines the meaning of such a nonzero value, the receiving endpoint MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 119
+      line: 116
   - label: websocket_frame_rsv_bits (2)
     section: § 5.2
     snippet: MUST be 0 unless an extension is negotiated that defines meanings for non-zero values.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 118
+      line: 115
   - label: websocket_frame_rsv_bits (3)
     section: § 5.2
     snippet: 'RSV1, RSV2, RSV3:  1 bit each'
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 89
+      line: 86
   - label: frame-rsv1 production
     section: § 5.2
     snippet: frame-rsv1 = %x0 / %x1 ; 1 bit in length, MUST be 0 unless ; negotiated otherwise
@@ -4429,19 +4429,19 @@ sources:
     snippet: Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 147
+      line: 140
   - label: quic_transport_parameters_valid (3)
     section: § 18.2
     snippet: the initial flow control limit for locally initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 105
+      line: 98
   - label: quic_transport_parameters_valid (4)
     section: § 18.2
     snippet: the initial value for the maximum amount of data that can be sent on the connection
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 90
+      line: 83
 - label: RFC 9110
   url: https://www.rfc-editor.org/rfc/rfc9110.txt
   type: text/plain
@@ -10215,39 +10215,39 @@ sources:
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
     cited_by:
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 110
+      line: 102
   - label: http3_goaway_semantics (2)
     section: § 5.2
     snippet: Receiving a GOAWAY containing a larger identifier than previously received MUST be treated as a connection error of type H3_ID_ERROR.
     cited_by:
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 75
+      line: 67
   - label: http3_goaway_semantics (3)
     section: § 5.2
     snippet: The server sends a client-initiated bidirectional stream ID; the client sends a push ID.
     cited_by:
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 68
+      line: 60
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 103
+      line: 95
   - label: http3_max_push_id
     section: § 7.2.7
     snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 66
+      line: 60
   - label: http3_max_push_id (2)
     section: § 7.2.7
     snippet: A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED.
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 50
+      line: 44
   - label: http3_max_push_id (3)
     section: § 7.2.7
     snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 97
+      line: 91
   - label: http3_pseudo_headers_valid
     section: § 4.3.1
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
@@ -10297,31 +10297,31 @@ sources:
     snippet: A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 73
+      line: 66
   - label: http3_settings_frame (3)
     section: § 7.2.4
     snippet: An implementation MUST ignore any parameter with an identifier it does not understand
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 132
+      line: 125
   - label: http3_settings_frame (4)
     section: § 7.2.4
     snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 67
+      line: 60
   - label: http3_settings_frame (5)
     section: § 7.2.4
     snippet: The same setting identifier MUST NOT occur more than once in the SETTINGS frame
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 115
+      line: 108
   - label: http3_settings_frame (6)
     section: § 7.2.4.1
     snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 96
+      line: 89
   - label: http3_status_code_valid
     section: § 4.5
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
@@ -10373,7 +10373,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 131
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 51
+      line: 43
   - label: lint-http-proxy/src/h3_instrument.rs (4)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
@@ -10439,21 +10439,21 @@ sources:
     snippet: HTTP/3 does not use server-initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 106
+      line: 99
   - label: quic_transport_parameters_valid (2)
     section: § 6.1
     snippet: In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 75
+      line: 68
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 120
+      line: 113
   - label: quic_transport_parameters_valid (3)
     section: § 6.2
     snippet: Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 133
+      line: 126
   - label: request_method_token_valid
     section: § 4.3.1
     snippet: '":method":  Contains the HTTP method (Section 9 of [HTTP])'


### PR DESCRIPTION
check_event now takes a RuleContext: the engine prepares each enabled protocol rule once at construction and hands dispatch a borrowed view, so the per-event severity parse — and the comment every rule carried arguing about where to place it — goes away. lint_protocol_event loses its config parameter; the protocol pipeline loses the config it was only holding to pass along.

Tests dispatch the way the engine does, through a helper that prepares then checks, and a config that fails preparation still answers None there — what a failed parse used to answer. This is the whole recipe rehearsed on seven files before the hundred and eighty-six.
