### PR TITLE
The second quarter of the rule tests dispatch through one door

### DIFF
--- a/lint-http-rules/src/rules/content_type_registered.rs
+++ b/lint-http-rules/src/rules/content_type_registered.rs
@@ -279,7 +279,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -310,7 +311,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -330,7 +332,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -360,7 +363,8 @@ mod tests {
             "content-type",
             "application/vnd.unknown",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -398,26 +402,26 @@ mod tests {
         let mut tx1 = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx1.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "application/json")]);
-        assert!(rule
-            .check_transaction(
-                &tx1,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx1,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_none());
 
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx2.response.as_mut().unwrap().headers = crate::test_helpers::make_headers_from_pairs(&[(
             "content-type",
             "application/ld+json",
         )]);
-        assert!(rule
-            .check_transaction(
-                &tx2,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx2,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_none());
     }
 
     #[test]
@@ -429,7 +433,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/x-custom")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -542,7 +547,8 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -557,7 +563,8 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx2.request.headers = hm2;
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/content_type_valid.rs
+++ b/lint-http-rules/src/rules/content_type_valid.rs
@@ -372,7 +372,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&pairs);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -394,7 +395,8 @@ mod tests {
                 "application/json",
             )]));
         }
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -425,7 +427,8 @@ mod tests {
         hm.insert("content-type", HeaderValue::from_bytes(raw).unwrap());
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -452,14 +455,14 @@ mod tests {
             ("content-type", "text/plain"),
             ("content-type", "*/plain"),
         ]);
