### PR TITLE
The last quarter of the rule tests dispatch through one door

### DIFF
--- a/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
@@ -171,7 +171,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -204,7 +205,8 @@ mod tests {
             "sec_fetch_site_value_valid",
         ]);
         // get_header_str will return None for non-utf8 and this rule treats non-UTF8 as violation
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -224,7 +226,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", "b@d")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -245,7 +248,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-site", " same-origin ")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -273,7 +277,8 @@ mod tests {
         tx.request.headers = hm;
 
         // Multiple header fields are always a violation (potential header injection)
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -303,7 +308,8 @@ mod tests {
         hm.append("sec-fetch-site", HeaderValue::from_static("bad2"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -330,7 +336,8 @@ mod tests {
         hm.append("sec-fetch-site", HeaderValue::from_static("cross-site"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
@@ -160,7 +160,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -188,7 +189,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?0")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -208,7 +210,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?1;param")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -228,7 +231,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "?1,?1")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -248,7 +252,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-fetch-user", "   ")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -273,7 +278,8 @@ mod tests {
         hm.append("sec-fetch-user", HeaderValue::from_static("?1"));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -297,7 +303,8 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "sec_fetch_user_value_valid",
         ]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
+++ b/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
@@ -368,7 +368,8 @@ mod tests {
             Section::Request => tx.request.headers = hm,
             Section::Response => tx.response.as_mut().expect("response").headers = hm,
         }
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -337,7 +337,8 @@ mod tests {
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = SecWebsocketHeadersConsistent;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/sec_websocket_version_advertised.rs
+++ b/lint-http-rules/src/rules/sec_websocket_version_advertised.rs
@@ -248,7 +248,8 @@ mod tests {
         }
         tx.response.as_mut().expect("response").headers = hm;
 
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -353,13 +354,13 @@ mod tests {
         ]);
         tx.response.as_mut().expect("response").headers =
             crate::test_helpers::make_headers_from_pairs(&[("sec-websocket-version", "013")]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     /// Every published snippet, run as the exchange it prints.

--- a/lint-http-rules/src/rules/server_header_product_valid.rs
+++ b/lint-http-rules/src/rules/server_header_product_valid.rs
@@ -173,7 +173,8 @@ mod tests {
         }
         tx.response = resp.response;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -198,7 +199,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -228,7 +230,8 @@ mod tests {
         hm.insert("server", HeaderValue::from_bytes(value).unwrap());
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -248,7 +251,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "Bad (unbalanced")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -268,7 +272,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "(Apache)")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -292,7 +297,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("server", "(test) nginx/1.18.0")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -319,7 +325,8 @@ mod tests {
             "Apache/2.4.41 (Ubuntu (LTS)) mod_x/1.0",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -352,7 +359,8 @@ mod tests {
             let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
             tx.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&pairs);
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -654,7 +654,8 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
-        ServerTimingHeaderSyntax.check_transaction(
+        crate::test_helpers::run_rule(
+            &ServerTimingHeaderSyntax,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[

--- a/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
+++ b/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -288,13 +288,13 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<String> {
-        SingletonFieldsNotRepeated
-            .check_transaction(
-                tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg(),
-            )
-            .map(|v| v.message)
+        crate::test_helpers::run_rule(
+            &SingletonFieldsNotRepeated,
+            tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg(),
+        )
+        .map(|v| v.message)
     }
 
     fn response_with_lines(pairs: &[(&str, &str)]) -> crate::http_transaction::HttpTransaction {

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -324,15 +324,15 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -344,15 +344,15 @@ mod tests {
             &[("upgrade", "h2c"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -364,15 +364,15 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -384,15 +384,15 @@ mod tests {
             &[],
         );
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -404,15 +404,15 @@ mod tests {
         ]);
         tx.response = None;
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     // ── Violation: unsolicited 101 ──
@@ -421,15 +421,15 @@ mod tests {
     fn unsolicited_101_no_upgrade_in_request() {
         let tx = make_upgrade_tx("HTTP/1.1", &[], 101, &[("upgrade", "websocket")]);
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("did not include an Upgrade header"));
     }
 
@@ -444,15 +444,15 @@ mod tests {
             &[("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("missing required Upgrade header"));
     }
 
@@ -467,15 +467,15 @@ mod tests {
             &[("upgrade", "h2c"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("was not offered by the client"));
     }
 
@@ -490,15 +490,15 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("HTTP/1.0"));
     }
 
@@ -520,7 +520,8 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -539,15 +540,15 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("HTTP/2"));
     }
 
@@ -562,15 +563,15 @@ mod tests {
             &[("upgrade", "websocket")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("HTTP/3"));
     }
 
@@ -597,15 +598,15 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &current,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &current,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("HTTP traffic after 101"));
     }
 
@@ -622,15 +623,15 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &current,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &current,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     // ── Violation: multiple offered protocols, server picks one ──
@@ -644,15 +645,15 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -664,15 +665,15 @@ mod tests {
             &[("upgrade", "IRC/6.9"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("was not offered"));
     }
 
@@ -687,15 +688,15 @@ mod tests {
             &[("upgrade", " websocket "), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -716,15 +717,15 @@ mod tests {
             ("connection", "Upgrade"),
         ]);
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -736,15 +737,15 @@ mod tests {
             &[("upgrade", "websocket"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("no protocol tokens"));
     }
 
@@ -757,15 +758,15 @@ mod tests {
             &[("upgrade", " , , "), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("no protocol tokens"));
     }
 
@@ -778,15 +779,15 @@ mod tests {
             &[("upgrade", "TLS/1.0"), ("connection", "Upgrade")],
         );
         let rule = Status101SwitchingProtocols;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols",
-                ]),
-            )
-            .unwrap();
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols",
+            ]),
+        )
+        .unwrap();
         assert!(v.message.contains("was not offered"));
     }
 
@@ -803,15 +804,15 @@ mod tests {
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![prev]);
         let rule = Status101SwitchingProtocols;
-        assert!(rule
-            .check_transaction(
-                &current,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "status_101_switching_protocols"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &current,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "status_101_switching_protocols"
+            ]),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
+++ b/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
@@ -212,7 +212,8 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
-        Status103EarlyHintsBeforeFinal.check_transaction(
+        crate::test_helpers::run_rule(
+            &Status103EarlyHintsBeforeFinal,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -272,7 +273,8 @@ mod tests {
         prev.request.uri = "/resource".to_string();
 
         let tx = tx_with(103, "HTTP/1.1");
-        let with_history = Status103EarlyHintsBeforeFinal.check_transaction(
+        let with_history = crate::test_helpers::run_rule(
+            &Status103EarlyHintsBeforeFinal,
             &tx,
             &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &cfg(),

--- a/lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
+++ b/lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -284,7 +284,8 @@ mod tests {
 
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -317,7 +318,8 @@ mod tests {
         let rule = Status200Vs204BodyConsistent;
         let tx = crate::test_helpers::make_test_transaction();
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -331,13 +333,13 @@ mod tests {
         let rule = Status200Vs204BodyConsistent;
         let tx = make_tx_with_response(200, "GET", &[("content-length", "0")]);
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("expected violation");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("expected violation");
         assert!(v.message.contains("Content-Length: 0"));
         Ok(())
     }
@@ -351,13 +353,13 @@ mod tests {
             resp.body_length = Some(0);
         }
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("expected violation");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("expected violation");
         assert!(v.message.contains("captured length 0"));
         Ok(())
     }
@@ -444,7 +446,8 @@ mod tests {
         let mut saw_a_finding = false;
 
         for ex in rule.examples() {
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx_from_snippet(ex.snippet),
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -486,7 +489,8 @@ mod tests {
         });
 
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
+++ b/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
@@ -232,7 +232,8 @@ mod tests {
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = Status3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -361,13 +362,13 @@ mod tests {
     fn the_configured_severity_is_carried() {
         let rule = Status3xxVsRequestMethod;
         let cfg = crate::test_helpers::make_test_config_with_severity(rule.id(), "error");
-        let v = rule
-            .check_transaction(
-                &exchange("POST", 302, Some("/new")),
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("expected a finding");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &exchange("POST", 302, Some("/new")),
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("expected a finding");
         assert_eq!(v.severity, crate::lint::Severity::Error);
     }
 

--- a/lint-http-rules/src/rules/status_405_allow_valid.rs
+++ b/lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -335,7 +335,8 @@ mod tests {
             },
         });
 
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/status_426_upgrade_valid.rs
+++ b/lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -252,7 +252,8 @@ mod tests {
         trailers: &[&str],
     ) -> Option<Violation> {
         let tx = transaction(version, status, lines, trailers);
-        RULE.check_transaction(
+        crate::test_helpers::run_rule(
+            &RULE,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[RULE.id()]),
@@ -396,13 +397,13 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction_with_response(426, &[]);
         tx.request.version = "HTTP/3.0".into();
         tx.response.as_mut().expect("response").version = "HTTP/1.1".into();
-        let v = RULE
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[RULE.id()]),
-            )
-            .expect("the MUST is unmet");
+        let v = crate::test_helpers::run_rule(
+            &RULE,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[RULE.id()]),
+        )
+        .expect("the MUST is unmet");
         assert!(
             v.message.contains("no Upgrade header field"),
             "{}",
@@ -413,7 +414,8 @@ mod tests {
     #[test]
     fn a_transaction_with_no_response_is_not_measured() {
         let tx = crate::test_helpers::make_test_transaction();
-        let v = RULE.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &RULE,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[RULE.id()]),
@@ -476,7 +478,8 @@ mod tests {
 
             let tx = transaction(version, status, &borrowed, &[]);
             for (neighbour, id) in neighbours {
-                let v = neighbour.check_transaction(
+                let v = crate::test_helpers::run_rule(
+                    neighbour,
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
                     &crate::test_helpers::make_test_config_with_severity(id, "warn"),

--- a/lint-http-rules/src/rules/status_and_caching_semantics.rs
+++ b/lint-http-rules/src/rules/status_and_caching_semantics.rs
@@ -171,7 +171,8 @@ mod tests {
         use crate::test_helpers::make_test_transaction_with_response;
         let tx = make_test_transaction_with_response(status, &hdrs);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -202,7 +203,8 @@ mod tests {
         hm.insert("cache-control", bad);
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/status_code_semantics.rs
+++ b/lint-http-rules/src/rules/status_code_semantics.rs
@@ -290,7 +290,8 @@ mod tests {
 
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = StatusCodeSemantics;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/status_code_valid_range.rs
+++ b/lint-http-rules/src/rules/status_code_valid_range.rs
@@ -209,7 +209,8 @@ mod tests {
         let config =
             crate::test_helpers::make_test_config_with_severity("status_code_valid_range", "error");
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
@@ -241,7 +242,8 @@ mod tests {
         tx.request.version = version.into();
         tx.response.as_mut().expect("response").version = version.into();
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -261,13 +263,13 @@ mod tests {
     fn the_message_names_the_case(#[case] status: u16, #[case] expected: &str) {
         let rule = StatusCodeValidRange;
         let tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .expect("expected violation");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .expect("expected violation");
 
         assert!(v.message.contains(&status.to_string()), "{}", v.message);
         assert!(
@@ -324,7 +326,8 @@ mod tests {
                 });
 
             let tx = crate::test_helpers::make_test_transaction_with_response(status, &[]);
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -344,7 +347,8 @@ mod tests {
         let config =
             crate::test_helpers::make_test_config_with_severity("status_code_valid_range", "error");
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/strict_transport_security_valid.rs
+++ b/lint-http-rules/src/rules/strict_transport_security_valid.rs
@@ -322,13 +322,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        let got = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some();
+        let got = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some();
         assert_eq!(got, expect_violation, "value: {}", val);
         Ok(())
     }
@@ -355,13 +355,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -372,13 +372,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -389,13 +389,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -406,13 +406,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -423,13 +423,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -440,13 +440,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_none());
     }
 
     #[test]
@@ -457,13 +457,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -474,13 +474,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -491,13 +491,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -508,13 +508,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]
@@ -525,13 +525,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_none());
     }
 
     #[test]
@@ -542,13 +542,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_none());
     }
 
     #[test]
@@ -571,13 +571,13 @@ mod tests {
             "strict_transport_security_valid",
             "warn",
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/structured_headers_valid.rs
+++ b/lint-http-rules/src/rules/structured_headers_valid.rs
@@ -411,7 +411,8 @@ mod tests {
             hyper::header::HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -476,7 +477,8 @@ mod tests {
             200,
             &[("x-struct", "\"unterminated")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -860,7 +862,8 @@ mod tests {
             tx.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&pairs);
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -906,7 +909,8 @@ mod tests {
             hyper::header::HeaderValue::from_static("\"unterminated"),
         );
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -932,7 +936,8 @@ mod tests {
         if let Some(resp) = &mut tx.response {
             resp.headers = rh;
         }
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1203,7 +1208,8 @@ mod tests {
         hm.append("x-struct", hyper::header::HeaderValue::from_static("\"foo"));
         hm.append("x-struct", hyper::header::HeaderValue::from_static("bar\""));
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1226,7 +1232,8 @@ mod tests {
             hyper::header::HeaderValue::from_static("BadKey=2"),
         );
         tx.request.headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1242,13 +1249,13 @@ mod tests {
             200,
             &[("x-struct", "\"unterminated")],
         );
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("should report");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("should report");
         assert!(
             v.message.contains("discards the whole field"),
             "{}",
@@ -1274,13 +1281,13 @@ mod tests {
             hyper::header::HeaderValue::from_bytes("caf\u{e9}".as_bytes()).unwrap(),
         );
         tx.request.headers = hm;
-        let v = rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .expect("should report");
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .expect("should report");
         assert!(v.message.contains("outside ASCII"), "{}", v.message);
         assert!(!v.message.contains("UTF-8"), "{}", v.message);
     }

--- a/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
+++ b/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
@@ -190,7 +190,8 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -215,7 +216,8 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -236,7 +238,8 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -253,20 +256,20 @@ mod tests {
         let tx2 =
             crate::test_helpers::make_test_transaction_with_response(200, &[("deprecation", "@0")]);
         let rule = SunsetAndDeprecationConsistent;
-        assert!(rule
-            .check_transaction(
-                &tx1,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
-        assert!(rule
-            .check_transaction(
-                &tx2,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx1,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx2,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[rstest]
@@ -289,7 +292,8 @@ mod tests {
         });
 
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -311,7 +315,8 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -326,7 +331,8 @@ mod tests {
             &[("sunset", "not-a-date"), ("deprecation", "@0")],
         );
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -347,13 +353,13 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -367,13 +373,13 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -387,7 +393,8 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -406,13 +413,13 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -426,13 +433,13 @@ mod tests {
             ],
         );
         let rule = SunsetAndDeprecationConsistent;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -452,13 +459,13 @@ mod tests {
         });
 
         let rule = SunsetAndDeprecationConsistent;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
     #[test]
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {

--- a/lint-http-rules/src/rules/te_header_valid.rs
+++ b/lint-http-rules/src/rules/te_header_valid.rs
@@ -589,7 +589,8 @@ mod tests {
             );
         }
         tx.request.headers = hm;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -607,7 +608,8 @@ mod tests {
         let mut hm = hyper::HeaderMap::new();
         hm.append("te", HeaderValue::from_bytes(te).expect("field value"));
         tx.response.as_mut().expect("response").headers = hm;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -862,7 +864,8 @@ mod tests {
         resp.version = version.to_string();
         resp.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "trailers")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -887,7 +890,8 @@ mod tests {
         resp.version = response_version.to_string();
         resp.headers = crate::test_helpers::make_headers_from_pairs(&[("te", "trailers")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -899,7 +903,8 @@ mod tests {
     fn a_response_without_te_is_not_a_finding() {
         let rule = TeHeaderValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -963,7 +968,8 @@ mod tests {
                     );
                 }
                 resp.headers = hm;
-                rule.check_transaction(
+                crate::test_helpers::run_rule(
+                    &rule,
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
                     &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -1052,7 +1058,8 @@ mod tests {
                 }
                 let mut tx = crate::test_helpers::make_test_transaction();
                 tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", value)]);
-                let found = owner.check_transaction(
+                let found = crate::test_helpers::run_rule(
+                    &owner,
                     &tx,
                     &crate::transaction_history::TransactionHistory::empty(),
                     &cfg,

--- a/lint-http-rules/src/rules/timing_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/timing_allow_origin_valid.rs
@@ -199,7 +199,8 @@ mod tests {
     fn no_response_no_violation() {
         let rule = TimingAllowOriginValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -214,7 +215,8 @@ mod tests {
             200,
             &[("content-type", "text/plain")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -234,7 +236,8 @@ mod tests {
             200,
             &[("timing-allow-origin", val)],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -268,7 +271,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -285,7 +289,8 @@ mod tests {
             200,
             &[("timing-allow-origin", "https://a,  ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -305,7 +310,8 @@ mod tests {
             200,
             &[("timing-allow-origin", " ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -321,7 +327,8 @@ mod tests {
             200,
             &[("timing-allow-origin", "https://[::1]:8080")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -336,7 +343,8 @@ mod tests {
             200,
             &[("timing-allow-origin", "*, https://example.com")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -366,7 +374,8 @@ mod tests {
             200,
             &[("timing-allow-origin", val)],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -382,7 +391,8 @@ mod tests {
             200,
             &[("timing-allow-origin", "NULL")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -398,7 +408,8 @@ mod tests {
             200,
             &[("timing-allow-origin", "https:///foo")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -425,7 +436,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/trace_method_echo.rs
+++ b/lint-http-rules/src/rules/trace_method_echo.rs
@@ -219,7 +219,8 @@ mod tests {
 
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = TraceMethodEcho;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -386,13 +387,13 @@ mod tests {
             .iter()
             .find(|r| r.id() == "content_type_present")
             .expect("the neighbour is registered");
-        assert!(neighbour
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[neighbour.id()]),
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            *neighbour,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[neighbour.id()]),
+        )
+        .is_some());
     }
 
     /// Every published snippet is run through the rule.

--- a/lint-http-rules/src/rules/trailer_fields_valid.rs
+++ b/lint-http-rules/src/rules/trailer_fields_valid.rs
@@ -345,7 +345,7 @@ mod tests {
         );
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(
             v.is_some(),
             "expected violation for prohibited trailer '{field}'"
@@ -373,7 +373,7 @@ mod tests {
         );
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(
             v.is_some(),
             "expected violation for prohibited request trailer '{field}'"
@@ -391,7 +391,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -403,7 +403,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -413,7 +413,7 @@ mod tests {
     fn no_trailers_no_violation() {
         let rule = TrailerFieldsValid;
         let tx = make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -421,7 +421,7 @@ mod tests {
     fn request_only_no_trailers_no_violation() {
         let rule = TrailerFieldsValid;
         let tx = make_test_transaction();
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -435,7 +435,7 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -449,7 +449,7 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -462,7 +462,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -484,7 +484,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(
             v.as_ref()
                 .is_some_and(|v| v.message.contains("not declared")),
@@ -500,7 +500,7 @@ mod tests {
         trailers.insert("x-checksum", "abc123".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -514,7 +514,7 @@ mod tests {
         trailers.insert("x-signature", "sig-value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -529,7 +529,7 @@ mod tests {
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
         // No Trailer header → declared is empty → undeclared check skipped
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -543,7 +543,7 @@ mod tests {
         trailers.insert("content-length", "42".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not permit"));
     }
@@ -558,7 +558,7 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("connection-option"));
     }
@@ -572,7 +572,7 @@ mod tests {
         trailers.insert("x-req-hop", "value".parse().unwrap());
         tx.request.trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("connection-option"));
     }
@@ -585,7 +585,7 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("connection-option"));
     }
@@ -607,7 +607,7 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some(), "second Connection line was not read");
         assert!(v.unwrap().message.contains("connection-option"));
     }
@@ -624,7 +624,7 @@ mod tests {
         trailers.insert("x-custom-hop", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none(), "{v:?}");
     }
 
@@ -636,7 +636,7 @@ mod tests {
         trailers.insert("x-other", "value".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -650,7 +650,7 @@ mod tests {
         trailers.insert("transfer-encoding", "chunked".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         // Should say "prohibited", not "hop-by-hop", since static check runs first.
         assert!(v.unwrap().message.contains("does not permit"));
@@ -673,7 +673,7 @@ mod tests {
         resp_trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("host"));
     }
@@ -700,7 +700,7 @@ mod tests {
         trailers.insert("x-signature", "sig".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -712,7 +712,7 @@ mod tests {
         let mut tx = make_test_transaction_with_response(200, &[("trailer", "x-checksum")]);
         tx.response.as_mut().unwrap().trailers = Some(hyper::HeaderMap::new());
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -731,7 +731,7 @@ mod tests {
         trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -747,7 +747,7 @@ mod tests {
         trailers.insert("etag", "\"abc\"".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -769,7 +769,7 @@ mod tests {
         );
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none(), "expected no violation for '{field}': {v:?}");
     }
 
@@ -781,7 +781,7 @@ mod tests {
         trailers.insert("server-timing", "db;dur=53".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -794,7 +794,7 @@ mod tests {
         trailers.insert("transfer-encoding", "chunked".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not permit"));
     }
@@ -809,7 +809,7 @@ mod tests {
         trailers.insert("x-extra", "extra".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -833,7 +833,7 @@ mod tests {
         trailers.insert("x-checksum", "abc".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("not declared"));
     }
@@ -855,7 +855,7 @@ mod tests {
         trailers.insert("content-type", "text/plain".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("does not permit"));
     }
@@ -873,7 +873,7 @@ mod tests {
         resp_trailers.insert("content-length", "99".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("authorization"));
     }
@@ -891,7 +891,7 @@ mod tests {
         resp_trailers.insert("date", "Sat, 01 Jan 2026 00:00:00 GMT".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(resp_trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_some());
         assert!(v.unwrap().message.contains("date"));
     }
@@ -909,7 +909,7 @@ mod tests {
         trailers.insert("server-timing", "total;dur=100".parse().unwrap());
         tx.response.as_mut().unwrap().trailers = Some(trailers);
 
-        let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+        let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
         assert!(v.is_none());
     }
 
@@ -961,7 +961,7 @@ mod tests {
             tx.response.as_mut().unwrap().trailers =
                 Some(crate::test_helpers::make_headers_from_pairs(&trailer_pairs));
 
-            let v = rule.check_transaction(&tx, &empty_history(), &cfg());
+            let v = crate::test_helpers::run_rule(&rule, &tx, &empty_history(), &cfg());
             match ex.compliance {
                 Compliance::Compliant => assert!(v.is_none(), "{}: {v:?}", ex.snippet),
                 Compliance::NonCompliant => assert!(v.is_some(), "{}", ex.snippet),
@@ -970,7 +970,7 @@ mod tests {
             if !matches!(ex.compliance, Compliance::Compliant) {
                 continue;
             }
-            let v = owner.check_transaction(&tx, &empty_history(), &owner_cfg);
+            let v = crate::test_helpers::run_rule(&owner, &tx, &empty_history(), &owner_cfg);
             assert!(
                 v.is_none(),
                 "the Compliant example writes a Trailer field its owner rejects: {v:?}\n{}",

--- a/lint-http-rules/src/rules/trailer_header_valid.rs
+++ b/lint-http-rules/src/rules/trailer_header_valid.rs
@@ -289,7 +289,8 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
-        TrailerHeaderValid.check_transaction(
+        crate::test_helpers::run_rule(
+            &TrailerHeaderValid,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg(),
@@ -562,7 +563,8 @@ mod tests {
                 );
             }
             tx.response.as_mut().unwrap().trailers = Some(trailers);
-            let v = owner.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &owner,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &owner_cfg,

--- a/lint-http-rules/src/rules/transfer_coding_registered.rs
+++ b/lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -541,7 +541,8 @@ mod tests {
             &[("transfer-encoding", b"gzip\xA0".as_slice())],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_cfg(),
@@ -570,7 +571,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -601,7 +603,8 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -623,7 +626,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x@bad")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -654,7 +658,8 @@ mod tests {
             HeaderValue::from_bytes(b"\xff").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -665,7 +670,8 @@ mod tests {
         let mut hm2 = hyper::HeaderMap::new();
         hm2.insert("te", HeaderValue::from_bytes(b"\xff").unwrap());
         tx2.request.headers = hm2;
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -687,7 +693,8 @@ mod tests {
             HeaderValue::from_bytes(b"gzip, \xe4, x-bogus").unwrap(),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -714,7 +721,8 @@ mod tests {
         hm.append(name, HeaderValue::from_static(second));
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -785,7 +793,8 @@ mod tests {
                 tx.request.headers = headers;
             }
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -840,7 +849,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(field, value)]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -863,7 +873,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(field, value)]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -886,7 +897,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("te", value)]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -908,7 +920,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "gzip, chunked")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -938,7 +951,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", value)]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -960,7 +974,8 @@ mod tests {
             "gzip;ext=\"x, x-bogus",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -979,7 +994,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", ";ext=1")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -998,7 +1014,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", ", chunked, ,")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1018,7 +1035,8 @@ mod tests {
         hm.append("transfer-encoding", HeaderValue::from_static("x-bogus"));
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1157,7 +1175,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "x-custom;q=0.5")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
@@ -1190,7 +1209,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x-custom")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &full_cfg,
@@ -1221,7 +1241,8 @@ mod tests {
         tx.response.as_mut().unwrap().headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x-foo")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1286,7 +1307,8 @@ mod tests {
                 crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", v)]);
         }
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1321,7 +1343,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("te", "trailers, x-custom")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -1342,7 +1365,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "x@bad")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -331,7 +331,8 @@ mod tests {
             value,
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -351,7 +352,8 @@ mod tests {
 
         let tx = crate::test_helpers::make_test_transaction();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -376,7 +378,8 @@ mod tests {
             &[("transfer-encoding", value)],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -404,7 +407,8 @@ mod tests {
             value,
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -425,7 +429,8 @@ mod tests {
             "chunked",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -477,7 +482,8 @@ mod tests {
                 tx.request.headers = headers;
             }
 
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -522,7 +528,8 @@ mod tests {
             value,
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -551,7 +558,8 @@ mod tests {
         );
         tx.request.method = method.to_string();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -570,7 +578,8 @@ mod tests {
         )]);
         tx.request.method = "HEAD".to_string();
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -591,7 +600,8 @@ mod tests {
             ],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -611,7 +621,8 @@ mod tests {
             ("transfer-encoding", "chunked"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -632,7 +643,8 @@ mod tests {
             &[("transfer-encoding", te), ("connection", "close")],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -661,7 +673,8 @@ mod tests {
                 ("connection", b"close\xA0".as_slice()),
             ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -682,7 +695,8 @@ mod tests {
             b"chunked\xA0".as_slice(),
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -710,7 +724,8 @@ mod tests {
             ],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -728,7 +743,8 @@ mod tests {
             ("connection", "close"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -746,7 +762,8 @@ mod tests {
             ("transfer-encoding", "gzip"),
         ]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -774,7 +791,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -800,7 +818,8 @@ mod tests {
             value,
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -818,7 +837,8 @@ mod tests {
             "gzip;ext=\"a,b\", chunked",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -837,7 +857,8 @@ mod tests {
             "chunked;ext=\"a, gzip",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
+++ b/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -218,7 +218,8 @@ mod tests {
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = UpgradeAndConnectionConsistent;
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/upgrade_header_syntax.rs
+++ b/lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -346,7 +346,8 @@ mod tests {
             Section::Request => tx.request.headers = hm,
             Section::Response => tx.response.as_mut().expect("response").headers = hm,
         }
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -503,7 +504,8 @@ mod tests {
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.version = version.into();
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("upgrade", "/1.1")]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -555,7 +557,8 @@ mod tests {
 
             let mut tx = crate::test_helpers::make_test_transaction();
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -565,7 +568,8 @@ mod tests {
                 Compliance::NonCompliant => assert!(v.is_some(), "{}", ex.snippet),
             }
 
-            let v = neighbour.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &neighbour,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &neighbour_cfg,

--- a/lint-http-rules/src/rules/user_agent_present.rs
+++ b/lint-http-rules/src/rules/user_agent_present.rs
@@ -135,7 +135,8 @@ mod tests {
     ) -> anyhow::Result<()> {
         let rule = UserAgentPresent;
         let tx = crate::test_helpers::make_test_transaction_with_headers(&header_pairs);
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -172,18 +173,19 @@ mod tests {
 
         let presence = UserAgentPresent;
         assert!(
-            presence
-                .check_transaction(
-                    &tx,
-                    &history,
-                    &crate::test_helpers::make_test_config_with_enabled_rules(&[presence.id()]),
-                )
-                .is_none(),
+            crate::test_helpers::run_rule(
+                &presence,
+                &tx,
+                &history,
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[presence.id()]),
+            )
+            .is_none(),
             "an empty field line is present, not missing"
         );
 
         let grammar = UserAgentTokenValid;
-        let found = grammar.check_transaction(
+        let found = crate::test_helpers::run_rule(
+            &grammar,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&[grammar.id()]),
@@ -228,7 +230,8 @@ mod tests {
         for ex in rule.examples() {
             let pairs = published_fields(ex.snippet);
             let tx = crate::test_helpers::make_test_transaction_with_headers(&pairs);
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -268,7 +271,8 @@ mod tests {
             }
             let pairs = published_fields(ex.snippet);
             let tx = crate::test_helpers::make_test_transaction_with_headers(&pairs);
-            let found = grammar.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &grammar,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,

--- a/lint-http-rules/src/rules/user_agent_token_valid.rs
+++ b/lint-http-rules/src/rules/user_agent_token_valid.rs
@@ -184,7 +184,8 @@ mod tests {
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("user-agent", v)]);
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -207,25 +208,25 @@ mod tests {
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "A@gen/1.0")]);
-        assert!(rule
-            .check_transaction(
-                &tx1,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx1,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
 
         // invalid character in version
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent/1@0")]);
-        assert!(rule
-            .check_transaction(
-                &tx2,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx2,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
 
         Ok(())
     }
@@ -241,13 +242,13 @@ mod tests {
         hm.append("user-agent", HeaderValue::from_static("Bad@UA/1.0"));
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = hm;
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &cfg,
-            )
-            .is_some());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .is_some());
 
         Ok(())
     }
@@ -266,7 +267,8 @@ mod tests {
         hm.insert("user-agent", HeaderValue::from_bytes(b"\xff").unwrap());
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -297,7 +299,8 @@ mod tests {
         );
         tx.request.headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -322,7 +325,8 @@ mod tests {
             tx.response.as_mut().unwrap().headers =
                 crate::test_helpers::make_headers_from_pairs(&[("user-agent", value)]);
 
-            let v = rule.check_transaction(
+            let v = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,
@@ -344,7 +348,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent  /1.0")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -371,7 +376,8 @@ mod tests {
         let mut tx1 = crate::test_helpers::make_test_transaction();
         tx1.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "A@gen/1.0")]);
-        let v1 = rule.check_transaction(
+        let v1 = crate::test_helpers::run_rule(
+            &rule,
             &tx1,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -384,7 +390,8 @@ mod tests {
         let mut tx2 = crate::test_helpers::make_test_transaction();
         tx2.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent/1@0")]);
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -408,7 +415,8 @@ mod tests {
             "(compatible; something)",
         )]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -436,7 +444,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent (unclosed")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -466,7 +475,8 @@ mod tests {
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("user-agent", "Agent\\(1.0\\)")]);
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -520,7 +530,8 @@ mod tests {
 
             let mut tx = crate::test_helpers::make_test_transaction();
             tx.request.headers = crate::test_helpers::make_headers_from_pairs(&pairs);
-            let found = rule.check_transaction(
+            let found = crate::test_helpers::run_rule(
+                &rule,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &cfg,

--- a/lint-http-rules/src/rules/vary_and_cache_consistent.rs
+++ b/lint-http-rules/src/rules/vary_and_cache_consistent.rs
@@ -176,7 +176,8 @@ mod tests {
     ) {
         let rule = VaryAndCacheConsistent;
         let tx = make_tx(vary, cc);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -216,7 +217,8 @@ mod tests {
                 "cache-control",
                 "max-age=3600".parse().expect("a directive"),
             );
-            VaryAndCacheConsistent.check_transaction(
+            crate::test_helpers::run_rule(
+                &VaryAndCacheConsistent,
                 &tx,
                 &crate::transaction_history::TransactionHistory::empty(),
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -250,7 +252,8 @@ mod tests {
             .unwrap()
             .headers
             .insert("cache-control", bad);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -286,7 +289,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -300,7 +304,8 @@ mod tests {
 
         // Public (mixed case) should be detected
         let tx = make_tx(Some("*"), Some("Public"));
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -309,7 +314,8 @@ mod tests {
 
         // MAX-AGE uppercase
         let tx2 = make_tx(Some("*"), Some("MAX-AGE=60"));
-        let v2 = rule.check_transaction(
+        let v2 = crate::test_helpers::run_rule(
+            &rule,
             &tx2,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -337,7 +343,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -350,7 +357,8 @@ mod tests {
         // Vary: * with a non-cacheability extension should not be flagged
         let rule = VaryAndCacheConsistent;
         let tx = make_tx(Some("*"), Some("foo=bar"));
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/vary_header_cache_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -293,15 +293,13 @@ mod tests {
         let rule = VaryHeaderCacheValid;
         let tx = make_tx_with_req("https://example.com/foo");
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "vary_header_cache_valid"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -323,15 +321,13 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "vary_header_cache_valid"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
+        )
+        .is_none());
     }
 
     /// The two ways the walk this rule used to hold could not read its `Vary`.
@@ -360,7 +356,8 @@ mod tests {
             ]);
             let history =
                 crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-            VaryHeaderCacheValid.check_transaction(
+            crate::test_helpers::run_rule(
+                &VaryHeaderCacheValid,
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -412,7 +409,8 @@ mod tests {
             }
             let history =
                 crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-            VaryHeaderCacheValid.check_transaction(
+            crate::test_helpers::run_rule(
+                &VaryHeaderCacheValid,
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -485,7 +483,8 @@ mod tests {
             }
             let history =
                 crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-            VaryHeaderCacheValid.check_transaction(
+            crate::test_helpers::run_rule(
+                &VaryHeaderCacheValid,
                 &tx,
                 &history,
                 &crate::test_helpers::make_test_config_with_enabled_rules(&[
@@ -529,7 +528,8 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
@@ -561,15 +561,13 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "vary_header_cache_valid"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -587,15 +585,13 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "vary_header_cache_valid"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -612,15 +608,13 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "vary_header_cache_valid"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -642,7 +636,8 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
@@ -670,7 +665,8 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
@@ -705,7 +701,8 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
@@ -732,7 +729,8 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
@@ -759,15 +757,13 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &history,
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "vary_header_cache_valid"
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -789,7 +785,8 @@ mod tests {
         ]);
 
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![past]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),
@@ -833,7 +830,8 @@ mod tests {
         // newest-first: later matching entry (good) must come first
         let history =
             crate::transaction_history::TransactionHistory::from_transactions(vec![good, old]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &history,
             &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_cache_valid"]),

--- a/lint-http-rules/src/rules/vary_header_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_valid.rs
@@ -185,7 +185,8 @@ mod tests {
 
         let config = crate::test_helpers::make_test_config_with_severity(rule.id(), "warn");
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
@@ -211,7 +212,8 @@ mod tests {
             &[("vary", "Accept-Encoding"), ("vary", "User-Agent")],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -230,7 +232,8 @@ mod tests {
             &[("vary", "*"), ("vary", "Accept-Encoding")],
         );
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -257,7 +260,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -286,7 +290,8 @@ mod tests {
     fn no_response_returns_none() {
         let rule = VaryHeaderValid;
         let tx = crate::test_helpers::make_test_transaction(); // request-only, no response
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -608,17 +608,15 @@ mod tests {
 
         let mut tx = crate::test_helpers::make_test_transaction();
         tx.request.headers = headers(&[("via", "1.1 example.com")]);
-        assert!(rule.check_transaction(&tx, &history, &cfg).is_none());
+        assert!(crate::test_helpers::run_rule(&rule, &tx, &history, &cfg).is_none());
 
         tx.request.headers = headers(&[("via", "1.1")]);
-        let v = rule
-            .check_transaction(&tx, &history, &cfg)
+        let v = crate::test_helpers::run_rule(&rule, &tx, &history, &cfg)
             .expect("the request field is judged");
         assert!(v.message.starts_with("Request Via header:"), "{v:?}");
 
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[("via", "1.1")]);
-        let v = rule
-            .check_transaction(&tx, &history, &cfg)
+        let v = crate::test_helpers::run_rule(&rule, &tx, &history, &cfg)
             .expect("the response field is judged");
         assert!(v.message.starts_with("Response Via header:"), "{v:?}");
         Ok(())

--- a/lint-http-rules/src/rules/warning_header_syntax.rs
+++ b/lint-http-rules/src/rules/warning_header_syntax.rs
@@ -565,15 +565,13 @@ mod tests {
     fn judged_response(value: &str) -> Option<String> {
         let tx =
             crate::test_helpers::make_test_transaction_with_response(200, &[("Warning", value)]);
-        WarningHeaderSyntax
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "warning_header_syntax",
-                ]),
-            )
-            .map(|v| v.message)
+        crate::test_helpers::run_rule(
+            &WarningHeaderSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["warning_header_syntax"]),
+        )
+        .map(|v| v.message)
     }
 
     #[rstest]
@@ -774,15 +772,13 @@ mod tests {
                 ),
             ],
         );
-        assert!(WarningHeaderSyntax
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "warning_header_syntax",
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &WarningHeaderSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["warning_header_syntax",]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -797,16 +793,13 @@ mod tests {
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["warning_header_syntax"]);
         let history = crate::transaction_history::TransactionHistory::empty();
-        assert!(WarningHeaderSyntax
-            .check_transaction(&tx, &history, &cfg)
-            .is_none());
+        assert!(crate::test_helpers::run_rule(&WarningHeaderSyntax, &tx, &history, &cfg).is_none());
 
         tx.request.headers.insert(
             "Warning",
             "110-\"bad\"".parse::<hyper::header::HeaderValue>().unwrap(),
         );
-        let message = WarningHeaderSyntax
-            .check_transaction(&tx, &history, &cfg)
+        let message = crate::test_helpers::run_rule(&WarningHeaderSyntax, &tx, &history, &cfg)
             .expect("a malformed request Warning is a finding")
             .message;
         assert!(
@@ -818,15 +811,13 @@ mod tests {
     #[test]
     fn a_message_with_no_warning_is_not_read() {
         let tx = crate::test_helpers::make_test_transaction();
-        assert!(WarningHeaderSyntax
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[
-                    "warning_header_syntax",
-                ]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &WarningHeaderSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["warning_header_syntax",]),
+        )
+        .is_none());
     }
 
     /// The quoted-string checks in this rule answer a question no input can

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -564,7 +564,8 @@ mod tests {
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
-        WebsocketHandshakeValid.check_transaction(
+        crate::test_helpers::run_rule(
+            &WebsocketHandshakeValid,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[

--- a/lint-http-rules/src/rules/well_known_uri_syntax.rs
+++ b/lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -421,7 +421,8 @@ mod tests {
         tx.request.uri = uri.into();
         let config =
             crate::test_helpers::make_test_config_with_severity("well_known_uri_syntax", "warn");
-        WellKnownUriSyntax.check_transaction(
+        crate::test_helpers::run_rule(
+            &WellKnownUriSyntax,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -148,7 +148,8 @@ mod tests {
             "www_authenticate_challenge_syntax",
         ]);
         let tx = make_resp(val);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -175,7 +176,8 @@ mod tests {
         );
         tx.response.as_mut().unwrap().headers = hm;
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -193,7 +195,8 @@ mod tests {
             401,
             &[("www-authenticate", "error=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -215,7 +218,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"x\", ")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -239,7 +243,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"a\", NewScheme abcdef=")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -264,7 +269,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic re@alm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -283,7 +289,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=abc@")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -317,7 +324,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic =\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -336,7 +344,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"unfinished")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -358,7 +367,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic a=\"good\"extra")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -380,7 +390,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"x\", , error=\"y\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -407,7 +418,8 @@ mod tests {
             401,
             &[("www-authenticate", " realm=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -429,7 +441,8 @@ mod tests {
             401,
             &[("www-authenticate", ",")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -455,7 +468,8 @@ mod tests {
             hyper::header::HeaderValue::from_static("NewScheme abc="),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -480,7 +494,8 @@ mod tests {
             hyper::header::HeaderValue::from_static("Basic realm=\"x\""),
         );
         tx.response.as_mut().unwrap().headers = hm;
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -498,7 +513,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -520,7 +536,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=\"a\\\"b\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -538,7 +555,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic realm=token123")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -556,7 +574,8 @@ mod tests {
             401,
             &[("www-authenticate", "NewScheme abc+/.=-_123")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -575,7 +594,8 @@ mod tests {
             401,
             &[("www-authenticate", "New abc/def=\"x\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -595,7 +615,8 @@ mod tests {
             401,
             &[("www-authenticate", "New abc/def=xyz")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -613,7 +634,8 @@ mod tests {
             401,
             &[("www-authenticate", "NonCommon abc=")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -631,7 +653,8 @@ mod tests {
             401,
             &[("www-authenticate", "Basic abc=")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -652,7 +675,8 @@ mod tests {
             401,
             &[("www-authenticate", "NewScheme realm")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,
@@ -671,7 +695,8 @@ mod tests {
             401,
             &[("www-authenticate", "New abc/def=\"x\", realm=\"y\"")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &cfg,

--- a/lint-http-rules/src/rules/x_content_type_options_present.rs
+++ b/lint-http-rules/src/rules/x_content_type_options_present.rs
@@ -245,7 +245,8 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
@@ -392,7 +393,8 @@ mod tests {
             trailers: None,
         });
 
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,
@@ -420,7 +422,8 @@ mod tests {
             "x_content_type_options_present".to_string(),
             toml::Value::Table(table),
         );
-        let violation = rule.check_transaction(
+        let violation = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &config,

--- a/lint-http-rules/src/rules/x_forwarded_consistent.rs
+++ b/lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -283,7 +283,8 @@ mod tests {
                 HeaderValue::from_bytes(value).expect("a field value"),
             );
         }
-        rule.check_transaction(
+        crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -474,13 +475,13 @@ mod tests {
                 ("x-forwarded-host", "user@host"),
             ],
         );
-        assert!(rule
-            .check_transaction(
-                &tx,
-                &crate::transaction_history::TransactionHistory::empty(),
-                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
-            )
-            .is_none());
+        assert!(crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .is_none());
     }
 
     #[test]

--- a/lint-http-rules/src/rules/x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/x_frame_options_value_valid.rs
@@ -184,7 +184,8 @@ mod tests {
                 &[("x-frame-options", h)],
             );
         }
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -212,7 +213,8 @@ mod tests {
             200,
             &[("x-frame-options", "ALLOW-FROM https://example.com")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -241,7 +243,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -271,7 +274,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),

--- a/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -177,7 +177,8 @@ mod tests {
             );
         }
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -212,7 +213,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -242,7 +244,8 @@ mod tests {
             trailers: None,
         });
 
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -261,7 +264,8 @@ mod tests {
     fn no_response_returns_none() {
         let rule = XXssProtectionValueValid;
         let tx = make_test_transaction(); // no response set
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -273,7 +277,8 @@ mod tests {
     fn response_without_header_returns_none() {
         let rule = XXssProtectionValueValid;
         let tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -288,7 +293,8 @@ mod tests {
             200,
             &[("x-xss-protection", "1")],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -306,7 +312,8 @@ mod tests {
             200,
             &[("x-xss-protection", val)],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
@@ -324,7 +331,8 @@ mod tests {
             200,
             &[("x-xss-protection", val)],
         );
-        let v = rule.check_transaction(
+        let v = crate::test_helpers::run_rule(
+            &rule,
             &tx,
             &crate::transaction_history::TransactionHistory::empty(),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),


### PR DESCRIPTION
Files s through z. Every rule file's tests now reach check_transaction only through run_rule; the direct calls that remain are the trait definition and the catalogue meta-tests beside it, which move with the signature.
