### PR TITLE
The third quarter of the rule tests dispatch through one door

### DIFF
--- a/lint-http-rules/src/rules/max_age_directive_valid.rs
+++ b/lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -234,7 +234,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(30);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -257,7 +258,8 @@ mod tests {
 
         let history =
             crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -277,7 +279,8 @@ mod tests {
         let history2 =
             crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
-            rule.check_transaction(
+            crate::test_helpers::run_rule(
+                &rule,
                 &tx2,
                 &history2,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -304,7 +307,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -328,7 +332,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -349,7 +354,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -370,7 +376,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -390,7 +397,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -411,7 +419,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -437,7 +446,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(30);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -465,7 +475,8 @@ mod tests {
         tx.timestamp = base;
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -492,7 +503,8 @@ mod tests {
             crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
         // age == max-age should be treated as stale; unconditional request
         // should therefore be flagged since validator exists.
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),
@@ -509,7 +521,8 @@ mod tests {
         let history2 =
             crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         assert!(
-            rule.check_transaction(
+            crate::test_helpers::run_rule(
+                &rule,
                 &tx2,
                 &history2,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -535,7 +548,8 @@ mod tests {
         tx.timestamp = base - chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // age computed from elapsed clamped to 0 yields fresh state; no violation expected
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["max_age_directive_valid"]),

--- a/lint-http-rules/src/rules/max_forwards_numeric.rs
+++ b/lint-http-rules/src/rules/max_forwards_numeric.rs
@@ -236,7 +236,8 @@ mod tests {
             );
         }
         tx.request.headers = hm;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -367,7 +368,8 @@ mod tests {
             HeaderValue::from_bytes(value).expect("field value"),
         );
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -406,7 +408,8 @@ mod tests {
 
             let mut tx = crate::test_helpers::make_test_transaction();
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/media_type_suffix_valid.rs
+++ b/lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -408,7 +408,7 @@ mod tests {
             }
             let history = crate::transaction_history::TransactionHistory::empty();
 
-            let v = rule.check_transaction(&tx, &history, &cfg);
+            let v = crate::test_helpers::run_rule(&rule, &tx, &history, &cfg);
             match ex.compliance {
                 Compliance::Compliant => {
                     assert!(
@@ -417,7 +417,7 @@ mod tests {
                         ex.snippet
                     );
                     for (name, sibling) in siblings {
-                        let other = sibling.check_transaction(&tx, &history, &cfg);
+                        let other = crate::test_helpers::run_rule(sibling, &tx, &history, &cfg);
                         assert!(
                             other.is_none(),
                             "the {name} rule rejects a Compliant example {:?}: {other:?}",
@@ -473,7 +473,8 @@ mod tests {
         hm.insert("content-type", HeaderValue::from_bytes(raw).unwrap());
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -492,7 +493,8 @@ mod tests {
         {
             let sib_cfg =
                 crate::test_helpers::make_test_config_with_enabled_rules(&["content_type_valid"]);
-            let other = crate::rules::content_type_valid::ContentTypeValid.check_transaction(
+            let other = crate::test_helpers::run_rule(
+                &crate::rules::content_type_valid::ContentTypeValid,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &sib_cfg,
@@ -515,7 +517,8 @@ mod tests {
         let cfg = make_cfg();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("accept", accept)]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -536,7 +539,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&pairs);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -558,7 +562,8 @@ mod tests {
         hm.insert("content-type", HeaderValue::from_bytes(raw).unwrap());
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -604,7 +609,8 @@ mod tests {
             &[("content-type", "application/ld+json")],
         );
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -619,7 +625,8 @@ mod tests {
             &[("content-type", "application/vnd.example+unknown")],
         );
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -636,7 +643,8 @@ mod tests {
             "application/vnd.foo+xml; q=0.8, application/bar+nope",
         )]);
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -652,7 +660,8 @@ mod tests {
             &[("content-type", "application/foo+")],
         );
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -668,7 +677,8 @@ mod tests {
             &[("content-type", "application/ld+JSON")],
         );
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -683,7 +693,8 @@ mod tests {
             &[("content-type", "text")],
         );
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -699,7 +710,8 @@ mod tests {
             "application/vnd.foo+unknown",
         )]);
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -716,7 +728,8 @@ mod tests {
             "application/example+JSON",
         )]);
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -732,7 +745,8 @@ mod tests {
             "application/vnd.foo+JSON; q=0.8, text/html",
         )]);
         let rule = MediaTypeSuffixValid;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),

--- a/lint-http-rules/src/rules/multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -479,7 +479,7 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(k, v)]);
             let history = crate::transaction_history::TransactionHistory::empty();
 
-            let found = rule.check_transaction(&tx, &history, &cfg);
+            let found = crate::test_helpers::run_rule(&rule, &tx, &history, &cfg);
             match ex.compliance {
                 Compliance::Compliant => {
                     assert!(
@@ -488,7 +488,7 @@ mod tests {
                         ex.snippet
                     );
                     for (name, sibling) in siblings {
-                        let other = sibling.check_transaction(&tx, &history, &cfg);
+                        let other = crate::test_helpers::run_rule(sibling, &tx, &history, &cfg);
                         assert!(
                             other.is_none(),
                             "the {name} rule rejects a Compliant example {:?}: {other:?}",
@@ -544,7 +544,8 @@ mod tests {
         let header = format!("multipart/mixed; boundary={}", "a".repeat(len));
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", &header)]);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -565,7 +566,8 @@ mod tests {
         let header = format!("multipart/mixed; boundary=\"{}\"", "é".repeat(36));
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", &header)]);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -627,7 +629,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", h)]);
         }
 
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -652,7 +655,8 @@ mod tests {
             tx2.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&[("content-type", h)]);
         }
-        let v2 = MultipartBoundarySyntax.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg2,
@@ -678,7 +682,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("content-type", "not-a-media-type")]);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -697,7 +702,8 @@ mod tests {
             "content-type",
             "multipart/mixed; boundary=\"unfinished",
         )]);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -725,7 +731,8 @@ mod tests {
         tx.request
             .headers
             .insert("content-type", HeaderValue::from_bytes(raw).unwrap());
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -751,7 +758,8 @@ mod tests {
         let pairs: Vec<(&str, &str)> = values.iter().map(|v| ("content-type", *v)).collect();
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -769,7 +777,8 @@ mod tests {
             "content-type",
             "text/plain; boundary=abc",
         )]);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -788,7 +797,8 @@ mod tests {
             "content-type",
             "multipart/mixed; boundary=\"bad$\"",
         )]);
-        let v = MultipartBoundarySyntax.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &MultipartBoundarySyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
+++ b/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
@@ -364,7 +364,8 @@ mod tests {
             b"--abc\r\nContent-Type: text/plain\r\n\r\nhi\r\n--abc--\r\n",
         ));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -396,7 +397,8 @@ mod tests {
             b"--x\xA0y\r\nContent-Type: text/plain\r\n\r\nhi\r\n--x\xA0y--\r\n",
         ));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -417,7 +419,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no delimiter here"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -436,7 +439,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -461,7 +465,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -483,7 +488,8 @@ mod tests {
         tx.response_body = Some(Bytes::from_static(b"--abc\r\nContent-Type: text/pl"));
         tx.response_body_over_limit = true;
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -499,7 +505,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--abc\r\nPart\r\n--abc\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -516,7 +523,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -531,7 +539,8 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=abc")],
         );
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -548,7 +557,8 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"--xyz\r\nfoo\r\n--xyz--\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -564,7 +574,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--a b\r\nx\r\n--a b--\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -580,7 +591,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -597,7 +609,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -610,7 +623,8 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=\"unterminated")],
         );
         tx2.response_body = Some(Bytes::from_static(b"no boundaries"));
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -627,7 +641,8 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"no boundaries here"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -647,7 +662,8 @@ mod tests {
         )]);
         tx.request_body = Some(Bytes::from_static(b"--xyz\r\nPart\r\n--xyz\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -669,13 +685,13 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--abc--\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .expect("a multipart body with no part is not a multipart body");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("a multipart body with no part is not a multipart body");
         assert!(v.message.contains("encapsulates no part"), "{v:?}");
     }
 
@@ -691,13 +707,13 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--abc--\r\n--abc\r\nnot a part\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .expect("the only part-opening line is in the epilogue");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("the only part-opening line is in the epilogue");
         assert!(v.message.contains("encapsulates no part"), "{v:?}");
     }
 