-        let msg = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("must be reported")
-            .message;
+        let msg = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("must be reported")
+        .message;
         assert!(
             msg.contains("Multiple Content-Type field lines in the request"),
             "{msg}"
@@ -477,14 +480,14 @@ mod tests {
         tx.response.as_mut().unwrap().trailers = Some(
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text/")]),
         );
-        let msg = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("must be reported")
-            .message;
+        let msg = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("must be reported")
+        .message;
         assert!(msg.contains("empty type or subtype"), "{msg}");
     }
 
@@ -523,7 +526,7 @@ mod tests {
             tx.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&pairs);
             let history = crate::transaction_history::TransactionHistory::empty();
-            let v = rule.check_transaction(&tx, &history, &cfg);
+            let v = crate::test_helpers::run_rule(&rule, &tx, &history, &cfg);
             match ex.compliance {
                 Compliance::Compliant => {
                     assert!(
@@ -537,8 +540,12 @@ mod tests {
                     // published here as good would contradict it. (The
                     // IANA-registry siblings are allowlist-driven and so depend
                     // on the operator's config, not on the example.)
-                    let other = crate::rules::charset_present::CharsetPresent
-                        .check_transaction(&tx, &history, &cfg);
+                    let other = crate::test_helpers::run_rule(
+                        &crate::rules::charset_present::CharsetPresent,
+                        &tx,
+                        &history,
+                        &cfg,
+                    );
                     assert!(
                         other.is_none(),
                         "the charset rule rejects a Compliant example {:?}: {other:?}",
@@ -565,7 +572,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "text")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -577,7 +585,8 @@ mod tests {
             200,
             &[("content-type", "text")],
         );
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -594,12 +603,14 @@ mod tests {
             200,
             &[("content-type", "application/json")],
         );
-        let v3 = rule.check_transaction(
+        let v3 = crate::test_helpers::run_rule(
+            &rule,
             &tx3,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
         );
-        let v4 = rule.check_transaction(
+        let v4 = crate::test_helpers::run_rule(
+            &rule,
             &tx4,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/context_fields_direction.rs
+++ b/lint-http-rules/src/rules/context_fields_direction.rs
@@ -236,13 +236,13 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<String> {
-        ContextFieldsDirection
-            .check_transaction(
-                tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .map(|v| v.message)
+        crate::test_helpers::run_rule(
+            &ContextFieldsDirection,
+            tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .map(|v| v.message)
     }
 
     /// Each field in its own direction draws nothing — that is the direction

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -359,7 +359,8 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = CookieAttributeConsistent;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -437,7 +438,8 @@ mod tests {
             .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
 
         let rule = CookieAttributeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -518,7 +520,8 @@ mod tests {
             .append("set-cookie", HeaderValue::from_static("=bad; Secure"));
 
         let rule = CookieAttributeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/cookie_domain_matching.rs
@@ -230,15 +230,13 @@ mod tests {
         let rule = CookieDomainMatching;
         let tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -249,15 +247,13 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/foo", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -272,7 +268,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
@@ -301,15 +298,13 @@ mod tests {
             prev2.clone(),
             prev1.clone(),
         ]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -324,7 +319,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://sub.example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
@@ -350,15 +346,13 @@ mod tests {
         let mut tx = make_tx_with_req("https://sub.example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -369,7 +363,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
@@ -383,15 +378,13 @@ mod tests {
         let rule = CookieDomainMatching;
         let tx = make_tx_with_req("https://example.com/", None);
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -408,15 +401,13 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=2"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -428,15 +419,13 @@ mod tests {
         let mut tx = make_tx_with_req("http://example.com/foo", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -452,15 +441,13 @@ mod tests {
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_domain_matching"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_domain_matching"]),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -160,7 +160,8 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = CookieDomainValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -212,7 +213,8 @@ mod tests {
         });
 
         let rule = CookieDomainValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -259,7 +261,8 @@ mod tests {
             .append("set-cookie", HeaderValue::from_bytes(&[0xff])?);
 
         let rule = CookieDomainValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/cookie_lifecycle.rs
@@ -321,13 +321,13 @@ mod tests {
         let rule = CookieLifecycle;
         let tx = make_tx_with_req("https://example.com/", Some("foo=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -339,13 +339,13 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("b=2"));
         tx.timestamp = ts + chrono::Duration::seconds(1);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -356,7 +356,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -372,13 +373,13 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(30);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -389,7 +390,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -414,7 +416,8 @@ mod tests {
             prev2.clone(),
             prev1.clone(),
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -431,7 +434,8 @@ mod tests {
         let mut tx = make_tx_with_req("http://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -465,7 +469,8 @@ mod tests {
             prev_nonsecure.clone(),
             prev_secure.clone(),
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -484,7 +489,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/public", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -502,7 +508,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://example.com/foobar", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -524,7 +531,8 @@ mod tests {
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
-            rule.check_transaction(
+            crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),
@@ -546,7 +554,8 @@ mod tests {
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["cookie_lifecycle"]),

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -156,7 +156,8 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(200, &[("set-cookie", value)]);
         let rule = CookiePathValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -242,7 +243,8 @@ mod tests {
         });
 
         let rule = CookiePathValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -271,7 +273,8 @@ mod tests {
         });
 
         let rule = CookiePathValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -319,7 +322,8 @@ mod tests {
     fn check_missing_response() {
         let tx = crate::test_helpers::make_test_transaction();
         let rule = CookiePathValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/cookie_same_site_enforced.rs
+++ b/lint-http-rules/src/rules/cookie_same_site_enforced.rs
@@ -271,15 +271,15 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -296,15 +296,15 @@ mod tests {
                 Some("a=1; SameSite=Strict"),
                 Some(Utc::now()),
             )]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -321,15 +321,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("none"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -346,15 +346,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("invalid"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -372,15 +372,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -398,15 +398,15 @@ mod tests {
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         // even though cross-site, the secure cookie should not match because of scheme
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -424,15 +424,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -453,15 +453,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("cors"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -482,15 +482,15 @@ mod tests {
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.method = "GET".parse().unwrap();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -511,15 +511,15 @@ mod tests {
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.method = "HEAD".parse().unwrap();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -536,15 +536,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -564,15 +564,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-mode", HeaderValue::from_static("cors"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -580,15 +580,15 @@ mod tests {
         let rule = CookieSameSiteEnforced;
         let tx = make_tx_with_req("https://example.com/", Some("a=1"));
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -612,15 +612,15 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("same-site"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -637,14 +637,14 @@ mod tests {
         tx.request
             .headers
             .append("sec-fetch-site", HeaderValue::from_static("cross-site"));
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "cookie_same_site_enforced"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_same_site_enforced"
+            ]),
+        )
+        .is_none());
     }
 }

--- a/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
@@ -177,7 +177,8 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -198,7 +199,8 @@ mod tests {
     fn no_response_no_violation() {
         let rule = CrossOriginEmbedderPolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -227,7 +229,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -260,7 +263,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -298,7 +302,8 @@ mod tests {
             200,
             &[("cross-origin-embedder-policy", "require-corp ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -313,13 +318,13 @@ mod tests {
             200,
             &[("cross-origin-embedder-policy", "unsafe-none")],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("does not enable cross-origin isolation"));
         assert!(v.message.contains("unsafe-none"));
     }
@@ -334,13 +339,13 @@ mod tests {
                 "require-corp, credentialless",
             )],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("single value"));
     }
 
@@ -365,7 +370,8 @@ mod tests {
             200,
             &[("cross-origin-embedder-policy", "CrEdEntIalLess")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
@@ -188,7 +188,8 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -209,7 +210,8 @@ mod tests {
     fn no_response_no_violation() {
         let rule = CrossOriginOpenerPolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -237,7 +239,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -270,7 +273,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -308,7 +312,8 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", "same-origin ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -323,13 +328,13 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", "other")],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("unsupported value"));
         assert!(v.message.contains("other"));
     }
@@ -341,13 +346,13 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", "same-origin, unsafe-none")],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("single value"));
     }
 
@@ -358,7 +363,8 @@ mod tests {
             200,
             &[("cross-origin-opener-policy", " same-origin-allow-popups ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
@@ -178,7 +178,8 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -199,7 +200,8 @@ mod tests {
     fn no_response_no_violation() {
         let rule = CrossOriginResourcePolicyValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -227,7 +229,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -260,7 +263,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -298,7 +302,8 @@ mod tests {
             200,
             &[("cross-origin-resource-policy", "same-origin ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -313,13 +318,13 @@ mod tests {
             200,
             &[("cross-origin-resource-policy", "other")],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("unsupported value"));
         assert!(v.message.contains("other"));
     }
@@ -331,13 +336,13 @@ mod tests {
             200,
             &[("cross-origin-resource-policy", "same-origin, cross-origin")],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("single value"));
     }
 }

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -291,7 +291,8 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&h);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -315,7 +316,8 @@ mod tests {
             ("last-modified", "Wed, 21 Oct 2015 07:30:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -335,7 +337,8 @@ mod tests {
             ("sunset", "Wed, 21 Oct 2015 07:27:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -355,7 +358,8 @@ mod tests {
             ("if-modified-since", "Wed, 21 Oct 2015 07:30:00 GMT"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -377,7 +381,8 @@ mod tests {
         hm.insert("date", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -395,7 +400,8 @@ mod tests {
             ("sunset", "not-a-date"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -420,7 +426,8 @@ mod tests {
         hm.insert("last-modified", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -442,7 +449,8 @@ mod tests {
         hm.insert("if-modified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -460,7 +468,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("date", "not-a-date")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -480,7 +489,8 @@ mod tests {
             "Tue, 01 Jan 2030 00:00:00 GMT",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -500,7 +510,8 @@ mod tests {
         hm.insert("date", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -520,7 +531,8 @@ mod tests {
             ("last-modified", "not-a-date"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -539,7 +551,8 @@ mod tests {
             ("if-modified-since", "not-a-date"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -558,7 +571,8 @@ mod tests {
             "Wed, 21 Oct 2015 07:30:00 GMT",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -582,7 +596,8 @@ mod tests {
         hm.insert("sunset", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/deprecation_header_syntax.rs
+++ b/lint-http-rules/src/rules/deprecation_header_syntax.rs
@@ -165,7 +165,8 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = DeprecationHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -199,7 +200,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -224,7 +226,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -242,7 +245,8 @@ mod tests {
             200,
             &[("deprecation", "   @1688169599   ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -258,7 +262,8 @@ mod tests {
             200,
             &[("deprecation", "@abc")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -275,7 +280,8 @@ mod tests {
         let rule = DeprecationHeaderSyntax;
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("deprecation", "@")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -291,7 +297,8 @@ mod tests {
             200,
             &[("deprecation", "@-1")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -307,7 +314,8 @@ mod tests {
             200,
             &[("deprecation", "TRUE")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -322,7 +330,8 @@ mod tests {
     fn no_response_no_violation() {
         let rule = DeprecationHeaderSyntax;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
@@ -382,7 +382,8 @@ mod tests {
     fn no_challenge_before_auth_is_reported() {
         let nonce1 = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -403,7 +404,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce1, Some("o1"), None)),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), Some("o2")));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -421,7 +423,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce1, Some("o1"), None)),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -437,7 +440,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Basic abc")]);
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -454,7 +458,8 @@ mod tests {
             "authorization",
             "Digest realm=\"r\"",
         )]);
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -472,7 +477,8 @@ mod tests {
             "authorization",
             "Digest bogus=\"x\", =bad",
         )]);
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -499,7 +505,8 @@ mod tests {
             prev_challenge,
         ]);
         let tx = tx_req_with_auth(&auth2);
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -520,7 +527,8 @@ mod tests {
         ]);
         // client correctly uses same nonce but wrong nc
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000005"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -543,7 +551,8 @@ mod tests {
             prev_challenge,
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000002"), Some("o1")));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -561,7 +570,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce1, None, None)),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -580,7 +590,8 @@ mod tests {
         ]);
         // request omits opaque entirely
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -600,7 +611,8 @@ mod tests {
         ]);
         // client uses different nonce entirely
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -621,7 +633,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce1, None, None)),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, None, None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -638,7 +651,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce1, None, None)),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce1, Some("GARBAGE"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -657,7 +671,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce1, None, Some("true"))),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce2, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -679,7 +694,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce, None, Some("TRUE"))),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000005"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -698,7 +714,8 @@ mod tests {
         ]);
         // correct reset
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -719,7 +736,8 @@ mod tests {
         );
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -736,7 +754,8 @@ mod tests {
             tx_resp_with_challenge(&make_challenge(&nonce, None, None)),
         ]);
         let tx = tx_req_with_auth(&make_auth(&nonce, None, None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -758,7 +777,8 @@ mod tests {
         );
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![txh]);
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -782,7 +802,8 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![txh]);
         let nonce = random_nonce();
         let tx = tx_req_with_auth(&make_auth(&nonce, Some("00000001"), None));
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -802,7 +823,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("authorization", "Digest")]);
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -822,7 +844,8 @@ mod tests {
             HeaderValue::from_bytes(&[0xff, 0xff]).unwrap(),
         );
         tx.request.headers = headers;
-        let v = DigestAuthNonceHandling.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &DigestAuthNonceHandling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[

--- a/lint-http-rules/src/rules/digest_auth_valid.rs
+++ b/lint-http-rules/src/rules/digest_auth_valid.rs
@@ -359,7 +359,8 @@ mod tests {
                 .append("authorization", h.parse().unwrap());
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -385,7 +386,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -409,7 +411,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -431,7 +434,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -450,7 +454,8 @@ mod tests {
             "authorization",
             hyper::header::HeaderValue::from_bytes(b"Digest \xff").unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -472,7 +477,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -498,7 +504,8 @@ mod tests {
             "Digest username=\"Mu\\\"fasa\", realm=\"test\", nonce=\"abc\", uri=\"/\", response=\"d\"".parse().unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -521,7 +528,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -559,7 +567,8 @@ mod tests {
             .headers
             .append("authorization", "Digest    ".parse().unwrap());
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -581,7 +590,8 @@ mod tests {
             .headers
             .append("authorization", "Digest".parse().unwrap());
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -605,7 +615,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -632,7 +643,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -659,7 +671,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -690,7 +703,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -724,7 +738,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -752,7 +767,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -771,7 +787,8 @@ mod tests {
         tx.request
             .headers
             .append("authorization", "".parse().unwrap());
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -792,7 +809,8 @@ mod tests {
                 .unwrap(),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -812,7 +830,8 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -838,7 +857,8 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -645,7 +645,8 @@ mod tests {
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -668,7 +669,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -683,7 +685,8 @@ mod tests {
         let tx = make_req_want_digest("sha-256=, , sha-512");
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -699,7 +702,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("want-digest", "SHA-256")]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -720,7 +724,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -752,7 +757,8 @@ mod tests {
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -773,7 +779,8 @@ mod tests {
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -791,7 +798,8 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction();
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -810,7 +818,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -836,7 +845,8 @@ mod tests {
         });
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -853,7 +863,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA@1=YWJj")]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -869,7 +880,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA-256=YWJj")]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -888,7 +900,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -905,7 +918,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -922,7 +936,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -942,7 +957,8 @@ mod tests {
         )]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -962,7 +978,8 @@ mod tests {
         )]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -979,7 +996,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -996,7 +1014,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1013,7 +1032,8 @@ mod tests {
             .append("want-content-digest", "sha-256=20".parse().unwrap());
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1031,7 +1051,8 @@ mod tests {
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
         // Add a simple check that presence of header yields a violation via our rule: we will add handling next
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1048,7 +1069,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1065,7 +1087,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1083,7 +1106,8 @@ mod tests {
         )]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1100,7 +1124,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1117,7 +1142,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1136,7 +1162,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1169,7 +1196,8 @@ mod tests {
         });
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1186,7 +1214,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1205,7 +1234,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1232,7 +1262,8 @@ mod tests {
         });
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1259,7 +1290,8 @@ mod tests {
         });
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1277,7 +1309,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1297,7 +1330,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1332,7 +1366,8 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1366,13 +1401,13 @@ mod tests {
         let tx = make_req_digest(value);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("legacy Digest is always reported as obsolete");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("legacy Digest is always reported as obsolete");
         assert!(
             v.message.contains("obsoleted by RFC 9530"),
             "expected the obsolescence report, not a syntax error: {}",
@@ -1389,13 +1424,13 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .unwrap_or_else(|| panic!("expected violation for '{}: {}'", header, value));
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .unwrap_or_else(|| panic!("expected violation for '{}: {}'", header, value));
         assert!(v.message.contains("structured-field key"));
     }
 
@@ -1411,7 +1446,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1438,7 +1474,8 @@ mod tests {
         });
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1465,7 +1502,8 @@ mod tests {
         });
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1483,7 +1521,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1507,7 +1546,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1530,7 +1570,8 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1561,7 +1602,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("content-md5", "dGVzdA==")]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1580,7 +1622,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1601,7 +1644,8 @@ mod tests {
 
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1625,7 +1669,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1647,7 +1692,8 @@ mod tests {
         )]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1668,7 +1714,8 @@ mod tests {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[(header, value)]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1697,7 +1744,8 @@ mod tests {
         tx.request.headers = hm;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1713,7 +1761,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA-256=YWJj,")]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1732,7 +1781,8 @@ mod tests {
         )]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1758,7 +1808,8 @@ mod tests {
         req.request.headers = hm_req;
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let vreq = rule.check_transaction(
+        let vreq = crate::test_helpers::run_rule(
+            &rule,
             &req,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1784,7 +1835,8 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let vresp = rule.check_transaction(
+        let vresp = crate::test_helpers::run_rule(
+            &rule,
             &resp_tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1801,7 +1853,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1820,7 +1873,8 @@ mod tests {
             200,
             &[("want-content-digest", "sha-512 = 2")],
         );
-        let v_ok = rule.check_transaction(
+        let v_ok = crate::test_helpers::run_rule(
+            &rule,
             &tx_ok,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1832,7 +1886,8 @@ mod tests {
             200,
             &[("want-content-digest", "sha-512=3, sha-256")],
         );
-        let v_bad = rule.check_transaction(
+        let v_bad = crate::test_helpers::run_rule(
+            &rule,
             &tx_bad,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1851,7 +1906,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1870,7 +1926,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1884,7 +1941,8 @@ mod tests {
         let tx = make_req_want_digest("sha@1");
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1903,7 +1961,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1923,7 +1982,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1942,7 +2002,8 @@ mod tests {
         );
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1958,7 +2019,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("digest", "SHA-256=YWJj,")]);
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["digest_header_syntax"]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/early_data_header_safe_method.rs
+++ b/lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -372,7 +372,8 @@ mod tests {
     }
 
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
-        EarlyDataHeaderSafeMethod.check_transaction(
+        crate::test_helpers::run_rule(
+            &EarlyDataHeaderSafeMethod,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -588,13 +589,13 @@ mod tests {
             .iter()
             .find(|r| r.id() == "trailer_fields_valid")
             .expect("the neighbour is registered");
-        assert!(neighbour
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[neighbour.id()]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            *neighbour,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[neighbour.id()]),
+        )
+        .is_some());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/etag_or_last_modified_present.rs
+++ b/lint-http-rules/src/rules/etag_or_last_modified_present.rs
@@ -127,7 +127,8 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -148,7 +149,8 @@ mod tests {
     fn check_missing_response() {
         let rule = EtagOrLastModifiedPresent;
         let tx = crate::test_helpers::make_test_transaction();
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -181,7 +181,8 @@ mod tests {
 
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "warn");
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -217,7 +218,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -245,7 +247,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -552,7 +552,8 @@ mod tests {
         history: &crate::transaction_history::TransactionHistory,
     ) -> Option<Violation> {
         let rule = ExpectHeaderValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
+++ b/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
@@ -286,7 +286,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -327,7 +328,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -346,7 +348,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -373,7 +376,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -399,7 +403,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -423,7 +428,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -451,7 +457,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -495,7 +502,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -521,7 +529,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -597,7 +606,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -620,7 +630,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "expires_and_cache_control_consistent",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/extension_headers_registered.rs
+++ b/lint-http-rules/src/rules/extension_headers_registered.rs
@@ -284,7 +284,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&header_pairs);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -311,7 +312,8 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -417,7 +419,8 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("x-unknown", "v")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -464,7 +467,8 @@ mod tests {
         let cfg = make_cfg_with_allowed(vec!["x-custom"]);
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("X-CUSTOM", "1")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -480,7 +484,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("x-a", "1"), ("x-b", "2")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -533,13 +538,13 @@ mod tests {
             tx.response.as_mut().unwrap().trailers = Some(trailers);
         }
 
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("a trailer field name the deployment did not list must be reported");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("a trailer field name the deployment did not list must be reported");
         assert!(v.message.contains("checksum"));
         assert!(
             v.message.contains(section),
@@ -561,13 +566,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("checksum", "abc123")]),
         );
 
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_none());
         Ok(())
     }
 
@@ -615,7 +620,8 @@ mod tests {
                 tx.request.headers = section;
             }
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,

--- a/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
+++ b/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
@@ -272,7 +272,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -305,7 +306,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-disposition", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -331,7 +333,8 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -352,7 +355,8 @@ mod tests {
             "content-disposition",
             "form-data; name=\"\"",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -372,7 +376,8 @@ mod tests {
             "content-disposition",
             "form-data; name=\"   \"",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -392,7 +397,8 @@ mod tests {
             "content-disposition",
             "form-data; name=\"unterminated",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -413,7 +419,8 @@ mod tests {
         hm.insert("content-disposition", HeaderValue::from_bytes(&[0xff])?);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -432,7 +439,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "form-data")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -452,7 +460,8 @@ mod tests {
             "content-disposition",
             "Form-Data; NAME=User",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -470,7 +479,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "; name=user")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -488,7 +498,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "form-data;")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -514,7 +525,8 @@ mod tests {
             HeaderValue::from_static("form-data; name=\"b\""),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -532,7 +544,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-disposition", "")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -552,7 +565,8 @@ mod tests {
             "content-disposition",
             "form-data; badparam",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -581,7 +595,8 @@ mod tests {
             HeaderValue::from_static("form-data; filename=example.txt"),
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/forwarded_header_valid.rs
+++ b/lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -456,15 +456,13 @@ mod tests {
                 HeaderValue::from_bytes(value.as_bytes()).expect("a field value"),
             );
         }
-        ForwardedHeaderValid
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "forwarded_header_valid",
-                ]),
-            )
-            .map(|v| v.message)
+        crate::test_helpers::run_rule(
+            &ForwardedHeaderValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["forwarded_header_valid"]),
+        )
+        .map(|v| v.message)
     }
 
     /// One field line, which is what all but a couple of the cases below need.
@@ -719,13 +717,13 @@ mod tests {
             HeaderValue::from_bytes(b"foo=\"\xdcnix\"").expect("a field value"),
         );
         let rule = ForwardedHeaderValid;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
 
         // The same octet outside a quoted-string is a finding, and about the
         // thing that is actually wrong with it.
@@ -734,14 +732,14 @@ mod tests {
             "forwarded",
             HeaderValue::from_bytes(b"for=\xff").expect("a field value"),
         );
-        let message = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .expect("a finding")
-            .message;
+        let message = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding")
+        .message;
         assert!(message.contains("neither a token"), "{message}");
     }
 
@@ -762,14 +760,14 @@ mod tests {
             200,
             &[("forwarded", "for=192.0.2.1")],
         );
-        let message = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &config,
-            )
-            .expect("a finding")
-            .message;
+        let message = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &config,
+        )
+        .expect("a finding")
+        .message;
         assert!(
             message.contains("only for use in HTTP requests"),
             "{message}"
@@ -781,26 +779,26 @@ mod tests {
         tx.response.as_mut().expect("a response").trailers = Some(
             crate::test_helpers::make_headers_from_pairs(&[("forwarded", "for=192.0.2.1")]),
         );
-        let message = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &config,
-            )
-            .expect("a finding")
-            .message;
+        let message = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &config,
+        )
+        .expect("a finding")
+        .message;
         assert!(message.contains("its trailer section"), "{message}");
 
         // A response with no `Forwarded` of its own is not a finding, whatever
         // the request carried.
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &config,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &config,
+        )
+        .is_none());
     }
 
     #[test]
@@ -850,14 +848,14 @@ mod tests {
             HeaderValue::from_bytes(b"foo=a\xa0b").expect("a field value"),
         );
         let rule = ForwardedHeaderValid;
-        let message = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .expect("a finding")
-            .message;
+        let message = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a finding")
+        .message;
         assert!(message.contains("neither a token"), "{message}");
     }
 

--- a/lint-http-rules/src/rules/from_header_email_syntax.rs
+++ b/lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -357,7 +357,8 @@ mod tests {
         tx.request.headers = headers;
         let config =
             crate::test_helpers::make_test_config_with_severity("from_header_email_syntax", "warn");
-        FromHeaderEmailSyntax.check_transaction(
+        crate::test_helpers::run_rule(
+            &FromHeaderEmailSyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/head_response_headers_match_get.rs
@@ -505,7 +505,8 @@ mod tests {
         // ensure URIs match
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type", "content-length"]),
@@ -520,7 +521,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -536,7 +538,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("x-foo", "bar")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["x-foo"]),
@@ -555,7 +558,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("content-length", "5")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
@@ -571,7 +575,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
@@ -586,7 +591,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
@@ -604,7 +610,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = get.request.uri.clone();
 
-        let v = HeadResponseHeadersMatchGet.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &HeadResponseHeadersMatchGet,
             &head,
             // newest first
             &crate::transaction_history::TransactionHistory::from_transactions(vec![
@@ -620,7 +627,8 @@ mod tests {
     fn no_previous_does_nothing() {
         let rule = HeadResponseHeadersMatchGet;
         let head = make_head_with_headers(&[("etag", "\"v1\"")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg_with_headers(vec!["etag"]),
@@ -636,7 +644,8 @@ mod tests {
         // different URIs
         head.request.uri = "/other".parse().unwrap();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -652,7 +661,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -677,7 +687,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -774,7 +785,8 @@ mod tests {
     ) -> Option<Violation> {
         let mut head = head.clone();
         head.request.uri = prev.request.uri.clone();
-        HeadResponseHeadersMatchGet.check_transaction(
+        crate::test_helpers::run_rule(
+            &HeadResponseHeadersMatchGet,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(headers),
@@ -951,7 +963,8 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // 'x-foo' is not in the configured headers list -> should be ignored
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -966,7 +979,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("transfer-encoding", "chunked")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
@@ -981,7 +995,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
@@ -996,7 +1011,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("content-length", "5")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
@@ -1011,7 +1027,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "accept, accept-encoding")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
@@ -1026,7 +1043,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "a, c")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
@@ -1050,7 +1068,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("vary", "a, b")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["vary"]),
@@ -1071,7 +1090,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\"")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -1086,7 +1106,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("etag", "\"v1\""), ("content-type", "text/html")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag", "content-type"]),
@@ -1102,7 +1123,8 @@ mod tests {
         let mut head = make_head_with_headers(&[("accept-encoding", "deflate, gzip")]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["accept-encoding"]),
@@ -1179,7 +1201,8 @@ mod tests {
         head.response = None;
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),
@@ -1195,7 +1218,8 @@ mod tests {
         head.request.uri = prev.request.uri.clone();
 
         // validate_content_length on prev will error -> rule must be lenient
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["content-length"]),
@@ -1210,7 +1234,8 @@ mod tests {
         let mut head = make_head_with_headers(&[]);
         head.request.uri = prev.request.uri.clone();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &head,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
             &make_cfg_with_headers(vec!["etag"]),

--- a/lint-http-rules/src/rules/header_field_names_token_valid.rs
+++ b/lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -189,7 +189,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(header_pairs.as_slice());
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -214,7 +215,8 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, header_pairs.as_slice());
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -301,7 +303,8 @@ mod tests {
             other => panic!("unknown section {}", other),
         }
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -354,7 +357,8 @@ mod tests {
                 tx.response.as_mut().unwrap().headers = section;
             }
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -392,13 +396,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("x-checksum", "abc123")]),
         );
 
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/host_and_authority_consistent.rs
+++ b/lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -492,7 +492,8 @@ mod tests {
             );
         }
 
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/host_header.rs
+++ b/lint-http-rules/src/rules/host_header.rs
@@ -269,7 +269,8 @@ mod tests {
     fn judge(headers: &[(&str, &str)]) -> Option<String> {
         let rule = HostHeader;
         let tx = crate::test_helpers::make_test_transaction_with_headers(headers);
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -374,7 +375,8 @@ mod tests {
             ("host", "example.com"),
             ("host", "other.example.com"),
         ]);
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -406,7 +408,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -437,7 +440,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -483,7 +487,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_headers(&[]);
         tx.request.version = version.into();
         tx.request.uri = uri.into();
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -515,7 +515,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<String> {
         let rule = Http2PseudoHeadersValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -536,7 +537,8 @@ mod tests {
         rule: &dyn crate::rules::Rule,
         tx: &crate::http_transaction::HttpTransaction,
     ) -> Option<String> {
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -620,13 +622,13 @@ mod tests {
         cfg.rules
             .insert(owner.id().to_string(), toml::Value::Table(table));
         assert!(
-            owner
-                .check_transaction(
-                    &tx,
-                    &crate::transaction_history::TransactionHistory::empty(),
-                    &cfg,
-                )
-                .is_some(),
+            crate::test_helpers::run_rule(
+                &owner,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+            .is_some(),
             "method {method:?} is reported by nobody"
         );
     }

--- a/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -359,7 +359,8 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = "".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -374,7 +375,8 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = "   ".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -390,7 +392,8 @@ mod tests {
         let mut tx = make_h3_transaction();
         tx.request.method = method.into();
         tx.request.uri = uri.into();
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -464,7 +467,8 @@ mod tests {
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com/path".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -481,7 +485,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -498,7 +503,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -516,7 +522,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -534,7 +541,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -557,7 +565,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -576,7 +585,8 @@ mod tests {
         tx.request.uri = "/resource".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -593,7 +603,8 @@ mod tests {
         tx.request.uri = "https://example.com/path".into();
         tx.request.headers = hyper::HeaderMap::new(); // no Host needed
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -609,7 +620,8 @@ mod tests {
         tx.request.uri = "*".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -627,7 +639,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -642,7 +655,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -658,7 +672,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "   ".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -677,7 +692,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -694,7 +710,8 @@ mod tests {
         tx.request.uri = "/ws".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -712,7 +729,8 @@ mod tests {
         tx.request.uri = "*".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -731,7 +749,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com:443")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -748,7 +767,8 @@ mod tests {
         tx.request.uri = "example.com:443".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -763,7 +783,8 @@ mod tests {
         let rule = Http3PseudoHeadersValid;
         let tx = make_h3_transaction_with_response(200, &[]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -786,7 +807,8 @@ mod tests {
         let tx = make_h3_transaction_with_response(status, &[]);
         let history = crate::transaction_history::TransactionHistory::empty();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -795,13 +817,13 @@ mod tests {
 
         let owner = crate::rules::status_code_valid_range::StatusCodeValidRange;
         assert!(
-            owner
-                .check_transaction(
-                    &tx,
-                    &history,
-                    &crate::test_helpers::make_test_config_with_enabled_rules(&[owner.id()]),
-                )
-                .is_some(),
+            crate::test_helpers::run_rule(
+                &owner,
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[owner.id()]),
+            )
+            .is_some(),
             "status {status} over HTTP/3 is reported by nobody"
         );
     }
@@ -817,7 +839,8 @@ mod tests {
         let rule = Http3PseudoHeadersValid;
         let tx = make_h3_transaction_with_response(status, &[]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -838,7 +861,8 @@ mod tests {
         tx.request.version = version.into();
         tx.request.method = "".into(); // would be a violation for HTTP/3
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -856,7 +880,8 @@ mod tests {
         tx.request.version = "HTTP/3.0".into();
         // Response version stays HTTP/1.1 — status 0 should not be flagged.
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -874,7 +899,8 @@ mod tests {
         tx.request.uri = "https://example.com/".into();
         tx.response = None;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -908,7 +934,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "[::1]:443".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -926,7 +953,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "https://example.com/ws".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -945,7 +973,8 @@ mod tests {
             ("content-type", "application/json"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -960,7 +989,8 @@ mod tests {
         tx.request.method = "HEAD".into();
         tx.request.uri = "https://example.com/resource".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -978,7 +1008,8 @@ mod tests {
         tx.request.uri = "/resource".into();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("host", "")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -993,7 +1024,8 @@ mod tests {
         tx.request.method = "DELETE".into();
         tx.request.uri = "https://example.com/resource/42".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1012,7 +1044,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1030,7 +1063,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1046,7 +1080,8 @@ mod tests {
         tx.request.method = "connect".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1061,7 +1096,8 @@ mod tests {
         tx.request.method = "GET".into();
         tx.request.uri = "https://example.com:8443/path".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1075,7 +1111,8 @@ mod tests {
         let rule = Http3PseudoHeadersValid;
         let tx = make_h3_transaction_with_response(100, &[]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1097,7 +1134,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1115,7 +1153,8 @@ mod tests {
         tx.request.method = "CONNECT".into();
         tx.request.uri = "example.com:443".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1132,7 +1171,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1153,7 +1193,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1172,7 +1213,8 @@ mod tests {
             ("content-type", "application/json"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1188,7 +1230,8 @@ mod tests {
         tx.request.uri = "/resource/1".into();
         tx.request.headers = hyper::HeaderMap::new();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/http3_status_code_valid.rs
+++ b/lint-http-rules/src/rules/http3_status_code_valid.rs
@@ -182,7 +182,8 @@ mod tests {
         let rule = Http3StatusCodeValid;
         let tx = make_h3_transaction_with_response(101, &[("upgrade", "websocket")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -199,7 +200,8 @@ mod tests {
         let rule = Http3StatusCodeValid;
         let tx = make_h3_transaction_with_response(101, &[]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -218,7 +220,8 @@ mod tests {
         let rule = Http3StatusCodeValid;
         let tx = make_h3_transaction_with_response(status, headers);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -256,7 +259,8 @@ mod tests {
         }
 
         assert!(
-            rule.check_transaction(
+            crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -270,13 +274,13 @@ mod tests {
             .find(|r| r.id() == "no_body_for_1xx_204_304")
             .expect("the owning rule is registered");
         assert!(
-            owner
-                .check_transaction(
-                    &tx,
-                    &crate::transaction_history::TransactionHistory::empty(),
-                    &crate::test_helpers::make_test_config_with_enabled_rules(&[owner.id()]),
-                )
-                .is_some(),
+            crate::test_helpers::run_rule(
+                *owner,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[owner.id()]),
+            )
+            .is_some(),
             "nothing reported a {status} carrying headers {headers:?} \
              body {body_length:?} trailers {trailer_pairs:?}"
         );
@@ -290,7 +294,8 @@ mod tests {
             resp.body_length = Some(0);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -311,7 +316,8 @@ mod tests {
         let rule = Http3StatusCodeValid;
         let tx = make_h3_transaction_with_response(status, &[]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -329,7 +335,8 @@ mod tests {
             &[("upgrade", "websocket")],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -348,7 +355,8 @@ mod tests {
         tx.request.version = "HTTP/3.0".into();
         // response.version stays HTTP/1.1
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -364,7 +372,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = "HTTP/3.0".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -380,7 +389,8 @@ mod tests {
         let rule = Http3StatusCodeValid;
         let tx = make_h3_transaction_with_response(200, &[("content-length", "42")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -398,7 +408,8 @@ mod tests {
             resp.body_length = Some(100);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -417,7 +428,8 @@ mod tests {
             )]));
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -437,7 +449,8 @@ mod tests {
             resp.body_length = Some(10);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -456,7 +469,8 @@ mod tests {
             resp.body_length = None;
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -473,7 +487,8 @@ mod tests {
             crate::test_helpers::make_test_transaction_with_response(101, &[("upgrade", "h2c")]);
         tx.request.version = "HTTP/2.0".into();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/http_version_syntax.rs
+++ b/lint-http-rules/src/rules/http_version_syntax.rs
@@ -189,7 +189,8 @@ mod tests {
             trailers: None,
         });
         let rule = HttpVersionSyntax;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/if_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -193,7 +193,8 @@ mod tests {
         let cfg =
             crate::test_helpers::make_test_config_with_severity("if_match_etag_syntax", "warn");
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -222,7 +223,8 @@ mod tests {
         hm.insert("if-match", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -245,7 +247,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", "")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -261,7 +264,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-match", ",")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -281,7 +285,8 @@ mod tests {
         hm.append("if-match", HeaderValue::from_static("\"b\""));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -302,7 +307,8 @@ mod tests {
         hm.append("if-match", HeaderValue::from_static("b"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -351,7 +357,8 @@ mod tests {
                 HeaderValue::from_bytes(line).expect("a test If-Match value"),
             );
         }
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
@@ -151,7 +151,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", h)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -176,7 +177,8 @@ mod tests {
         hm.insert("if-modified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -192,7 +194,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", "")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -217,7 +220,8 @@ mod tests {
         hm.append("if-modified-since", HeaderValue::from_static("not-a-date"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -244,7 +248,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -197,7 +197,8 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -226,7 +227,8 @@ mod tests {
         hm.insert("if-none-match", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -249,7 +251,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -266,7 +269,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", ",")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -286,7 +290,8 @@ mod tests {
         hm.append("if-none-match", HeaderValue::from_static("\"b\""));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -307,7 +312,8 @@ mod tests {
         hm.append("if-none-match", HeaderValue::from_static("b"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -356,7 +362,8 @@ mod tests {
                 HeaderValue::from_bytes(line).expect("a test If-None-Match value"),
             );
         }
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
@@ -152,7 +152,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("if-unmodified-since", h)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -177,7 +178,8 @@ mod tests {
         hm.insert("if-unmodified-since", bad);
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -193,7 +195,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-unmodified-since", "")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -221,7 +224,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -248,7 +252,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/immutable_cache_never_stale.rs
+++ b/lint-http-rules/src/rules/immutable_cache_never_stale.rs
@@ -270,7 +270,8 @@ mod tests {
     fn no_history_no_violation() {
         let rule = ImmutableCacheNeverStale;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -286,7 +287,8 @@ mod tests {
         let prev = make_prev_with_headers(&[("cache-control", "max-age=60")], Utc::now());
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -309,7 +311,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -338,15 +341,15 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "immutable_cache_never_stale"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "immutable_cache_never_stale"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -361,15 +364,15 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "immutable_cache_never_stale"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "immutable_cache_never_stale"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -380,15 +383,15 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "immutable_cache_never_stale"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "immutable_cache_never_stale"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -407,7 +410,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -437,7 +441,8 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // age_val=5, elapsed clamped to 0 -> current_age=5 < freshness(50) => violation
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -460,14 +465,14 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // freshness lifetime zero, so no violation should be reported
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "immutable_cache_never_stale"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "immutable_cache_never_stale"
+            ]),
+        )
+        .is_none());
     }
 }

--- a/lint-http-rules/src/rules/immutable_requires_freshness.rs
+++ b/lint-http-rules/src/rules/immutable_requires_freshness.rs
@@ -212,7 +212,8 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -256,7 +257,8 @@ mod tests {
             "warn",
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -287,7 +289,8 @@ mod tests {
             .insert("cache-control", bad);
 
         let rule = ImmutableRequiresFreshness;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/keep_alive_header_valid.rs
+++ b/lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -679,7 +679,8 @@ mod tests {
     }
 
     fn check(tx: &crate::http_transaction::HttpTransaction, max: i64) -> Option<Violation> {
-        KeepAliveHeaderValid.check_transaction(
+        crate::test_helpers::run_rule(
+            &KeepAliveHeaderValid,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_max(max),
@@ -922,13 +923,13 @@ mod tests {
     /// in it cannot read as a clean run of the grammar checks.
     #[test]
     fn an_unreadable_config_reports_nothing_at_all() {
-        assert!(KeepAliveHeaderValid
-            .check_transaction(
-                &response_with(Some("timeout=bad")),
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg_with_optional_max(None),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &KeepAliveHeaderValid,
+            &response_with(Some("timeout=bad")),
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg_with_optional_max(None),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/language_tag_syntax.rs
+++ b/lint-http-rules/src/rules/language_tag_syntax.rs
@@ -271,7 +271,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -301,7 +302,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -340,7 +342,8 @@ mod tests {
         tx.request
             .headers
             .insert(name, HeaderValue::from_bytes(raw).unwrap());
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -379,7 +382,8 @@ mod tests {
                 .collect();
             let mut tx = crate::test_helpers::make_test_transaction();
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -435,7 +439,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         let pairs: Vec<(&str, &str)> = values.iter().map(|v| (header, *v)).collect();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -472,7 +477,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("accept-language", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -495,7 +501,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-language", "en, fr")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -525,7 +532,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_octet_pairs(&[(field, value)]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
+++ b/lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
@@ -147,7 +147,8 @@ mod tests {
             });
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -181,7 +182,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/link_header_valid.rs
+++ b/lint-http-rules/src/rules/link_header_valid.rs
@@ -1056,13 +1056,13 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<String> {
-        LinkHeaderValid
-            .check_transaction(
-                tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .map(|v| v.message)
+        crate::test_helpers::run_rule(
+            &LinkHeaderValid,
+            tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .map(|v| v.message)
     }
 
     fn judge_response(status: u16, value: &[u8]) -> Option<String> {

--- a/lint-http-rules/src/rules/location_header_uri_valid.rs
+++ b/lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -288,7 +288,8 @@ mod tests {
             "location_header_uri_valid",
             "warn",
         );
-        LocationHeaderUriValid.check_transaction(
+        crate::test_helpers::run_rule(
+            &LocationHeaderUriValid,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/location_on_redirect_present.rs
+++ b/lint-http-rules/src/rules/location_on_redirect_present.rs
@@ -265,7 +265,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = LocationOnRedirectPresent;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -331,7 +332,8 @@ mod tests {
     fn no_response_no_violation() {
         let rule = LocationOnRedirectPresent;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),


### PR DESCRIPTION
Files c through h, same indirection as the last commit: call sites move to run_rule, whose body is still the direct call they were making.