@@ -711,7 +727,8 @@ mod tests {
         );
         tx.response_body = Some(Bytes::from_static(b"--abc\r\n\r\n\r\n--abc--\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -728,7 +745,8 @@ mod tests {
         // unescaped boundary is: a"b
         tx.response_body = Some(Bytes::from_static(b"--a\"b\r\nx\r\n--a\"b--\r\n"));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -749,7 +767,8 @@ mod tests {
             b"--gc0pJq0M:08jU534c0p\r\npart\r\n--gc0pJq0M:08jU534c0p--\r\n",
         ));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -771,7 +790,8 @@ mod tests {
             b"--bin\r\n\r\n\x00\x01\x02--bin\x03\r\n--bin--\r\n",
         ));
         let rule = MultipartContentTypeAndBodyConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -799,7 +819,8 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=abc")],
         );
         tx.response_body = Some(Bytes::copy_from_slice(body));
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -884,7 +905,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&pairs);
             tx.response_body = Some(Bytes::copy_from_slice(body.as_bytes()));
 
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -927,7 +949,8 @@ mod tests {
             ("content-type", "multipart/mixed; boundary=abc"),
         ]);
         tx.response_body = Some(Bytes::from_static(b"no boundaries here"));
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -948,7 +971,8 @@ mod tests {
             HeaderValue::from_bytes(b"multipart/mixed; boundary=abc; foo=\"\xe4\"").unwrap(),
         );
         tx.response_body = Some(Bytes::from_static(b"no boundaries here"));
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -967,13 +991,13 @@ mod tests {
             &[("content-type", "multipart/mixed; boundary=abc")],
         );
         tx.response_body = Some(Bytes::from_static(b"hello --abc-- world"));
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .expect("text that delimits nothing is a violation");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("text that delimits nothing is a violation");
         assert!(v.message.contains("never at the start of a line"), "{v:?}");
     }
 

--- a/lint-http-rules/src/rules/must_revalidate_enforced.rs
+++ b/lint-http-rules/src/rules/must_revalidate_enforced.rs
@@ -232,7 +232,8 @@ mod tests {
     fn no_history_no_violation() {
         let rule = MustRevalidateEnforced;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -248,7 +249,8 @@ mod tests {
         let prev = make_prev(200, &[("cache-control", "max-age=60")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -307,7 +309,8 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // current_age should equal age header (5) not negative elapsed
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -342,7 +345,8 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history =
             crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -377,7 +381,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(1);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -400,7 +405,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -421,7 +427,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -447,7 +454,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(10);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -473,7 +481,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -500,7 +509,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -527,7 +537,8 @@ mod tests {
         tx.timestamp = base + chrono::Duration::seconds(5);
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -553,7 +564,8 @@ mod tests {
         tx.timestamp = base; // no elapsed time
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -579,7 +591,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"v\"")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[

--- a/lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
+++ b/lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
@@ -341,7 +341,8 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
-        NoBodyFor1xx204304.check_transaction(
+        crate::test_helpers::run_rule(
+            &NoBodyFor1xx204304,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_severity(

--- a/lint-http-rules/src/rules/no_cache_revalidation.rs
+++ b/lint-http-rules/src/rules/no_cache_revalidation.rs
@@ -186,7 +186,8 @@ mod tests {
     fn no_history_no_violation() {
         let rule = NoCacheRevalidation;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&["no_cache_revalidation"]),
@@ -249,7 +250,8 @@ mod tests {
         tx.request.uri = "/resource".to_string();
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["no_cache_revalidation"]),
@@ -271,7 +273,8 @@ mod tests {
         tx.request.uri = "/resource".to_string();
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["no_cache_revalidation"]),
@@ -293,15 +296,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "no_cache_revalidation"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_cache_revalidation"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -315,15 +316,13 @@ mod tests {
         tx.request.uri = "/resource".to_string();
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "no_cache_revalidation"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_cache_revalidation"]),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -419,7 +419,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = version.to_string();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(headers);
-        RULE.check_transaction(
+        crate::test_helpers::run_rule(
+            &RULE,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -439,7 +440,8 @@ mod tests {
         if let Some(resp) = tx.response.as_mut() {
             resp.version = response_version.to_string();
         }
-        RULE.check_transaction(
+        crate::test_helpers::run_rule(
+            &RULE,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -658,13 +660,13 @@ mod tests {
             .headers
             .append("te", hyper::header::HeaderValue::from_static("gzip"));
 
-        let v = RULE
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .expect("violation");
+        let v = crate::test_helpers::run_rule(
+            &RULE,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .expect("violation");
         assert!(v.message.contains("holds 'gzip'"), "{}", v.message);
     }
 
@@ -682,13 +684,13 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(&[0xff]).expect("obs-text is a field-content"),
         );
 
-        let v = RULE
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .expect("violation");
+        let v = crate::test_helpers::run_rule(
+            &RULE,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .expect("violation");
         assert!(v.message.contains("TE header field holds"), "{}", v.message);
         assert!(!v.message.contains("UTF-8"), "{}", v.message);
     }

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -301,13 +301,13 @@ mod tests {
     fn no_violation_without_history() {
         let rule = NoStoreEnforced;
         let tx = crate::test_helpers::make_test_transaction();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -319,13 +319,13 @@ mod tests {
         tx.client = crate::test_helpers::make_test_client();
         tx.request.uri = "/resource".to_string();
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -339,7 +339,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
@@ -361,13 +362,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -387,7 +388,8 @@ mod tests {
             "Wed, 21 Oct 2015 07:28:00 GMT",
         )]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
@@ -407,13 +409,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"b\"")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -438,13 +440,13 @@ mod tests {
             prev2.clone(),
             prev1.clone(),
         ]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -472,13 +474,13 @@ mod tests {
             prev2.clone(),
             prev1.clone(),
         ]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -506,13 +508,13 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"x\", \"a\"")]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -528,13 +530,13 @@ mod tests {
         hm.append("if-none-match", "\"a\"".parse().unwrap());
         tx.request.headers = hm;
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -556,13 +558,13 @@ mod tests {
             "Sun, 06 Nov 1994 08:49:37 GMT",
         )]);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["no_store_enforced"]),
+        )
+        .is_some());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/oauth2_code_flow.rs
+++ b/lint-http-rules/src/rules/oauth2_code_flow.rs
@@ -216,13 +216,13 @@ mod tests {
         let rule = Oauth2CodeFlow;
         let tx = make_tx("https://idp.example.com/authorize?response_type=code&client_id=1");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .unwrap();
         assert!(v.message.contains("missing or empty state"));
     }
 
@@ -231,13 +231,13 @@ mod tests {
         let rule = Oauth2CodeFlow;
         let tx = make_tx("https://idp.example.com/authorize?response_type=code&state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -245,13 +245,13 @@ mod tests {
         let rule = Oauth2CodeFlow;
         let tx = make_tx("https://app.example.com/callback?code=abc");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .unwrap();
         assert!(v.message.contains("missing or empty state"));
     }
 
@@ -260,13 +260,13 @@ mod tests {
         let rule = Oauth2CodeFlow;
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .unwrap();
         assert!(v.message.contains("not seen"));
     }
 
@@ -279,13 +279,13 @@ mod tests {
                 "https://idp.example.com/authorize?response_type=code&state=xyz",
             )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=xyz");
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -294,13 +294,13 @@ mod tests {
         // a request with state but not response_type=code shouldn't trigger
         let tx = make_tx("https://example.com/foo?state=xyz");
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -312,13 +312,13 @@ mod tests {
                 "https://idp.example.com/authorize?response_type=code&state=foo#frag",
             )]);
         let tx = make_tx("https://app.example.com/callback?code=abc&state=foo#bar");
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -326,13 +326,13 @@ mod tests {
         let rule = Oauth2CodeFlow;
         let tx = make_tx("https://idp.example.com/authorize?response_type=code#frag");
         let history = crate::transaction_history::TransactionHistory::empty();
-        let v = rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .unwrap();
         assert!(v.message.contains("missing or empty state"));
     }
 
@@ -345,21 +345,21 @@ mod tests {
             crate::transaction_history::TransactionHistory::from_transactions(vec![tx1.clone()]);
         // callback with empty state should flag missing or empty
         let tx2 = make_tx("https://app.example.com/callback?code=123&state=");
-        let v = rule
-            .check_transaction(
-                &tx1,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx1,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .unwrap();
         assert!(v.message.contains("missing or empty state"));
-        let v2 = rule
-            .check_transaction(
-                &tx2,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
-            )
-            .unwrap();
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
+            &tx2,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["oauth2_code_flow"]),
+        )
+        .unwrap();
         assert!(v2.message.contains("missing or empty state"));
     }
 

--- a/lint-http-rules/src/rules/options_method_capabilities.rs
+++ b/lint-http-rules/src/rules/options_method_capabilities.rs
@@ -301,7 +301,8 @@ mod tests {
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = OptionsMethodCapabilities;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -159,7 +159,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "origin_isolated_header_valid",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -192,7 +193,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -217,7 +219,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -242,7 +245,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -259,7 +263,8 @@ mod tests {
             200,
             &[("origin-agent-cluster", "?0")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -275,7 +280,8 @@ mod tests {
             200,
             &[("origin-agent-cluster", "?1, ?1")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -294,7 +300,8 @@ mod tests {
             200,
             &[("origin-agent-cluster", "?0")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -306,7 +313,8 @@ mod tests {
     fn no_response_returns_none() {
         let rule = OriginIsolatedHeaderValid;
         let tx = crate::test_helpers::make_test_transaction(); // no response set
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -208,7 +208,8 @@ mod tests {
     fn no_origin_header_ignored() {
         let rule = OriginMatchingForCors;
         let tx = make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -222,7 +223,8 @@ mod tests {
         let mut tx = make_test_transaction();
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
         // response has no ACAO
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -238,7 +240,8 @@ mod tests {
             &[("access-control-allow-origin", "https://example.com")],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -252,7 +255,8 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "*")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -271,13 +275,13 @@ mod tests {
             ],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("'*' is not allowed"));
     }
 
@@ -289,13 +293,13 @@ mod tests {
             &[("access-control-allow-origin", "https://other.com")],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("does not match request Origin"));
     }
 
@@ -305,7 +309,8 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -324,13 +329,13 @@ mod tests {
             ],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://example.com")]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("'*' is not allowed"));
     }
 
@@ -342,13 +347,13 @@ mod tests {
             &[("access-control-allow-origin", "https://a, https://b")],
         );
         tx.request.headers = make_headers_from_pairs(&[("origin", "https://a")]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("single value"));
     }
 
@@ -369,13 +374,13 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         assert!(v.message.contains("Multiple Access-Control-Allow-Origin"));
     }
 
@@ -385,7 +390,8 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "NULL")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -398,7 +404,8 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "NULL")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -412,7 +419,8 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "null")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "null")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -425,13 +433,13 @@ mod tests {
         let mut tx =
             make_test_transaction_with_response(200, &[("access-control-allow-origin", "*")]);
         tx.request.headers = make_headers_from_pairs(&[("origin", "bad://")]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .unwrap();
         // The helper now returns a generic message for missing authority,
         // so we simply check for the word "Origin" to avoid brittle tests.
         assert!(v.message.contains("Origin"));

--- a/lint-http-rules/src/rules/patch_method_content_type_match.rs
+++ b/lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -353,7 +353,7 @@ mod tests {
             .collect();
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(entries);
-        rule.check_transaction(&tx, &history, &cfg)
+        crate::test_helpers::run_rule(&rule, &tx, &history, &cfg)
     }
 
     #[rstest]
@@ -496,13 +496,13 @@ mod tests {
         );
         hm.append("content-type", HeaderValue::from_static("application/json"));
         tx.request.headers = hm;
-        assert!(neighbour
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &neighbour,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     /// `type` and `subtype` are `token`, so a value carrying an octet outside
@@ -527,13 +527,13 @@ mod tests {
         tx.request.method = "PATCH".into();
         tx.request.headers = HeaderMap::new();
         tx.request.body_length = Some(12);
-        assert!(neighbour
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &neighbour,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     /// The octets of an advertisement are kept, so a member outside US-ASCII

--- a/lint-http-rules/src/rules/patch_partial_update.rs
+++ b/lint-http-rules/src/rules/patch_partial_update.rs
@@ -222,7 +222,8 @@ mod tests {
         let rule = PatchPartialUpdate;
         let tx = make_tx_with_req(headers);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -251,7 +252,8 @@ mod tests {
         );
         tx.request.body_length = Some(1);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -268,7 +270,8 @@ mod tests {
         tx.request.body_length = Some(5);
         tx.request_body = Some(Bytes::from("hello"));
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -286,7 +289,8 @@ mod tests {
         let mut tx = make_tx_with_req(vec![("content-length", "5")]);
         tx.request.body_length = Some(0);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -303,7 +307,8 @@ mod tests {
         tx.request.method = "patch".into();
         tx.request.body_length = Some(5);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -320,7 +325,8 @@ mod tests {
         let mut tx = make_tx_with_req(vec![("transfer-encoding", "chunked")]);
         tx.request.body_length = Some(0);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -338,7 +344,8 @@ mod tests {
         let tx = make_tx_with_req(vec![("content-length", "10")]);
         assert!(tx.request.body_length.is_none());
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
@@ -468,7 +468,8 @@ mod tests {
             tx.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&pairs);
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -534,7 +535,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -567,7 +569,8 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -612,7 +615,8 @@ mod tests {
             ",geolocation=(self)",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -632,7 +636,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "geolocation=")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -654,7 +659,8 @@ mod tests {
             "geolocation=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -676,7 +682,8 @@ mod tests {
             "geolocation=(self",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -698,7 +705,8 @@ mod tests {
             "geolocation=(self  )",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -720,7 +728,8 @@ mod tests {
             "geolocation=\"abc",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -742,7 +751,8 @@ mod tests {
             "geolocation=1abc",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -764,7 +774,8 @@ mod tests {
             "geolocation=(self);",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -786,7 +797,8 @@ mod tests {
             "geolocation=(self);123",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -808,7 +820,8 @@ mod tests {
             "geolocation=(self);foo=!",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -849,7 +862,8 @@ mod tests {
             "geolocation=(self);report-to=\"endpoint\"",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -871,7 +885,8 @@ mod tests {
             "geolocation;meta=1=(self)",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -892,7 +907,8 @@ mod tests {
             "geolocation=1.2",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -914,7 +930,8 @@ mod tests {
             "geolocation=:YWJj:",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -936,7 +953,8 @@ mod tests {
             "geolocation=(self);foo=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -957,7 +975,8 @@ mod tests {
             "geolocation=(self);foo",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -978,7 +997,8 @@ mod tests {
             "geolocation=(self);foo=\"bar\"",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -999,7 +1019,8 @@ mod tests {
             "geolocation=feat:sub/1.2-_",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1022,7 +1043,8 @@ mod tests {
             "geolocation=(self);*=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1043,7 +1065,8 @@ mod tests {
             "geolocation=(self);Foo=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1063,7 +1086,8 @@ mod tests {
             "permissions-policy",
             "1feature=(self)",
         )]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1082,7 +1106,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", "")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1102,7 +1127,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("permissions-policy", value)]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1130,13 +1156,13 @@ mod tests {
         );
         hm.append("permissions-policy", HeaderValue::from_static("camera=()"));
         ok.response.as_mut().unwrap().headers = hm;
-        assert!(rule
-            .check_transaction(
-                &ok,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &ok,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg
+        )
+        .is_none());
 
         let mut dup = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let mut hm = hyper::HeaderMap::new();
@@ -1149,7 +1175,8 @@ mod tests {
             HeaderValue::from_static("geolocation=()"),
         );
         dup.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &dup,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1173,7 +1200,8 @@ mod tests {
             "geolocation=(self);a.b_c*=1",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/post_creates_resource.rs
+++ b/lint-http-rules/src/rules/post_creates_resource.rs
@@ -182,7 +182,8 @@ mod tests {
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = PostCreatesResource;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/pragma_token_valid.rs
@@ -223,7 +223,8 @@ mod tests {
     fn request_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = PragmaTokenValid;
         let tx = make_req(value);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -254,7 +255,8 @@ mod tests {
     fn response_cases(#[case] value: &str, #[case] expect_violation: bool) -> anyhow::Result<()> {
         let rule = PragmaTokenValid;
         let tx = make_resp(value);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -281,7 +283,8 @@ mod tests {
     fn trailing_comma_reports_violation() {
         let rule = PragmaTokenValid;
         let tx = make_req("no-cache,");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -293,7 +296,8 @@ mod tests {
     fn directive_name_invalid_char_reports_violation() {
         let rule = PragmaTokenValid;
         let tx = make_req("n@me=1");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -305,7 +309,8 @@ mod tests {
     fn token_value_invalid_char_reports_violation() {
         let rule = PragmaTokenValid;
         let tx = make_req("foo=ba@d");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -317,7 +322,8 @@ mod tests {
     fn quoted_value_unterminated_reports_violation() {
         let rule = PragmaTokenValid;
         let tx = make_req("foo=\"unterminated");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -329,7 +335,8 @@ mod tests {
     fn empty_directive_value_is_accepted() {
         let rule = PragmaTokenValid;
         let tx = make_req("foo=");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -341,7 +348,8 @@ mod tests {
     fn list_with_invalid_middle_member_reports_violation() {
         let rule = PragmaTokenValid;
         let tx = make_req("no-cache, bad@name=1, max-age=0");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -358,7 +366,8 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.insert("pragma", bad);
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -371,7 +380,8 @@ mod tests {
     fn quoted_string_with_extra_chars_reports_violation() {
         let rule = PragmaTokenValid;
         let tx = make_req("foo=\"bar\"x");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -394,7 +404,8 @@ mod tests {
             body_length: None,
             trailers: None,
         });
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -407,7 +418,8 @@ mod tests {
     fn empty_directive_value_in_response_is_accepted() {
         let rule = PragmaTokenValid;
         let tx = make_resp("foo=");
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -422,7 +434,8 @@ mod tests {
             ("pragma", "no-cache"),
             ("pragma", "foo=bar"),
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
+++ b/lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
@@ -326,7 +326,8 @@ mod tests {
         tx.request.method = method.to_string();
         tx.request.headers = headers(req);
         tx.response.as_mut().unwrap().headers = headers(resp);
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/prefer_header_valid.rs
+++ b/lint-http-rules/src/rules/prefer_header_valid.rs
@@ -449,7 +449,8 @@ mod tests {
 
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = PreferHeaderValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -634,7 +635,7 @@ mod tests {
             "the request's own syntax is clean, so this rule says nothing"
         );
         assert!(
-            neighbour.check_transaction(&tx, &hist, &cfg).is_some(),
+            crate::test_helpers::run_rule(*neighbour, &tx, &hist, &cfg).is_some(),
             "the neighbour is the rule that compares the two fields"
         );
     }

--- a/lint-http-rules/src/rules/preference_applied_header_valid.rs
+++ b/lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -389,7 +389,8 @@ mod tests {
 
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = PreferenceAppliedHeaderValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -551,7 +552,7 @@ mod tests {
         ]);
         let hist = crate::transaction_history::TransactionHistory::empty();
         assert!(
-            neighbour.check_transaction(&tx, &hist, &cfg).is_some(),
+            crate::test_helpers::run_rule(*neighbour, &tx, &hist, &cfg).is_some(),
             "the Prefer rule reports the member this one declines to read"
         );
     }

--- a/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
+++ b/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
@@ -147,7 +147,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("priority", "u=3")]);
 
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -163,7 +164,8 @@ mod tests {
             &[("priority", "u=1"), ("cache-control", "public, max-age=60")],
         );
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -178,7 +180,8 @@ mod tests {
             &[("priority", "u=1"), ("vary", "Accept-Encoding")],
         );
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -190,7 +193,8 @@ mod tests {
     fn no_priority_is_ignored() {
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -206,7 +210,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -225,7 +230,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers = hm;
 
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -239,7 +245,8 @@ mod tests {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(503, &[("priority", "u=1")]);
         let rule = PriorityAndCacheabilityConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/priority_header_syntax.rs
+++ b/lint-http-rules/src/rules/priority_header_syntax.rs
@@ -374,7 +374,8 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(
             &values.iter().map(|v| ("priority", *v)).collect::<Vec<_>>(),
         );
-        PriorityHeaderSyntax.check_transaction(
+        crate::test_helpers::run_rule(
+            &PriorityHeaderSyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -384,7 +385,8 @@ mod tests {
     fn check_resp(value: &str) -> Option<Violation> {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("priority", value)]);
-        PriorityHeaderSyntax.check_transaction(
+        crate::test_helpers::run_rule(
+            &PriorityHeaderSyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -509,13 +511,13 @@ mod tests {
         tx.request
             .headers
             .append("priority", HeaderValue::from_bytes(&[0xff])?);
-        let v = PriorityHeaderSyntax
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .expect("a non-ASCII byte fails § 4.2 step 1");
+        let v = crate::test_helpers::run_rule(
+            &PriorityHeaderSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .expect("a non-ASCII byte fails § 4.2 step 1");
         assert!(v.message.contains("outside ASCII"), "{}", v.message);
         Ok(())
     }
@@ -560,7 +562,8 @@ mod tests {
                 let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
                 tx.response.as_mut().unwrap().headers =
                     crate::test_helpers::make_headers_from_pairs(&pairs);
-                rule.check_transaction(
+                crate::test_helpers::run_rule(
+                    &rule,
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
                     &cfg(),
@@ -568,7 +571,8 @@ mod tests {
             } else {
                 let mut tx = crate::test_helpers::make_test_transaction();
                 tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-                rule.check_transaction(
+                crate::test_helpers::run_rule(
+                    &rule,
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
                     &cfg(),

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -231,15 +231,15 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "private_cache_visibility"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "private_cache_visibility"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -255,15 +255,15 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "private_cache_visibility"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "private_cache_visibility"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -281,7 +281,8 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -308,7 +309,8 @@ mod tests {
             .headers
             .append("if-modified-since", lm.parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -333,14 +335,14 @@ mod tests {
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "private_cache_visibility"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "private_cache_visibility"
+            ]),
+        )
+        .is_none());
     }
 }

--- a/lint-http-rules/src/rules/problem_details_content_type.rs
+++ b/lint-http-rules/src/rules/problem_details_content_type.rs
@@ -216,7 +216,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -249,7 +250,8 @@ mod tests {
         let pairs: Vec<(&str, &str)> = values.iter().map(|v| ("content-type", *v)).collect();
         let tx = crate::test_helpers::make_test_transaction_with_response(500, &pairs);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -270,7 +272,8 @@ mod tests {
                 ("content-type", "application/problem+json"),
             ],
         );
-        let v = owner.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &owner,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[owner.id()]),
@@ -315,7 +318,8 @@ mod tests {
                 .collect();
 
             let tx = crate::test_helpers::make_test_transaction_with_response(status, &headers);
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/problem_details_structure_valid.rs
+++ b/lint-http-rules/src/rules/problem_details_structure_valid.rs
@@ -289,7 +289,8 @@ mod tests {
 
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<crate::lint::Violation> {
         let rule = ProblemDetailsStructureValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -405,7 +406,8 @@ mod tests {
             Some(b"not json"),
             Some(8),
         );
-        let v = owner.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &owner,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[owner.id()]),

--- a/lint-http-rules/src/rules/proxy_connection_discouraged.rs
+++ b/lint-http-rules/src/rules/proxy_connection_discouraged.rs
@@ -163,7 +163,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = version.to_string();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(headers);
-        RULE.check_transaction(
+        crate::test_helpers::run_rule(
+            &RULE,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -235,13 +236,13 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(&[0xff]).expect("obs-text is a field-content"),
         );
 
-        let v = RULE
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .expect("violation");
+        let v = crate::test_helpers::run_rule(
+            &RULE,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .expect("violation");
         // The comma is § 5.2's join, and the `char` after it is the octet %xFF
         // standing for itself — `escape_debug` leaves a printable one alone,
         // which is how every as-written value in the tree is spelled.
@@ -257,7 +258,8 @@ mod tests {
             &[("proxy-connection", "keep-alive")],
         );
         tx.request.version = "HTTP/1.1".into();
-        let v = RULE.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &RULE,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -493,7 +493,8 @@ mod tests {
             .insert("range", "bytes=0-499".parse().unwrap());
 
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -508,7 +509,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -527,7 +529,8 @@ mod tests {
             .headers
             .insert("range", "bytes=5-3".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -542,7 +545,8 @@ mod tests {
             &[("content-range", "bytes 0-1/10")],
         );
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -567,7 +571,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-499".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -592,21 +597,24 @@ mod tests {
     #[rstest]
     fn test_416_requires_unsatisfiable_content_range() {
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx_416("bytes=0-499", &[("content-range", "bytes */1234")]),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
         );
         assert!(v.is_none(), "conforming 416 reported: {:?}", v);
 
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx_416("bytes=0-499", &[("content-range", "bytes 0-0/1234")]),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
         );
         assert!(v2.unwrap().message.contains("'*/complete-length' form"));
 
-        let v3 = rule.check_transaction(
+        let v3 = crate::test_helpers::run_rule(
+            &rule,
             &tx_416("bytes=0-499", &[]),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -622,7 +630,8 @@ mod tests {
     #[rstest]
     fn missing_content_range_on_a_non_byte_range_416_is_not_reported() {
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx_416("pages=1-2", &[]),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -631,7 +640,8 @@ mod tests {
 
         // ...but a form the status cannot mean is still reported, because the
         // server chose to send that field.
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx_416("pages=1-2", &[("content-range", "pages 1-2/9")]),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -655,7 +665,8 @@ mod tests {
         tx.request
             .headers
             .insert("content-range", "bytes 100-199/*".parse().unwrap());
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -671,7 +682,8 @@ mod tests {
         tx.request
             .headers
             .insert("content-range", "bytes 100-199/*".parse().unwrap());
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -688,7 +700,8 @@ mod tests {
             416,
             &[("content-range", "bytes */1234")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -706,7 +719,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -728,7 +742,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-1".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -739,7 +754,8 @@ mod tests {
         );
 
         let owner = crate::rules::content_length_valid::ContentLengthValid;
-        let found = owner.check_transaction(
+        let found = crate::test_helpers::run_rule(
+            &owner,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[crate::rules::Rule::id(
@@ -768,7 +784,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-499".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -846,7 +863,8 @@ mod tests {
         let mut saw_a_finding = false;
         for ex in rule.examples() {
             let tx = transaction_from_example(ex.snippet);
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -885,7 +903,8 @@ mod tests {
             let history = crate::transaction_history::TransactionHistory::empty();
 
             let boundary = MultipartBoundarySyntax;
-            let found = boundary.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &boundary,
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[boundary.id()]),
@@ -897,7 +916,8 @@ mod tests {
             );
 
             let length = ContentLengthValid;
-            let found = length.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &length,
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[length.id()]),
@@ -937,7 +957,8 @@ mod tests {
     #[rstest]
     fn unconfigured_unit_is_not_reported() {
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx_206_with_unit("items 0-1/3", "items=0-1"),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -950,7 +971,8 @@ mod tests {
     #[rstest]
     fn configured_unit_is_checked() {
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx_206_with_unit("items 0-5/9", "items=0-5"),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes", "items"]),
@@ -976,7 +998,8 @@ mod tests {
             .headers
             .insert("range", "bytes=500-999,7000-7999".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -999,7 +1022,8 @@ mod tests {
             .headers
             .insert("range", "bytes=500-999,7000-7999".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -1023,7 +1047,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-499".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -1045,7 +1070,8 @@ mod tests {
             .headers
             .insert("range", "bytes=0-499,".parse().unwrap());
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),
@@ -1066,7 +1092,8 @@ mod tests {
             vec![("content-type", "multipart/byteranges; boundary=SEP")],
         ] {
             let tx = crate::test_helpers::make_test_transaction_with_response(206, &headers);
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg_with_units(&["bytes"]),
@@ -1082,7 +1109,8 @@ mod tests {
     #[rstest]
     fn non_token_unit_is_reported() {
         let rule = RangeAndContentRangeConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx_206_with_unit("by(tes 0-1/3", "bytes=0-1"),
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg_with_units(&["bytes"]),

--- a/lint-http-rules/src/rules/range_header_syntax.rs
+++ b/lint-http-rules/src/rules/range_header_syntax.rs
@@ -392,7 +392,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = RangeHeaderSyntax;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -353,7 +353,8 @@ mod tests {
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
     ) -> Option<Violation> {
-        RangeRequestAndCaching.check_transaction(
+        crate::test_helpers::run_rule(
+            &RangeRequestAndCaching,
             tx,
             history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[

--- a/lint-http-rules/src/rules/redirect_chain_valid.rs
+++ b/lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -380,7 +380,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = RedirectChainValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -586,15 +587,15 @@ mod tests {
         let tx = exchange("/a", Some("example.com"), 301, locations);
         let owner = crate::rules::location_header_uri_valid::LocationHeaderUriValid;
         assert!(
-            owner
-                .check_transaction(
-                    &tx,
-                    &crate::transaction_history::TransactionHistory::empty(),
-                    &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                        "location_header_uri_valid",
-                    ]),
-                )
-                .is_some(),
+            crate::test_helpers::run_rule(
+                &owner,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "location_header_uri_valid",
+                ]),
+            )
+            .is_some(),
             "{locations:?}"
         );
     }

--- a/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
+++ b/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -206,7 +206,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = RedirectStatusAndLocationValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -310,7 +311,8 @@ mod tests {
     fn no_response_is_ignored() {
         let rule = RedirectStatusAndLocationValid;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/referer_uri_valid.rs
@@ -504,13 +504,13 @@ mod tests {
         tx.request.headers = headers;
         let config =
             crate::test_helpers::make_test_config_with_severity("referer_uri_valid", "warn");
-        RefererUriValid
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &config,
-            )
-            .map(|v| v.message)
+        crate::test_helpers::run_rule(
+            &RefererUriValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &config,
+        )
+        .map(|v| v.message)
     }
 
     fn judge(referer: &str) -> Option<String> {
@@ -668,14 +668,14 @@ mod tests {
         tx.request.headers = headers;
         let config =
             crate::test_helpers::make_test_config_with_severity("referer_uri_valid", "warn");
-        let m = RefererUriValid
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &config,
-            )
-            .expect("an obs-text octet is reported")
-            .message;
+        let m = crate::test_helpers::run_rule(
+            &RefererUriValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &config,
+        )
+        .expect("an obs-text octet is reported")
+        .message;
         assert!(
             m.contains("holds 0xE9, which no part of a URI is composed from"),
             "{m}"

--- a/lint-http-rules/src/rules/refresh_header_syntax.rs
+++ b/lint-http-rules/src/rules/refresh_header_syntax.rs
@@ -356,7 +356,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = RefreshHeaderSyntax;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/request_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/request_body_length_accuracy.rs
@@ -197,7 +197,8 @@ mod tests {
         };
 
         let rule = RequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -218,7 +219,8 @@ mod tests {
         };
 
         let rule = RequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -240,7 +242,8 @@ mod tests {
         };
 
         let rule = RequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -261,7 +264,8 @@ mod tests {
         };
 
         let rule = RequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -286,7 +290,8 @@ mod tests {
         };
 
         let rule = RequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -307,7 +312,8 @@ mod tests {
         };
 
         let rule = RequestBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -333,7 +339,8 @@ mod tests {
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<crate::lint::Violation> {
         let rule = RequestBodyLengthAccuracy;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -376,7 +383,8 @@ mod tests {
             // is never measured -- the Transfer-Encoding sees to it.
             tx.request.body_length = Some(body.len() as u64);
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,

--- a/lint-http-rules/src/rules/request_method_token_valid.rs
+++ b/lint-http-rules/src/rules/request_method_token_valid.rs
@@ -329,7 +329,8 @@ mod tests {
         let rule = RequestMethodTokenValid;
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.method = method.to_string();
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config_with_methods(rule.id(), TEST_METHODS),
@@ -373,17 +374,21 @@ mod tests {
         tx.request.method = "purge".to_string();
         let history = crate::transaction_history::TransactionHistory::empty();
 
-        assert!(rule
-            .check_transaction(&tx, &history, &config_with_methods(rule.id(), TEST_METHODS))
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &config_with_methods(rule.id(), TEST_METHODS)
+        )
+        .is_none());
 
-        let v = rule
-            .check_transaction(
-                &tx,
-                &history,
-                &config_with_methods(rule.id(), &["GET", "PURGE"]),
-            )
-            .expect("a name in the array is the whole reason this spelling is reported");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &config_with_methods(rule.id(), &["GET", "PURGE"]),
+        )
+        .expect("a name in the array is the whole reason this spelling is reported");
         assert!(v.message.contains("'purge'") && v.message.contains("'PURGE'"));
     }
 
@@ -425,13 +430,13 @@ mod tests {
         tx.request.method = "GET".to_string();
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         assert!(parse_method_token_config(&cfg, rule.id()).is_err());
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg
+        )
+        .is_none());
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
@@ -159,7 +159,8 @@ mod tests {
         tx.request.method = "OPTIONS".into();
         tx.request.headers = make_headers_from_pairs(&[("access-control-request-method", "POST")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -178,7 +179,8 @@ mod tests {
             ("origin", "https://example.com"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -196,7 +198,8 @@ mod tests {
             ("origin", "http:///bad"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -212,7 +215,8 @@ mod tests {
         tx.request.uri = "http://other.example/resource".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -231,7 +235,8 @@ mod tests {
         tx.request.uri = "http://example.com/resource".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -249,7 +254,8 @@ mod tests {
         tx.request.uri = "/oauth/authorize?redirect_uri=https://client.example/cb".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "auth.example")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -267,7 +273,8 @@ mod tests {
         tx.request.uri = "http://example.com?x=1".into();
         tx.request.headers = make_headers_from_pairs(&[("host", "example.com")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -392,7 +392,8 @@ mod tests {
         tx.request.version = version.into();
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/request_target_no_fragment.rs
+++ b/lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -230,7 +230,8 @@ mod tests {
         tx.request.uri = uri.to_string();
         tx.request.version = version.to_string();
 
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_severity(rule.id(), "error"),

--- a/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
+++ b/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -233,7 +233,8 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
 
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/request_version_method_valid.rs
+++ b/lint-http-rules/src/rules/request_version_method_valid.rs
@@ -221,7 +221,8 @@ mod tests {
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = RequestVersionMethodValid;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/response_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/response_body_length_accuracy.rs
@@ -245,7 +245,8 @@ mod tests {
         });
 
         let rule = ResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -265,7 +266,8 @@ mod tests {
         });
 
         let rule = ResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -286,7 +288,8 @@ mod tests {
         });
 
         let rule = ResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -306,7 +309,8 @@ mod tests {
         });
 
         let rule = ResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -326,7 +330,8 @@ mod tests {
         });
 
         let rule = ResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -350,7 +355,8 @@ mod tests {
         });
 
         let rule = ResponseBodyLengthAccuracy;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -379,7 +385,8 @@ mod tests {
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<crate::lint::Violation> {
         let rule = ResponseBodyLengthAccuracy;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -426,7 +433,8 @@ mod tests {
             let mut tx = resp_with(status, &pairs, Some(body.len() as u64));
             tx.request.method = method.to_string();
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -541,7 +549,8 @@ mod tests {
             .iter()
             .find(|r| r.id() == "no_body_for_1xx_204_304")
             .expect("the sibling rule is registered");
-        let found = sibling.check_transaction(
+        let found = crate::test_helpers::run_rule(
+            *sibling,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[sibling.id()]),

--- a/lint-http-rules/src/rules/retry_after_date_or_delay.rs
+++ b/lint-http-rules/src/rules/retry_after_date_or_delay.rs
@@ -143,7 +143,8 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = RetryAfterDateOrDelay;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, hdrs);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -182,7 +183,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -198,7 +200,8 @@ mod tests {
     fn no_response_no_violation() -> anyhow::Result<()> {
         let rule = RetryAfterDateOrDelay;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -220,7 +223,8 @@ mod tests {
             503,
             &[("retry-after", "bad")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -250,7 +254,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -268,7 +273,8 @@ mod tests {
             503,
             &[("retry-after", "120, 240")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/retry_after_status_valid.rs
+++ b/lint-http-rules/src/rules/retry_after_status_valid.rs
@@ -207,7 +207,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = RetryAfterStatusValid;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -257,7 +258,8 @@ mod tests {
         let rule = RetryAfterStatusValid;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/s_max_age_enforced.rs
+++ b/lint-http-rules/src/rules/s_max_age_enforced.rs
@@ -168,7 +168,8 @@ mod tests {
     fn no_history_no_violation() {
         let rule = SMaxAgeEnforced;
         let tx = crate::test_helpers::make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
@@ -189,13 +190,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -212,13 +213,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
         tx.timestamp = base + chrono::Duration::seconds(6);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_none());
 
         // max-age smaller than s-maxage also irrelevant
         let prev2 = make_prev_with_headers(&[("cache-control", "max-age=3, s-maxage=10")], base);
@@ -230,13 +231,13 @@ mod tests {
         tx2.timestamp = base + chrono::Duration::seconds(4);
         let history2 =
             crate::transaction_history::TransactionHistory::from_transactions(vec![prev2]);
-        assert!(rule
-            .check_transaction(
-                &tx2,
-                &history2,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx2,
+            &history2,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -259,7 +260,8 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(20);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
@@ -287,13 +289,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -315,13 +317,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(40);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -341,13 +343,13 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.timestamp = base + chrono::Duration::seconds(20);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -371,13 +373,13 @@ mod tests {
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"e\"")]);
         tx.timestamp = base + chrono::Duration::seconds(5);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_some());
     }
 
     #[test]
@@ -402,13 +404,13 @@ mod tests {
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         // age clamped to 0, so current_age=0 < s_max_age -> no violation even though
         // the conditional header is present
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["s_max_age_enforced"]),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
@@ -210,7 +210,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -242,7 +243,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "sec_fetch_dest_value_valid",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -262,7 +264,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "b@d")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -283,7 +286,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", " image ")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -306,7 +310,8 @@ mod tests {
             ("sec-fetch-dest", "invalid"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -328,7 +333,8 @@ mod tests {
             ("sec-fetch-dest", "bad2"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -350,7 +356,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "bogus")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -372,7 +379,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-dest", "image,script")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
@@ -171,7 +171,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -203,7 +204,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "sec_fetch_mode_value_valid",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -223,7 +225,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", "b@d")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -249,7 +252,8 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("invalid"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -274,7 +278,8 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("navigate"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -299,7 +304,8 @@ mod tests {
         hm.append("sec-fetch-mode", HeaderValue::from_static("bad2"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -319,7 +325,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-mode", " same-origin ")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,


### PR DESCRIPTION
Files h through r, same indirection: run_rule instead of the direct call, one body to change when the signature moves.
