### PR TITLE
No rule reads configuration at lint time any more

### DIFF
--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -308,7 +308,7 @@ async fn lint_app(
         match record {
             capture::CaptureRecord::HttpTransaction(tx) => {
                 tx_count += 1;
-                let mut violations = engine.lint_transaction(&tx, &cfg, &state);
+                let mut violations = engine.lint_transaction(&tx, &state);
                 // Record *before* gating: stateful rules must see every
                 // transaction in the file regardless of what the report includes.
                 state.record_transaction(&tx);

--- a/lint-http-proxy/src/proxy/pipeline.rs
+++ b/lint-http-proxy/src/proxy/pipeline.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::capture::CaptureWriter;
-use crate::config::Config;
 use crate::engine::PreparedEngine;
 use crate::http_transaction::HttpTransaction;
 use crate::lint::Violation;
@@ -31,10 +30,10 @@ use crate::state::StateStore;
 use super::Shared;
 
 /// Orchestrates the per-transaction cycle: lint, record to state, write the
-/// capture line.
+/// capture line. No config here: the rules' configuration was resolved into
+/// the engine when it was built.
 pub(super) struct TransactionPipeline {
     engine: Arc<PreparedEngine>,
-    cfg: Arc<Config>,
     state: Arc<StateStore>,
     captures: CaptureWriter,
 }
@@ -45,7 +44,7 @@ impl TransactionPipeline {
     /// cannot be re-committed or mutated after capture; returns the
     /// violations for callers that need them.
     pub(super) async fn commit(&self, mut tx: HttpTransaction) -> Vec<Violation> {
-        tx.violations = self.engine.lint_transaction(&tx, &self.cfg, &self.state);
+        tx.violations = self.engine.lint_transaction(&tx, &self.state);
         self.state.record_transaction(&tx);
         // Extract violations before moving the transaction into the writer.
         let violations = tx.violations.clone();
@@ -84,7 +83,6 @@ impl Shared {
     pub(super) fn pipeline(&self) -> TransactionPipeline {
         TransactionPipeline {
             engine: self.engine.clone(),
-            cfg: self.cfg.clone(),
             state: self.state.clone(),
             captures: self.captures.clone(),
         }

--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -17,11 +17,15 @@ use crate::lint::Violation;
 use crate::rules::{ProtocolRule, Rule};
 
 /// One enabled rule with everything the engine resolved about it at
-/// construction. `query` is the [`crate::rules::STATEFUL_RULES`] lookup,
-/// answered once here instead of hashing the rule id on every transaction.
+/// construction: `query` is the [`crate::rules::STATEFUL_RULES`] lookup,
+/// answered once here instead of hashing the rule id on every transaction,
+/// and `resolved` is what the rule's own `prepare` made of its config.
+/// Dispatch borrows `resolved` into a [`crate::rules::RuleContext`] per
+/// transaction — no per-dispatch config reads.
 struct PreparedRule {
     rule: &'static dyn Rule,
     query: Option<crate::queries::QueryType>,
+    resolved: crate::rules::ResolvedRule,
 }
 
 /// One enabled protocol rule with its configuration resolved by its own
@@ -69,15 +73,18 @@ impl PreparedEngine {
             rules
                 .iter()
                 .filter(|r| cfg.is_enabled(r.id()))
-                .map(|&rule| PreparedRule {
-                    rule,
-                    query: crate::rules::query_type_for(rule.id()),
+                .map(|&rule| {
+                    Ok(PreparedRule {
+                        rule,
+                        query: crate::rules::query_type_for(rule.id()),
+                        resolved: rule.prepare(cfg)?,
+                    })
                 })
-                .collect()
+                .collect::<anyhow::Result<_>>()
         };
         Ok(Self {
-            enabled_full: prepare_enabled(&crate::rules::RULES),
-            enabled_request_only: prepare_enabled(&crate::rules::REQUEST_ONLY_RULES),
+            enabled_full: prepare_enabled(&crate::rules::RULES)?,
+            enabled_request_only: prepare_enabled(&crate::rules::REQUEST_ONLY_RULES)?,
             enabled_protocol: crate::rules::PROTOCOL_RULES
                 .iter()
                 .copied()
@@ -92,11 +99,12 @@ impl PreparedEngine {
         })
     }
 
-    /// Lint an entire `HttpTransaction` against the enabled rule set.
+    /// Lint an entire `HttpTransaction` against the enabled rule set. No
+    /// config parameter: everything config-derived was resolved when the
+    /// engine was built.
     pub fn lint_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        cfg: &Config,
         state: &crate::state::StateStore,
     ) -> Vec<Violation> {
         let mut out = Vec::new();
@@ -163,7 +171,8 @@ impl PreparedEngine {
                 None => &empty_history,
             };
 
-            out.extend(rule.check_transaction(tx, history, cfg));
+            let ctx = crate::rules::RuleContext::new(&prepared.resolved);
+            out.extend(rule.check_transaction(tx, history, &ctx));
         }
 
         out
@@ -188,7 +197,7 @@ pub fn lint_transaction(
 ) -> Vec<Violation> {
     PreparedEngine::new(cfg)
         .expect("config failed rule validation")
-        .lint_transaction(tx, cfg, state)
+        .lint_transaction(tx, state)
 }
 
 #[cfg(test)]
@@ -267,7 +276,7 @@ mod tests {
         let via_free = lint_transaction(&tx, &cfg, &state);
         let via_prepared = PreparedEngine::new(&cfg)
             .unwrap()
-            .lint_transaction(&tx, &cfg, &state);
+            .lint_transaction(&tx, &state);
 
         let ids = |vs: &[Violation]| {
             let mut v: Vec<_> = vs.iter().map(|x| x.rule.clone()).collect();

--- a/lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
+++ b/lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
@@ -28,10 +28,8 @@ impl Rule for AcceptAndContentTypeNegotiation {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // What this rule is, stated before anything it does: an advisory, not a
         // conformance check. RFC 9110 gives the origin server the choice
         // outright — a representation the Accept header does not cover may be
@@ -225,7 +223,7 @@ impl Rule for AcceptAndContentTypeNegotiation {
         if !matched {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Response Content-Type '{}' does not match request Accept header '{}', consider returning 406 Not Acceptable",
                     content_type, accept

--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -27,10 +27,8 @@ impl Rule for AcceptEncodingParameterValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The production the whole rule is a reading of. Two things about it
         // decide almost every branch below: a member is a coding and at most
         // one weight, and `codings` has exactly three alternatives.
@@ -72,7 +70,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 if primary.is_empty() {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Empty content-coding in Accept-Encoding member '{}'",
                                             part
@@ -84,7 +82,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Invalid token '{}' in Accept-Encoding header",
                                             c
@@ -118,7 +116,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 if param.is_empty() {
                                     return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Accept-Encoding member '{}' has a ';' with no weight after it",
                                         part
@@ -138,7 +136,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 if !name.eq_ignore_ascii_case("q") {
                                     return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "'{}' is not a weight, and a weight is the only thing an Accept-Encoding coding may carry (member '{}')",
                                         param, part
@@ -148,7 +146,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 if weight_seen {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "More than one weight in Accept-Encoding member '{}'",
                                             part
@@ -160,7 +158,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 let Some(v) = val else {
                                     return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Missing parameter value for '{}' in Accept-Encoding member '{}'",
                                         name, part
@@ -172,7 +170,7 @@ impl Rule for AcceptEncodingParameterValid {
                                 if !crate::helpers::headers::valid_qvalue(v) {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Invalid qvalue '{}' in Accept-Encoding member '{}'",
                                             v, part
@@ -193,7 +191,7 @@ impl Rule for AcceptEncodingParameterValid {
                     // of this field whatever else the value contains.
                     return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "Accept-Encoding contains an octet no part of this field's grammar admits"
                             .into(),

--- a/lint-http-rules/src/rules/accept_encoding_present.rs
+++ b/lint-http-rules/src/rules/accept_encoding_present.rs
@@ -20,10 +20,8 @@ impl Rule for AcceptEncodingPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // A CONNECT does not ask for a representation, so there is no response
         // content for a content coding to apply to. This is the method's own
         // semantics rather than a guess about the status it will get back:
@@ -72,7 +70,7 @@ impl Rule for AcceptEncodingPresent {
         if !present {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Request expresses no content-coding preference (no Accept-Encoding \
                           header); any coding is acceptable, but most servers will not compress \
                           without an explicit signal"
@@ -83,7 +81,7 @@ impl Rule for AcceptEncodingPresent {
         if !any_coding {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Request declines all content codings (empty Accept-Encoding header)"
                     .into(),
             });

--- a/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -27,9 +27,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The list grammar, and the one production every branch below is a
         // piece of. A member is a media-range and at most one weight; the
         // media-range carries the parameters.
@@ -68,7 +67,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                 if media.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Empty media-range in {} header", hdr),
                     });
                 }
@@ -84,7 +83,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                 if media.contains(char::is_whitespace) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid media-range '{}' in {} header: whitespace inside a media-range",
                             media, hdr
@@ -100,7 +99,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                 if media == "*" {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid media-range '*' in {} header", hdr),
                     });
                 }
@@ -112,7 +111,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                     if !media.contains('/') {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid media-range '{}' in {} header: missing '/'",
                                 media, hdr
@@ -132,7 +131,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Invalid token '{}' in media type '{}' of {}",
                                     c, parsed.type_, hdr
@@ -152,7 +151,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         if parsed.type_ == "*" {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Invalid media-range '{}' in {} header: a wildcard type is only meaningful with a wildcard subtype ('*/*'), since the asterisk names all media types or all subtypes of one type and nothing else",
                                     media, hdr
@@ -165,7 +164,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Invalid token '{}' in media subtype '{}' of {}",
                                         c, parsed.subtype, hdr
@@ -176,7 +175,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                     } else {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid media-range '{}' in {} header", media, hdr),
                         });
                     }
@@ -200,7 +199,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                     if weight_seen {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Parameter '{}' follows the weight in {} header: the weight closes a media-range, and the extension parameters that once came after it were removed from the grammar",
                                 p, hdr
@@ -222,7 +221,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         Err(crate::helpers::headers::ParameterDefect::NoEquals(_)) => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Invalid parameter '{}' in {} header: missing '='",
                                     p, hdr
@@ -245,7 +244,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                     if k.is_empty() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Empty parameter name in '{}' of {} header: a token is one or more characters",
                                 p, hdr
@@ -255,7 +254,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(k) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid character '{}' in parameter name '{}' in {} header",
                                 c, k, hdr
@@ -280,7 +279,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         if !crate::helpers::headers::valid_qvalue(v) {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Invalid qvalue '{}' in {} header", v, hdr),
                             });
                         }
@@ -302,7 +301,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             Err(crate::helpers::headers::WordDefect::Empty) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Empty parameter value in '{}' of {} header: a parameter-value is a token or a quoted-string, and neither derives the empty string",
                                         p, hdr
@@ -312,7 +311,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Invalid quoted-string parameter '{}' in {} header: {}",
                                         p, hdr, e
@@ -322,7 +321,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             Err(crate::helpers::headers::WordDefect::NotToken(c)) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Invalid token '{}' in parameter value '{}' of {} header",
                                         c, v, hdr

--- a/lint-http-rules/src/rules/accept_language_weight_valid.rs
+++ b/lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -28,9 +28,8 @@ impl Rule for AcceptLanguageWeightValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The production the rule is a reading of. A member is a range and at
         // most one weight; nothing else derives from it.
         // cite(RFC 9110 § 12.5.4): "Accept-Language = #( language-range [ weight ] )"
@@ -70,7 +69,7 @@ impl Rule for AcceptLanguageWeightValid {
                     if param.is_empty() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Accept-Language member '{}' has a ';' with no weight after it",
                                 member
@@ -88,7 +87,7 @@ impl Rule for AcceptLanguageWeightValid {
                     if !name.eq_ignore_ascii_case("q") {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "'{}' is not a weight, and a weight is the only thing an Accept-Language range may carry (member '{}')",
                                 param, member
@@ -98,7 +97,7 @@ impl Rule for AcceptLanguageWeightValid {
                     if weight_seen {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "More than one weight in Accept-Language member '{}'",
                                 member
@@ -110,7 +109,7 @@ impl Rule for AcceptLanguageWeightValid {
                     let Some(val) = val_opt else {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Missing parameter value for '{}' in Accept-Language member '{}'",
                                 name, member
@@ -122,7 +121,7 @@ impl Rule for AcceptLanguageWeightValid {
                     if !crate::helpers::headers::valid_qvalue(val) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid qvalue '{}' in Accept-Language member '{}'",
                                 val, member
@@ -143,7 +142,7 @@ impl Rule for AcceptLanguageWeightValid {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "Accept-Language contains an octet no part of this field's grammar admits"
                             .into(),
@@ -165,7 +164,7 @@ impl Rule for AcceptLanguageWeightValid {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message:
                             "Accept-Language contains an octet no part of this field's grammar admits"
                                 .into(),

--- a/lint-http-rules/src/rules/accept_patch_header_valid.rs
+++ b/lint-http-rules/src/rules/accept_patch_header_valid.rs
@@ -48,11 +48,11 @@ impl AcceptPatchHeaderValid {
     ///
     /// cite(RFC 5789 § 3.1, label: Accept-Patch grammar): "Accept-Patch = "Accept-Patch" ":" 1#media-type"
     /// cite(RFC 5789 § 3.1): "The Accept-Patch header specifies a comma-separated listing of media-types (with optional parameters) as defined by [RFC2616], Section 3.7."
-    fn check_value(&self, value: &str, config: &crate::rules::RuleConfig) -> Option<Violation> {
+    fn check_value(&self, value: &str, severity: crate::lint::Severity) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -211,7 +211,7 @@ impl Rule for AcceptPatchHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
@@ -222,16 +222,13 @@ impl Rule for AcceptPatchHeaderValid {
         // name may arrive as a trailer at all is § 6.5.1's question, asked of
         // every name at once by `trailer_fields_valid`.
         //
-        // Each of the reads below is one `HeaderMap` probe, and
-        // `parse_rule_config` is several map probes plus a hash over the rule
-        // id; a response carrying no `Accept-Patch` and answering neither of the
-        // two methods below is the overwhelming majority of traffic, so it pays
-        // for none of them.
+        // Each of the reads below is one `HeaderMap` probe; a response carrying
+        // no `Accept-Patch` and answering neither of the two methods below is
+        // the overwhelming majority of traffic.
         //
         // cite(RFC 5789 § 3.1): "The presence of the Accept-Patch header in response to any method is an implicit indication that PATCH is allowed on the resource identified by the Request-URI."
         if let Some(value) = combined_field_value_as_written(&resp.headers, "accept-patch") {
-            let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-            return self.check_value(&value, &config);
+            return self.check_value(&value, ctx.severity);
         }
 
         // Compared exactly, both of them: a request whose method is `patch` or
@@ -254,10 +251,9 @@ impl Rule for AcceptPatchHeaderValid {
             // cite(RFC 9110 § 15.5.16): "The format problem might be due to the request's indicated Content-Type or Content-Encoding, or as a result of inspecting the data directly."
             // cite(RFC 9110 § 15.5.16): "If the problem was caused by an unsupported content coding, the Accept-Encoding response header field (Section 12.5.3) ought to be used"
             if resp.status == 415 && !resp.headers.contains_key("accept-encoding") {
-                let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "415 (Unsupported Media Type) response to a PATCH carries no Accept-Patch; RFC 5789 § 2.2 says such a response SHOULD include an Accept-Patch response header to notify the client what patch document media types are supported".into(),
                 });
             }
@@ -299,10 +295,9 @@ impl Rule for AcceptPatchHeaderValid {
             // cite(RFC 5789 § 3): "The PATCH method MAY appear in the "Allow" header even if the Accept-Patch header is absent, in which case the list of allowed patch documents is not advertised."
             // cite(RFC 9110 § 9.3.7): "An OPTIONS request with an asterisk ("*") as the request target (Section 7.1) applies to the server in general rather than to a specific resource."
             if tx.request.uri != "*" && allow_names_patch(&resp.headers) {
-                let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "OPTIONS response ({}) advertises PATCH in Allow and carries no Accept-Patch; RFC 5789 § 3.1 says Accept-Patch SHOULD appear in the OPTIONS response for any resource that supports the use of the PATCH method. § 3 leaves the Allow listing conforming without it and names what is lost: the list of allowed patch documents is not advertised",
                         resp.status

--- a/lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
+++ b/lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
@@ -20,10 +20,8 @@ impl Rule for AcceptRangesAnd206Consistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // `Accept-Ranges` is a response field, which is the sentence behind
         // reading one side only -- not the scope enum, which in this engine only
         // decides when the rule is dispatched.
@@ -58,7 +56,7 @@ impl Rule for AcceptRangesAnd206Consistent {
         if !advertised.present {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "206 Partial Content response carries no Accept-Ranges field, so a client resuming this transfer has nothing telling it which range units the resource supports (advice: nothing requires the field)".into(),
             });
         }
@@ -73,7 +71,7 @@ impl Rule for AcceptRangesAnd206Consistent {
         if advertised.advertises("none") {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Accept-Ranges: none says this resource supports no kind of range request, in the very response that fulfilled one (206 Partial Content)".into(),
             });
         }
@@ -107,7 +105,7 @@ impl Rule for AcceptRangesAnd206Consistent {
         if !advertised.advertises(unit) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Content-Range describes a range in '{}', a unit this response's Accept-Ranges does not advertise (advice: nothing requires the two to agree)",
                     unit

--- a/lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
+++ b/lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
@@ -65,10 +65,8 @@ impl Rule for AcceptRangesOnPartialContent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The subject is a request that asks for a range, and presence is the
         // whole of it: the advice below is against attempting a range request at
         // all, so a value this rule cannot read is still a range request.
@@ -119,7 +117,7 @@ impl Rule for AcceptRangesOnPartialContent {
         if advertised.advertises("none") {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Previous response for this resource sent Accept-Ranges: none, advising against a range request on the same request path, and this request sends Range anyway (advice: nothing forbids it)".into(),
             });
         }
@@ -143,7 +141,7 @@ impl Rule for AcceptRangesOnPartialContent {
         if !advertised.advertises(&unit) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Range asks in '{}', a unit the previous response for this resource did not advertise, so a server that does not understand it will ignore the field and send the whole representation (advice: nothing forbids it)",
                     unit

--- a/lint-http-rules/src/rules/accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -29,9 +29,8 @@ impl Rule for AcceptRangesValuesValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // Both of the sections the field is defined for, and every line inside
@@ -73,7 +72,7 @@ impl Rule for AcceptRangesValuesValid {
                 let Ok(value) = hv.to_str() else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Accept-Ranges holds an octet no range-unit admits: a range unit name is a token, whose characters are all visible US-ASCII".into(),
                     });
                 };
@@ -97,7 +96,7 @@ impl Rule for AcceptRangesValuesValid {
             if let Err(e) = read_units(&value, &mut units) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Invalid Accept-Ranges field value '{}': {}", value, e),
                 });
             }
@@ -136,7 +135,7 @@ impl Rule for AcceptRangesValuesValid {
         if units.iter().any(|u| u == "none") && !others.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Accept-Ranges advertises '{}' beside 'none', which is reserved for advising that no kind of range request is supported: the field says both that this resource supports range requests and that it does not (advice: nothing forbids it)",
                     others.join("', '")

--- a/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
@@ -20,9 +20,8 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
@@ -44,7 +43,7 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Access-Control-Allow-Origin header contains non-ASCII or control characters".into(),
                     })
                 }
@@ -73,7 +72,7 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Access-Control-Allow-Credentials header contains non-ASCII or control characters".into(),
                 })
             }
@@ -89,7 +88,7 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
         if acc_val.eq_ignore_ascii_case("true") && acao_has_star {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Access-Control-Allow-Credentials must not be 'true' when Access-Control-Allow-Origin is '*'".into(),
             });
         }
@@ -420,7 +419,7 @@ mod tests {
         );
 
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
@@ -20,9 +20,8 @@ impl Rule for AccessControlAllowOriginValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let headers = &resp.headers;
@@ -41,7 +40,7 @@ impl Rule for AccessControlAllowOriginValid {
         if acao_count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Access-Control-Allow-Origin header fields present; only a single value ('*' or a single origin) is allowed".into(),
             });
         }
@@ -56,7 +55,7 @@ impl Rule for AccessControlAllowOriginValid {
             Ok(v) => v.trim(),
             Err(_) => return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message:
                     "Access-Control-Allow-Origin header contains non-ASCII or control characters"
                         .into(),
@@ -70,7 +69,7 @@ impl Rule for AccessControlAllowOriginValid {
         if members.len() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Access-Control-Allow-Origin must be a single value ('*', 'null', or a serialized origin)".into(),
             });
         }
@@ -83,7 +82,7 @@ impl Rule for AccessControlAllowOriginValid {
         if !crate::helpers::headers::is_valid_serialized_origin(&member) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Access-Control-Allow-Origin contains invalid origin: '{}'",
                     member
@@ -407,7 +406,7 @@ mod tests {
         );
 
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/age_header_numeric.rs
+++ b/lint-http-rules/src/rules/age_header_numeric.rs
@@ -22,9 +22,8 @@ impl Rule for AgeHeaderNumeric {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to responses only
         let resp = tx.response.as_ref()?;
 
@@ -40,7 +39,7 @@ impl Rule for AgeHeaderNumeric {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Age header contains non-UTF8 value".into(),
                     })
                 }
@@ -61,7 +60,7 @@ impl Rule for AgeHeaderNumeric {
 
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Age value '{}' is invalid: must be a non-negative integer (delta-seconds)",
                     s

--- a/lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
+++ b/lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
@@ -37,12 +37,12 @@ impl AllowHeaderMethodTokensValid {
         &self,
         value: &str,
         section: &str,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -178,7 +178,7 @@ impl Rule for AllowHeaderMethodTokensValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // One field section is one list however many lines carry it, so the lines are
         // joined before the members are counted: an `Allow:` written as a second line
@@ -199,10 +199,8 @@ impl Rule for AllowHeaderMethodTokensValid {
         // `description()` says so rather than leaving the silence to be read as a
         // verdict.
         //
-        // Each read is one `HeaderMap` probe, and a message carrying no `Allow` at all
-        // is the overwhelming majority of traffic; `parse_rule_config` is several map
-        // probes plus a hash over the rule id, so only a message that carries the
-        // field pays for it.
+        // Each read is one `HeaderMap` probe, and a message carrying no `Allow`
+        // at all is the overwhelming majority of traffic.
         let request = combined_field_value_as_written(&tx.request.headers, "allow");
         let response = tx
             .response
@@ -213,16 +211,14 @@ impl Rule for AllowHeaderMethodTokensValid {
             return None;
         }
 
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         if let Some(value) = &request {
-            if let Some(v) = self.check_field_section(value, "request", &config) {
+            if let Some(v) = self.check_field_section(value, "request", ctx.severity) {
                 return Some(v);
             }
         }
 
         if let Some(value) = &response {
-            if let Some(v) = self.check_field_section(value, "response", &config) {
+            if let Some(v) = self.check_field_section(value, "response", ctx.severity) {
                 return Some(v);
             }
         }
@@ -634,7 +630,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
+++ b/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
@@ -56,7 +56,7 @@ impl Rule for AltSvcH3AdvertisementValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
@@ -77,7 +77,6 @@ impl Rule for AltSvcH3AdvertisementValid {
         // cite(RFC 7838 § 3): "An HTTP(S) origin server can advertise the availability of alternative services to clients by adding an Alt-Svc header field to responses."
         // cite(RFC 9110 § 5.3): "A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3)."
         let value = combined_field_value_as_written(&resp.headers, "alt-svc")?;
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let value = trim_ows(&value);
 
         // The other alternative of the top production, which advertises no
@@ -132,7 +131,7 @@ impl Rule for AltSvcH3AdvertisementValid {
             // cite(RFC 9114 § 3.1.1): "An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token."
             if proto_lower.starts_with("h3-") {
                 return Some(self.violation(
-                    config.severity,
+                    ctx.severity,
                     format!(
                         "Alt-Svc uses draft HTTP/3 protocol identifier '{}'; use the final 'h3' token instead (RFC 9114 §3.1.1)",
                         shown_in_finding(protocol_id)
@@ -146,7 +145,7 @@ impl Rule for AltSvcH3AdvertisementValid {
             }
 
             if let Some(message) = h3_ma_defect(parameters) {
-                return Some(self.violation(config.severity, message));
+                return Some(self.violation(ctx.severity, message));
             }
         }
 

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -381,15 +381,13 @@ impl Rule for AltSvcHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // No status gate, and the sentence below is the whole reason there is
         // none: every response is a response this field may ride on.
         // cite(RFC 7838 § 3): "Alt-Svc MAY occur in any HTTP response message, regardless of the status code."
         let resp = tx.response.as_ref()?;
-        let severity = crate::rules::parse_rule_config(cfg, self.id())
-            .ok()?
-            .severity;
+        let severity = ctx.severity;
 
         // One `char` per octet, because the findings below are about what a
         // sender wrote: `to_str` would fold a field carrying `obs-text` into

--- a/lint-http-rules/src/rules/alt_svc_protocol_registered.rs
+++ b/lint-http-rules/src/rules/alt_svc_protocol_registered.rs
@@ -204,22 +204,22 @@ impl Rule for AltSvcProtocolRegistered {
         crate::rules::RuleScope::Server
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // No status gate: the section says in one sentence that there is no
         // status this field may not ride on. § 6's *"An Alt-Svc header field in
@@ -229,7 +229,7 @@ impl Rule for AltSvcProtocolRegistered {
         // written the same defect whatever the status line says.
         // cite(RFC 7838 § 3): "Alt-Svc MAY occur in any HTTP response message, regardless of the status code."
         let resp = tx.response.as_ref()?;
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &AltSvcProtocolConfig = ctx.state();
 
         // One `char` per octet. `to_str` folds a field carrying `obs-text` into
         // "no such field here", which for this rule would drop every alternative
@@ -663,7 +663,7 @@ mod tests {
             (too_long.as_str(), "octets long"),
         ] {
             let err = AltSvcProtocolRegistered
-                .validate(&allowing(&[entry]))
+                .prepare(&allowing(&[entry]))
                 .expect_err("the entry names no ALPN protocol");
             assert!(err.to_string().contains(expected), "{err}");
         }

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -67,24 +67,24 @@ impl Rule for AuthSchemeRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &AuthSchemeConfig = ctx.state();
         // Helper to check a single scheme token against allowed list
         let check_scheme =
             |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {

--- a/lint-http-rules/src/rules/authentication_challenge_valid.rs
+++ b/lint-http-rules/src/rules/authentication_challenge_valid.rs
@@ -20,9 +20,8 @@ impl Rule for AuthenticationChallengeValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers; ignore non-UTF8 header values
         if let Some(resp) = &tx.response {
             use std::collections::{HashMap, HashSet};
@@ -100,7 +99,7 @@ impl Rule for AuthenticationChallengeValid {
                     );
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: msg,
                     });
                 }

--- a/lint-http-rules/src/rules/authentication_failure_loop.rs
+++ b/lint-http-rules/src/rules/authentication_failure_loop.rs
@@ -22,9 +22,8 @@ impl Rule for AuthenticationFailureLoop {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only 401 responses matter — the status that means credentials were missing
         // or rejected, i.e. an authentication attempt that did not succeed.
         // cite(RFC 9110 § 15.5.2): "The 401 (Unauthorized) status code indicates that the request has not been applied because it lacks valid authentication credentials for the target resource."
@@ -58,7 +57,7 @@ impl Rule for AuthenticationFailureLoop {
         if consecutive_401s >= 3 {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Authentication failure loop detected: client has received {} consecutive 401 Unauthorized challenges for this origin.",
                     consecutive_401s + 1

--- a/lint-http-rules/src/rules/authorization_credentials_present.rs
+++ b/lint-http-rules/src/rules/authorization_credentials_present.rs
@@ -20,9 +20,8 @@ impl Rule for AuthorizationCredentialsPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             match hv.to_str() {
                 Ok(s) => {
@@ -35,7 +34,7 @@ impl Rule for AuthorizationCredentialsPresent {
                     if let Err(msg) = crate::helpers::auth::validate_authorization_syntax(s) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid Authorization header: {}", msg),
                         });
                     }
@@ -43,7 +42,7 @@ impl Rule for AuthorizationCredentialsPresent {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Authorization header contains non-UTF8 value".into(),
                     })
                 }

--- a/lint-http-rules/src/rules/basic_auth_base64_valid.rs
+++ b/lint-http-rules/src/rules/basic_auth_base64_valid.rs
@@ -20,9 +20,8 @@ impl Rule for BasicAuthBase64Valid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             match hv.to_str() {
                 Ok(s) => {
@@ -35,7 +34,7 @@ impl Rule for BasicAuthBase64Valid {
                         if creds.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Basic Authorization missing credentials".into(),
                             });
                         }
@@ -47,7 +46,7 @@ impl Rule for BasicAuthBase64Valid {
                         if let Err(msg) = crate::helpers::auth::validate_basic_credentials(creds) {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Invalid Basic credentials: {} (RFC 7617)", msg),
                             });
                         }
@@ -56,7 +55,7 @@ impl Rule for BasicAuthBase64Valid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Authorization header contains non-UTF8 value".into(),
                     })
                 }

--- a/lint-http-rules/src/rules/bearer_token_syntax.rs
+++ b/lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -20,16 +20,15 @@ impl Rule for BearerTokenSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             let s = match hv.to_str() {
                 Ok(s) => s,
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Authorization header contains non-UTF8 value".into(),
                     })
                 }
@@ -48,7 +47,7 @@ impl Rule for BearerTokenSyntax {
                 if creds.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Authorization: Bearer missing token".into(),
                     });
                 }
@@ -56,7 +55,7 @@ impl Rule for BearerTokenSyntax {
                 if let Err(msg) = crate::helpers::auth::validate_bearer_token(creds) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid Bearer token: {}", msg),
                     });
                 }

--- a/lint-http-rules/src/rules/cache_coherence.rs
+++ b/lint-http-rules/src/rules/cache_coherence.rs
@@ -33,9 +33,8 @@ impl Rule for CacheCoherence {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // ignore 304 responses, they have no representation body of their own
@@ -108,7 +107,7 @@ impl Rule for CacheCoherence {
             if curr_time < prev_max {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "response for '{}' appears stale ({} < previous {})",
                         tx.request.uri, curr_time, prev_max

--- a/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
+++ b/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
@@ -20,9 +20,8 @@ impl Rule for CacheControlAndPragmaConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Check requests: Pragma: no-cache vs Cache-Control: only-if-cached contradiction
         // `Pragma` is the HTTP/1.0 spelling of a request `no-cache`, and `Cache-Control`
         // is the one that means anything now. A message carrying both is asking to be
@@ -52,7 +51,7 @@ impl Rule for CacheControlAndPragmaConsistent {
                                     // in the tracker.
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: "Request contains 'Pragma: no-cache' and 'Cache-Control: only-if-cached' which are contradictory (RFC 9111 §5.4)".to_string(),
                                     });
                                 }
@@ -72,7 +71,7 @@ impl Rule for CacheControlAndPragmaConsistent {
             if resp.headers.contains_key("pragma") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Response contains 'Pragma' header; its meaning in responses was never specified and Pragma is deprecated — use 'Cache-Control' instead (RFC 9111 §5.4)".into(),
                 });
             }

--- a/lint-http-rules/src/rules/cache_control_directive_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_directive_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CacheControlDirectiveValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Apply to both request and response messages
         // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
         for header_val in tx.request.headers.get_all("cache-control").iter() {
@@ -36,14 +35,14 @@ impl Rule for CacheControlDirectiveValid {
                 if let Some(msg) = check_cache_control_directives(v) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid Cache-Control header in request: {}", msg),
                     });
                 }
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Cache-Control header contains non-UTF8 value".into(),
                 });
             }
@@ -61,14 +60,14 @@ impl Rule for CacheControlDirectiveValid {
                     if let Some(msg) = check_cache_control_directives(v) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid Cache-Control header in response: {}", msg),
                         });
                     }
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Cache-Control header contains non-UTF8 value".into(),
                     });
                 }
@@ -478,7 +477,7 @@ mod tests {
         );
 
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cache_control_present.rs
+++ b/lint-http-rules/src/rules/cache_control_present.rs
@@ -22,9 +22,8 @@ impl Rule for CacheControlPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         if let Some(resp) = &tx.response {
             // Nothing requires a `Cache-Control` on a 200. What the absence of one buys is
             // a cache guessing: with no explicit expiration time, a heuristic freshness
@@ -41,7 +40,7 @@ impl Rule for CacheControlPresent {
             if resp.status == 200 && !resp.headers.contains_key("cache-control") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Response 200 without Cache-Control header".into(),
                 });
             }

--- a/lint-http-rules/src/rules/cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CacheControlTokenValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Apply to both request and response messages
         // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
         for header_val in tx.request.headers.get_all("cache-control").iter() {
@@ -36,14 +35,14 @@ impl Rule for CacheControlTokenValid {
                 if let Some(msg) = check_cache_control_value(v) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid Cache-Control header in request: {}", msg),
                     });
                 }
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Cache-Control header contains non-UTF8 value".into(),
                 });
             }
@@ -61,14 +60,14 @@ impl Rule for CacheControlTokenValid {
                     if let Some(msg) = check_cache_control_value(v) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid Cache-Control header in response: {}", msg),
                         });
                     }
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Cache-Control header contains non-UTF8 value".into(),
                     });
                 }
@@ -398,7 +397,7 @@ mod tests {
         );
 
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/cache_validation_chain.rs
@@ -45,9 +45,8 @@ impl Rule for CacheValidationChain {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let has_inm = req.headers.contains_key("if-none-match");
         let has_ims = req.headers.contains_key("if-modified-since");
@@ -133,7 +132,7 @@ impl Rule for CacheValidationChain {
                     // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Conditional request uses If-None-Match '{}' which does not match most recent validator '{}' from history; cache validation chain may be broken",
                             reported.trim(),
@@ -172,7 +171,7 @@ impl Rule for CacheValidationChain {
                     if mismatch {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Conditional request uses If-Modified-Since '{}' which does not match most recent Last-Modified '{}' from history; cache validation chain may be broken",
                                 ims_str,

--- a/lint-http-rules/src/rules/cached_validators_reused.rs
+++ b/lint-http-rules/src/rules/cached_validators_reused.rs
@@ -22,10 +22,8 @@ impl Rule for CachedValidatorsReused {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Only GET/HEAD re-requests are in scope. If-None-Match / If-Modified-Since
         // are the cache-revalidation preconditions, and RFC 9110 §13.1.2's client
         // SHOULD is written "when making a GET request". On other methods a validator
@@ -68,7 +66,7 @@ impl Rule for CachedValidatorsReused {
         if !has_if_none_match && !has_if_modified_since {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Client re-requesting resource without conditional headers. \
                      Server provided validators (ETag: {}, Last-Modified: {}) but client \

--- a/lint-http-rules/src/rules/caching_directive_interaction.rs
+++ b/lint-http-rules/src/rules/caching_directive_interaction.rs
@@ -27,9 +27,8 @@ impl Rule for CachingDirectiveInteraction {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to check a single HeaderMap for contradictions
         let check_headers = |hdrs: &hyper::HeaderMap| -> Option<Violation> {
             use crate::helpers::headers::split_commas_respecting_quotes;
@@ -43,7 +42,7 @@ impl Rule for CachingDirectiveInteraction {
                     Err(_) => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Cache-Control header contains non-UTF8 value".into(),
                         })
                     }
@@ -64,7 +63,7 @@ impl Rule for CachingDirectiveInteraction {
                         // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Cache-Control header contains empty member".into(),
                         });
                     }
@@ -102,7 +101,7 @@ impl Rule for CachingDirectiveInteraction {
             if seen.contains_key("public") && private_unqualified {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Cache-Control contains both 'public' and 'private' directives (contradictory visibility)".into(),
                 });
             }
@@ -117,7 +116,7 @@ impl Rule for CachingDirectiveInteraction {
                 // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Cache-Control contains 'no-store' together with 'public' or 'private' (contradiction)".into(),
                 });
             }
@@ -150,7 +149,7 @@ impl Rule for CachingDirectiveInteraction {
                         if nums.iter().any(|x| x != first) {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Cache-Control contains multiple '{}' directives with differing values", key),
                             });
                         }

--- a/lint-http-rules/src/rules/charset_present.rs
+++ b/lint-http-rules/src/rules/charset_present.rs
@@ -20,9 +20,8 @@ impl Rule for CharsetPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Response-only, though Content-Type is equally a request field. The concern
         // driving this rule — a recipient guessing the encoding of text it renders —
         // is a response-side one, so a request that omits charset is left alone.
@@ -86,7 +85,7 @@ impl Rule for CharsetPresent {
                     if !has_charset {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Text-based Content-Type header missing charset parameter."
                                 .into(),
                         });

--- a/lint-http-rules/src/rules/charset_registered.rs
+++ b/lint-http-rules/src/rules/charset_registered.rs
@@ -75,24 +75,24 @@ impl Rule for CharsetRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &CharsetConfig = ctx.state();
         use crate::helpers::headers::parse_media_type;
 
         let check_header = |which: &str, val: &str| -> Option<Violation> {

--- a/lint-http-rules/src/rules/clear_site_data_present.rs
+++ b/lint-http-rules/src/rules/clear_site_data_present.rs
@@ -82,22 +82,22 @@ impl Rule for ClearSiteDataPresent {
         crate::rules::RuleScope::Server
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_paths_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_paths_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Only check successful responses. This 2xx gate is the rule's own tolerance,
         // not a specified scope: the spec processes the header on any response, but a
@@ -112,7 +112,7 @@ impl Rule for ClearSiteDataPresent {
 
         // Parse config only after the cheap response/status guards — non-2xx
         // responses (redirects, errors) skip the paths allocation entirely.
-        let config = parse_paths_config(cfg, self.id()).ok()?;
+        let config: &ClearSiteDataConfig = ctx.state();
 
         // Check if the current resource path matches any configured path
         let resource_path = extract_path_from_resource(&tx.request.uri);
@@ -384,7 +384,7 @@ mod tests {
             _ => panic!("unknown scenario"),
         }
 
-        let res = rule.validate(&cfg);
+        let res = rule.prepare(&cfg);
         if valid {
             res?;
             let parsed = super::parse_paths_config(&cfg, rule.id())?;

--- a/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
+++ b/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -27,10 +27,8 @@ impl Rule for CompressionAndTransferEncodingConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Both fields are lists whose members a sender may spread over several
         // field lines, and there the resemblance ends: their grammars differ in
         // a way that decides how each is split.
@@ -152,7 +150,7 @@ impl Rule for CompressionAndTransferEncodingConsistent {
             if !overlap.is_empty() {
                 return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Compression coding(s) '{}' appear in both Content-Encoding and Transfer-Encoding of the {}; the representation is coded once and then coded again in transit, which is decodable but almost never intended",
                     overlap.join(", "),

--- a/lint-http-rules/src/rules/conditional_headers_consistent.rs
+++ b/lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -28,9 +28,8 @@ impl Rule for ConditionalHeadersConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         let req = &tx.request;
 
@@ -40,7 +39,7 @@ impl Rule for ConditionalHeadersConsistent {
         if has_if_none_match && has_if_modified_since {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "If-Modified-Since MUST be ignored when If-None-Match is present; prefer entity-tag conditionals".into(),
             });
         }
@@ -51,7 +50,7 @@ impl Rule for ConditionalHeadersConsistent {
         if has_if_match && has_if_unmodified_since {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "If-Unmodified-Since MUST be ignored when If-Match is present; prefer entity-tag conditionals".into(),
             });
         }
@@ -63,7 +62,7 @@ impl Rule for ConditionalHeadersConsistent {
             if req.headers.get("range").is_none() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "If-Range present in request without Range header; If-Range MUST only be used with Range requests".into(),
                 });
             }
@@ -77,7 +76,7 @@ impl Rule for ConditionalHeadersConsistent {
                 if trimmed.starts_with("W/") {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "If-Range MUST not contain a weak entity-tag (W/...)".into(),
                     });
                 }
@@ -86,7 +85,7 @@ impl Rule for ConditionalHeadersConsistent {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "If-Range header contains non-UTF8 value".into(),
                 });
             }
@@ -110,7 +109,7 @@ impl Rule for ConditionalHeadersConsistent {
             if req.headers.get_all(name).iter().count() > 1 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Multiple {} header fields present; the combined value is a list of dates, which the recipient MUST ignore",
                         label
@@ -129,7 +128,7 @@ impl Rule for ConditionalHeadersConsistent {
         {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "If-Modified-Since is only defined for GET/HEAD and MUST be ignored for other methods".into(),
             });
         }

--- a/lint-http-rules/src/rules/conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/conditional_request_handling.rs
@@ -27,9 +27,8 @@ impl Rule for ConditionalRequestHandling {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies when request contains one or more conditional headers
         let req = &tx.request;
         let has_inm = req.headers.get("if-none-match").is_some();
@@ -48,7 +47,7 @@ impl Rule for ConditionalRequestHandling {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Conditional request sent but no previous response recorded for this resource (no ETag/Last-Modified to validate against)".into(),
                 })
             }
@@ -64,7 +63,7 @@ impl Rule for ConditionalRequestHandling {
             if (has_inm || has_imatch) && resp.headers.get("etag").is_none() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Request contains entity-tag conditional (If-Match/If-None-Match) but previous response did not include an ETag".into(),
                 });
             }
@@ -74,14 +73,14 @@ impl Rule for ConditionalRequestHandling {
             if (has_ifm || has_iunmod) && resp.headers.get("last-modified").is_none() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Request contains time-based conditional (If-Modified-Since/If-Unmodified-Since) but previous response did not include Last-Modified".into(),
                 });
             }
         } else {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message:
                     "Conditional request sent but previous transaction has no response recorded"
                         .into(),
@@ -108,7 +107,7 @@ impl Rule for ConditionalRequestHandling {
                                         if member == resp_etag.trim() || member == "*" {
                                             return Some(Violation {
                                                 rule: self.id().into(),
-                                                severity: config.severity,
+                                                severity: ctx.severity,
                                                 message: "Conditional GET/HEAD: the If-None-Match condition was not met (response ETag matched) but the server returned 200; RFC 9110 §13.1.2 requires a 304 (Not Modified) for GET/HEAD".into(),
                                             });
                                         }
@@ -151,7 +150,7 @@ impl Rule for ConditionalRequestHandling {
                                     if resp_dt <= req_dt {
                                         return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: "Conditional GET/HEAD used If-Modified-Since but server returned 200 even though Last-Modified indicates the resource was not modified; consider returning 304 Not Modified".into(),
                                         });
                                     }

--- a/lint-http-rules/src/rules/connection_header_tokens_valid.rs
+++ b/lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -24,12 +24,12 @@ impl ConnectionHeaderTokensValid {
     fn check_field_section(
         &self,
         headers: &hyper::HeaderMap,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -137,16 +137,14 @@ impl Rule for ConnectionHeaderTokensValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
-        if let Some(v) = self.check_field_section(&tx.request.headers, &config) {
+        if let Some(v) = self.check_field_section(&tx.request.headers, ctx.severity) {
             return Some(v);
         }
 
         if let Some(resp) = &tx.response {
-            if let Some(v) = self.check_field_section(&resp.headers, &config) {
+            if let Some(v) = self.check_field_section(&resp.headers, ctx.severity) {
                 return Some(v);
             }
         }

--- a/lint-http-rules/src/rules/content_disposition_parameter_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_parameter_valid.rs
@@ -22,9 +22,8 @@ impl Rule for ContentDispositionParameterValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // This rule owns `disposition-parm` and nothing above it. An empty field
         // value and a missing disposition-type are defects in the part of the
         // grammar `content_disposition_token_valid` owns, and it reports
@@ -56,7 +55,7 @@ impl Rule for ContentDispositionParameterValid {
                 if eq.is_none() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "{} has malformed parameter '{}': missing '='",
                             hdr_name, p
@@ -80,14 +79,14 @@ impl Rule for ContentDispositionParameterValid {
                 if bare_name.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("{} contains empty parameter name", hdr_name),
                     });
                 }
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(bare_name) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "{} parameter name contains invalid token character: '{}'",
                             hdr_name, c
@@ -99,7 +98,7 @@ impl Rule for ContentDispositionParameterValid {
                 if seen.contains(&name_lc) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("{} contains duplicate parameter: '{}'", hdr_name, name),
                     });
                 }
@@ -109,7 +108,7 @@ impl Rule for ContentDispositionParameterValid {
                 if val.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("{} parameter '{}' has empty value", hdr_name, name),
                     });
                 }
@@ -121,7 +120,7 @@ impl Rule for ContentDispositionParameterValid {
                         if let Err(e) = crate::helpers::headers::validate_quoted_string(val) {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "{} filename parameter invalid quoted-string: {}",
                                     hdr_name, e
@@ -131,7 +130,7 @@ impl Rule for ContentDispositionParameterValid {
                     } else if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "{} filename parameter contains invalid token character: '{}'",
                                 hdr_name, c
@@ -145,7 +144,7 @@ impl Rule for ContentDispositionParameterValid {
                     if let Err(e) = crate::helpers::headers::validate_ext_value(val) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "{} filename* extended value invalid: {}",
                                 hdr_name, e
@@ -160,7 +159,7 @@ impl Rule for ContentDispositionParameterValid {
                             Err(e) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "{} size parameter invalid quoted-string: {}",
                                         hdr_name, e
@@ -175,7 +174,7 @@ impl Rule for ContentDispositionParameterValid {
                     if !raw_val.chars().all(|c| c.is_ascii_digit()) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "{} size parameter must be numeric: '{}'",
                                 hdr_name, raw_val
@@ -189,7 +188,7 @@ impl Rule for ContentDispositionParameterValid {
                         if let Err(e) = crate::helpers::headers::validate_ext_value(val) {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "{} extended parameter '{}' invalid: {}",
                                     hdr_name, name, e
@@ -200,7 +199,7 @@ impl Rule for ContentDispositionParameterValid {
                         if let Err(e) = crate::helpers::headers::validate_quoted_string(val) {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "{} parameter '{}' invalid quoted-string: {}",
                                     hdr_name, name, e
@@ -210,7 +209,7 @@ impl Rule for ContentDispositionParameterValid {
                     } else if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "{} parameter '{}' contains invalid token character: '{}'",
                                 hdr_name, name, c

--- a/lint-http-rules/src/rules/content_disposition_token_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_token_valid.rs
@@ -30,9 +30,8 @@ impl Rule for ContentDispositionTokenValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a single Content-Disposition header value
         let check_value = |hdr_name: &str, val: &str| -> Option<Violation> {
             // Trim whitespace and split off parameters
@@ -43,7 +42,7 @@ impl Rule for ContentDispositionTokenValid {
             if s.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("{} header value must not be empty", hdr_name),
                 });
             }
@@ -57,7 +56,7 @@ impl Rule for ContentDispositionTokenValid {
             if dispo.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("{} header disposition-type must not be empty", hdr_name),
                 });
             }
@@ -73,7 +72,7 @@ impl Rule for ContentDispositionTokenValid {
             if let Some(c) = crate::helpers::token::find_invalid_token_char(dispo) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "{} disposition-type contains invalid token character: '{}'",
                         hdr_name, c
@@ -135,7 +134,7 @@ impl Rule for ContentDispositionTokenValid {
                 };
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Multiple Content-Disposition header fields in the {}; {}",
                         kind, basis
@@ -152,7 +151,7 @@ impl Rule for ContentDispositionTokenValid {
                 let Ok(s) = hv.to_str() else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Disposition header value contains octets outside visible US-ASCII; non-ASCII filenames belong in a `filename*` parameter (RFC 6266 §4.3)".into(),
                     });
                 };

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -20,9 +20,8 @@ impl Rule for ContentEncodingAndTypeConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to validate a Content-Encoding-like header value (comma-separated members).
         // This helper validates members in `val` and updates `seen` with found codings so duplicates
         // across multiple header fields can be detected when `seen` is shared between calls.
@@ -37,21 +36,21 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 if token.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("{} header contains empty member", hdr_name),
                     });
                 }
                 if token == "*" && hdr_name.eq_ignore_ascii_case("Content-Encoding") {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Wildcard '*' is not valid in {} header", hdr_name),
                     });
                 }
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid token '{}' in {} header", c, hdr_name),
                     });
                 }
@@ -65,7 +64,7 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 if !seen.insert(key.clone()) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Duplicate content-coding '{}' in {} header",
                             key, hdr_name
@@ -87,7 +86,7 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Encoding header value is not valid UTF-8".into(),
                     });
                 }
@@ -120,7 +119,7 @@ impl Rule for ContentEncodingAndTypeConsistent {
             if is_no_body_status && resp.headers.contains_key("content-encoding") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Response {} carries no content, so it should not send Content-Encoding",
                         status
@@ -137,7 +136,7 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Encoding header value is not valid UTF-8".into(),
                     });
                 }

--- a/lint-http-rules/src/rules/content_encoding_registered.rs
+++ b/lint-http-rules/src/rules/content_encoding_registered.rs
@@ -69,24 +69,24 @@ impl Rule for ContentEncodingRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &ContentEncodingConfig = ctx.state();
         // Helper to check a single header value against allowed list
         // `is_accept` distinguishes the two grammars. They are not the same vocabulary:
         // Content-Encoding is a list of plain content-codings, while Accept-Encoding
@@ -438,7 +438,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "content_encoding_registered",
         ]);
-        let res = rule.validate(&cfg);
+        let res = rule.prepare(&cfg);
         assert!(res.is_err());
     }
 

--- a/lint-http-rules/src/rules/content_length_valid.rs
+++ b/lint-http-rules/src/rules/content_length_valid.rs
@@ -20,9 +20,8 @@ impl Rule for ContentLengthValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The field is defined by what it describes, not by direction, so it is checked
         // on both sides below. The `1*DIGIT` grammar and the §6.3 comma-list rule are
         // deliberately *not* re-quoted here: `validate_content_length` owns both, and a
@@ -54,7 +53,7 @@ impl Rule for ContentLengthValid {
 
                     Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message,
                     })
                 }

--- a/lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
+++ b/lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
@@ -20,9 +20,8 @@ impl Rule for ContentLengthVsTransferEncoding {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // "in any message" is what puts both directions in scope; the same check runs
         // over the response below.
         // cite(RFC 9112 § 6.2): "A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field."
@@ -41,7 +40,7 @@ impl Rule for ContentLengthVsTransferEncoding {
         {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Both Content-Length and Transfer-Encoding present".into(),
             });
         }
@@ -53,7 +52,7 @@ impl Rule for ContentLengthVsTransferEncoding {
             {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Both Content-Length and Transfer-Encoding present".into(),
                 });
             }

--- a/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
+++ b/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
@@ -28,9 +28,8 @@ impl Rule for ContentLocationAndUriConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -61,7 +60,7 @@ impl Rule for ContentLocationAndUriConsistent {
             .expect("the branch is reached only when the field has more than one line");
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "{}. The comma a recipient joins them with is a `sub-delims` character both alternatives admit inside a path or a query (RFC 3986 §2.2), so the joined value is a well-formed reference to a resource neither line named",
                     crate::helpers::headers::singleton_field_preamble(
@@ -96,7 +95,7 @@ impl Rule for ContentLocationAndUriConsistent {
             if s.trim().is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-Location header must not be empty".into(),
                 });
             }
@@ -119,7 +118,7 @@ impl Rule for ContentLocationAndUriConsistent {
             if let Some(c) = crate::helpers::uri::find_non_uri_char(s) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Content-Location value holds {}, which no part of a URI is composed from: an octet outside that set is percent-encoded before the reference is formed, or the value is not a URI reference at all",
                         crate::helpers::headers::describe_char(c)
@@ -132,7 +131,7 @@ impl Rule for ContentLocationAndUriConsistent {
             if let Some(msg) = crate::helpers::uri::check_percent_encoding(s) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: msg,
                 });
             }
@@ -142,7 +141,7 @@ impl Rule for ContentLocationAndUriConsistent {
             if let Some(msg) = crate::helpers::uri::validate_scheme_if_present(s) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: msg,
                 });
             }
@@ -171,7 +170,7 @@ impl Rule for ContentLocationAndUriConsistent {
             if let Some(hash) = s.find('#') {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Content-Location value '{}' carries the fragment component '{}': neither alternative of `Content-Location = absolute-URI / partial-URI` generates one — each is a URI rule with the `[ \"#\" fragment ]` group dropped (RFC 9110 §4.1, RFC 3986 §4.3) — so the value derives from no reading of the grammar (RFC 9110 §2.2)",
                         crate::helpers::headers::shown_in_finding(s),
@@ -275,7 +274,7 @@ impl Rule for ContentLocationAndUriConsistent {
                 if !matches {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Location identifies a different resource than the request target; RFC 9110 §8.7 permits this (a negotiated variant, a 201 pointing at the created resource, or a report on a POST), so confirm it is deliberate".into(),
                     });
                 }

--- a/lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
+++ b/lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
@@ -20,9 +20,8 @@ impl Rule for ContentMd5VsDigestPreference {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Helper to check a header map for both Content-Digest and Content-MD5.
         // The same check runs over the request and the response below, which is
         // what this sentence licenses — Content-Digest is defined for both
@@ -48,7 +47,7 @@ impl Rule for ContentMd5VsDigestPreference {
             if has_new && has_md5 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Both Content-Digest and Content-MD5 present in {}; they are independent integrity values that can disagree, and nothing specifies which a recipient validates. Content-MD5 was removed from HTTP by RFC 7231 — send only Content-Digest",
                         which

--- a/lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
+++ b/lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
@@ -20,9 +20,8 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
         let resp = tx.response.as_ref()?;
 
@@ -122,7 +121,7 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
             if csp_self || !csp_origins.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "X-Frame-Options: DENY contradicts Content-Security-Policy frame-ancestors which permits framing".into(),
                 });
             }
@@ -134,7 +133,7 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
             if csp_none {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-Security-Policy frame-ancestors: 'none' forbids framing while X-Frame-Options: SAMEORIGIN permits same-origin frames".into(),
                 });
             }
@@ -158,7 +157,7 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
             if csp_none {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("X-Frame-Options: ALLOW-FROM {} permits framing but Content-Security-Policy frame-ancestors is 'none'", rest),
                 });
             }
@@ -186,7 +185,7 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
 
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("X-Frame-Options: ALLOW-FROM {} is not included in Content-Security-Policy frame-ancestors", rest),
                     });
                 }
@@ -201,7 +200,7 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
                     } else {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("X-Frame-Options: ALLOW-FROM {} does not match Content-Security-Policy frame-ancestors 'self' (origin {})", rest, rorig),
                         });
                     }

--- a/lint-http-rules/src/rules/content_security_policy_valid.rs
+++ b/lint-http-rules/src/rules/content_security_policy_valid.rs
@@ -26,9 +26,8 @@ impl Rule for ContentSecurityPolicyValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check responses
         let resp = tx.response.as_ref()?;
 
@@ -39,7 +38,7 @@ impl Rule for ContentSecurityPolicyValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Security-Policy header value is not valid UTF-8".into(),
                     });
                 }
@@ -49,7 +48,7 @@ impl Rule for ContentSecurityPolicyValid {
             if s_trim.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-Security-Policy header MUST not be empty".into(),
                 });
             }
@@ -61,7 +60,7 @@ impl Rule for ContentSecurityPolicyValid {
                     // Empty directive (e.g., trailing or consecutive semicolons)
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Content-Security-Policy contains empty directive at position {}",
                             i
@@ -85,7 +84,7 @@ impl Rule for ContentSecurityPolicyValid {
                 {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid character '{}' in CSP directive-name '{}', at position {}",
                             c, name, i
@@ -100,7 +99,7 @@ impl Rule for ContentSecurityPolicyValid {
                         if !val.ends_with('\'') || val.len() < 2 {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Unterminated or empty single-quoted source expression '{}' in directive '{}'", val, name),
                             });
                         }
@@ -108,7 +107,7 @@ impl Rule for ContentSecurityPolicyValid {
                         if inner.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Empty single-quoted source expression '{}' in directive '{}'",
                                     val, name
@@ -121,14 +120,14 @@ impl Rule for ContentSecurityPolicyValid {
                             if rest.is_empty() {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Empty nonce value in directive '{}'", name),
                                 });
                             }
                             if rest.chars().any(|c: char| c.is_whitespace()) {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Invalid nonce value containing whitespace in directive '{}'", name),
                                 });
                             }
@@ -138,7 +137,7 @@ impl Rule for ContentSecurityPolicyValid {
                             if rest.is_empty() {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Empty hash value in directive '{}'", name),
                                 });
                             }
@@ -146,7 +145,7 @@ impl Rule for ContentSecurityPolicyValid {
                             if rest.is_empty() {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Empty hash value in directive '{}'", name),
                                 });
                             }
@@ -154,7 +153,7 @@ impl Rule for ContentSecurityPolicyValid {
                             if rest.is_empty() {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Empty hash value in directive '{}'", name),
                                 });
                             }
@@ -166,13 +165,13 @@ impl Rule for ContentSecurityPolicyValid {
                         if rest.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Empty nonce value in directive '{}'", name),
                             });
                         }
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message:
                                 "Nonce source expressions MUST be single-quoted (e.g., 'nonce-...')"
                                     .into(),
@@ -183,13 +182,13 @@ impl Rule for ContentSecurityPolicyValid {
                         if rest.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Empty hash value in directive '{}'", name),
                             });
                         }
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message:
                                 "Hash source expressions MUST be single-quoted (e.g., 'sha256-...')"
                                     .into(),
@@ -198,13 +197,13 @@ impl Rule for ContentSecurityPolicyValid {
                         if rest.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Empty hash value in directive '{}'", name),
                             });
                         }
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message:
                                 "Hash source expressions MUST be single-quoted (e.g., 'sha384-...')"
                                     .into(),
@@ -213,13 +212,13 @@ impl Rule for ContentSecurityPolicyValid {
                         if rest.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Empty hash value in directive '{}'", name),
                             });
                         }
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message:
                                 "Hash source expressions MUST be single-quoted (e.g., 'sha512-...')"
                                     .into(),

--- a/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
+++ b/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
@@ -20,9 +20,8 @@ impl Rule for ContentTransferEncodingValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The five named mechanisms. The grammar admits two more alternatives —
         // `ietf-token` and `x-token` — so this list is not the whole of it; see the
         // x-token branch below.
@@ -89,7 +88,7 @@ impl Rule for ContentTransferEncodingValid {
             let detail = describe_value(shown).map(|d| format!("; {}", d));
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Content-Transfer-Encoding: {} present in {}; HTTP does not use this field and a gateway is required to remove it{}",
                     shown.trim(),

--- a/lint-http-rules/src/rules/content_type_present.rs
+++ b/lint-http-rules/src/rules/content_type_present.rs
@@ -20,9 +20,8 @@ impl Rule for ContentTypePresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -110,7 +109,7 @@ impl Rule for ContentTypePresent {
         if has_content {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Response contains content but no Content-Type header".into(),
             });
         }

--- a/lint-http-rules/src/rules/content_type_registered.rs
+++ b/lint-http-rules/src/rules/content_type_registered.rs
@@ -69,24 +69,24 @@ impl Rule for ContentTypeRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &ContentTypeConfig = ctx.state();
         let check_media_type =
             |hdr_name: &str, val: &str, allowed: &Vec<String>| -> Option<Violation> {
                 // Parse media-type; if it fails, let other rules (well-formed) report it.

--- a/lint-http-rules/src/rules/content_type_valid.rs
+++ b/lint-http-rules/src/rules/content_type_valid.rs
@@ -24,10 +24,8 @@ impl Rule for ContentTypeValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         let check_message = |which: &str,
                              headers: &hyper::HeaderMap,
                              trailers: Option<&hyper::HeaderMap>|
@@ -66,7 +64,7 @@ impl Rule for ContentTypeValid {
             if vals.len() > 1 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Multiple Content-Type field lines in the {}; Content-Type is a singleton field (RFC 9110 §8.3) and recipients differ over which member wins, so the media type the peer acts on is not the one this message states. Individual values are not validated while more than one is present",
                         which
@@ -83,7 +81,7 @@ impl Rule for ContentTypeValid {
                 // reject it, so the decode decides nothing on its own.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
                 let s = crate::helpers::headers::field_line_as_written(hv);
-                if let Some(v) = check_content_type(which, &s, &config) {
+                if let Some(v) = check_content_type(which, &s, ctx.severity) {
                     return Some(v);
                 }
             }
@@ -211,7 +209,7 @@ impl Rule for ContentTypeValid {
 fn check_content_type(
     _which: &str,
     val: &str,
-    config: &crate::rules::RuleConfig,
+    severity: crate::lint::Severity,
 ) -> Option<Violation> {
     use crate::helpers::headers::parse_media_type;
 
@@ -229,7 +227,7 @@ fn check_content_type(
             };
             return Some(Violation {
                 rule: ContentTypeValid.id().into(),
-                severity: config.severity,
+                severity,
                 message,
             });
         }
@@ -245,7 +243,7 @@ fn check_content_type(
     if parsed.type_ == "*" || parsed.subtype == "*" {
         return Some(Violation {
             rule: ContentTypeValid.id().into(),
-            severity: config.severity,
+            severity,
             message: format!(
                 "Content-Type '{}' uses a wildcard, which names a set of media types rather than one; a representation's Content-Type is expected to identify a single media type (wildcards belong to Accept's media-range)",
                 val
@@ -267,7 +265,7 @@ fn check_content_type(
     if let Some(reason) = crate::helpers::headers::media_type_parts_defect(&parsed) {
         return Some(Violation {
             rule: ContentTypeValid.id().into(),
-            severity: config.severity,
+            severity,
             message: format!("Invalid Content-Type '{}': {}", val, reason),
         });
     }
@@ -311,7 +309,7 @@ mod tests {
     #[case("text/plain; charset=\"\"", false)]
     fn content_type_parsing_cases(#[case] val: &str, #[case] expect_violation: bool) {
         let cfg = crate::test_helpers::make_test_rule_config();
-        let res = super::check_content_type("test", val, &cfg);
+        let res = super::check_content_type("test", val, cfg.severity);
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", val);
         } else {
@@ -342,7 +340,7 @@ mod tests {
     #[case("text/plain; foo=\"\"", false)]
     fn extra_content_type_cases(#[case] val: &str, #[case] expect_violation: bool) {
         let cfg = crate::test_helpers::make_test_rule_config();
-        let res = super::check_content_type("test", val, &cfg);
+        let res = super::check_content_type("test", val, cfg.severity);
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", val);
         } else {

--- a/lint-http-rules/src/rules/context_fields_direction.rs
+++ b/lint-http-rules/src/rules/context_fields_direction.rs
@@ -79,10 +79,8 @@ impl Rule for ContextFieldsDirection {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // A response context field in a request, then a request context field
         // in a response. Each table is probed against the *other* direction
         // only — in its own direction the field is what its section says it
@@ -108,7 +106,7 @@ impl Rule for ContextFieldsDirection {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message,
         })
     }

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -20,9 +20,8 @@ impl Rule for CookieAttributeConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("set-cookie").iter() {
@@ -31,7 +30,7 @@ impl Rule for CookieAttributeConsistent {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Set-Cookie header value is not valid UTF-8".into(),
                     })
                 }
@@ -42,7 +41,7 @@ impl Rule for CookieAttributeConsistent {
             if parts.is_empty() || parts[0].is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Set-Cookie header missing cookie-pair".into(),
                 });
             }
@@ -54,7 +53,7 @@ impl Rule for CookieAttributeConsistent {
             if name.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Set-Cookie cookie name is empty".into(),
                 });
             }
@@ -63,7 +62,7 @@ impl Rule for CookieAttributeConsistent {
             if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Set-Cookie cookie-name contains invalid character: '{}'", c),
                 });
             }
@@ -90,7 +89,7 @@ impl Rule for CookieAttributeConsistent {
                     if val_opt.is_some() && !val_opt.unwrap().is_empty() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Set-Cookie attribute 'Secure' must not have a value".into(),
                         });
                     }
@@ -103,7 +102,7 @@ impl Rule for CookieAttributeConsistent {
                     if val_opt.is_some() && !val_opt.unwrap().is_empty() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Set-Cookie attribute 'HttpOnly' must not have a value".into(),
                         });
                     }
@@ -116,7 +115,7 @@ impl Rule for CookieAttributeConsistent {
                         None => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Set-Cookie attribute 'SameSite' requires a value".into(),
                             })
                         }
@@ -127,7 +126,7 @@ impl Rule for CookieAttributeConsistent {
                     if vnorm != "strict" && vnorm != "lax" && vnorm != "none" {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Set-Cookie attribute 'SameSite' has invalid value: '{}'",
                                 v
@@ -144,7 +143,7 @@ impl Rule for CookieAttributeConsistent {
                         None => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Set-Cookie attribute 'Max-Age' requires a numeric value"
                                     .into(),
                             })
@@ -160,7 +159,7 @@ impl Rule for CookieAttributeConsistent {
                     if v.parse::<i64>().is_err() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Set-Cookie attribute 'Max-Age' is not a valid integer: '{}'",
                                 v
@@ -176,7 +175,7 @@ impl Rule for CookieAttributeConsistent {
                         None => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message:
                                     "Set-Cookie attribute 'Expires' requires a HTTP-date value"
                                         .into(),
@@ -187,7 +186,7 @@ impl Rule for CookieAttributeConsistent {
                     if !crate::http_date::is_valid_http_date(v) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Set-Cookie attribute 'Expires' is not a valid HTTP-date: '{}'",
                                 v
@@ -204,7 +203,7 @@ impl Rule for CookieAttributeConsistent {
                             // path with no value is acceptable? flag it
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Set-Cookie attribute 'Path' requires a value".into(),
                             });
                         }
@@ -212,7 +211,7 @@ impl Rule for CookieAttributeConsistent {
                     if !v.starts_with('/') {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Set-Cookie attribute 'Path' should start with '/': '{}'",
                                 v
@@ -228,7 +227,7 @@ impl Rule for CookieAttributeConsistent {
                         None => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Set-Cookie attribute 'Domain' requires a value".into(),
                             })
                         }
@@ -236,14 +235,14 @@ impl Rule for CookieAttributeConsistent {
                     if v.is_empty() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Set-Cookie attribute 'Domain' must not be empty".into(),
                         });
                     }
                     if v.contains(' ') {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Set-Cookie attribute 'Domain' must not contain spaces: '{}'",
                                 v
@@ -264,7 +263,7 @@ impl Rule for CookieAttributeConsistent {
                 if sv == "none" && !secure_present {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Set-Cookie with 'SameSite=None' must also set 'Secure'".into(),
                     });
                 }
@@ -410,7 +409,7 @@ mod tests {
         );
 
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/cookie_domain_matching.rs
@@ -33,9 +33,8 @@ impl Rule for CookieDomainMatching {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
         let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
         if cookie_headers.is_empty() {
@@ -103,7 +102,7 @@ impl Rule for CookieDomainMatching {
             if domain_mismatch {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Cookie '{}' with value '{}' was set for a different domain and should not be sent to host '{}'",
                         name, value, req_host
@@ -117,7 +116,7 @@ impl Rule for CookieDomainMatching {
             if path_mismatch {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Cookie '{}' with value '{}' is not valid for path '{}'",
                         name, value, req_path

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CookieDomainValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("set-cookie").iter() {
@@ -31,7 +30,7 @@ impl Rule for CookieDomainValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Set-Cookie header value is not valid UTF-8".into(),
                     })
                 }
@@ -51,7 +50,7 @@ impl Rule for CookieDomainValid {
                     if val.is_empty() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Set-Cookie attribute 'Domain' requires a value".into(),
                         });
                     }
@@ -66,7 +65,7 @@ impl Rule for CookieDomainValid {
                             if val.starts_with('.') {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Set-Cookie 'Domain' attribute uses a leading '.' which is deprecated; prefer the registry form without leading dot".into(),
                                 });
                             }
@@ -74,7 +73,7 @@ impl Rule for CookieDomainValid {
                         Err(e) => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Invalid Set-Cookie Domain attribute '{}': {}",
                                     val, e

--- a/lint-http-rules/src/rules/cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/cookie_lifecycle.rs
@@ -29,9 +29,8 @@ impl Rule for CookieLifecycle {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
         let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
         if cookie_headers.is_empty() {
@@ -130,7 +129,7 @@ impl Rule for CookieLifecycle {
                     // cite(RFC 6265 § 4.1.2.5): "The Secure attribute limits the scope of the cookie to "secure" channels"
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Secure cookie '{}' sent over insecure transport", name),
                     });
                 }
@@ -141,7 +140,7 @@ impl Rule for CookieLifecycle {
                 if c.value != value {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Cookie '{}' value '{}' does not match stored value '{}', likely stale",
                             name, value, c.value
@@ -186,7 +185,7 @@ impl Rule for CookieLifecycle {
                     // cite(RFC 6265 § 5.3): "The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store."
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Cookie '{}' was previously set but is expired or removed and should not be sent",
                             name
@@ -197,7 +196,7 @@ impl Rule for CookieLifecycle {
                     // a cookie existed for the domain but path did not match
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Cookie '{}' is not valid for path '{}' and should not be sent",
                             name, req_path

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CookiePathValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         for hv in resp.headers.get_all("set-cookie").iter() {
@@ -31,7 +30,7 @@ impl Rule for CookiePathValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Set-Cookie header value is not valid UTF-8".into(),
                     })
                 }
@@ -59,7 +58,7 @@ impl Rule for CookiePathValid {
                         None => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Set-Cookie attribute 'Path' requires a value".into(),
                             })
                         }
@@ -68,7 +67,7 @@ impl Rule for CookiePathValid {
                     if let Err(e) = crate::helpers::cookie::validate_cookie_path(v) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Set-Cookie attribute 'Path' invalid: {}", e),
                         });
                     }

--- a/lint-http-rules/src/rules/cookie_same_site_enforced.rs
+++ b/lint-http-rules/src/rules/cookie_same_site_enforced.rs
@@ -29,9 +29,8 @@ impl Rule for CookieSameSiteEnforced {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about outgoing requests that carry Cookie headers
         let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
         if cookie_headers.is_empty() {
@@ -134,7 +133,7 @@ impl Rule for CookieSameSiteEnforced {
                         crate::helpers::cookie::SameSite::Strict => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Cookie '{}' has SameSite=Strict but is sent in a cross-site context",
                                     name
@@ -148,7 +147,7 @@ impl Rule for CookieSameSiteEnforced {
                         crate::helpers::cookie::SameSite::Lax if !allow_lax => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Cookie '{}' has SameSite=Lax but is sent in a restricted cross-site context",
                                     name

--- a/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CrossOriginEmbedderPolicyValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // COEP is a response-only header per spec; ignore requests
         let resp = if let Some(resp) = &tx.response {
             resp
@@ -42,7 +41,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Cross-Origin-Embedder-Policy header fields present".into(),
             });
         }
@@ -54,7 +53,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
             Some(v) => v.trim(),
             None => return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message:
                     "Cross-Origin-Embedder-Policy header contains non-ASCII or control characters"
                         .into(),
@@ -65,7 +64,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
         if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Cross-Origin-Embedder-Policy must be a single value".into(),
             });
         }
@@ -82,7 +81,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Cross-Origin-Embedder-Policy value '{}' does not enable cross-origin isolation (use 'require-corp' or 'credentialless')",
                 val
@@ -291,7 +290,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 
@@ -363,7 +362,7 @@ mod tests {
         );
 
         // validate configuration parsing still succeeds
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
 
         // Mixed-case header value must be accepted (case-insensitive)
         let tx = crate::test_helpers::make_test_transaction_with_response(

--- a/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CrossOriginOpenerPolicyValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // COOP is a response-only header per spec; ignore requests
         let resp = if let Some(resp) = &tx.response {
             resp
@@ -39,7 +38,7 @@ impl Rule for CrossOriginOpenerPolicyValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Cross-Origin-Opener-Policy header fields present".into(),
             });
         }
@@ -49,7 +48,7 @@ impl Rule for CrossOriginOpenerPolicyValid {
                 Some(v) => v.trim(),
                 None => return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "Cross-Origin-Opener-Policy header contains non-ASCII or control characters"
                             .into(),
@@ -60,7 +59,7 @@ impl Rule for CrossOriginOpenerPolicyValid {
         if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Cross-Origin-Opener-Policy must be a single value".into(),
             });
         }
@@ -83,7 +82,7 @@ impl Rule for CrossOriginOpenerPolicyValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Cross-Origin-Opener-Policy contains unsupported value: '{}'",
                 val
@@ -301,7 +300,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
@@ -20,9 +20,8 @@ impl Rule for CrossOriginResourcePolicyValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // CORP is a response-only header per spec; ignore requests
         let resp = if let Some(resp) = &tx.response {
             resp
@@ -42,7 +41,7 @@ impl Rule for CrossOriginResourcePolicyValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Cross-Origin-Resource-Policy header fields present".into(),
             });
         }
@@ -54,7 +53,7 @@ impl Rule for CrossOriginResourcePolicyValid {
             Some(v) => v.trim(),
             None => return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message:
                     "Cross-Origin-Resource-Policy header contains non-ASCII or control characters"
                         .into(),
@@ -65,7 +64,7 @@ impl Rule for CrossOriginResourcePolicyValid {
         if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Cross-Origin-Resource-Policy must be a single value".into(),
             });
         }
@@ -83,7 +82,7 @@ impl Rule for CrossOriginResourcePolicyValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Cross-Origin-Resource-Policy contains unsupported value: '{}'",
                 val
@@ -291,7 +290,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -21,9 +21,8 @@ impl Rule for DateAndTimeHeadersConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use chrono::Duration;
 
         // Tolerate some small clock skew when comparing dates. 60s is a linter
@@ -46,14 +45,14 @@ impl Rule for DateAndTimeHeadersConsistent {
                 if crate::http_date::parse_http_date_to_datetime(s).is_err() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
                     });
                 }
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Date header contains non-UTF8 bytes and is invalid".into(),
                 });
             }
@@ -67,7 +66,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                     if crate::http_date::parse_http_date_to_datetime(s).is_err() {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)"
                                 .into(),
                         });
@@ -75,7 +74,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Date header contains non-UTF8 bytes and is invalid".into(),
                     });
                 }
@@ -94,7 +93,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                                         if lm_dt > date_dt + skew {
                                             return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: format!(
                                                 "Last-Modified '{}' is later than Date '{}'; Last-Modified must not be in the future relative to Date",
                                                 lm_str, date_str
@@ -110,7 +109,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                             Err(_) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Last-Modified header contains non-UTF8 bytes and is invalid".into(),
                                 });
                             }
@@ -129,7 +128,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                                         if sunset_dt <= date_dt - skew {
                                             return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: format!(
                                                 "Sunset header '{}' is before or equal to Date '{}'; Sunset should indicate a future shutdown date",
                                                 s, date_str
@@ -140,7 +139,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                                     Err(_) => {
                                         return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into(),
                                     });
                                     }
@@ -149,7 +148,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                             Err(_) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Sunset header contains non-UTF8 bytes and is invalid"
                                         .into(),
                                 });
@@ -185,7 +184,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                                 if ifms_dt > date_dt + skew {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "If-Modified-Since '{}' is later than Date '{}'; conditional requests should not use a future date",
                                             ifms_str, date_str
@@ -202,7 +201,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "If-Modified-Since header contains non-UTF8 bytes and is invalid"
                             .into(),
                     });

--- a/lint-http-rules/src/rules/deprecation_header_syntax.rs
+++ b/lint-http-rules/src/rules/deprecation_header_syntax.rs
@@ -20,9 +20,8 @@ impl Rule for DeprecationHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Deprecation is a response header field, which is why this rule is Server-scoped.
         // cite(RFC 9745 § 2): "The Deprecation HTTP response header field allows a server to communicate to a client application that the resource in the context of the message will be or has been deprecated."
         let resp = tx.response.as_ref()?;
@@ -41,7 +40,7 @@ impl Rule for DeprecationHeaderSyntax {
         if vals.len() > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Deprecation header fields present; Deprecation is a single Structured Field Item (RFC 9745 §2.1), so a response carries at most one Deprecation field line (RFC 9110 §5.3)".into(),
             });
         }
@@ -53,7 +52,7 @@ impl Rule for DeprecationHeaderSyntax {
             Err(_) => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Deprecation header contains non-UTF8 value".into(),
                 })
             }
@@ -75,7 +74,7 @@ impl Rule for DeprecationHeaderSyntax {
         if s.eq_ignore_ascii_case("true") {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Deprecation header uses legacy token 'true'; RFC 9745 defines Deprecation as a structured date '@<epoch>' (prefer '@<seconds>' form)".into(),
             });
         }
@@ -84,7 +83,7 @@ impl Rule for DeprecationHeaderSyntax {
         if crate::http_date::is_valid_http_date(s) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Deprecation header uses legacy HTTP-date format; RFC 9745 specifies Deprecation as a structured date '@<seconds>' (see RFC 9745 §2.1)".into(),
             });
         }
@@ -92,7 +91,7 @@ impl Rule for DeprecationHeaderSyntax {
         // Otherwise it's invalid
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("Deprecation value '{}' is invalid: must be a structured Date item (e.g., '@1688169599') per RFC 9745", s),
         })
     }

--- a/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
@@ -129,9 +129,8 @@ impl Rule for DigestAuthNonceHandling {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only care about client-side requests with Digest Authorization
         // cite(RFC 7616 § 3.3): "The nonce is opaque to the client."
         for hv in tx.request.headers.get_all("authorization").iter() {
@@ -172,7 +171,7 @@ impl Rule for DigestAuthNonceHandling {
             if nonce.is_some() && last_challenge_nonce.is_none() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Digest Authorization used without prior Digest challenge".into(),
                 });
             }
@@ -186,7 +185,7 @@ impl Rule for DigestAuthNonceHandling {
                 if o != expected {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Digest Authorization opaque does not match most recent challenge"
                             .into(),
                     });
@@ -195,7 +194,7 @@ impl Rule for DigestAuthNonceHandling {
                 // Challenge included opaque, but client omitted it
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Digest Authorization missing opaque from most recent challenge"
                         .into(),
                 });
@@ -210,7 +209,7 @@ impl Rule for DigestAuthNonceHandling {
                 if n != expected {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Digest Authorization nonce differs from most recent challenge"
                             .into(),
                     });
@@ -224,7 +223,7 @@ impl Rule for DigestAuthNonceHandling {
                     Err(msg) => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid nc (nonce-count) value: {}", msg),
                         });
                     }
@@ -242,7 +241,7 @@ impl Rule for DigestAuthNonceHandling {
                 if current_nc <= highest {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Digest Authorization nonce-count did not increase".into(),
                     });
                 }
@@ -259,7 +258,7 @@ impl Rule for DigestAuthNonceHandling {
                 {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Digest Authorization with new nonce after stale challenge must reset nc to 00000001".into(),
                     });
                 }

--- a/lint-http-rules/src/rules/digest_auth_valid.rs
+++ b/lint-http-rules/src/rules/digest_auth_valid.rs
@@ -20,9 +20,8 @@ impl Rule for DigestAuthValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         for hv in tx.request.headers.get_all("authorization").iter() {
             match hv.to_str() {
                 Ok(s) => {
@@ -43,7 +42,7 @@ impl Rule for DigestAuthValid {
                         None => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Authorization Digest scheme missing parameters".into(),
                             })
                         }
@@ -77,7 +76,7 @@ impl Rule for DigestAuthValid {
                                         if is_empty {
                                             return Some(Violation {
                                                 rule: self.id().into(),
-                                                severity: config.severity,
+                                                severity: ctx.severity,
                                                 message: format!(
                                                     "Digest Authorization missing or empty required parameter '{}'",
                                                     k
@@ -88,7 +87,7 @@ impl Rule for DigestAuthValid {
                                     None => {
                                         return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: format!(
                                                 "Digest Authorization missing or empty required parameter '{}'",
                                                 k
@@ -115,7 +114,7 @@ impl Rule for DigestAuthValid {
                                     if !map.contains_key(k) {
                                         return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: format!(
                                                 "Digest Authorization sends 'qop' and no '{k}': RFC 7616 \u{a7}3.4 marks the parameter \"MUST be used by all implementations\", RFC 2617 \u{a7}3.2.2 requires it whenever a qop directive is sent, and both documents compute the response value over it, so without it the credential cannot be verified"
                                             ),
@@ -131,7 +130,7 @@ impl Rule for DigestAuthValid {
                                 {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Invalid character '{}' in Digest auth-param name",
                                             inv
@@ -159,7 +158,7 @@ impl Rule for DigestAuthValid {
                                 if MUST_QUOTE.contains(&k.as_str()) && !quoted {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Digest Authorization sends '{k}' unquoted, and RFC 7616 \u{a7}3.4 admits only the quoted string syntax for it (\"a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque\")"
                                         ),
@@ -168,7 +167,7 @@ impl Rule for DigestAuthValid {
                                 if MUST_NOT_QUOTE.contains(&k.as_str()) && quoted {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Digest Authorization sends '{k}' as a quoted string, and RFC 7616 \u{a7}3.4 forbids that spelling for it (\"a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc\")"
                                         ),
@@ -183,7 +182,7 @@ impl Rule for DigestAuthValid {
                                     {
                                         return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: format!(
                                                 "Invalid quoted-string in Digest auth-param '{}': {}",
                                                 k, msg
@@ -199,7 +198,7 @@ impl Rule for DigestAuthValid {
                                     {
                                         return Some(Violation {
                                             rule: self.id().into(),
-                                            severity: config.severity,
+                                            severity: ctx.severity,
                                             message: format!(
                                                 "Invalid character '{}' in Digest auth-param value for '{}'",
                                                 inv, k
@@ -212,7 +211,7 @@ impl Rule for DigestAuthValid {
                         Err(msg) => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!("Invalid Digest auth parameters: {}", msg),
                             })
                         }
@@ -221,7 +220,7 @@ impl Rule for DigestAuthValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Authorization header contains non-UTF8 value".into(),
                     })
                 }

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -21,9 +21,8 @@ impl Rule for DigestHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Shared parser for comma-separated key=value members
         let parse_key_value_members = |value: &str,
                                        empty_member_msg: &str,
@@ -241,7 +240,7 @@ impl Rule for DigestHeaderSyntax {
                 if let Some(msg) = validate_legacy_digest(s) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid Digest header in request: {} (obsoleted by RFC 9530)",
                             msg
@@ -254,13 +253,13 @@ impl Rule for DigestHeaderSyntax {
                 // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest".into(),
                 });
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Digest header value is not valid UTF-8".into(),
                 });
             }
@@ -273,7 +272,7 @@ impl Rule for DigestHeaderSyntax {
                 if let Some(msg) = validate_want_digest(s) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid Want-Digest header in request: {} (obsoleted by RFC 9530)",
                             msg
@@ -286,13 +285,13 @@ impl Rule for DigestHeaderSyntax {
                 // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Want-Digest header is obsoleted by RFC 9530; prefer Want-Content-Digest or Want-Repr-Digest".into(),
                 });
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Want-Digest header value is not valid UTF-8".into(),
                 });
             }
@@ -305,7 +304,7 @@ impl Rule for DigestHeaderSyntax {
                     if let Some(msg) = validate_legacy_digest(s) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid Digest header in response: {} (obsoleted by RFC 9530)",
                                 msg
@@ -315,13 +314,13 @@ impl Rule for DigestHeaderSyntax {
 
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest".into(),
                     });
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Digest header value is not valid UTF-8".into(),
                     });
                 }
@@ -334,7 +333,7 @@ impl Rule for DigestHeaderSyntax {
                 if let Some(msg) = validate_structured_digest(s) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid Content-Digest header in request: {} (RFC 9530 §2)",
                             msg
@@ -344,7 +343,7 @@ impl Rule for DigestHeaderSyntax {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-Digest header value is not valid UTF-8".into(),
                 });
             }
@@ -355,7 +354,7 @@ impl Rule for DigestHeaderSyntax {
                 if let Some(msg) = validate_structured_digest(s) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid Repr-Digest header in request: {} (RFC 9530 §3)",
                             msg
@@ -365,7 +364,7 @@ impl Rule for DigestHeaderSyntax {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Repr-Digest header value is not valid UTF-8".into(),
                 });
             }
@@ -377,7 +376,7 @@ impl Rule for DigestHeaderSyntax {
                 if let Some(msg) = validate_want_field(s) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid Want-Content-Digest header in request: {} (RFC 9530 §4)",
                             msg
@@ -387,7 +386,7 @@ impl Rule for DigestHeaderSyntax {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Want-Content-Digest header value is not valid UTF-8".into(),
                 });
             }
@@ -398,7 +397,7 @@ impl Rule for DigestHeaderSyntax {
                 if let Some(msg) = validate_want_field(s) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Invalid Want-Repr-Digest header in request: {} (RFC 9530 §4)",
                             msg
@@ -408,7 +407,7 @@ impl Rule for DigestHeaderSyntax {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Want-Repr-Digest header value is not valid UTF-8".into(),
                 });
             }
@@ -421,7 +420,7 @@ impl Rule for DigestHeaderSyntax {
                     if let Some(msg) = validate_structured_digest(s) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid Content-Digest header in response: {} (RFC 9530 §2)",
                                 msg
@@ -431,7 +430,7 @@ impl Rule for DigestHeaderSyntax {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Digest header value is not valid UTF-8".into(),
                     });
                 }
@@ -442,7 +441,7 @@ impl Rule for DigestHeaderSyntax {
                     if let Some(msg) = validate_structured_digest(s) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid Repr-Digest header in response: {} (RFC 9530 §3)",
                                 msg
@@ -452,7 +451,7 @@ impl Rule for DigestHeaderSyntax {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Repr-Digest header value is not valid UTF-8".into(),
                     });
                 }
@@ -463,7 +462,7 @@ impl Rule for DigestHeaderSyntax {
                     if let Some(msg) = validate_want_field(s) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid Want-Content-Digest header in response: {} (RFC 9530 §4)",
                                 msg
@@ -473,7 +472,7 @@ impl Rule for DigestHeaderSyntax {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Want-Content-Digest header value is not valid UTF-8".into(),
                     });
                 }
@@ -484,7 +483,7 @@ impl Rule for DigestHeaderSyntax {
                     if let Some(msg) = validate_want_field(s) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Invalid Want-Repr-Digest header in response: {} (RFC 9530 §4)",
                                 msg
@@ -494,7 +493,7 @@ impl Rule for DigestHeaderSyntax {
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Want-Repr-Digest header value is not valid UTF-8".into(),
                     });
                 }
@@ -510,7 +509,7 @@ impl Rule for DigestHeaderSyntax {
             if hv.to_str().is_ok() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead"
                             .into(),
@@ -518,7 +517,7 @@ impl Rule for DigestHeaderSyntax {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-MD5 header value is not valid UTF-8".into(),
                 });
             }
@@ -529,13 +528,13 @@ impl Rule for DigestHeaderSyntax {
                 if hv.to_str().is_ok() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead".into(),
                     });
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-MD5 header value is not valid UTF-8".into(),
                     });
                 }

--- a/lint-http-rules/src/rules/early_data_header_safe_method.rs
+++ b/lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -123,24 +123,24 @@ impl Rule for EarlyDataHeaderSafeMethod {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_early_data_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_early_data_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_early_data_config(cfg, self.id()).ok()?;
+        let config: &EarlyDataConfig = ctx.state();
 
         // A count, not a value: the field is a singleton whose whole grammar is one
         // literal, so several field lines is a defect of its own rather than a longer
@@ -220,7 +220,7 @@ impl Rule for EarlyDataHeaderSafeMethod {
         // before this one forbids removing it.
         // cite(RFC 8470 § 5.1): "An intermediary MUST NOT remove this header field if it is present in a request."
         // cite(RFC 8470 § 5.1): "Early-Data MUST NOT appear in a Connection header field."
-        if let Some(v) = self.connection_names_early_data(&config, "request", &tx.request.headers) {
+        if let Some(v) = self.connection_names_early_data(config, "request", &tx.request.headers) {
             return Some(v);
         }
 
@@ -232,7 +232,7 @@ impl Rule for EarlyDataHeaderSafeMethod {
                     "Response carries an Early-Data header field. The field is a request header field: it tells a server that a request reached it through early data, and a response has nothing to mark".to_string(),
                 ));
             }
-            if let Some(v) = self.connection_names_early_data(&config, "response", &resp.headers) {
+            if let Some(v) = self.connection_names_early_data(config, "response", &resp.headers) {
                 return Some(v);
             }
         }
@@ -608,7 +608,8 @@ mod tests {
 
     #[test]
     fn validate_rules_with_valid_config() -> anyhow::Result<()> {
-        EarlyDataHeaderSafeMethod.validate(&make_cfg())
+        EarlyDataHeaderSafeMethod.prepare(&make_cfg())?;
+        Ok(())
     }
 
     /// A `safe_methods` array is required, and the rule says so rather than passing.
@@ -618,7 +619,7 @@ mod tests {
             "early_data_header_safe_method",
         ]);
         let err = EarlyDataHeaderSafeMethod
-            .validate(&cfg)
+            .prepare(&cfg)
             .expect_err("refused");
         assert!(err.to_string().contains("safe_methods"), "{err}");
     }
@@ -626,7 +627,7 @@ mod tests {
     #[test]
     fn an_empty_array_is_refused() {
         assert!(EarlyDataHeaderSafeMethod
-            .validate(&make_cfg_with(&[]))
+            .prepare(&make_cfg_with(&[]))
             .is_err());
     }
 

--- a/lint-http-rules/src/rules/etag_or_last_modified_present.rs
+++ b/lint-http-rules/src/rules/etag_or_last_modified_present.rs
@@ -20,9 +20,8 @@ impl Rule for EtagOrLastModifiedPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -41,7 +40,7 @@ impl Rule for EtagOrLastModifiedPresent {
         {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Response 200 without ETag or Last-Modified validator".into(),
             })
         } else {

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -22,9 +22,8 @@ impl Rule for EtagSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // ETag is a response field, which is why this rule is Server-scoped and only
         // inspects the response.
         // cite(RFC 9110 § 8.8.3): "The "ETag" field in a response provides the current entity tag for the selected representation, as determined at the conclusion of handling the request."
@@ -40,7 +39,7 @@ impl Rule for EtagSyntax {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "ETag header value is not valid UTF-8".into(),
                     })
                 }
@@ -58,7 +57,7 @@ impl Rule for EtagSyntax {
             if t == "*" {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "ETag header value '*' is invalid for responses; ETag must be an entity-tag"
                             .into(),
@@ -69,7 +68,7 @@ impl Rule for EtagSyntax {
             if let Err(msg) = crate::helpers::headers::validate_entity_tag(t) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("ETag header invalid: {}", msg),
                 });
             }
@@ -82,7 +81,7 @@ impl Rule for EtagSyntax {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Multiple ETag header fields present ({}); ETag must be a single entity-tag",
                     count

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -38,7 +38,7 @@ impl Rule for ExpectHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The field is defined on the request, so the request is where it is read.
         //
@@ -63,11 +63,10 @@ impl Rule for ExpectHeaderValid {
         // Read after the field, not before it: both this and a missing `Expect`
         // end the rule, and the header probe is one map lookup where the config
         // read is several.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let report = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
+++ b/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
@@ -25,9 +25,8 @@ impl Rule for ExpiresAndCacheControlConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // If either header is missing, nothing to check
@@ -108,7 +107,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
             if cc_max_age.unwrap_or(-1) > 0 || cc_s_maxage.unwrap_or(-1) > 0 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Expires '{}' is not a valid HTTP-date, so a cache MUST read it as already expired, but Cache-Control max-age/s-maxage says the response is still fresh — values are contradictory (RFC 9111 §5.3)",
                         expires_raw
@@ -147,7 +146,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
         if (cc_no_cache || cc_no_store || cc_max_age == Some(0)) && expires > date_ref {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Response contains Cache-Control directives {:?} that make it non-fresh, but Expires indicates freshness until {} — Cache-Control takes precedence (RFC 9111 §4.2.1)",
                     if cc_no_cache { "no-cache" } else if cc_no_store { "no-store" } else { "max-age=0" },
@@ -164,7 +163,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
         if (cc_max_age.unwrap_or(-1) > 0 || cc_s_maxage.unwrap_or(-1) > 0) && expires <= date_ref {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Response contains Cache-Control max-age/s-maxage but Expires {} is not in the future relative to Date {} — values are contradictory (RFC 9111 §4.2, §5.3)",
                     expires, date_ref
@@ -185,7 +184,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
                     if diff > 1 {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Cache-Control max-age={} suggests Expires should be {} (Date + max-age), but Expires is {} — prefer consistent values or omit Expires (RFC 9111 §5.3)",
                                 max_age, expected, expires

--- a/lint-http-rules/src/rules/extension_headers_registered.rs
+++ b/lint-http-rules/src/rules/extension_headers_registered.rs
@@ -77,24 +77,24 @@ impl Rule for ExtensionHeadersRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &ExtensionHeadersConfig = ctx.state();
 
         // All four, in wire order, from the shared walk. A trailer field name is
         // a field name, so the allowlist reaches it on the same terms; a
@@ -102,7 +102,7 @@ impl Rule for ExtensionHeadersRegistered {
         // which sections exist at all is the framing's answer, not this rule's.
         // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
         for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
-            if let Some(v) = check_section(section, headers, &config) {
+            if let Some(v) = check_section(section, headers, config) {
                 return Some(v);
             }
         }

--- a/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
+++ b/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
@@ -20,9 +20,8 @@ impl Rule for FormDataContentDispositionValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Scope worth being honest about: RFC 7578 §4.2 places its requirement on
         // each *part* of a multipart/form-data body, and this proxy does not parse
         // bodies — the transaction carries header maps, not parts. So what is
@@ -64,7 +63,7 @@ impl Rule for FormDataContentDispositionValid {
             if params_part.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-Disposition: 'form-data' missing 'name' parameter".into(),
                 });
             }
@@ -92,7 +91,7 @@ impl Rule for FormDataContentDispositionValid {
                             Ok(true) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Content-Disposition 'form-data' has empty 'name' parameter"
                                         .into(),
                                 });
@@ -104,7 +103,7 @@ impl Rule for FormDataContentDispositionValid {
                             Err(e) => {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Content-Disposition 'form-data' has invalid quoted 'name' parameter: {}",
                                         e
@@ -117,7 +116,7 @@ impl Rule for FormDataContentDispositionValid {
                         if raw.is_empty() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message:
                                     "Content-Disposition 'form-data' has empty 'name' parameter"
                                         .into(),
@@ -139,7 +138,7 @@ impl Rule for FormDataContentDispositionValid {
             if !name_found && crate::helpers::headers::quoting_is_balanced(params_part) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Content-Disposition: 'form-data' missing 'name' parameter".into(),
                 });
             }
@@ -159,7 +158,7 @@ impl Rule for FormDataContentDispositionValid {
                     Err(_) => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Content-Disposition header value is not valid UTF-8".into(),
                         })
                     }
@@ -178,7 +177,7 @@ impl Rule for FormDataContentDispositionValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Content-Disposition header value is not valid UTF-8".into(),
                     })
                 }

--- a/lint-http-rules/src/rules/forwarded_header_valid.rs
+++ b/lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -81,11 +81,11 @@ impl ForwardedHeaderValid {
     /// The element arrives trimmed of the whitespace the *list* allows around
     /// its commas. Everything inside it is the element's own production, which
     /// has no `OWS` in it anywhere.
-    fn check_element(&self, elem: &str, config: &crate::rules::RuleConfig) -> Option<Violation> {
+    fn check_element(&self, elem: &str, severity: crate::lint::Severity) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -208,11 +208,11 @@ impl ForwardedHeaderValid {
     }
 
     /// One `Forwarded` field line.
-    fn check_field_line(&self, line: &str, config: &crate::rules::RuleConfig) -> Option<Violation> {
+    fn check_field_line(&self, line: &str, severity: crate::lint::Severity) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -254,7 +254,7 @@ impl ForwardedHeaderValid {
                 continue;
             }
             carried_an_element = true;
-            if let Some(v) = self.check_element(elem, config) {
+            if let Some(v) = self.check_element(elem, severity) {
                 return Some(v);
             }
         }
@@ -293,10 +293,8 @@ impl Rule for ForwardedHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Every field line of the request's header section. A list may be split
         // over several of them and each holds whole elements — a comma is what
         // separates members, and joining the lines would put one there — so each
@@ -310,7 +308,7 @@ impl Rule for ForwardedHeaderValid {
         //
         // cite(RFC 7239 § 7.1): "Note that an HTTP list allows white spaces to occur between the identifiers, and the list may be split over multiple header fields."
         for hv in tx.request.headers.get_all("forwarded").iter() {
-            if let Some(v) = self.check_field_line(&field_line(hv.as_bytes()), &config) {
+            if let Some(v) = self.check_field_line(&field_line(hv.as_bytes()), ctx.severity) {
                 return Some(v);
             }
         }
@@ -336,7 +334,7 @@ impl Rule for ForwardedHeaderValid {
             if resp.headers.contains_key("forwarded") || in_trailers {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Response carries a Forwarded field in its {} section: the field is only for use in HTTP requests, and copying it into a response reveals the proxy chain to the client",
                         match in_trailers && !resp.headers.contains_key("forwarded") {

--- a/lint-http-rules/src/rules/from_header_email_syntax.rs
+++ b/lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -28,14 +28,12 @@ impl Rule for FromHeaderEmailSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let req = &tx.request;
 
-        // The field probe first and the config after it. `parse_rule_config` is
-        // several map lookups and a hash of the rule id; a request with no `From`
-        // — which is nearly all of them, since § 10.1.2 says the field is rarely
-        // sent — should not pay for them.
+        // A request with no `From` — which is nearly all of them, since § 10.1.2
+        // says the field is rarely sent — ends the rule at one field probe.
         //
         // Read as the sender wrote it, one `char` per octet. The `to_str` this
         // replaced answered "From header value is not valid UTF-8" for any octet
@@ -53,11 +51,10 @@ impl Rule for FromHeaderEmailSyntax {
         // cite(RFC 9110 § 10.1.2): "The address ought to be machine-usable, as defined by "mailbox" in Section 3.4 of [RFC5322]"
         // cite(RFC 9110 § 10.1.2): "mailbox = <mailbox, see [RFC5322], Section 3.4>"
         let value = combined_field_value_as_written(&req.headers, "from")?;
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/head_response_headers_match_get.rs
@@ -181,22 +181,22 @@ impl Rule for HeadResponseHeadersMatchGet {
         crate::rules::RuleScope::Server
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_headers_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_headers_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The sentence the whole rule enforces, and the response it is about.
         // cite(RFC 9110 § 9.3.2): "The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET."
@@ -245,7 +245,7 @@ impl Rule for HeadResponseHeadersMatchGet {
 
         // Parse config only after the cheap method/response/history guards above —
         // non-HEAD transactions (the common case) skip the allocation entirely.
-        let config = parse_headers_config(cfg, self.id()).ok()?;
+        let config: &SemanticHeadResponseHeadersMatchGetConfig = ctx.state();
 
         let report = |message: String| {
             Some(Violation {
@@ -700,7 +700,7 @@ mod tests {
     fn parse_config_requires_headers_array() {
         let cfg = crate::config::Config::default();
         let rule = HeadResponseHeadersMatchGet;
-        let res = rule.validate(&cfg);
+        let res = rule.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -721,7 +721,7 @@ mod tests {
         );
 
         let rule = HeadResponseHeadersMatchGet;
-        let res = rule.validate(&cfg);
+        let res = rule.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -745,7 +745,7 @@ mod tests {
         );
 
         let rule = HeadResponseHeadersMatchGet;
-        let res = rule.validate(&cfg);
+        let res = rule.prepare(&cfg);
         assert!(res.is_err());
     }
 

--- a/lint-http-rules/src/rules/header_field_names_token_valid.rs
+++ b/lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -23,17 +23,15 @@ impl Rule for HeaderFieldNamesTokenValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // All four, in wire order, from the shared walk. A trailer field name is
         // a field name, so the same grammar reaches it; a transaction the
         // upstream never answered has no response half; and which sections exist
         // at all is the framing's answer, not this rule's.
         // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
         for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
-            if let Some(v) = check_section(section, headers, &config) {
+            if let Some(v) = check_section(section, headers, ctx.severity) {
                 return Some(v);
             }
         }
@@ -106,7 +104,7 @@ impl Rule for HeaderFieldNamesTokenValid {
 fn check_section(
     section: &str,
     fields: &hyper::HeaderMap,
-    config: &crate::rules::RuleConfig,
+    severity: crate::lint::Severity,
 ) -> Option<Violation> {
     for (k, _v) in fields.iter() {
         // The one check a § 5.1 validator still owes -- that the name is not
@@ -115,7 +113,7 @@ fn check_section(
         // HTTP/2 and HTTP/3 decoders reject an uppercase name outright, so `as_str()`
         // has already been made lowercase by the time any rule reads it.
         // cite(RFC 9114 § 4.2): "A request or response containing uppercase characters in field names MUST be treated as malformed"
-        if let Some(v) = check_header_name(section, k.as_str(), config) {
+        if let Some(v) = check_header_name(section, k.as_str(), severity) {
             return Some(v);
         }
     }
@@ -133,7 +131,7 @@ fn check_section(
 fn check_header_name(
     section: &str,
     name: &str,
-    config: &crate::rules::RuleConfig,
+    severity: crate::lint::Severity,
 ) -> Option<Violation> {
     // The production is defined in § 5.1; the quote is the collected grammar's copy,
     // where it sits beside a neighbour rather than alone between two paragraphs, so
@@ -143,7 +141,7 @@ fn check_header_name(
     if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
         return Some(Violation {
             rule: HeaderFieldNamesTokenValid.id().into(),
-            severity: config.severity,
+            severity,
             message: format!(
                 "Field name '{}' in the {} contains invalid character: '{}'",
                 name, section, c
@@ -264,7 +262,7 @@ mod tests {
         #[case] expected_char: Option<char>,
     ) -> anyhow::Result<()> {
         let cfg = &crate::test_helpers::make_test_rule_config();
-        let res = super::check_header_name("request header section", name, cfg);
+        let res = super::check_header_name("request header section", name, cfg.severity);
 
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", name);

--- a/lint-http-rules/src/rules/host_and_authority_consistent.rs
+++ b/lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -148,7 +148,7 @@ impl Rule for HostAndAuthorityConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Two fields can only disagree where both exist, and only HTTP/2 and
         // HTTP/3 carry an `:authority`. This is not a narrowing of either
@@ -244,13 +244,11 @@ impl Rule for HostAndAuthorityConsistent {
         let host = trim_ows(&value);
 
         // Every gate above ends the rule, and a request carrying both fields is
-        // the only one this can report; `parse_rule_config` is several map
-        // probes plus a hash over the rule id.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
+        // the only one this can report.
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/host_header.rs
+++ b/lint-http-rules/src/rules/host_header.rs
@@ -44,9 +44,8 @@ impl Rule for HostHeader {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let host_lines = tx.request.headers.get_all("host");
         let host_count = host_lines.iter().count();
 
@@ -63,7 +62,7 @@ impl Rule for HostHeader {
             }
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Request carries no Host header field and no :authority pseudo-header"
                     .into(),
             });
@@ -78,7 +77,7 @@ impl Rule for HostHeader {
         if host_count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "{} Host header field lines: the field is not defined as a list, so they are not one value",
                     host_count
@@ -126,7 +125,7 @@ impl Rule for HostHeader {
         if s.contains('@') {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Host field value '{}' carries a userinfo subcomponent and its '@' delimiter",
                     s
@@ -145,7 +144,7 @@ impl Rule for HostHeader {
         {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "IPv6 literal '{}' in a Host field value must be enclosed in square brackets",
                     s
@@ -162,7 +161,7 @@ impl Rule for HostHeader {
         if let Err(msg) = crate::helpers::uri::validate_host_and_optional_port(s) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!("Host field value '{}' is not a host and port: {}", s, msg),
             });
         }

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -125,7 +125,7 @@ impl Rule for Http2PseudoHeadersValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Only applies to HTTP/2 transactions. The gate is scoping, not a
         // normative check, so it carries no cite; each requirement below cites
@@ -187,12 +187,6 @@ impl Rule for Http2PseudoHeadersValid {
         // cite(RFC 9113 § 8.5): "The ":method" pseudo-header field is set to CONNECT."
         let is_connect = method == "CONNECT";
 
-        // Read once the two cheapest and most selective gates above have had
-        // their say: `parse_rule_config` is several map probes and a hash of
-        // the rule id, where a version comparison is nine characters and a
-        // method comparison is seven.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Which of the three forms the transport reassembled is what says which
         // CONNECT this is, and it is the only thing that does: the capture
         // records no `:protocol`, so an absolute-form target -- `:scheme` and
@@ -217,7 +211,7 @@ impl Rule for Http2PseudoHeadersValid {
                 if !tx.request.headers.contains_key("host") {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "CONNECT request carries a path and no authority: an extended \
                                   CONNECT sends ':scheme' and ':path' beside an ':authority', and \
                                   a basic one sends only the host and port to connect to"
@@ -228,7 +222,7 @@ impl Rule for Http2PseudoHeadersValid {
                 if let Some(msg) = connect_authority_finding(target) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: msg,
                     });
                 }
@@ -244,7 +238,7 @@ impl Rule for Http2PseudoHeadersValid {
                 if method != "OPTIONS" {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Asterisk ('*') is the ':path' value of a server-wide OPTIONS request \
                              and of nothing else, and this request's ':method' is '{method}'"
@@ -257,7 +251,7 @@ impl Rule for Http2PseudoHeadersValid {
                 if crate::helpers::uri::extract_path_from_request_target(target).is_none() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Request target '{}' carries no path, and every non-CONNECT request \
                              sends exactly one ':path': an 'http' or 'https' URI with no path \
@@ -286,7 +280,7 @@ impl Rule for Http2PseudoHeadersValid {
             if let Some(msg) = crate::helpers::uri::validate_scheme_if_present(target) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Request target's scheme is not a scheme name: {msg}"),
                 });
             }
@@ -304,7 +298,7 @@ impl Rule for Http2PseudoHeadersValid {
             else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Request target '{}' names the scheme '{scheme}' and then no authority",
                         crate::helpers::headers::shown_in_finding(target)
@@ -326,7 +320,7 @@ impl Rule for Http2PseudoHeadersValid {
                     .unwrap_or_else(|| authority.to_string());
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Authority '{}' of an '{scheme}' target carries the deprecated userinfo \
                          subcomponent and its '@' delimiter",
@@ -343,7 +337,7 @@ impl Rule for Http2PseudoHeadersValid {
             if let Err(msg) = crate::helpers::uri::validate_host_and_optional_port(&authority) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Authority '{}' is not a host and port: {msg}",
                         crate::helpers::headers::shown_in_finding(&authority)

--- a/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -20,7 +20,7 @@ impl Rule for Http3PseudoHeadersValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Only applies to HTTP/3 transactions. The version gate is scoping, not a
         // normative check, so it carries no cite; each requirement below cites the
@@ -31,11 +31,6 @@ impl Rule for Http3PseudoHeadersValid {
             return None;
         }
 
-        // Read after the gate, not before it: one digit comparison ends the rule
-        // for every request that is not HTTP/3, and `parse_rule_config` looks the
-        // rule id up twice (its doc comment costs it).
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // :method is required. (The :scheme half of the same sentence is not
         // checked — the canonical model does not retain scheme for origin-form
         // requests, as the description says.)
@@ -44,7 +39,7 @@ impl Rule for Http3PseudoHeadersValid {
         if method.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "HTTP/3 request missing required ':method' pseudo-header".into(),
             });
         }
@@ -60,7 +55,7 @@ impl Rule for Http3PseudoHeadersValid {
             if uri_trimmed.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "HTTP/3 CONNECT request missing required ':authority' pseudo-header or Host header"
                             .into(),
@@ -75,7 +70,7 @@ impl Rule for Http3PseudoHeadersValid {
                 if !has_host {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "HTTP/3 extended CONNECT request with origin-form target must include Host header as authority"
                             .into(),
                     });
@@ -84,7 +79,7 @@ impl Rule for Http3PseudoHeadersValid {
                 // Authority-form (or absolute-form) CONNECT without any authority.
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "HTTP/3 CONNECT request must include ':authority' pseudo-header or Host header"
                             .into(),
@@ -113,7 +108,7 @@ impl Rule for Http3PseudoHeadersValid {
                     .unwrap_or(authority);
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "HTTP/3 CONNECT ':authority' '{}' carries a userinfo subcomponent and its '@' delimiter: the field is only the host and port to connect to",
                         crate::helpers::headers::shown_in_finding(&shown)
@@ -131,7 +126,7 @@ impl Rule for Http3PseudoHeadersValid {
                 if !method.eq_ignore_ascii_case("OPTIONS") {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message:
                             "Asterisk ('*') request-target is only permitted with OPTIONS method"
                                 .into(),
@@ -144,7 +139,7 @@ impl Rule for Http3PseudoHeadersValid {
                 if !has_path {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "HTTP/3 request missing required ':path' pseudo-header".into(),
                     });
                 }
@@ -160,7 +155,7 @@ impl Rule for Http3PseudoHeadersValid {
             if authority.is_none() && !has_host {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "HTTP/3 request must include ':authority' pseudo-header or Host header"
                             .into(),
@@ -186,7 +181,7 @@ impl Rule for Http3PseudoHeadersValid {
                             .unwrap_or(authority);
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "HTTP/3 ':authority' '{}' of an '{scheme}' target includes the deprecated userinfo subcomponent and its '@' delimiter",
                                 crate::helpers::headers::shown_in_finding(&shown)

--- a/lint-http-rules/src/rules/http3_status_code_valid.rs
+++ b/lint-http-rules/src/rules/http3_status_code_valid.rs
@@ -20,7 +20,7 @@ impl Rule for Http3StatusCodeValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Only applies to HTTP/3 connections. Scoping, not a normative check — no cite.
         // Both gates read the major digit rather than a string: neither direction
@@ -38,18 +38,12 @@ impl Rule for Http3StatusCodeValid {
             return None;
         }
 
-        // Read after all three gates: only an exchange that is HTTP/3 on both
-        // sides can be reported here, reaching that verdict costs two digit
-        // comparisons and a borrow, and `parse_rule_config` looks the rule id up
-        // twice (its doc comment costs it).
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // § 4.5 is the only place RFC 9114 mentions 101 at all.
         // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
         if resp.status == 101 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message:
                     "HTTP/3 does not support 101 (Switching Protocols); use extended CONNECT instead"
                         .into(),

--- a/lint-http-rules/src/rules/http_version_syntax.rs
+++ b/lint-http-rules/src/rules/http_version_syntax.rs
@@ -27,7 +27,7 @@ impl Rule for HttpVersionSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The request's version sits in the first line of the request message,
         // the response's in the first line of the response message. One
@@ -40,13 +40,9 @@ impl Rule for HttpVersionSyntax {
             judge("response", &resp.version)
         })?;
 
-        // The config is read last. `parse_rule_config` is several map probes and
-        // a hash over the rule id, and both gates above end the rule; only a
-        // message about to be reported should pay for it.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: finding,
         })
     }

--- a/lint-http-rules/src/rules/if_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -23,9 +23,8 @@ impl Rule for IfMatchEtagSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests. **One value, however many field lines carry
         // it**: `#entity-tag` is a list, so § 5.2 combines the lines with a
         // comma before the members are counted -- and the alternation above the
@@ -64,7 +63,7 @@ impl Rule for IfMatchEtagSyntax {
         if value.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "If-Match header is empty or contains only whitespace".into(),
             });
         }
@@ -83,14 +82,14 @@ impl Rule for IfMatchEtagSyntax {
             if member.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "If-Match header contains an empty list element".into(),
                 });
             }
             if let Err(msg) = crate::helpers::headers::validate_entity_tag(member) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "If-Match header has invalid member '{}': {}",
                         crate::helpers::headers::shown_in_finding(member),

--- a/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
@@ -22,9 +22,8 @@ impl Rule for IfModifiedSinceDateSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests
         for hv in tx.request.headers.get_all("if-modified-since").iter() {
             let s = match hv.to_str() {
@@ -32,7 +31,7 @@ impl Rule for IfModifiedSinceDateSyntax {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "If-Modified-Since header contains non-UTF8 value".into(),
                     })
                 }
@@ -45,7 +44,7 @@ impl Rule for IfModifiedSinceDateSyntax {
             if crate::helpers::headers::trim_ows(s).is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "If-Modified-Since header is empty or contains only whitespace".into(),
                 });
             }
@@ -68,7 +67,7 @@ impl Rule for IfModifiedSinceDateSyntax {
             if !crate::http_date::is_valid_imf_fixdate(crate::helpers::headers::trim_ows(s)) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "If-Modified-Since header is not a valid IMF-fixdate (RFC 9110 §5.6.7)"
                             .into(),

--- a/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -23,9 +23,8 @@ impl Rule for IfNoneMatchEtagSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applies to requests. **One value, however many field lines carry
         // it**: `#entity-tag` is a list, so § 5.2 combines the lines with a
         // comma before the members are counted -- and the alternation above the
@@ -65,7 +64,7 @@ impl Rule for IfNoneMatchEtagSyntax {
         if value.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "If-None-Match header is empty or contains only whitespace".into(),
             });
         }
@@ -84,14 +83,14 @@ impl Rule for IfNoneMatchEtagSyntax {
             if member.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "If-None-Match header contains an empty list element".into(),
                 });
             }
             if let Err(msg) = crate::helpers::headers::validate_entity_tag(member) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "If-None-Match header has invalid member '{}': {}",
                         crate::helpers::headers::shown_in_finding(member),

--- a/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
@@ -22,9 +22,8 @@ impl Rule for IfUnmodifiedSinceDateSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Applies to requests only
         for hv in tx.request.headers.get_all("if-unmodified-since").iter() {
             let s = match hv.to_str() {
@@ -32,7 +31,7 @@ impl Rule for IfUnmodifiedSinceDateSyntax {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "If-Unmodified-Since header contains non-UTF8 value".into(),
                     })
                 }
@@ -45,7 +44,7 @@ impl Rule for IfUnmodifiedSinceDateSyntax {
             if crate::helpers::headers::trim_ows(s).is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "If-Unmodified-Since header is empty or contains only whitespace"
                         .into(),
                 });
@@ -68,7 +67,7 @@ impl Rule for IfUnmodifiedSinceDateSyntax {
             if !crate::http_date::is_valid_imf_fixdate(crate::helpers::headers::trim_ows(s)) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "If-Unmodified-Since header is not a valid IMF-fixdate (RFC 9110 §5.6.7)"
                             .into(),

--- a/lint-http-rules/src/rules/immutable_cache_never_stale.rs
+++ b/lint-http-rules/src/rules/immutable_cache_never_stale.rs
@@ -44,9 +44,8 @@ impl Rule for ImmutableCacheNeverStale {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent prior response with an immutable
         // directive that isn't simultaneously forbidding caching.
         let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
@@ -109,7 +108,7 @@ impl Rule for ImmutableCacheNeverStale {
         if has_conditional && current_age < freshness_lifetime {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Unnecessary revalidation of immutable response while still fresh (age {} < freshness {})",
                     current_age, freshness_lifetime

--- a/lint-http-rules/src/rules/immutable_requires_freshness.rs
+++ b/lint-http-rules/src/rules/immutable_requires_freshness.rs
@@ -39,9 +39,8 @@ impl Rule for ImmutableRequiresFreshness {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let mut found_immutable = false;
@@ -53,7 +52,7 @@ impl Rule for ImmutableRequiresFreshness {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Cache-Control header contains non-UTF8 value".into(),
                     })
                 }
@@ -106,7 +105,7 @@ impl Rule for ImmutableRequiresFreshness {
         if let (true, Some(conflict)) = (found_immutable, conflicting) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Cache-Control pairs 'immutable' with '{}', which leaves the response no freshness lifetime; 'immutable' only applies during one, so it has no effect here",
                     conflict
@@ -316,7 +315,7 @@ mod tests {
         table.insert("severity".to_string(), toml::Value::String("warn".into()));
         cfg.rules
             .insert(rule.id().to_string(), toml::Value::Table(table));
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/keep_alive_header_valid.rs
+++ b/lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -77,22 +77,22 @@ impl Rule for KeepAliveHeaderValid {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_keep_alive_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_keep_alive_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The field probe is one lookup per section; `parse_keep_alive_config`
         // is several map probes and a hash of the rule id. Nearly every message
@@ -107,7 +107,7 @@ impl Rule for KeepAliveHeaderValid {
             return None;
         }
 
-        let config = parse_keep_alive_config(cfg, self.id()).ok()?;
+        let config: &MessageKeepAliveConfig = ctx.state();
         let message = judge(
             &tx.request.headers,
             &tx.request.version,
@@ -915,7 +915,7 @@ mod tests {
     #[case(Some(-1))]
     fn validate_requires_a_positive_max_timeout(#[case] max: Option<i64>) {
         let cfg = cfg_with_optional_max(max);
-        assert!(KeepAliveHeaderValid.validate(&cfg).is_err());
+        assert!(KeepAliveHeaderValid.prepare(&cfg).is_err());
         assert!(crate::rules::validate_rules(&cfg).is_err());
     }
 

--- a/lint-http-rules/src/rules/language_tag_syntax.rs
+++ b/lint-http-rules/src/rules/language_tag_syntax.rs
@@ -26,10 +26,8 @@ impl Rule for LanguageTagSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The two fields this rule reads do not use the same production, and
         // RFC 9110 says so in one sentence. `Content-Language` carries
         // `language-tag` (RFC 5646 §2.1); `Accept-Language` carries the broader
@@ -54,7 +52,7 @@ impl Rule for LanguageTagSyntax {
             if let Err(e) = crate::helpers::language::validate_language_tag(tag) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Invalid language tag '{}' in {}: {}", tag, hdr, e),
                 });
             }

--- a/lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
+++ b/lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
@@ -20,9 +20,8 @@ impl Rule for LastModifiedRfc1123Syntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -48,7 +47,7 @@ impl Rule for LastModifiedRfc1123Syntax {
             if !crate::http_date::is_valid_imf_fixdate(crate::helpers::headers::trim_ows(s)) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Last-Modified header is not a valid IMF-fixdate (RFC 9110)".into(),
                 });
             }
@@ -56,7 +55,7 @@ impl Rule for LastModifiedRfc1123Syntax {
             // Non-UTF8 header values are considered invalid for date parsing
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Last-Modified header contains non-UTF8 bytes and is invalid".into(),
             });
         }

--- a/lint-http-rules/src/rules/link_header_valid.rs
+++ b/lint-http-rules/src/rules/link_header_valid.rs
@@ -40,7 +40,7 @@ impl Rule for LinkHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Most messages carry no `Link`, and the config read is several map
         // probes and a hash of the rule id against one lookup per section.
@@ -53,8 +53,6 @@ impl Rule for LinkHeaderValid {
             return None;
         }
 
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         let message = judge(&tx.request.headers, "Request", false).or_else(|| {
             tx.response
                 .as_ref()
@@ -63,7 +61,7 @@ impl Rule for LinkHeaderValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message,
         })
     }

--- a/lint-http-rules/src/rules/location_header_uri_valid.rs
+++ b/lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -26,16 +26,15 @@ impl Rule for LocationHeaderUriValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let Some(resp) = &tx.response else {
             return None;
         };
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/location_on_redirect_present.rs
+++ b/lint-http-rules/src/rules/location_on_redirect_present.rs
@@ -97,9 +97,8 @@ impl Rule for LocationOnRedirectPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // The status is read first because the status is what gives the field a
@@ -128,7 +127,7 @@ impl Rule for LocationOnRedirectPresent {
         // carried into the message from there.
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Response with status {status} carries no Location header field, and {reason}. \
                  A user agent has no target to redirect to",

--- a/lint-http-rules/src/rules/max_age_directive_valid.rs
+++ b/lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -44,9 +44,8 @@ impl Rule for MaxAgeDirectiveValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate most recent prior response with a usable max-age
         let mut candidate: Option<(&crate::http_transaction::HttpTransaction, i64)> = None;
 
@@ -116,7 +115,7 @@ impl Rule for MaxAgeDirectiveValid {
                 // cite(RFC 9111 § 4.2): "When a response is fresh, it can be used to satisfy subsequent requests without contacting the origin server, thereby improving efficiency"
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Request revalidated resource while response is still fresh (age {} < max-age {})",
                         current_age, max_age
@@ -136,7 +135,7 @@ impl Rule for MaxAgeDirectiveValid {
                 // cite(RFC 9111 § 4.3): "it can use the conditional request mechanism"
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Stale cached entry (age {} >= max-age {}) refetched without a conditional request, though a validator was available to revalidate with",
                         current_age, max_age

--- a/lint-http-rules/src/rules/max_forwards_numeric.rs
+++ b/lint-http-rules/src/rules/max_forwards_numeric.rs
@@ -25,13 +25,12 @@ impl Rule for MaxForwardsNumeric {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/media_type_suffix_valid.rs
+++ b/lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -71,24 +71,24 @@ impl Rule for MediaTypeSuffixValid {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &MessageMediaTypeSuffixConfig = ctx.state();
         let check_media = |hdr_name: &str, val: &str| -> Option<Violation> {
             // A value that is not a media-type has no subtype to inspect, and
             // saying so is `content_type_valid`'s finding. The

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -64,13 +64,11 @@ pub fn parse_rule_config(cfg: &crate::config::Config, rule_id: &str) -> anyhow::
 
 /// Both keys a rule's table must carry, checked once at startup.
 ///
-/// This is the reading [`parse_rule_config`] used to perform on every
-/// transaction: `enabled` must be present and a boolean, and `severity` present
-/// and one of the three names. It is the default body of `Rule::validate` and
-/// `ProtocolRule::validate`, so a rule that overrides `validate` to check its own
-/// options is the one place the pair can be forgotten — which is why
-/// `validate_rules` also walks `Config::rules` itself before it calls any of
-/// them.
+/// `enabled` must be present and a boolean, and `severity` present and one of
+/// the three names. The two `prepare` defaults ask it, and every custom
+/// `prepare` is expected to ask it after its own options — which is the one
+/// place the pair could be forgotten, and why `validate_rules` also walks
+/// `Config::rules` itself before it calls any of them.
 pub fn validate_rule_table(cfg: &crate::config::Config, rule_id: &str) -> anyhow::Result<()> {
     get_rule_severity_required(cfg, rule_id)?;
     get_rule_enabled_required(cfg, rule_id)?;
@@ -87,6 +85,16 @@ pub fn validate_rule_table(cfg: &crate::config::Config, rule_id: &str) -> anyhow
 pub struct ResolvedRule {
     pub severity: crate::lint::Severity,
     pub state: Box<dyn std::any::Any + Send + Sync>,
+}
+
+impl std::fmt::Debug for ResolvedRule {
+    /// `state` is `dyn Any`, so only the severity can say anything; tests
+    /// `expect_err` on `prepare` results, which needs the Ok side printable.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedRule")
+            .field("severity", &self.severity)
+            .finish_non_exhaustive()
+    }
 }
 
 /// One rule's resolved configuration, borrowed for one dispatch.
@@ -208,24 +216,17 @@ impl std::fmt::Display for SpecRef {
 pub trait Rule: Send + Sync {
     fn id(&self) -> &'static str;
 
-    /// Validate the rule's configuration section. Called once per enabled
-    /// rule at startup so a malformed config fails fast rather than silently
-    /// disabling the rule at lint time.
+    /// Resolve this rule's configuration once, when the engine is built —
+    /// which is also when it is validated: a malformed section fails fast at
+    /// startup rather than silently disabling the rule at lint time.
     ///
-    /// The default checks the base `enabled` / `severity` fields. Rules with
-    /// a custom config section override this to validate their own fields.
-    fn validate(&self, cfg: &crate::config::Config) -> anyhow::Result<()> {
-        validate_rule_table(cfg, self.id())
-    }
-
-    /// Resolve this rule's configuration once, when the engine is built.
-    ///
-    /// Validation *is* successful preparation: what `validate` answers with
-    /// `Ok(())`, this answers with the resolved values themselves, so the
-    /// same parse cannot run again — typed or untyped — on the lint path.
-    /// The default resolves what every rule needs (the table's two required
-    /// keys, of which severity is the one carried forward); a rule with a
-    /// custom config section overrides this to parse it into its own `state`.
+    /// Validation *is* successful preparation: what a separate `validate`
+    /// hook would answer with `Ok(())`, this answers with the resolved values
+    /// themselves, so the same parse cannot run again — typed or untyped —
+    /// on the lint path. The default resolves what every rule needs (the
+    /// table's two required keys, of which severity is the one carried
+    /// forward); a rule with a custom config section overrides this to parse
+    /// it into its own `state`.
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<ResolvedRule> {
         validate_rule_table(cfg, self.id())?;
         Ok(ResolvedRule {
@@ -277,13 +278,14 @@ pub trait Rule: Send + Sync {
         }
     }
 
-    /// Evaluate an `HttpTransaction` against this rule. Rules parse whatever
-    /// configuration they need directly from the global `cfg: &Config`.
+    /// Evaluate an `HttpTransaction` against this rule. Everything the rule
+    /// derived from its configuration arrives resolved in `ctx` — its own
+    /// `prepare` ran when the engine was built, so nothing here reads TOML.
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &RuleContext<'_>,
     ) -> Option<Violation>;
 
     /// Doc title override (the `# ` heading of the generated per-rule doc).
@@ -454,14 +456,14 @@ pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
     // a malformed section (including custom fields) fails fast at startup.
     for rule in RULES.iter() {
         if config.is_enabled(rule.id()) {
-            rule.validate(config).map_err(|e| {
+            rule.prepare(config).map_err(|e| {
                 anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
             })?;
         }
     }
     for rule in PROTOCOL_RULES.iter() {
         if config.is_enabled(rule.id()) {
-            rule.validate(config).map_err(|e| {
+            rule.prepare(config).map_err(|e| {
                 anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
             })?;
         }
@@ -485,12 +487,6 @@ include!(concat!(env!("OUT_DIR"), "/rule_modules.rs"));
 /// control frames, QUIC transport events) rather than HTTP transactions.
 pub trait ProtocolRule: Send + Sync {
     fn id(&self) -> &'static str;
-
-    /// Validate the rule's configuration section at startup. See
-    /// [`Rule::validate`] for the contract.
-    fn validate(&self, cfg: &crate::config::Config) -> anyhow::Result<()> {
-        validate_rule_table(cfg, self.id())
-    }
 
     /// Resolve this rule's configuration once, when the engine is built. See
     /// [`Rule::prepare`] for the contract.
@@ -1293,7 +1289,7 @@ severity = "warn"
                 &self,
                 _tx: &crate::http_transaction::HttpTransaction,
                 _history: &crate::transaction_history::TransactionHistory,
-                _cfg: &crate::config::Config,
+                _ctx: &crate::rules::RuleContext<'_>,
             ) -> Option<Violation> {
                 None
             }
@@ -1305,6 +1301,28 @@ severity = "warn"
         // Also verify through a trait object (now object-safe).
         let v: &dyn Rule = &r;
         assert_eq!(v.scope(), RuleScope::Both);
+    }
+
+    /// Every registered rule prepares successfully under the shipped example
+    /// config. This is the startup-time replacement for the coverage the
+    /// per-transaction `.ok()?` parses used to get incidentally: a rule whose
+    /// `prepare` cannot digest its own shipped `[rules.*]` section fails here
+    /// by name, and no per-rule test has to remember to ask.
+    #[test]
+    fn every_rule_prepares_under_the_example_config() -> anyhow::Result<()> {
+        let toml_src = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../config_example.toml"),
+        )?;
+        let cfg: crate::config::Config = toml::from_str(&toml_src)?;
+        for rule in RULES.iter() {
+            rule.prepare(&cfg)
+                .map_err(|e| anyhow::anyhow!("rule '{}' failed to prepare: {e}", rule.id()))?;
+        }
+        for rule in PROTOCOL_RULES.iter() {
+            rule.prepare(&cfg)
+                .map_err(|e| anyhow::anyhow!("rule '{}' failed to prepare: {e}", rule.id()))?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/lint-http-rules/src/rules/multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -26,9 +26,8 @@ impl Rule for MultipartBoundarySyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Every Content-Type field line, not just the first. `HeaderMap::get`
         // returns one value, and RFC 9110 §8.3 is explicit that implementations
         // differ over which member of a duplicated Content-Type they act on, so
@@ -48,7 +47,7 @@ impl Rule for MultipartBoundarySyntax {
                 // below rejects it, as `bcharsnospace` is US-ASCII throughout.
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
                 let s = crate::helpers::headers::field_line_as_written(hv);
-                if let Some(v) = check_multipart_boundary(which, &s, &config) {
+                if let Some(v) = check_multipart_boundary(which, &s, ctx.severity) {
                     return Some(v);
                 }
             }
@@ -160,7 +159,7 @@ impl Rule for MultipartBoundarySyntax {
 fn check_multipart_boundary(
     which: &str,
     val: &str,
-    config: &crate::rules::RuleConfig,
+    severity: crate::lint::Severity,
 ) -> Option<Violation> {
     // A value that is not a media-type at all has no type to compare and no
     // parameters to read. Saying so is `content_type_valid`'s
@@ -220,7 +219,7 @@ fn check_multipart_boundary(
                     if value.is_empty() {
                         return Some(Violation {
                             rule: MultipartBoundarySyntax.id().into(),
-                            severity: config.severity,
+                            severity,
                             message: format!(
                                 "Invalid multipart Content-Type in {}: empty 'boundary' parameter",
                                 which
@@ -249,7 +248,7 @@ fn check_multipart_boundary(
                             Err(e) => {
                                 return Some(Violation {
                                     rule: MultipartBoundarySyntax.id().into(),
-                                    severity: config.severity,
+                                    severity,
                                     message: format!(
                                         "Invalid multipart Content-Type in {}: boundary quoted-string invalid: {}",
                                         which, e
@@ -270,7 +269,7 @@ fn check_multipart_boundary(
                         if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
                             return Some(Violation {
                                 rule: MultipartBoundarySyntax.id().into(),
-                                severity: config.severity,
+                                severity,
                                 message: format!(
                                     "Invalid multipart Content-Type in {}: boundary contains invalid token character '{}'",
                                     which, c
@@ -318,7 +317,7 @@ fn check_multipart_boundary(
                         }
                         return Some(Violation {
                             rule: MultipartBoundarySyntax.id().into(),
-                            severity: config.severity,
+                            severity,
                             message: format!(
                                 "Invalid multipart Content-Type in {}: boundary contains invalid character '{}'",
                                 which, ch
@@ -337,7 +336,7 @@ fn check_multipart_boundary(
                     if len == 0 || len > 70 {
                         return Some(Violation {
                             rule: MultipartBoundarySyntax.id().into(),
-                            severity: config.severity,
+                            severity,
                             message: format!(
                                 "Invalid multipart Content-Type in {}: 'boundary' must be between 1 and 70 characters",
                                 which
@@ -357,7 +356,7 @@ fn check_multipart_boundary(
                     if boundary_unquoted.ends_with(' ') {
                         return Some(Violation {
                             rule: MultipartBoundarySyntax.id().into(),
-                            severity: config.severity,
+                            severity,
                             message: format!(
                                 "Invalid multipart Content-Type in {}: 'boundary' must not end with whitespace",
                                 which
@@ -383,7 +382,7 @@ fn check_multipart_boundary(
         if !found && !unreadable {
             return Some(Violation {
                 rule: MultipartBoundarySyntax.id().into(),
-                severity: config.severity,
+                severity,
                 message: format!(
                     "Invalid multipart Content-Type in {}: missing required 'boundary' parameter",
                     which

--- a/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
+++ b/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
@@ -26,10 +26,8 @@ impl Rule for MultipartContentTypeAndBodyConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Why a MIME grammar governs an HTTP body at all, and why the boundary
         // named in the header is the one the body must use: RFC 9110 adopts
         // §5.1.1 for every multipart type and makes the parameter part of the
@@ -72,7 +70,8 @@ impl Rule for MultipartContentTypeAndBodyConsistent {
                 // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
                 let s = crate::helpers::headers::field_line_as_written(hv);
                 if let Some(boundary) = crate::helpers::headers::extract_multipart_boundary(&s) {
-                    if let Some(v) = check_body_delimiters(which, &boundary, body.as_ref(), &config)
+                    if let Some(v) =
+                        check_body_delimiters(which, &boundary, body.as_ref(), ctx.severity)
                     {
                         return Some(v);
                     }
@@ -279,7 +278,7 @@ fn check_body_delimiters(
     which: &str,
     boundary: &str,
     body: &[u8],
-    config: &crate::rules::RuleConfig,
+    severity: crate::lint::Severity,
 ) -> Option<Violation> {
     // The boundary is text for the three findings below and octets for the scan,
     // and the two are not the same string. `boundary` is the as-written reading —
@@ -307,7 +306,7 @@ fn check_body_delimiters(
         };
         return Some(Violation {
             rule: MultipartContentTypeAndBodyConsistent.id().into(),
-            severity: config.severity,
+            severity,
             message: format!("Invalid multipart Content-Type in {}: {}", which, detail),
         });
     }
@@ -320,7 +319,7 @@ fn check_body_delimiters(
     if !scan.opens_a_part {
         return Some(Violation {
             rule: MultipartContentTypeAndBodyConsistent.id().into(),
-            severity: config.severity,
+            severity,
             message: format!(
                 "Invalid multipart Content-Type in {}: the only boundary delimiter line is the terminating '--{}--', so the body encapsulates no part",
                 which, shown
@@ -334,7 +333,7 @@ fn check_body_delimiters(
     if !scan.closes {
         return Some(Violation {
             rule: MultipartContentTypeAndBodyConsistent.id().into(),
-            severity: config.severity,
+            severity,
             message: format!(
                 "Invalid multipart Content-Type in {}: body missing terminating boundary '--{}--'",
                 which, boundary

--- a/lint-http-rules/src/rules/must_revalidate_enforced.rs
+++ b/lint-http-rules/src/rules/must_revalidate_enforced.rs
@@ -47,9 +47,8 @@ impl Rule for MustRevalidateEnforced {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // find the most recent past response that contained must-revalidate
         let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
         for past in history.iter() {
@@ -114,7 +113,7 @@ impl Rule for MustRevalidateEnforced {
             if has_validator {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Cached response with 'must-revalidate' directive is stale (age {} >= freshness {}) and was reused without conditional request",
                         current_age, freshness_lifetime

--- a/lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
+++ b/lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
@@ -35,9 +35,8 @@ impl Rule for NoBodyFor1xx204304 {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
         let status = resp.status;
 
@@ -92,7 +91,7 @@ impl Rule for NoBodyFor1xx204304 {
         if let Some(n) = resp.body_length {
             if n > 0 {
                 return Some(self.report(
-                    config.severity,
+                    ctx.severity,
                     status,
                     &format!(
                         "is terminated by the end of its header section and cannot contain \
@@ -117,7 +116,7 @@ impl Rule for NoBodyFor1xx204304 {
         // answer -- that `#[test]` is the reason the empty case is pinned here.
         if resp.trailers.is_some() {
             return Some(self.report(
-                config.severity,
+                ctx.severity,
                 status,
                 "is terminated by the end of its header section and cannot contain trailers, \
                  but a trailer section was received",
@@ -156,7 +155,7 @@ impl Rule for NoBodyFor1xx204304 {
                 // finding, and nothing here is measuring a length.
                 let shown = crate::helpers::headers::field_line_as_written(value);
                 return Some(self.report(
-                    config.severity,
+                    ctx.severity,
                     status,
                     &format!(
                         "must not carry a Content-Length header field at any value, \
@@ -195,7 +194,7 @@ impl Rule for NoBodyFor1xx204304 {
             && resp.headers.contains_key("transfer-encoding")
         {
             return Some(self.report(
-                config.severity,
+                ctx.severity,
                 status,
                 "must not carry a Transfer-Encoding header field",
             ));

--- a/lint-http-rules/src/rules/no_cache_revalidation.rs
+++ b/lint-http-rules/src/rules/no_cache_revalidation.rs
@@ -50,9 +50,8 @@ impl Rule for NoCacheRevalidation {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent past response with a no-cache directive.
         let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
         for past in history.iter() {
@@ -86,7 +85,7 @@ impl Rule for NoCacheRevalidation {
         if !has_conditional {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Possible reuse of response marked 'no-cache' without conditional revalidation: subsequent request lacked If-None-Match/If-Modified-Since despite earlier no-cache response with a validator".into(),
             });
         }

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -139,7 +139,7 @@ impl NoConnectionSpecificFields {
         governing: ConnectionlessVersion,
         direction: Direction,
         headers: &hyper::HeaderMap,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         // Presence is the whole defect, so the value is never read: what both
         // documents forbid is generating a message that *contains* the field.
@@ -153,7 +153,7 @@ impl NoConnectionSpecificFields {
         for &name in CONNECTION_SPECIFIC_FIELDS {
             if headers.contains_key(name) {
                 return Some(self.violation(
-                    config.severity,
+                    severity,
                     format!(
                         "{} {} carries the connection-specific header field '{}'; \
                          {} makes such a message malformed",
@@ -166,7 +166,7 @@ impl NoConnectionSpecificFields {
             }
         }
 
-        self.check_te(governing, direction, headers, config)
+        self.check_te(governing, direction, headers, severity)
     }
 
     /// The one field both documents take back out of the set, and only for one
@@ -179,7 +179,7 @@ impl NoConnectionSpecificFields {
         governing: ConnectionlessVersion,
         direction: Direction,
         headers: &hyper::HeaderMap,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         // A response is not the request the exception is written for, so the
         // field is connection-specific there like the five above it and the
@@ -192,7 +192,7 @@ impl NoConnectionSpecificFields {
         if direction == Direction::Response {
             if headers.contains_key("te") {
                 return Some(self.violation(
-                    config.severity,
+                    severity,
                     format!(
                         "{} response carries a TE header field; the exception {} makes is \
                          for a request, so in a response TE is a connection-specific field \
@@ -245,7 +245,7 @@ impl NoConnectionSpecificFields {
             .find(|member| !member.eq_ignore_ascii_case("trailers"))?;
 
         Some(self.violation(
-            config.severity,
+            severity,
             format!(
                 "{} request's TE header field holds '{}'; the only value {} permits it \
                  to contain is 'trailers'",
@@ -274,7 +274,7 @@ impl Rule for NoConnectionSpecificFields {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Each section's own version, decided before anything else is read.
         let request = ConnectionlessVersion::of(&tx.request.version);
@@ -282,29 +282,30 @@ impl Rule for NoConnectionSpecificFields {
             ConnectionlessVersion::of(&resp.version).map(|governing| (governing, resp))
         });
 
-        // Read after the gates and not before them: a transaction neither half
-        // of which was carried by one of these versions ends here, and
-        // `parse_rule_config` looks the rule id up twice.
+        // A transaction neither half of which was carried by one of these
+        // versions ends here.
         if request.is_none() && response.is_none() {
             return None;
         }
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         if let Some(governing) = request {
             if let Some(violation) = self.check_field_section(
                 governing,
                 Direction::Request,
                 &tx.request.headers,
-                &config,
+                ctx.severity,
             ) {
                 return Some(violation);
             }
         }
 
         if let Some((governing, resp)) = response {
-            if let Some(violation) =
-                self.check_field_section(governing, Direction::Response, &resp.headers, &config)
-            {
+            if let Some(violation) = self.check_field_section(
+                governing,
+                Direction::Response,
+                &resp.headers,
+                ctx.severity,
+            ) {
                 return Some(violation);
             }
         }

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -45,9 +45,8 @@ impl Rule for NoStoreEnforced {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Build maps of validators to a boolean indicating whether the most
         // recent occurrence of that validator came from a no-store response.
         //
@@ -150,7 +149,7 @@ impl Rule for NoStoreEnforced {
                     if no_store_etags.contains(&normalized) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Conditional request uses ETag '{}' from a no-store response",
                                 member
@@ -181,7 +180,7 @@ impl Rule for NoStoreEnforced {
                 {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Conditional request uses Last-Modified '{}' from a no-store response",
                             candidate

--- a/lint-http-rules/src/rules/oauth2_code_flow.rs
+++ b/lint-http-rules/src/rules/oauth2_code_flow.rs
@@ -41,9 +41,8 @@ impl Rule for Oauth2CodeFlow {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req_uri = &tx.request.uri;
         // simple query extraction: portion after '?' if present, ignoring any
         // URI fragment (`#...`) which is not part of the query string.
@@ -81,7 +80,7 @@ impl Rule for Oauth2CodeFlow {
                     _ => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "OAuth2 authorization request with response_type=code missing or empty state parameter".into(),
                         });
                     }
@@ -119,7 +118,7 @@ impl Rule for Oauth2CodeFlow {
                     if !seen {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "OAuth2 authorization callback used a state value that was not seen in a prior request".into(),
                         });
                     }
@@ -127,7 +126,7 @@ impl Rule for Oauth2CodeFlow {
                 _ => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "OAuth2 authorization callback missing or empty state parameter"
                             .into(),
                     });

--- a/lint-http-rules/src/rules/options_method_capabilities.rs
+++ b/lint-http-rules/src/rules/options_method_capabilities.rs
@@ -71,10 +71,8 @@ impl Rule for OptionsMethodCapabilities {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Two sentences meet at this gate and both are load-bearing: the first
         // is why the rule looks at OPTIONS at all, the second is why the
         // comparison is exact. `options` is not the OPTIONS method, and a method
@@ -102,7 +100,7 @@ impl Rule for OptionsMethodCapabilities {
             if !tx.request.headers.contains_key("content-type") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "OPTIONS request carries content ({evidence}) with no Content-Type header field; RFC 9110 § 9.3.7 says a client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type"
                     ),
@@ -158,7 +156,7 @@ impl Rule for OptionsMethodCapabilities {
             let named: Vec<&str> = ADVERTISED_CAPABILITIES.iter().map(|(_, n, _)| *n).collect();
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Successful OPTIONS response ({}) carries none of {}; RFC 9110 § 9.3.7 says a server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource",
                     resp.status,

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -20,9 +20,8 @@ impl Rule for OriginIsolatedHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = if let Some(r) = &tx.response {
             r
         } else {
@@ -37,7 +36,7 @@ impl Rule for OriginIsolatedHeaderValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Origin-Agent-Cluster header fields present".into(),
             });
         }
@@ -48,7 +47,7 @@ impl Rule for OriginIsolatedHeaderValid {
                 None => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message:
                             "Origin-Agent-Cluster header contains non-ASCII or control characters"
                                 .into(),
@@ -61,7 +60,7 @@ impl Rule for OriginIsolatedHeaderValid {
         if crate::helpers::headers::list_members(val).count() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Origin-Agent-Cluster must be a single value".into(),
             });
         }
@@ -77,7 +76,7 @@ impl Rule for OriginIsolatedHeaderValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", val),
         })
     }
@@ -333,7 +332,7 @@ mod tests {
         let rule = OriginIsolatedHeaderValid;
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "origin_isolated_header_valid");
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -20,9 +20,8 @@ impl Rule for OriginMatchingForCors {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let headers = &req.headers;
 
@@ -33,7 +32,7 @@ impl Rule for OriginMatchingForCors {
         if let Some(reason) = crate::helpers::uri::validate_origin_value(origin) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!("Invalid Origin header value '{}': {}", origin, reason),
             });
         }
@@ -48,7 +47,7 @@ impl Rule for OriginMatchingForCors {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Access-Control-Allow-Origin header contains non-ASCII or control characters".into(),
                     });
                 }
@@ -63,7 +62,7 @@ impl Rule for OriginMatchingForCors {
         if acao_values.len() > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Access-Control-Allow-Origin header fields present; only a single value is allowed".into(),
             });
         }
@@ -77,7 +76,7 @@ impl Rule for OriginMatchingForCors {
         if members.len() != 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Access-Control-Allow-Origin must be a single value".into(),
             });
         }
@@ -97,7 +96,7 @@ impl Rule for OriginMatchingForCors {
                 if cred.trim().eq_ignore_ascii_case("true") {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Access-Control-Allow-Origin '*' is not allowed when Access-Control-Allow-Credentials is true".into(),
                     });
                 }
@@ -112,7 +111,7 @@ impl Rule for OriginMatchingForCors {
         if acao_val != origin {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Access-Control-Allow-Origin '{}' does not match request Origin '{}'",
                     acao_val, origin
@@ -460,7 +459,7 @@ mod tests {
         table.insert("severity".to_string(), toml::Value::String("warn".into()));
         cfg.rules
             .insert("origin_matching_for_cors".into(), toml::Value::Table(table));
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/patch_method_content_type_match.rs
+++ b/lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -114,10 +114,8 @@ impl Rule for PatchMethodContentTypeMatch {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Compared exactly: a request whose method is `patch` is a request with
         // some other method, and its content has whatever semantics that method
         // gives it. `request_method_token_valid` reports the spelling.
@@ -210,7 +208,7 @@ impl Rule for PatchMethodContentTypeMatch {
         // cite(RFC 5789 § 2.2): "Can be specified using a 415 (Unsupported Media Type) response when the client sends a patch document format that the server does not support for the resource identified by the Request-URI."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "PATCH request sends Content-Type '{}', which no Accept-Patch for this resource has mentioned; the most recent advertisement listed {}. A format the advertisement does not mention is one the server has said it does not accept, and 415 (Unsupported Media Type) is the answer RFC 5789 offers for it{}",
                 sent,

--- a/lint-http-rules/src/rules/patch_partial_update.rs
+++ b/lint-http-rules/src/rules/patch_partial_update.rs
@@ -38,10 +38,8 @@ impl Rule for PatchPartialUpdate {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The method token is case-sensitive, so the comparison is exact: a
         // request whose method is `patch` did not use PATCH, it used a method
         // with no defined semantics, and RFC 5789 § 2 is not a sentence about
@@ -99,7 +97,7 @@ impl Rule for PatchPartialUpdate {
         // cite(RFC 9110 § 8.3): "If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([RFC2046], Section 4.5.1) or examine the data to determine its type."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "PATCH request carries content ({evidence}) with no Content-Type naming the patch document format"
             ),

--- a/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
@@ -21,9 +21,8 @@ impl Rule for PermissionsPolicyDirectivesValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only inspect responses (server header)
         let resp = tx.response.as_ref()?;
 
@@ -44,7 +43,7 @@ impl Rule for PermissionsPolicyDirectivesValid {
             let Ok(v) = hv.to_str() else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Permissions-Policy contains a byte outside ASCII, so the field \
                               fails Structured Fields parsing and every directive in it is \
                               discarded"
@@ -71,7 +70,7 @@ impl Rule for PermissionsPolicyDirectivesValid {
             if s.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Permissions-Policy is empty, which grants and denies nothing; an \
                               empty policy is written by omitting the field"
                         .into(),
@@ -100,7 +99,7 @@ impl Rule for PermissionsPolicyDirectivesValid {
             if let Some(msg) = validate_permissions_policy(s) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Permissions-Policy will not be enforced as written: {}",
                         msg

--- a/lint-http-rules/src/rules/post_creates_resource.rs
+++ b/lint-http-rules/src/rules/post_creates_resource.rs
@@ -20,10 +20,8 @@ impl Rule for PostCreatesResource {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // The sentence this rule enforces is in the POST method's own section, so the
         // method is the first gate. It is compared exactly: a request whose method is
         // `post` is a request with an unrecognized method, and §9.3.3 says nothing
@@ -87,7 +85,7 @@ impl Rule for PostCreatesResource {
         // cite(RFC 9112 § 3.3): "Otherwise, the target URI's combined path and query component is the request-target."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "201 Created response to a POST request carries no Location header field. \
                  RFC 9110 §9.3.3 asks an origin server that has created one or more resources \

--- a/lint-http-rules/src/rules/pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/pragma_token_valid.rs
@@ -29,9 +29,8 @@ impl Rule for PragmaTokenValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Validate request headers
         // cite(RFC 9111 § 5.4): "The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request"
         for header_val in tx.request.headers.get_all("pragma").iter() {
@@ -44,14 +43,14 @@ impl Rule for PragmaTokenValid {
                 if let Some(msg) = check_pragma_value(v) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid Pragma header in request: {}", msg),
                     });
                 }
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Pragma header contains non-UTF8 value".into(),
                 });
             }
@@ -72,14 +71,14 @@ impl Rule for PragmaTokenValid {
                     if let Some(msg) = check_pragma_value(v) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid Pragma header in response: {}", msg),
                         });
                     }
                 } else {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Pragma header contains non-UTF8 value".into(),
                     });
                 }
@@ -452,7 +451,7 @@ mod tests {
         table.insert("severity".to_string(), toml::Value::String("warn".into()));
         cfg.rules
             .insert("pragma_token_valid".into(), toml::Value::Table(table));
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
+++ b/lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
@@ -108,7 +108,7 @@ impl Rule for PreferHeaderAndPreferenceApplied {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
@@ -175,7 +175,6 @@ impl Rule for PreferHeaderAndPreferenceApplied {
         // above ends the rule, and each of them is a map lookup or a comparison
         // where the config read is several. Only a response that is about to be
         // reported pays for it.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // The name reached here through `parse_token_bws_word`, which admits only
         // `tchar`, so it is safe in a message as written; the `Vary` value is
@@ -190,7 +189,7 @@ impl Rule for PreferHeaderAndPreferenceApplied {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Response states the '{}' preference was applied — {} — but {}, so a cache holding this response under the target URI alone can serve it to a request that preferred otherwise",
                 name, why, vary_state

--- a/lint-http-rules/src/rules/prefer_header_valid.rs
+++ b/lint-http-rules/src/rules/prefer_header_valid.rs
@@ -104,14 +104,12 @@ impl Rule for PreferHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };
@@ -650,7 +648,7 @@ mod tests {
         cfg.rules
             .insert("prefer_header_valid".into(), toml::Value::Table(table));
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/preference_applied_header_valid.rs
+++ b/lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -118,15 +118,14 @@ impl Rule for PreferenceAppliedHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
+++ b/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
@@ -24,9 +24,8 @@ impl Rule for PriorityAndCacheabilityConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // Only consider responses that include a Priority header field (§5: the
@@ -71,7 +70,7 @@ impl Rule for PriorityAndCacheabilityConsistent {
         if !has_cache_control && !has_vary {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Response includes Priority header ('{}') but lacks Cache-Control or Vary to control cacheability; origin servers emitting Priority should control cacheability per RFC 9218 §5",
                     priority

--- a/lint-http-rules/src/rules/priority_header_syntax.rs
+++ b/lint-http-rules/src/rules/priority_header_syntax.rs
@@ -102,19 +102,17 @@ impl Rule for PriorityHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The two sections are judged separately and never joined across the
         // pair: the sentence on `check_section` gathers the lines "in the same
         // section", and § 8 has an intermediary combine the two afterwards as
         // two signals rather than reading them as one field.
-        if let Some(v) = self.check_section(&tx.request.headers, Section::Request, config.severity)
-        {
+        if let Some(v) = self.check_section(&tx.request.headers, Section::Request, ctx.severity) {
             return Some(v);
         }
         if let Some(resp) = &tx.response {
-            if let Some(v) = self.check_section(&resp.headers, Section::Response, config.severity) {
+            if let Some(v) = self.check_section(&resp.headers, Section::Response, ctx.severity) {
                 return Some(v);
             }
         }
@@ -604,7 +602,7 @@ mod tests {
         table.insert("severity".to_string(), toml::Value::String("warn".into()));
         cfg.rules
             .insert("priority_header_syntax".into(), toml::Value::Table(table));
-        PriorityHeaderSyntax.validate(&cfg)?;
+        PriorityHeaderSyntax.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -31,9 +31,8 @@ impl Rule for PrivateCacheVisibility {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only conditional requests are evidence: a precondition header carries a validator a
         // client could only have from a prior response.
         // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields."
@@ -87,7 +86,7 @@ impl Rule for PrivateCacheVisibility {
                                         if val_norm == normalized {
                                             return Some(Violation {
                                                 rule: self.id().into(),
-                                                severity: config.severity,
+                                                severity: ctx.severity,
                                                 message: format!(
                                                     "Validator '{}' from a private response seen by a different client",
                                                     member
@@ -124,7 +123,7 @@ impl Rule for PrivateCacheVisibility {
                                             if val_dt == candidate_dt {
                                                 return Some(Violation {
                                                     rule: self.id().into(),
-                                                    severity: config.severity,
+                                                    severity: ctx.severity,
                                                     message: format!(
                                                         "Validator '{}' from a private response seen by a different client",
                                                         candidate

--- a/lint-http-rules/src/rules/problem_details_content_type.rs
+++ b/lint-http-rules/src/rules/problem_details_content_type.rs
@@ -24,9 +24,8 @@ impl Rule for ProblemDetailsContentType {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // The permission is unconditional and the fit is not, so the gate is the
@@ -98,7 +97,7 @@ impl Rule for ProblemDetailsContentType {
         // cite(RFC 9457 § 1): "This specification's aim is to define common error formats for applications that need one so that they aren't required to define their own or, worse, tempted to redefine the semantics of existing HTTP status codes."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Error response carries the generic media type '{}'; problem details (RFC 9457) would describe the error in a machine-readable form, as 'application/problem+json' or 'application/problem+xml'. Advisory: no RFC requires them, and an application that already has an error format of its own should keep using it",
                 ct_str

--- a/lint-http-rules/src/rules/problem_details_structure_valid.rs
+++ b/lint-http-rules/src/rules/problem_details_structure_valid.rs
@@ -67,9 +67,8 @@ impl Rule for ProblemDetailsStructureValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // Two field lines: `get` below reads the first while the recipient is
@@ -131,7 +130,7 @@ impl Rule for ProblemDetailsStructureValid {
             // JSON text is, and an empty octet sequence serializes no value.
             // cite(RFC 8259 § 2): "A JSON text is a serialized value."
             if b.is_empty() {
-                return Some(self.report(config.severity, "its content is empty"));
+                return Some(self.report(ctx.severity, "its content is empty"));
             }
             if coded {
                 return None;
@@ -149,7 +148,7 @@ impl Rule for ProblemDetailsStructureValid {
                 // Well-formed JSON, but not the structure the media type names.
                 // cite(RFC 9457 § 3): "The canonical model for problem details is a JSON [JSON] object."
                 Ok(other) => Some(self.report(
-                    config.severity,
+                    ctx.severity,
                     &format!(
                         "its content is a JSON {}, not a JSON object",
                         json_kind(&other)
@@ -160,7 +159,7 @@ impl Rule for ProblemDetailsStructureValid {
                 // recipient cannot decode, let alone parse.
                 // cite(RFC 8259 § 2): "A JSON text is a serialized value."
                 // cite(RFC 8259 § 8.1): "JSON text exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8"
-                Err(_) => Some(self.report(config.severity, "its content is not a JSON document")),
+                Err(_) => Some(self.report(ctx.severity, "its content is not a JSON document")),
             };
         }
 
@@ -171,7 +170,7 @@ impl Rule for ProblemDetailsStructureValid {
         // cite(RFC 9110 § 6.4): "This abstract definition of content reflects the data after it has been extracted from the message framing."
         if let Some(len) = resp.body_length {
             return (len == 0)
-                .then(|| self.report(config.severity, "the capture counted zero content octets"));
+                .then(|| self.report(ctx.severity, "the capture counted zero content octets"));
         }
 
         // Nothing counted either -- a transaction deserialized from a capture
@@ -189,7 +188,7 @@ impl Rule for ProblemDetailsStructureValid {
                 Ok(Some(0))
             )
         {
-            return Some(self.report(config.severity, "it declares a Content-Length of zero"));
+            return Some(self.report(ctx.severity, "it declares a Content-Length of zero"));
         }
 
         // A declared length above zero, an unreadable one, or none at all: the

--- a/lint-http-rules/src/rules/proxy_connection_discouraged.rs
+++ b/lint-http-rules/src/rules/proxy_connection_discouraged.rs
@@ -34,7 +34,7 @@ impl Rule for ProxyConnectionDiscouraged {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The versions that have a `Connection` field are the versions this
         // advice is about: `Proxy-Connection` was invented for HTTP/1.0 proxies
@@ -55,11 +55,6 @@ impl Rule for ProxyConnectionDiscouraged {
         if matches!(crate::http_version::major(&tx.request.version), Some(2 | 3)) {
             return None;
         }
-
-        // Read after the gate: one digit comparison ends the rule for the two
-        // versions that have their own rule, and `parse_rule_config` looks the
-        // rule id up twice.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // Presence is what the sentence is about — *"not to send the
         // Proxy-Connection header field in any requests"* names the field and
@@ -83,7 +78,7 @@ impl Rule for ProxyConnectionDiscouraged {
         //
         // cite(RFC 9112 § C.2.2): "One attempted solution was the introduction of a Proxy-Connection header field, targeted specifically at proxies.  In practice, this was also unworkable, because proxies are often deployed in multiple layers, bringing about the same problem discussed above."
         Some(self.violation(
-            config.severity,
+            ctx.severity,
             format!(
                 "Request carries a Proxy-Connection header field: '{}'. RFC 9112 Appendix C.2.2 \
                  encourages clients not to send it in any request — it was an attempted fix for \

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -101,24 +101,24 @@ impl Rule for RangeAndContentRangeConsistent {
         crate::rules::RuleScope::Server
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_units_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_units_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_units_config(cfg, self.id()).ok()?;
+        let config: &RangeConsistencyConfig = ctx.state();
         let resp = tx.response.as_ref()?;
 
         let status = resp.status;

--- a/lint-http-rules/src/rules/range_header_syntax.rs
+++ b/lint-http-rules/src/rules/range_header_syntax.rs
@@ -26,9 +26,8 @@ impl Rule for RangeHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         use hyper::header::RANGE;
 
         // A request that names no range is every other request. The absence is
@@ -57,7 +56,7 @@ impl Rule for RangeHeaderSyntax {
             if hv.to_str().is_err() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Range header holds an octet no part of a ranges-specifier admits"
                         .into(),
                 });
@@ -92,7 +91,7 @@ impl Rule for RangeHeaderSyntax {
         else {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Invalid Range header '{}': not a ranges-specifier (a range-unit token, '=', then a range-set)",
                     value
@@ -108,7 +107,7 @@ impl Rule for RangeHeaderSyntax {
         if let Err(e) = validate_range_set(&unit, range_set) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!("Invalid Range header '{}': {}", value, e),
             });
         }

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -63,9 +63,8 @@ impl Rule for RangeRequestAndCaching {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
 
         // `Range` asks something of a GET and of nothing else. On any other
@@ -160,7 +159,7 @@ impl Rule for RangeRequestAndCaching {
         let Some(raw_if_range) = req.headers.get("if-range") else {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Range request for a resource this client holds a 206 of, whose stored entity tag is {stored_etag}, carries none of If-Range, If-Match or If-None-Match; the entity tags of the stored response being validated have to be sent in one of those three"
                 ),
@@ -197,7 +196,7 @@ impl Rule for RangeRequestAndCaching {
             // cite(RFC 9110 § 13.1.5): "Range header field containing an HTTP-date unless the client has no entity tag for the corresponding representation and the date is a strong validator in the sense defined by Section 8.8.2.2."
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "If-Range carries the date '{if_range}' although entity tag {stored_etag} was provided for this representation; a date is only permitted there when the client has no entity tag"
                 ),
@@ -208,7 +207,7 @@ impl Rule for RangeRequestAndCaching {
         if if_range != stored_etag {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "If-Range entity tag {if_range} is not {stored_etag}, the tag most recently provided for this representation; a server still holding that tag will ignore Range and send the whole representation"
                 ),

--- a/lint-http-rules/src/rules/redirect_chain_valid.rs
+++ b/lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -109,9 +109,8 @@ impl Rule for RedirectChainValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let referent = location_names_another_resource(resp.status)?;
@@ -235,7 +234,7 @@ impl Rule for RedirectChainValid {
         // cite(RFC 9110 § 15.4): "A client SHOULD detect and intervene in cyclical redirections (i.e., "infinite" redirection loops)."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Location '{}' resolves to '{}', the target URI of the request it answers, so the response redirects the client to where it already was: {}. A client that follows it issues the same request again — RFC 9110 §15.4 asks one to detect and intervene in cyclical redirections, and this is the shortest one there is",
                 value.escape_debug(),

--- a/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
+++ b/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -67,10 +67,8 @@ impl Rule for RedirectStatusAndLocationValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // `Location` is a response context field, so the response is the message this
         // rule measures and a request-only transaction is out of its subject entirely.
         // cite(RFC 9110 § 10.2): "The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources."
@@ -101,7 +99,7 @@ impl Rule for RedirectStatusAndLocationValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Response with status {status} carries a Location header field. RFC 9110 §10.2.2 \
                  defines what the value refers to on a 201 (Created) response and on a 3xx \

--- a/lint-http-rules/src/rules/referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/referer_uri_valid.rs
@@ -61,7 +61,7 @@ impl Rule for RefererUriValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let req = &tx.request;
 
@@ -83,11 +83,10 @@ impl Rule for RefererUriValid {
         // cite(RFC 9110 § 10.1.3): "The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled)."
         // cite(RFC 9110 § 10.1.3, label: Referer grammar): "Referer = absolute-URI / partial-URI"
         let value = combined_field_value_as_written(&req.headers, "referer")?;
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/refresh_header_syntax.rs
+++ b/lint-http-rules/src/rules/refresh_header_syntax.rs
@@ -205,9 +205,8 @@ impl Rule for RefreshHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let lines = resp.headers.get_all("refresh");
@@ -226,7 +225,7 @@ impl Rule for RefreshHeaderSyntax {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Response carries {count} Refresh header field lines; HTML specifies no \
                      handling for more than one, so what a recipient does with them is not \
@@ -256,7 +255,7 @@ impl Rule for RefreshHeaderSyntax {
         // makes it this field's requirement too.
         refresh_value_error(value).map(|why| Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("Refresh header value '{value}': {why}"),
         })
     }
@@ -506,7 +505,7 @@ mod tests {
         cfg.rules
             .insert("refresh_header_syntax".into(), toml::Value::Table(table));
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/request_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/request_body_length_accuracy.rs
@@ -20,9 +20,8 @@ impl Rule for RequestBodyLengthAccuracy {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
 
         // This rule used to transcribe the whole `Content-Length` grammar
@@ -105,7 +104,7 @@ impl Rule for RequestBodyLengthAccuracy {
             if declared != body_len as u128 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Content-Length ({}) does not match captured body bytes ({})",
                         declared, body_len

--- a/lint-http-rules/src/rules/request_method_token_valid.rs
+++ b/lint-http-rules/src/rules/request_method_token_valid.rs
@@ -108,19 +108,22 @@ impl Rule for RequestMethodTokenValid {
     /// and `registered_methods` was read for the first time **at lint time** —
     /// where the `.ok()?` below turns a missing or malformed array into silence
     /// rather than into the startup error every sibling gives.
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_method_token_config(config, self.id())?;
-        // Its fifteen siblings check the two standard keys here, after their own
-        // options, so a config naming a bad option still fails on that option.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_method_token_config(cfg, self.id())?;
+        // The two standard keys, **after** this rule's own options, so a config
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let m = tx.request.method.as_str();
 
@@ -136,10 +139,8 @@ impl Rule for RequestMethodTokenValid {
         // cite(RFC 9113 § 8.3.1): "The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP])."
         // cite(RFC 9114 § 4.3.1): "":method":  Contains the HTTP method (Section 9 of [HTTP])"
         //
-        // Nothing above the configuration read costs more than two scans of a token a
-        // handful of octets long, and each of the three questions ends the rule on its
-        // own. `parse_rule_config` is several map probes plus a hash over the rule id,
-        // so only a request about to be reported pays it.
+        // Each of the three questions below ends the rule on its own, at a scan or
+        // two of a token a handful of octets long.
         let invalid_char = crate::helpers::token::find_invalid_token_char(m);
         // A string that is not a token has no case to be in yet: the character scan is
         // what decides whether this is a `method` at all, and the convention below is
@@ -151,7 +152,7 @@ impl Rule for RequestMethodTokenValid {
             return None;
         }
 
-        let config = parse_method_token_config(cfg, self.id()).ok()?;
+        let config: &MethodTokenConfig = ctx.state();
 
         // `token` is `1*tchar` -- one character at minimum, transcribed in full at
         // `helpers::token::is_tchar`. A character scan answers `None` for the empty

--- a/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
@@ -20,9 +20,8 @@ impl Rule for RequestOriginHeaderPresentForCors {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         let headers = &req.headers;
 
@@ -40,7 +39,7 @@ impl Rule for RequestOriginHeaderPresentForCors {
                     if let Some(err) = crate::helpers::uri::validate_origin_value(origin_val) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Origin header invalid: {}", err),
                         });
                     }
@@ -48,7 +47,7 @@ impl Rule for RequestOriginHeaderPresentForCors {
                 None => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "CORS preflight request missing Origin header".into(),
                     })
                 }
@@ -70,7 +69,7 @@ impl Rule for RequestOriginHeaderPresentForCors {
                         if crate::helpers::headers::get_header_str(headers, "origin").is_none() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Cross-origin absolute-form request missing Origin header"
                                     .into(),
                             });
@@ -300,7 +299,7 @@ mod tests {
             toml::Value::Table(table),
         );
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -131,7 +131,7 @@ impl Rule for RequestTargetFormValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // The four forms are a request-line's, and a request-line is what a
         // major version 1 message has. HTTP/2 and HTTP/3 send the same target
@@ -194,9 +194,7 @@ impl Rule for RequestTargetFormValid {
         // cite(RFC 9112 § 3.2): "A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain."
         // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
         if let Some(ws) = target.chars().find(|c| c.is_ascii_whitespace()) {
-            let severity = crate::rules::parse_rule_config(cfg, self.id())
-                .ok()?
-                .severity;
+            let severity = ctx.severity;
             return Some(self.violation(
                 severity,
                 format!(
@@ -212,9 +210,7 @@ impl Rule for RequestTargetFormValid {
         // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
         // cite(RFC 9112 § 3.2): "Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded."
         if target.is_empty() {
-            let severity = crate::rules::parse_rule_config(cfg, self.id())
-                .ok()?
-                .severity;
+            let severity = ctx.severity;
             return Some(self.violation(
                 severity,
                 "Request carries an empty request-target. Every one of the four forms derives at least one character -- an absolute path opens with '/', an absolute-URI has a scheme and its colon, a host and port has the colon between them, and the asterisk is itself -- so the empty string is none of them and the request-line naming it is invalid".into(),
@@ -309,12 +305,7 @@ impl Rule for RequestTargetFormValid {
             ),
         };
 
-        // Read last: every gate above ends the rule on its own and each costs a
-        // scan or two of a short string, where `parse_rule_config` is several map
-        // probes plus a hash over the rule id.
-        let severity = crate::rules::parse_rule_config(cfg, self.id())
-            .ok()?
-            .severity;
+        let severity = ctx.severity;
         Some(self.violation(severity, message))
     }
 

--- a/lint-http-rules/src/rules/request_target_no_fragment.rs
+++ b/lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -27,7 +27,7 @@ impl Rule for RequestTargetNoFragment {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // What this field holds is version-specific -- an HTTP/1.x
         // request-target, or the target URI the transport reassembled from
@@ -51,9 +51,7 @@ impl Rule for RequestTargetNoFragment {
         // probes and a hash of the rule id, where the test above is one scan of
         // a string the transaction already holds, and every return above this
         // one ends the rule.
-        let severity = crate::rules::parse_rule_config(cfg, self.id())
-            .ok()?
-            .severity;
+        let severity = ctx.severity;
 
         // A target read back from a capture can hold characters that print as
         // nothing or, worse, print as something else: an escape sequence in a

--- a/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
+++ b/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -27,7 +27,7 @@ impl Rule for RequestUriPercentEncodingValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // What this field holds is version-specific -- an HTTP/1.x
         // request-target, or the target URI the transport reassembled from
@@ -62,9 +62,7 @@ impl Rule for RequestUriPercentEncodingValid {
             // Read after the finding is certain: parsing the config is several
             // map probes and a hash of the rule id, where the scan above walks a
             // string the transaction already holds.
-            let severity = crate::rules::parse_rule_config(cfg, self.id())
-                .ok()?
-                .severity;
+            let severity = ctx.severity;
 
             // A target read back from a capture can hold characters that print
             // as nothing or, worse, print as something else: an escape sequence
@@ -110,9 +108,7 @@ impl Rule for RequestUriPercentEncodingValid {
         // cite(RFC 3986 § 2): "The ABNF notation defines its terminal values to be non-negative integers (codepoints) based on the US-ASCII coded character set [ASCII]."
         // cite(RFC 3986 § 2): "the integer values used by the ABNF must be mapped back to their corresponding characters via US-ASCII in order to complete the syntax rules."
         if let Some(ch) = crate::helpers::uri::find_non_uri_char(target) {
-            let severity = crate::rules::parse_rule_config(cfg, self.id())
-                .ok()?
-                .severity;
+            let severity = ctx.severity;
 
             let shown = crate::helpers::headers::shown_in_finding(target);
             let shown_char = crate::helpers::headers::shown_in_finding(&ch.to_string());

--- a/lint-http-rules/src/rules/request_version_method_valid.rs
+++ b/lint-http-rules/src/rules/request_version_method_valid.rs
@@ -64,10 +64,8 @@ impl Rule for RequestVersionMethodValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Matched exactly, never case-folded. `get` is not the GET method, and
         // none of the sentences below say anything about it: an unrecognized
         // method has no defined content semantics, so there is nothing to
@@ -94,7 +92,7 @@ impl Rule for RequestVersionMethodValid {
             "CONNECT" => {
                 return request_declares_content(&tx.request).then(|| Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "CONNECT request declares content in its header section; RFC 9110 § 9.3.6 defines a CONNECT request message as having none".into(),
                 });
             }
@@ -114,7 +112,7 @@ impl Rule for RequestVersionMethodValid {
         // cite(RFC 9110 § 9.3.1): "An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "{} request carries content; RFC 9110 {}, and content received in one has no generally defined semantics",
                 method, sentence

--- a/lint-http-rules/src/rules/response_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/response_body_length_accuracy.rs
@@ -20,9 +20,8 @@ impl Rule for ResponseBodyLengthAccuracy {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // The whole `Content-Length` grammar used to be transcribed here --
@@ -90,7 +89,7 @@ impl Rule for ResponseBodyLengthAccuracy {
             if !bodiless_status && resp.body_length.is_some_and(|n| n > 0) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "A {} response to {} cannot contain a message body, but {} body \
                          octets were received",
@@ -147,7 +146,7 @@ impl Rule for ResponseBodyLengthAccuracy {
             if declared != body_len as u128 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Content-Length ({}) does not match captured body bytes ({})",
                         declared, body_len

--- a/lint-http-rules/src/rules/retry_after_date_or_delay.rs
+++ b/lint-http-rules/src/rules/retry_after_date_or_delay.rs
@@ -20,9 +20,8 @@ impl Rule for RetryAfterDateOrDelay {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Retry-After is a server-sent response field, which is why this rule is Server-scoped.
         // cite(RFC 9110 § 10.2.3): "Servers send the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request."
         let resp = tx.response.as_ref()?;
@@ -35,7 +34,7 @@ impl Rule for RetryAfterDateOrDelay {
         if resp.headers.get_all("retry-after").iter().count() > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Retry-After header fields present; Retry-After takes a single value and cannot be combined into a list".into(),
             });
         }
@@ -48,7 +47,7 @@ impl Rule for RetryAfterDateOrDelay {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Retry-After header contains non-UTF8 value".into(),
                     })
                 }
@@ -72,7 +71,7 @@ impl Rule for RetryAfterDateOrDelay {
 
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Retry-After value '{}' is invalid: must be a non-negative delay-seconds integer or an HTTP-date",
                     s

--- a/lint-http-rules/src/rules/retry_after_status_valid.rs
+++ b/lint-http-rules/src/rules/retry_after_status_valid.rs
@@ -54,10 +54,8 @@ impl Rule for RetryAfterStatusValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // `Retry-After` is defined among §10.2's response context fields and its
         // own sentence names the server as the sender, which is why this rule
         // reads the response and never the request. A request carrying the field
@@ -91,7 +89,7 @@ impl Rule for RetryAfterStatusValid {
         // cite(RFC 9110 § 10.2.3): "Servers send the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Retry-After arrived on status {status}, which neither RFC 9110 nor RFC 6585 pairs with \
                  this field; the two documents pair it with any 3xx redirection, 413 Content Too Large, \

--- a/lint-http-rules/src/rules/s_max_age_enforced.rs
+++ b/lint-http-rules/src/rules/s_max_age_enforced.rs
@@ -38,9 +38,8 @@ impl Rule for SMaxAgeEnforced {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // locate the most recent prior response with both s-maxage and a
         // larger max-age value.  s-maxage by itself is not actionable for this
         // check; we need a "real" private freshness lifetime to compare.
@@ -100,7 +99,7 @@ impl Rule for SMaxAgeEnforced {
         if has_conditional && current_age >= s_max_age && current_age < max_age {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Resource revalidated after s-maxage={} but before max-age={} (age {}) — private caches must ignore s-maxage and use max-age for freshness",
                     s_max_age, max_age, current_age

--- a/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
@@ -27,9 +27,8 @@ impl Rule for SecFetchDestValueValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
         // cite(Fetch Metadata § 2.1): "HTTP request header exposes a request’s destination to a server"
         let headers = &tx.request.headers;
@@ -44,7 +43,7 @@ impl Rule for SecFetchDestValueValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Sec-Fetch-Dest header fields present".into(),
             });
         }
@@ -55,7 +54,7 @@ impl Rule for SecFetchDestValueValid {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Sec-Fetch-Dest header contains non-ASCII or control characters"
                         .into(),
                 })
@@ -67,7 +66,7 @@ impl Rule for SecFetchDestValueValid {
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Sec-Fetch-Dest header is empty".into(),
             });
         }
@@ -80,7 +79,7 @@ impl Rule for SecFetchDestValueValid {
         if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Sec-Fetch-Dest header contains invalid token character: '{}'",
                     c
@@ -107,7 +106,7 @@ impl Rule for SecFetchDestValueValid {
             | "video" | "webidentity" | "worker" | "xslt" => None,
             _ => Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!("Unrecognized Sec-Fetch-Dest value: '{}'", val),
             }),
         }

--- a/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
@@ -24,9 +24,8 @@ impl Rule for SecFetchModeValueValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
         // cite(Fetch Metadata § 2.2): "HTTP request header exposes a request’s mode to a server"
         let headers = &tx.request.headers;
@@ -41,7 +40,7 @@ impl Rule for SecFetchModeValueValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Sec-Fetch-Mode header fields present".into(),
             });
         }
@@ -52,7 +51,7 @@ impl Rule for SecFetchModeValueValid {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Sec-Fetch-Mode header contains non-ASCII or control characters"
                         .into(),
                 })
@@ -64,7 +63,7 @@ impl Rule for SecFetchModeValueValid {
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Sec-Fetch-Mode header is empty".into(),
             });
         }
@@ -77,7 +76,7 @@ impl Rule for SecFetchModeValueValid {
         if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Sec-Fetch-Mode header contains invalid token character: '{}'",
                     c
@@ -94,7 +93,7 @@ impl Rule for SecFetchModeValueValid {
             "cors" | "no-cors" | "same-origin" | "navigate" | "websocket" => None,
             _ => Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!("Unrecognized Sec-Fetch-Mode value: '{}'", val),
             }),
         }

--- a/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
@@ -24,9 +24,8 @@ impl Rule for SecFetchSiteValueValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Sec-Fetch-* are request-sent headers; check only requests
         // cite(Fetch Metadata § 2.3): "HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin"
         let headers = &tx.request.headers;
@@ -41,7 +40,7 @@ impl Rule for SecFetchSiteValueValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Sec-Fetch-Site header fields present".into(),
             });
         }
@@ -52,7 +51,7 @@ impl Rule for SecFetchSiteValueValid {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Sec-Fetch-Site header contains non-ASCII or control characters"
                         .into(),
                 })
@@ -65,7 +64,7 @@ impl Rule for SecFetchSiteValueValid {
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Sec-Fetch-Site header is empty".into(),
             });
         }
@@ -78,7 +77,7 @@ impl Rule for SecFetchSiteValueValid {
         if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Sec-Fetch-Site header contains invalid token character: '{}'",
                     c
@@ -95,7 +94,7 @@ impl Rule for SecFetchSiteValueValid {
             "cross-site" | "same-origin" | "same-site" | "none" => None,
             _ => Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!("Unrecognized Sec-Fetch-Site value: '{}'", val),
             }),
         }

--- a/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
@@ -23,9 +23,8 @@ impl Rule for SecFetchUserValueValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // A request header; absence is the normal case (it rides only user-activated
         // navigations).
         // cite(Fetch Metadata § 2.4): "HTTP request header exposes whether or not a navigation request was triggered by user activation."
@@ -41,7 +40,7 @@ impl Rule for SecFetchUserValueValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple Sec-Fetch-User header fields present".into(),
             });
         }
@@ -52,7 +51,7 @@ impl Rule for SecFetchUserValueValid {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Sec-Fetch-User header contains non-ASCII or control characters"
                         .into(),
                 })
@@ -64,7 +63,7 @@ impl Rule for SecFetchUserValueValid {
         if val.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Sec-Fetch-User header is empty".into(),
             });
         }
@@ -76,7 +75,7 @@ impl Rule for SecFetchUserValueValid {
         if val != "?1" {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Unrecognized Sec-Fetch-User value: '{}'; expected '?1'",
                     val

--- a/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
+++ b/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
@@ -252,15 +252,14 @@ impl Rule for SecWebsocketExtensionsSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let message = Self::defect(&tx.request.headers, "Request").or_else(|| {
             let resp = tx.response.as_ref()?;
             Self::defect(&resp.headers, "Response")
         })?;
 
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        Some(self.violation(config.severity, message))
+        Some(self.violation(ctx.severity, message))
     }
 
     fn description(&self) -> &'static str {

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -174,7 +174,7 @@ impl Rule for SecWebsocketHeadersConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let req = &tx.request;
 
@@ -190,11 +190,10 @@ impl Rule for SecWebsocketHeadersConsistent {
         // Every gate above ends the rule, and reading the configuration is several
         // map probes and a hash of the id -- so only a request about to be measured
         // pays for it.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/sec_websocket_version_advertised.rs
+++ b/lint-http-rules/src/rules/sec_websocket_version_advertised.rs
@@ -109,7 +109,7 @@ impl Rule for SecWebsocketVersionAdvertised {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
@@ -133,9 +133,8 @@ impl Rule for SecWebsocketVersionAdvertised {
 
         let message = Self::defect(&resp.headers, requested.as_deref())?;
 
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         Some(self.violation(
-            config.severity,
+            ctx.severity,
             format!("The response to a WebSocket opening handshake {message}"),
         ))
     }

--- a/lint-http-rules/src/rules/server_header_product_valid.rs
+++ b/lint-http-rules/src/rules/server_header_product_valid.rs
@@ -24,9 +24,8 @@ impl Rule for ServerHeaderProductValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // The response trailer section is deliberately not walked. §10.2.4
@@ -51,7 +50,7 @@ impl Rule for ServerHeaderProductValid {
             if let Err(e) = crate::helpers::product::validate_product_list(hv.as_bytes()) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Invalid Server header: {}", e),
                 });
             }

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -145,10 +145,9 @@ impl Rule for ServerTimingHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // Both field sections, because the specification's own worked exchange
         // uses both: § 6 announces `Trailer: Server-Timing` and then writes
@@ -187,7 +186,7 @@ impl Rule for ServerTimingHeaderSyntax {
             // it reads as an afterthought about the first.
             if let Some(message) = check_field_value(&value) {
                 return Some(self.violation(
-                    config.severity,
+                    ctx.severity,
                     format!("In the response {section}: {message}"),
                 ));
             }

--- a/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
+++ b/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -109,10 +109,8 @@ impl Rule for SingletonFieldsNotRepeated {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         let message =
             judge(&tx.request.headers, tx.request.trailers.as_ref(), "Request").or_else(|| {
                 tx.response
@@ -122,7 +120,7 @@ impl Rule for SingletonFieldsNotRepeated {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message,
         })
     }

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -33,9 +33,8 @@ impl Rule for Status101SwitchingProtocols {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // ── Check: HTTP traffic after a prior 101 on the same connection ──
@@ -52,7 +51,7 @@ impl Rule for Status101SwitchingProtocols {
                     if prev_resp.status == 101 {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message:
                                 "HTTP traffic after 101 Switching Protocols on the same connection; \
                                  the connection should have been handed off to the upgraded protocol"
@@ -86,7 +85,7 @@ impl Rule for Status101SwitchingProtocols {
         ) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message:
                     "101 Switching Protocols must not be sent in response to an HTTP/1.0 request; \
                      Upgrade is not supported in HTTP/1.0 (RFC 9110 §7.8)"
@@ -102,7 +101,7 @@ impl Rule for Status101SwitchingProtocols {
         if crate::http_version::is_major(&tx.request.version, 2) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "101 Switching Protocols must not be sent over HTTP/2 (RFC 9113 §8.6)"
                     .into(),
             });
@@ -116,7 +115,7 @@ impl Rule for Status101SwitchingProtocols {
         if crate::http_version::is_major(&tx.request.version, 3) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "101 Switching Protocols must not be sent over HTTP/3 (RFC 9114 §4.5)"
                     .into(),
             });
@@ -136,7 +135,7 @@ impl Rule for Status101SwitchingProtocols {
         if req_upgrade_combined.is_none() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Server sent 101 Switching Protocols but the request did not include an \
                      Upgrade header (RFC 9110 §7.8)"
                     .into(),
@@ -151,7 +150,7 @@ impl Rule for Status101SwitchingProtocols {
         if resp_upgrade_combined.is_none() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "101 Switching Protocols response missing required Upgrade header \
                      (RFC 9110 §15.2.2)"
                     .into(),
@@ -177,7 +176,7 @@ impl Rule for Status101SwitchingProtocols {
         if offered.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Server sent 101 Switching Protocols but the request Upgrade header \
                      contains no protocol tokens (RFC 9110 §7.8)"
                     .into(),
@@ -190,7 +189,7 @@ impl Rule for Status101SwitchingProtocols {
         if chosen_list.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "101 Switching Protocols response Upgrade header contains no protocol \
                      tokens (RFC 9110 §15.2.2)"
                     .into(),
@@ -206,7 +205,7 @@ impl Rule for Status101SwitchingProtocols {
         if !all_matched {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "101 response Upgrade '{}' was not offered by the client's Upgrade '{}' \
                      (RFC 9110 §7.8)",

--- a/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
+++ b/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
@@ -76,7 +76,7 @@ impl Rule for Status103EarlyHintsBeforeFinal {
         // answered by the transaction in hand. Registering it anyway would make
         // the engine build a `ByResource` history nothing looks at.
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
@@ -88,10 +88,6 @@ impl Rule for Status103EarlyHintsBeforeFinal {
         if resp.status != 103 {
             return None;
         }
-
-        // Read last: `parse_rule_config` is several map probes and a hash over
-        // the id, and the gate above ends the rule for all but one status.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // ── The HTTP/1.0 client ──
         // Reported first because it is the narrower fact and the only sentence
@@ -109,7 +105,7 @@ impl Rule for Status103EarlyHintsBeforeFinal {
         ) {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "103 (Early Hints) answering an HTTP/1.0 request: HTTP/1.0 defined no \
                           1xx status codes, so a server must not send one to that client"
                     .into(),
@@ -127,7 +123,7 @@ impl Rule for Status103EarlyHintsBeforeFinal {
         // cite(RFC 8297 § 3): "In particular, an HTTP/1.1 client that mishandles an informational response as a final response is likely to consider all responses to the succeeding requests sent over the same connection to be part of the final response."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "103 (Early Hints) is recorded as the response to '{}', and a 103 is an interim \
                  response that exactly one final response has to follow: either the final \

--- a/lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
+++ b/lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -48,9 +48,8 @@ impl Rule for Status200Vs204BodyConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // Both sentences this rule rests on are written for one status code. The
@@ -109,7 +108,7 @@ impl Rule for Status200Vs204BodyConsistent {
             // cite(RFC 9110 § 8.6): "The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets."
             match crate::helpers::headers::validate_content_length(&resp.headers) {
                 // Zero octets, said by the sender rather than counted by the capture.
-                Ok(Some(0)) => return Some(self.report(config.severity, "Content-Length: 0")),
+                Ok(Some(0)) => return Some(self.report(ctx.severity, "Content-Length: 0")),
                 // A declared length above zero is content, and the expectation quoted
                 // at the status gate is met.
                 Ok(Some(_)) => return None,
@@ -128,7 +127,7 @@ impl Rule for Status200Vs204BodyConsistent {
             // count is of content, not of framing: chunk sizes and the trailer section
             // are not in it.
             // cite(RFC 9110 § 6.4): "This abstract definition of content reflects the data after it has been extracted from the message framing."
-            Some(0) => Some(self.report(config.severity, "captured length 0")),
+            Some(0) => Some(self.report(ctx.severity, "captured length 0")),
             // Content was counted.
             Some(_) => None,
             // Neither the sender nor the capture says how long the content is (a

--- a/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
+++ b/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
@@ -60,10 +60,8 @@ impl Rule for Status3xxVsRequestMethod {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Both halves of the question are on the transaction: the status the server
         // chose and the method the client sent. `RuleScope::Server` only means the
         // engine skips a transaction that has no response yet.
@@ -102,7 +100,7 @@ impl Rule for Status3xxVsRequestMethod {
         // cite(RFC 9110 § 9.3.3): "If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field."
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "{status} response to a POST request: for historical reasons a user agent MAY \
                  change the method to GET before following this redirect (RFC 9110 {section}), so \

--- a/lint-http-rules/src/rules/status_405_allow_valid.rs
+++ b/lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -73,15 +73,13 @@ impl Rule for Status405AllowValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
         // The status is the whole antecedent of both findings: the field is a MAY on
         // every other response, so a 200 carrying no `Allow` is a server taking the
-        // licence rather than a defect. The status is one integer comparison and
-        // `parse_rule_config` is several map probes plus a hash over the rule id, so
-        // only a response this rule could report pays for the configuration.
+        // licence rather than a defect.
         //
         // No version gate. The sentence defining this status names the request-line,
         // which only an HTTP/1.x message has — it is quoted below, where it decides
@@ -94,11 +92,10 @@ impl Rule for Status405AllowValid {
             return None;
         }
 
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };
@@ -596,7 +593,7 @@ mod tests {
         cfg.rules
             .insert("status_405_allow_valid".into(), toml::Value::Table(table));
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/status_426_upgrade_valid.rs
+++ b/lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -26,7 +26,7 @@ impl Rule for Status426UpgradeValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let resp = tx.response.as_ref()?;
 
@@ -65,7 +65,6 @@ impl Rule for Status426UpgradeValid {
 
         // Read after both gates: only a response this rule could report pays for
         // the map probes and the two lookups of the rule id.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // One field section is one value however many lines carry it, and the join
         // is over the octets as written: reading them back through a UTF-8 decoder
@@ -93,7 +92,7 @@ impl Rule for Status426UpgradeValid {
                 .is_some_and(|trailers| trailers.contains_key("upgrade"));
 
             return Some(self.violation(
-                config.severity,
+                ctx.severity,
                 format!(
                     "426 Upgrade Required with no Upgrade header field. The status says the server \
                      refuses the request under the current protocol but might comply after the \
@@ -126,7 +125,7 @@ impl Rule for Status426UpgradeValid {
         // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value."
         if trim_ows(&value).is_empty() {
             return Some(self.violation(
-                config.severity,
+                ctx.severity,
                 "426 Upgrade Required whose Upgrade header field names no protocol. The field is \
                  `#protocol`, so an empty value is a well-formed list of none — but the requirement \
                  is to send the field *to indicate the required protocol(s)*, and a client reading \

--- a/lint-http-rules/src/rules/status_and_caching_semantics.rs
+++ b/lint-http-rules/src/rules/status_and_caching_semantics.rs
@@ -23,9 +23,8 @@ impl Rule for StatusAndCachingSemantics {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         let status = resp.status;
@@ -86,7 +85,7 @@ impl Rule for StatusAndCachingSemantics {
         // cite(RFC 9111 § 3): "A cache MUST NOT store a response to a request unless"
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Response {} is not cacheable by default and lacks explicit freshness information (Cache-Control: max-age/s-maxage or Expires)",
                 status

--- a/lint-http-rules/src/rules/status_code_semantics.rs
+++ b/lint-http-rules/src/rules/status_code_semantics.rs
@@ -54,10 +54,8 @@ impl Rule for StatusCodeSemantics {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // This rule reads the response and never the request, and the two fields say
         // so differently. `WWW-Authenticate` is called a response header field in its
         // definition's first words; `Proxy-Authenticate`'s definition never uses the
@@ -82,7 +80,7 @@ impl Rule for StatusCodeSemantics {
             if !resp.headers.contains_key("www-authenticate") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "401 Unauthorized response carries no WWW-Authenticate field; a \
                               server generating a 401 MUST send one containing at least one \
                               challenge applicable to the target resource"
@@ -102,7 +100,7 @@ impl Rule for StatusCodeSemantics {
             if !carries_a_challenge(&resp.headers, "www-authenticate") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "401 Unauthorized response carries a WWW-Authenticate field with no \
                               challenge in it (the value is empty, or every element of it is); a \
                               server generating a 401 MUST send at least one challenge applicable \
@@ -132,7 +130,7 @@ impl Rule for StatusCodeSemantics {
             if !resp.headers.contains_key("proxy-authenticate") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "407 Proxy Authentication Required response carries no \
                               Proxy-Authenticate field; the proxy generating a 407 MUST send at \
                               least one, containing a challenge applicable to that proxy for the \
@@ -148,7 +146,7 @@ impl Rule for StatusCodeSemantics {
             if !carries_a_challenge(&resp.headers, "proxy-authenticate") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "407 Proxy Authentication Required response carries a \
                               Proxy-Authenticate field with no challenge in it (the value is \
                               empty, or every element of it is); the proxy generating a 407 MUST \
@@ -173,7 +171,7 @@ impl Rule for StatusCodeSemantics {
         if resp.headers.contains_key("proxy-authenticate") {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "Proxy-Authenticate arrived on status {status}; RFC 9110 pairs this field \
                      with 407 Proxy Authentication Required, the one response a proxy MUST send \

--- a/lint-http-rules/src/rules/status_code_valid_range.rs
+++ b/lint-http-rules/src/rules/status_code_valid_range.rs
@@ -20,10 +20,8 @@ impl Rule for StatusCodeValidRange {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // A status code is something a *response* has. `RuleScope::Server` above is
         // the engine's dispatch filter and not a sentence; this is the sentence, and
         // it is the definition the range check below used to be hung on.
@@ -104,7 +102,7 @@ impl Rule for StatusCodeValidRange {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!(
                 "Response status code {status} is outside the range 100-599; RFC 9110 §15 states that values outside it are invalid, and directs a client that receives one to process the response as if it had a 5xx (Server Error) status code. {detail}"
             ),

--- a/lint-http-rules/src/rules/strict_transport_security_valid.rs
+++ b/lint-http-rules/src/rules/strict_transport_security_valid.rs
@@ -20,9 +20,8 @@ impl Rule for StrictTransportSecurityValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only applicable to responses
         let resp = tx.response.as_ref()?;
 
@@ -35,7 +34,7 @@ impl Rule for StrictTransportSecurityValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Strict-Transport-Security header contains non-UTF8 value".into(),
                     });
                 }
@@ -44,7 +43,7 @@ impl Rule for StrictTransportSecurityValid {
             if v.is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Strict-Transport-Security header must not be empty".into(),
                 });
             }
@@ -58,7 +57,7 @@ impl Rule for StrictTransportSecurityValid {
                     // skip stray semicolons but flag as violation
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Empty directive in Strict-Transport-Security header".into(),
                     });
                 }
@@ -69,7 +68,7 @@ impl Rule for StrictTransportSecurityValid {
                 if name.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Empty directive name in Strict-Transport-Security header".into(),
                     });
                 }
@@ -78,7 +77,7 @@ impl Rule for StrictTransportSecurityValid {
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Strict-Transport-Security directive name contains invalid character: '{}'", c),
                     });
                 }
@@ -97,35 +96,35 @@ impl Rule for StrictTransportSecurityValid {
                             if vpart.is_empty() {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Strict-Transport-Security 'max-age' must have a numeric value".into(),
                                 });
                             }
                             if let Some(c) = crate::helpers::token::find_invalid_token_char(vpart) {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Strict-Transport-Security 'max-age' contains invalid character: '{}'", c),
                                 });
                             }
                             if vpart.chars().any(|ch| !ch.is_ascii_digit()) {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Strict-Transport-Security 'max-age' must be a non-negative integer".into(),
                                 });
                             }
                             if vpart.parse::<u64>().is_err() {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: "Strict-Transport-Security 'max-age' value is not a valid integer".into(),
                                 });
                             }
                         } else {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Strict-Transport-Security 'max-age' must have a value"
                                     .into(),
                             });
@@ -138,7 +137,7 @@ impl Rule for StrictTransportSecurityValid {
                         if kv.next().is_some() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Strict-Transport-Security 'includeSubDomains' directive must not have a value".into(),
                             });
                         }
@@ -151,7 +150,7 @@ impl Rule for StrictTransportSecurityValid {
                         if kv.next().is_some() {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: "Strict-Transport-Security 'preload' directive must not have a value".into(),
                             });
                         }
@@ -167,7 +166,7 @@ impl Rule for StrictTransportSecurityValid {
                                 {
                                     return Some(Violation {
                                         rule: self.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!("Invalid quoted-string in Strict-Transport-Security directive value: {}", e),
                                     });
                                 }
@@ -176,7 +175,7 @@ impl Rule for StrictTransportSecurityValid {
                             {
                                 return Some(Violation {
                                     rule: self.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!("Strict-Transport-Security directive '{}' value contains invalid character: '{}'", name, c),
                                 });
                             }
@@ -189,7 +188,7 @@ impl Rule for StrictTransportSecurityValid {
             if max_age_count > 1 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "Strict-Transport-Security MUST NOT contain multiple 'max-age' directives"
                             .into(),
@@ -199,7 +198,7 @@ impl Rule for StrictTransportSecurityValid {
             if !saw_max_age {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message:
                         "Strict-Transport-Security header missing required 'max-age' directive"
                             .into(),

--- a/lint-http-rules/src/rules/structured_headers_valid.rs
+++ b/lint-http-rules/src/rules/structured_headers_valid.rs
@@ -148,35 +148,35 @@ impl Rule for StructuredHeadersValid {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_headers_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_headers_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_headers_config(cfg, self.id()).ok()?;
+        let config: &MessageStructuredHeadersConfig = ctx.state();
         // cite(RFC 9651): "This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,"
         for hdr in &config.headers {
             // The two sections are joined separately, never across the pair: the
             // sentence cited on `check_section` gathers the lines "in the same
             // section", so a request's field and a response's field of the same
             // name are two field values, not one.
-            if let Some(v) = self.check_section(&tx.request.headers, hdr, "request", &config) {
+            if let Some(v) = self.check_section(&tx.request.headers, hdr, "request", config) {
                 return Some(v);
             }
             if let Some(resp) = &tx.response {
-                if let Some(v) = self.check_section(&resp.headers, hdr, "response", &config) {
+                if let Some(v) = self.check_section(&resp.headers, hdr, "response", config) {
                     return Some(v);
                 }
             }
@@ -610,7 +610,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate(&full_cfg).is_err());
+        assert!(rule.prepare(&full_cfg).is_err());
         Ok(())
     }
 
@@ -630,7 +630,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate(&full_cfg).is_err());
+        assert!(rule.prepare(&full_cfg).is_err());
         Ok(())
     }
 
@@ -650,7 +650,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate(&full_cfg).is_err());
+        assert!(rule.prepare(&full_cfg).is_err());
         Ok(())
     }
 
@@ -673,7 +673,7 @@ mod tests {
             }),
         );
 
-        assert!(rule.validate(&full_cfg).is_err());
+        assert!(rule.prepare(&full_cfg).is_err());
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
+++ b/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
@@ -22,9 +22,8 @@ impl Rule for SunsetAndDeprecationConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // only applies to responses
         let resp = tx.response.as_ref()?;
 
@@ -38,7 +37,7 @@ impl Rule for SunsetAndDeprecationConsistent {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into(),
                     });
                 }
@@ -86,7 +85,7 @@ impl Rule for SunsetAndDeprecationConsistent {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Deprecation header contains non-UTF8 value".into(),
                     })
                 }
@@ -104,7 +103,7 @@ impl Rule for SunsetAndDeprecationConsistent {
             if dep_dt > sun_dt + allowed_skew {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Deprecation '{}' indicates a time after Sunset '{}'; the Sunset timestamp must not be earlier than Deprecation (RFC 9745 §4)",
                         dep_raw, sun_raw

--- a/lint-http-rules/src/rules/te_header_valid.rs
+++ b/lint-http-rules/src/rules/te_header_valid.rs
@@ -24,11 +24,11 @@ impl TeHeaderValid {
     ///
     /// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
     /// cite(RFC 9110 § 10.1.4): "The TE field value is a list of members, with each member (aside from "trailers") consisting of a transfer coding name token with an optional weight indicating the client's relative preference for that transfer coding (Section 12.4.2) and optional parameters for that transfer coding."
-    fn check_members(&self, value: &str, config: &crate::rules::RuleConfig) -> Option<Violation> {
+    fn check_members(&self, value: &str, severity: crate::lint::Severity) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -127,7 +127,7 @@ impl TeHeaderValid {
             //
             // cite(RFC 9110 § A): "transfer-coding = token *( OWS ";" OWS transfer-parameter )"
             for parameter in segments.iter().skip(1) {
-                if let Some(v) = self.check_parameter(member, parameter, config) {
+                if let Some(v) = self.check_parameter(member, parameter, severity) {
                     return Some(v);
                 }
             }
@@ -163,7 +163,7 @@ impl TeHeaderValid {
     fn check_connection_option(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         // The major digit decides whether this version has a `Connection` field
         // to carry the option; `http_version` owns the production that reads it.
@@ -187,7 +187,7 @@ impl TeHeaderValid {
 
         Some(Violation {
             rule: self.id().to_string(),
-            severity: config.severity,
+            severity,
             message:
                 "Request carries a TE header field without a 'TE' connection option in Connection; \
                  TE applies to the immediate connection only, and the option is what stops an \
@@ -203,12 +203,12 @@ impl TeHeaderValid {
         &self,
         member: &str,
         parameter: &str,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -368,10 +368,8 @@ impl Rule for TeHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         if let Some(resp) = &tx.response {
             // The field is defined in § 10.1, whose subject is stated in its first
             // sentence, and § 10.1.4 defines this one as describing the *client*.
@@ -404,7 +402,7 @@ impl Rule for TeHeaderValid {
                     combined_field_value_as_written(&resp.headers, "te").unwrap_or_default();
                 return Some(Violation {
                     rule: self.id().to_string(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Response carries a TE header field: '{}'; TE is a request context field describing the client's capabilities, and RFC 9110 gives it no meaning in a response",
                         value.escape_debug()
@@ -415,11 +413,11 @@ impl Rule for TeHeaderValid {
 
         let value = combined_field_value_as_written(&tx.request.headers, "te")?;
 
-        if let Some(v) = self.check_members(&value, &config) {
+        if let Some(v) = self.check_members(&value, ctx.severity) {
             return Some(v);
         }
 
-        self.check_connection_option(tx, &config)
+        self.check_connection_option(tx, ctx.severity)
     }
 
     fn description(&self) -> &'static str {

--- a/lint-http-rules/src/rules/timing_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/timing_allow_origin_valid.rs
@@ -20,9 +20,8 @@ impl Rule for TimingAllowOriginValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // The header is server-sent: it rides responses, so only the response side is
         // inspected.
         // cite(Resource Timing § 3.5.2): "Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions."
@@ -47,7 +46,7 @@ impl Rule for TimingAllowOriginValid {
                     Ok(v) => v,
                     Err(_) => return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message:
                             "Timing-Allow-Origin header contains non-ASCII or control characters"
                                 .into(),
@@ -60,7 +59,7 @@ impl Rule for TimingAllowOriginValid {
             if s.trim().is_empty() {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Timing-Allow-Origin header value is empty".into(),
                 });
             }
@@ -78,7 +77,7 @@ impl Rule for TimingAllowOriginValid {
                     if parts.iter().skip(i + 1).any(|p| !p.trim().is_empty()) {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "Timing-Allow-Origin header contains empty member".into(),
                         });
                     }
@@ -101,7 +100,7 @@ impl Rule for TimingAllowOriginValid {
                 if !crate::helpers::headers::is_valid_serialized_origin(m) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Timing-Allow-Origin contains invalid origin: '{}'", m),
                     });
                 }
@@ -468,7 +467,7 @@ mod tests {
         );
 
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/trace_method_echo.rs
+++ b/lint-http-rules/src/rules/trace_method_echo.rs
@@ -67,10 +67,8 @@ impl Rule for TraceMethodEcho {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Matched exactly, never case-folded: `trace` is not the TRACE method,
         // and § 9.3.8 says nothing about it. A method this specification does
         // not define has no loop-back semantics for content to be measured
@@ -90,7 +88,7 @@ impl Rule for TraceMethodEcho {
         {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "TRACE request carries content ({evidence}); RFC 9110 § 9.3.8 says a client MUST NOT send content in a TRACE request"
                 ),
@@ -110,7 +108,7 @@ impl Rule for TraceMethodEcho {
         if !present.is_empty() {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "TRACE request carries {}; RFC 9110 § 9.3.8 says a client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response, and names credentials and cookies as its example",
                     present.join(", ")

--- a/lint-http-rules/src/rules/trailer_fields_valid.rs
+++ b/lint-http-rules/src/rules/trailer_fields_valid.rs
@@ -40,23 +40,22 @@ impl Rule for TrailerFieldsValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // Each trailer section is measured against the header section of its own
         // message. A request's `Trailer` announces what that request will send and
         // its `Connection` names options for that message, so neither says anything
         // about what the response may put after its content.
         if let Some(ref trailers) = tx.request.trailers {
-            if let Some(v) = check_trailers(self.id(), &config, trailers, &tx.request.headers) {
+            if let Some(v) = check_trailers(self.id(), ctx.severity, trailers, &tx.request.headers)
+            {
                 return Some(v);
             }
         }
 
         if let Some(ref resp) = tx.response {
             if let Some(ref trailers) = resp.trailers {
-                if let Some(v) = check_trailers(self.id(), &config, trailers, &resp.headers) {
+                if let Some(v) = check_trailers(self.id(), ctx.severity, trailers, &resp.headers) {
                     return Some(v);
                 }
             }
@@ -185,7 +184,7 @@ fn collect_declared_trailers(headers: &hyper::HeaderMap) -> Option<Vec<String>> 
 /// Validate one message's trailer section against its own header section.
 fn check_trailers(
     rule_id: &str,
-    config: &crate::rules::RuleConfig,
+    severity: crate::lint::Severity,
     trailers: &hyper::HeaderMap,
     headers: &hyper::HeaderMap,
 ) -> Option<Violation> {
@@ -213,7 +212,7 @@ fn check_trailers(
         if crate::helpers::headers::is_prohibited_trailer_field(name) {
             return Some(Violation {
                 rule: rule_id.to_string(),
-                severity: config.severity,
+                severity,
                 // The message names the field's own definition rather than the
                 // category §6.5.1 sorts it under, because the category is not what
                 // decides: `Authentication-Info` is an authentication field and its
@@ -240,7 +239,7 @@ fn check_trailers(
         if crate::helpers::headers::is_nominated_by_connection(name, connection_val.as_deref()) {
             return Some(Violation {
                 rule: rule_id.to_string(),
-                severity: config.severity,
+                severity,
                 message: format!(
                     "Trailer field '{}' is named as a connection-option in this \
                      message's Connection header, so it is control information for \
@@ -262,7 +261,7 @@ fn check_trailers(
             if !declared.iter().any(|d| d == name) {
                 return Some(Violation {
                     rule: rule_id.to_string(),
-                    severity: config.severity,
+                    severity,
                     message: format!(
                         "Trailer field '{}' was not declared in the Trailer header; \
                          senders should list the fields that might appear in the \

--- a/lint-http-rules/src/rules/trailer_header_valid.rs
+++ b/lint-http-rules/src/rules/trailer_header_valid.rs
@@ -33,12 +33,12 @@ impl TrailerHeaderValid {
     fn check_field_section(
         &self,
         hdrs: &hyper::HeaderMap,
-        config: &crate::rules::RuleConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity,
                 message,
             })
         };
@@ -148,16 +148,14 @@ impl Rule for TrailerHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
-        if let Some(v) = self.check_field_section(&tx.request.headers, &config) {
+        if let Some(v) = self.check_field_section(&tx.request.headers, ctx.severity) {
             return Some(v);
         }
 
         if let Some(resp) = &tx.response {
-            if let Some(v) = self.check_field_section(&resp.headers, &config) {
+            if let Some(v) = self.check_field_section(&resp.headers, ctx.severity) {
                 return Some(v);
             }
         }
@@ -587,7 +585,7 @@ mod tests {
         cfg.rules
             .insert("trailer_header_valid".into(), toml::Value::Table(table));
 
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/transfer_coding_registered.rs
+++ b/lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -85,24 +85,24 @@ impl Rule for TransferCodingRegistered {
         crate::rules::RuleScope::Both
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_allowed_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_allowed_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_allowed_config(cfg, self.id()).ok()?;
+        let config: &TransferCodingConfig = ctx.state();
         // check a list-style header value (Transfer-Encoding or TE) against allowed list
         let check_value = |hdr_name: &str, val: &str, allowed: &[String]| -> Option<Violation> {
             // An odd number of unescaped DQUOTEs means the quoting never

--- a/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -20,9 +20,8 @@ impl Rule for TransferEncodingChunkedFinal {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Collect the coding names in wire order across every field line.
         //
         // `None` means the value could not be read as a list at all: quoting
@@ -117,7 +116,7 @@ impl Rule for TransferEncodingChunkedFinal {
             if chunked_count > 1 {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "The chunked transfer coding must not be applied more than once: \
                          codings found '{}'",
@@ -158,7 +157,7 @@ impl Rule for TransferEncodingChunkedFinal {
                 if pos != codings.len() - 1 {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                         "Transfer-Encoding 'chunked' must be the final coding: codings found '{}'",
                         codings.join(", ")
@@ -187,7 +186,7 @@ impl Rule for TransferEncodingChunkedFinal {
             {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "A request that applies any transfer coding other than chunked must apply \
                          chunked as the final coding: codings found '{}'",

--- a/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
+++ b/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -118,7 +118,7 @@ impl Rule for UpgradeAndConnectionConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // Each half is measured against its own version. In a reverse-proxy capture
         // the request may have arrived over HTTP/3 while the response came back from
@@ -132,10 +132,9 @@ impl Rule for UpgradeAndConnectionConsistent {
 
         // Read last: every gate above ends the rule, so only a message about to be
         // reported pays for the map probes and the hash over the rule id.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message,
         })
     }

--- a/lint-http-rules/src/rules/upgrade_header_syntax.rs
+++ b/lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -189,7 +189,7 @@ impl Rule for UpgradeHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         // No version gate, and the sibling that reports presence is why. A
         // grammar is what a value is measured against whatever carried it, and
@@ -207,8 +207,7 @@ impl Rule for UpgradeHeaderSyntax {
 
         // Read last: a message about to be reported is the only one that pays
         // for the map probes and the two lookups of the rule id.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-        Some(self.violation(config.severity, message))
+        Some(self.violation(ctx.severity, message))
     }
 
     fn description(&self) -> &'static str {

--- a/lint-http-rules/src/rules/user_agent_present.rs
+++ b/lint-http-rules/src/rules/user_agent_present.rs
@@ -28,9 +28,8 @@ impl Rule for UserAgentPresent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // A sentence does ask for the field, and it is a SHOULD -- but it ends
         // in a condition about the sender's configuration, and a request that
         // omits the field because it was told to is byte-for-byte a request that
@@ -54,7 +53,7 @@ impl Rule for UserAgentPresent {
         if !tx.request.headers.contains_key("user-agent") {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Request missing User-Agent header".into(),
             })
         } else {

--- a/lint-http-rules/src/rules/user_agent_token_valid.rs
+++ b/lint-http-rules/src/rules/user_agent_token_valid.rs
@@ -28,9 +28,8 @@ impl Rule for UserAgentTokenValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // `User-Agent` and `Server` are one production, and RFC 9110 defines
         // `product` once — under this field — for both. The grammar walk lives
         // in the shared helper so the two fields cannot be validated by two
@@ -71,7 +70,7 @@ impl Rule for UserAgentTokenValid {
             if let Err(e) = crate::helpers::product::validate_product_list(hv.as_bytes()) {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Invalid User-Agent header: {}", e),
                 });
             }

--- a/lint-http-rules/src/rules/vary_and_cache_consistent.rs
+++ b/lint-http-rules/src/rules/vary_and_cache_consistent.rs
@@ -26,9 +26,8 @@ impl Rule for VaryAndCacheConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let resp = tx.response.as_ref()?;
 
         // A `Vary: *` can never be matched by a cache, so any explicit
@@ -75,7 +74,7 @@ impl Rule for VaryAndCacheConsistent {
                     "max-age" | "s-maxage" | "public" => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Response includes Vary: '*' and Cache-Control directive '{}'; Vary: '*' prevents caches from selecting stored responses, making cache directives like '{}' ineffective (see RFC 9111 §4.1)",
                                 name, name
@@ -373,7 +372,7 @@ mod tests {
             "vary_and_cache_consistent",
         ]);
         // validate should succeed without error
-        rule.validate(&cfg)?;
+        rule.prepare(&cfg)?;
         Ok(())
     }
 }

--- a/lint-http-rules/src/rules/vary_header_cache_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -48,9 +48,8 @@ impl Rule for VaryHeaderCacheValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let req = &tx.request;
         // Only a conditional request reuses a stored validator — the precondition header ties
         // the request to a specific stored representation whose Vary key we can check.
@@ -194,7 +193,7 @@ impl Rule for VaryHeaderCacheValid {
                 let reported_validator = matched_validator.as_deref().unwrap_or("<unknown>");
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Conditional request with validator '{}' differs in Vary field '{}'; cache key must incorporate all Vary dimensions",
                         reported_validator, field

--- a/lint-http-rules/src/rules/vary_header_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_valid.rs
@@ -25,9 +25,8 @@ impl Rule for VaryHeaderValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Vary is a response header field; the rule inspects responses only.
         // cite(RFC 9110 § 12.5.5): "The "Vary" header field in a response describes what parts of a request message, aside from the method and target URI, might have influenced the origin server's process for selecting the content of this response."
         let resp = tx.response.as_ref()?;
@@ -41,7 +40,7 @@ impl Rule for VaryHeaderValid {
                 Err(_) => {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Vary header contains non-UTF8 value".into(),
                     })
                 }
@@ -61,7 +60,7 @@ impl Rule for VaryHeaderValid {
                 if raw.trim().is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "Vary header contains empty token (e.g., trailing or consecutive commas)".into(),
                     });
                 }
@@ -89,7 +88,7 @@ impl Rule for VaryHeaderValid {
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Vary header contains invalid field-name token character: '{}'",
                             c

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -27,15 +27,13 @@ impl Rule for ViaHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         // cite(RFC 9110 § 7.6.3): "A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards."
         if let Some(err) = judge(&tx.request.headers, "Request") {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: err,
             });
         }
@@ -45,7 +43,7 @@ impl Rule for ViaHeaderSyntax {
             if let Some(err) = judge(&resp.headers, "Response") {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: err,
                 });
             }

--- a/lint-http-rules/src/rules/warning_header_syntax.rs
+++ b/lint-http-rules/src/rules/warning_header_syntax.rs
@@ -30,21 +30,17 @@ impl Rule for WarningHeaderSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        // The config is read last. `parse_rule_config` is several map probes and
-        // a hash of the rule id; the field probe under it is one lookup, and a
-        // message carrying no `Warning` is nearly every message.
         let message = judge(&tx.request.headers, "Request").or_else(|| {
             tx.response
                 .as_ref()
                 .and_then(|resp| judge(&resp.headers, "Response"))
         })?;
 
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message,
         })
     }

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -371,7 +371,7 @@ impl Rule for WebsocketHandshakeValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let req = &tx.request;
 
@@ -410,7 +410,6 @@ impl Rule for WebsocketHandshakeValid {
         // Every gate above ends the rule, and reading the configuration is several
         // map probes and a hash of the id — so only an exchange about to be measured
         // pays for it.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
 
         // § 4.1's numbered order, which is the order a client validating this
         // response would reach them, with the question about the handshake's
@@ -430,7 +429,7 @@ impl Rule for WebsocketHandshakeValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("This 101 completes a WebSocket opening handshake, but {defect}"),
         })
     }

--- a/lint-http-rules/src/rules/well_known_uri_syntax.rs
+++ b/lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -99,7 +99,7 @@ impl Rule for WellKnownUriSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         let target = tx.request.uri.as_str();
 
@@ -187,11 +187,10 @@ impl Rule for WellKnownUriSyntax {
         // The config after the probe: a request whose path holds no such segment
         // — every request but a handful — should not pay a map lookup and a hash
         // of the rule id to learn that there is nothing to say.
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         let violation = |message: String| {
             Some(Violation {
                 rule: self.id().to_string(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -22,9 +22,8 @@ impl Rule for WwwAuthenticateChallengeSyntax {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // Only check response headers; ignore non-UTF8 header values
         if let Some(resp) = &tx.response {
             for hv in resp.headers.get_all("www-authenticate").iter() {
@@ -37,7 +36,7 @@ impl Rule for WwwAuthenticateChallengeSyntax {
                         Err(msg) => {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: msg,
                             });
                         }
@@ -49,7 +48,7 @@ impl Rule for WwwAuthenticateChallengeSyntax {
                         {
                             return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: msg,
                             });
                         }

--- a/lint-http-rules/src/rules/x_content_type_options_present.rs
+++ b/lint-http-rules/src/rules/x_content_type_options_present.rs
@@ -65,24 +65,24 @@ impl Rule for XContentTypeOptionsPresent {
         crate::rules::RuleScope::Server
     }
 
-    fn validate(&self, config: &crate::config::Config) -> anyhow::Result<()> {
-        parse_x_content_type_options_config(config, self.id())?;
+    fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
+        let config = parse_x_content_type_options_config(cfg, self.id())?;
         // The two standard keys, **after** this rule's own options, so a config
-        // naming a bad option still fails on that option. `enabled` is checked
-        // here because the parser above stopped reading it: that read ran once
-        // per message at lint time and the flag was discarded, since
-        // `PreparedEngine` had already decided whether the rule runs.
-        crate::rules::validate_rule_table(config, self.id())?;
-        Ok(())
+        // naming a bad option still fails on that option.
+        crate::rules::validate_rule_table(cfg, self.id())?;
+        Ok(crate::rules::ResolvedRule {
+            severity: config.severity,
+            state: Box::new(config),
+        })
     }
 
     fn check_transaction(
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = parse_x_content_type_options_config(cfg, self.id()).ok()?;
+        let config: &XContentTypeOptionsConfig = ctx.state();
         let Some(resp) = &tx.response else {
             return None;
         };
@@ -345,7 +345,7 @@ mod tests {
             _ => panic!("unknown scenario"),
         }
 
-        let res = rule.validate(&cfg);
+        let res = rule.prepare(&cfg);
         if expect_error {
             assert!(res.is_err());
             if let Some(sub) = expected_substring {

--- a/lint-http-rules/src/rules/x_forwarded_consistent.rs
+++ b/lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -139,10 +139,8 @@ impl Rule for XForwardedConsistent {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
-
         for (name, field, kind) in FIELDS {
             // Every line of the field, and every octet of every line. A proxy
             // chain appends by adding a field line as often as by extending the
@@ -157,7 +155,7 @@ impl Rule for XForwardedConsistent {
                 if let Some(message) = check_member(field, *kind, member) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message,
                     });
                 }

--- a/lint-http-rules/src/rules/x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/x_frame_options_value_valid.rs
@@ -20,9 +20,8 @@ impl Rule for XFrameOptionsValueValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // It is a response header, so only the response side is inspected. RFC 7034
         // originally defined it; the HTML Standard's §7.7 definition governs now.
         // cite(HTML Speculative Loading § 7.7): "It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document."
@@ -42,7 +41,7 @@ impl Rule for XFrameOptionsValueValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple X-Frame-Options header fields present".into(),
             });
         }
@@ -53,7 +52,7 @@ impl Rule for XFrameOptionsValueValid {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "X-Frame-Options header contains non-ASCII or control characters"
                         .into(),
                 })
@@ -77,7 +76,7 @@ impl Rule for XFrameOptionsValueValid {
         if val.len() >= 10 && val[..10].eq_ignore_ascii_case("ALLOW-FROM") {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: format!(
                     "X-Frame-Options: ALLOW-FROM is obsolete and not implemented by browsers \
                      (use the Content-Security-Policy frame-ancestors directive instead): '{}'",
@@ -88,7 +87,7 @@ impl Rule for XFrameOptionsValueValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("X-Frame-Options contains unsupported value: '{}'", val),
         })
     }

--- a/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -20,9 +20,8 @@ impl Rule for XXssProtectionValueValid {
         &self,
         tx: &crate::http_transaction::HttpTransaction,
         _history: &crate::transaction_history::TransactionHistory,
-        cfg: &crate::config::Config,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config = crate::rules::parse_rule_config(cfg, self.id()).ok()?;
         // A response header (a legacy browser feature; no standard ever defined it),
         // so only the response side is inspected. Its absence is fine — CSP is the
         // replacement — which is why count == 0 simply passes.
@@ -41,7 +40,7 @@ impl Rule for XXssProtectionValueValid {
         if count > 1 {
             return Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message: "Multiple X-XSS-Protection header fields present".into(),
             });
         }
@@ -52,7 +51,7 @@ impl Rule for XXssProtectionValueValid {
             None => {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "X-XSS-Protection header contains non-ASCII or control characters"
                         .into(),
                 })
@@ -81,7 +80,7 @@ impl Rule for XXssProtectionValueValid {
 
         Some(Violation {
             rule: self.id().into(),
-            severity: config.severity,
+            severity: ctx.severity,
             message: format!("X-XSS-Protection contains unsupported value: '{}'", val),
         })
     }

--- a/lint-http-rules/src/test_helpers.rs
+++ b/lint-http-rules/src/test_helpers.rs
@@ -21,21 +21,20 @@ pub fn make_test_rule_config() -> crate::rules::RuleConfig {
     }
 }
 
-/// Dispatch one transaction through `rule` under `cfg`, the way a test would
-/// have called `check_transaction` directly.
+/// Prepare `rule` under `cfg`, then dispatch one transaction through it — the
+/// way the engine does, collapsed to one call for tests.
 ///
-/// Today this is that direct call. When the trait's check signature moves to
-/// a prepared [`crate::rules::RuleContext`], this body becomes
-/// prepare-then-dispatch — like [`run_protocol_rule`] below — and no test
-/// call site moves again. A config that fails preparation will answer `None`
-/// here, which is what a failed per-dispatch parse answers today.
+/// Returns `None` when `prepare` rejects the config, which preserves what a
+/// direct `check_transaction` call answered when its own per-dispatch parse
+/// failed. Tests asserting *why* preparation fails call `prepare` directly.
 pub fn run_rule(
     rule: &dyn crate::rules::Rule,
     tx: &crate::http_transaction::HttpTransaction,
     history: &crate::transaction_history::TransactionHistory,
     cfg: &crate::config::Config,
 ) -> Option<crate::lint::Violation> {
-    rule.check_transaction(tx, history, cfg)
+    let resolved = rule.prepare(cfg).ok()?;
+    rule.check_transaction(tx, history, &crate::rules::RuleContext::new(&resolved))
 }
 
 /// Prepare `rule` under `cfg`, then dispatch one event through it — the way

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -8,35 +8,35 @@ sources:
     snippet: If credentials is `true`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
-      line: 88
+      line: 87
   - label: access_control_allow_credentials_when_origin (2)
     section: § 4.10
     snippet: If request’s credentials mode is not "include" and origin is `*`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
-      line: 87
+      line: 86
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 91
+      line: 90
   - label: access_control_allow_origin_valid
     section: § 3.3.3
     snippet: Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_origin_valid.rs
-      line: 40
+      line: 39
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 62
+      line: 61
   - label: cross_origin_resource_policy_valid
     section: § 3.7
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 78
+      line: 77
   - label: cross_origin_resource_policy_valid (2)
     section: § 3.7
     snippet: If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 79
+      line: 78
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 3.2
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
@@ -60,37 +60,37 @@ sources:
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 111
+      line: 110
   - label: refresh_header_syntax
     section: § 2.2.2
     snippet: Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 220
+      line: 219
   - label: request_origin_header_present_for_cors
     section: § 3.2
     snippet: It is used for all HTTP fetches whose request’s response tainting is "cors", as well as those where request’s method is neither `GET` nor `HEAD`.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 32
+      line: 31
   - label: request_origin_header_present_for_cors (2)
     section: § 3.2
     snippet: The `Origin` request header indicates where a fetch originates from.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 69
+      line: 68
   - label: sec_fetch_dest_value_valid
     section: § 2.2.5
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 99
+      line: 98
   - label: timing_allow_origin_valid
     section: § 3.2
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 94
+      line: 93
   - label: x_content_type_options_present
     section: § 3.6
     snippet: If values[0] is an ASCII case-insensitive match for "nosniff", then return true.
@@ -124,25 +124,25 @@ sources:
     snippet: An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
-      line: 78
+      line: 77
   - label: cross_origin_opener_policy_valid
     section: § 7.1.3.1
     snippet: Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
-      line: 75
+      line: 74
   - label: origin_isolated_header_valid
     section: § 7.1.2
     snippet: This header is a structured header whose value must be a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 60
+      line: 59
   - label: origin_isolated_header_valid (2)
     section: § 7.1.2
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 73
+      line: 72
 - label: HTML Links
   url: https://html.spec.whatwg.org/multipage/links.html
   type: text/html
@@ -152,13 +152,13 @@ sources:
     snippet: A preload destination is "fetch", "font", "image", "script", "style", or "track".
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 854
+      line: 852
   - label: link_header_valid (2)
     section: § 4.6.8.20
     snippet: If destination is not a preload destination, then return null.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 855
+      line: 853
 - label: HTML Speculative Loading
   url: https://html.spec.whatwg.org/multipage/speculative-loading.html
   type: text/html
@@ -168,13 +168,13 @@ sources:
     snippet: The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 100
+      line: 99
   - label: refresh_header_syntax
     section: § 7.8
     snippet: It takes the same value and works largely the same.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 253
+      line: 252
   - label: refresh_header_syntax (2)
     section: § 7.8
     snippet: The `Refresh` HTTP response header is the HTTP-equivalent to a meta element with an http-equiv attribute in the Refresh state.
@@ -186,31 +186,31 @@ sources:
     snippet: For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 66
+      line: 65
   - label: x_frame_options_value_valid (2)
     section: § 7.7
     snippet: HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 29
+      line: 28
   - label: x_frame_options_value_valid (3)
     section: § 7.7
     snippet: In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 76
+      line: 75
   - label: x_frame_options_value_valid (4)
     section: § 7.7
     snippet: It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 28
+      line: 27
   - label: x_frame_options_value_valid (5)
     section: § 7.7
     snippet: X-Frame-Options = "DENY" / "SAMEORIGIN"
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 65
+      line: 64
 - label: HTML Semantics
   url: https://html.spec.whatwg.org/multipage/semantics.html
   type: text/html
@@ -220,37 +220,37 @@ sources:
     snippet: Apply link options from parsed header attributes to options given attribs
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 810
+      line: 808
   - label: link_header_valid (2)
     section: § 4.2.4.4
     snippet: If attribs["as"] does not exist, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 811
+      line: 809
   - label: link_header_valid (3)
     section: § 4.2.4.4
     snippet: If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 831
+      line: 829
   - label: link_header_valid (4)
     section: § 4.2.4.4
     snippet: If destination is null, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 830
+      line: 828
   - label: link_header_valid (5)
     section: § 4.2.4.4
     snippet: Let destination be the result of translating attribs["as"].
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 829
+      line: 827
   - label: link_header_valid (6)
     section: § 4.2.4.4
     snippet: To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 809
+      line: 807
   - label: refresh_header_syntax
     section: § 4.2.5.3
     snippet: 'For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:'
@@ -324,13 +324,13 @@ sources:
     snippet: Let value be the isomorphic decoding of the value of the header.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 239
+      line: 238
   - label: refresh_header_syntax (2)
     section: § 7.5.1
     snippet: We do not currently have a spec for how to handle multiple `Refresh` headers.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 219
+      line: 218
 - label: URL
   url: https://url.spec.whatwg.org/
   type: text/html
@@ -386,7 +386,7 @@ sources:
     snippet: To isomorphic decode a byte sequence input, return a string whose code point length is equal to input’s length and whose code points have the same values as the values of input’s bytes, in the same order.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 240
+      line: 239
   - label: refresh_header_syntax (2)
     section: § 4.6
     snippet: ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
@@ -402,19 +402,19 @@ sources:
     snippet: The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 99
+      line: 98
   - label: content_security_policy_and_frame_options_consistent (2)
     section: § 6.4.2.2
     snippet: the frame-ancestors directive overrides the ``X-Frame-Options`` header.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 98
+      line: 97
   - label: content_security_policy_valid
     section: § 2.3
     snippet: directive-name = 1*( ALPHA / DIGIT / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_valid.rs
-      line: 81
+      line: 80
 - label: Clear-Site-Data
   url: https://www.w3.org/TR/clear-site-data/
   type: text/html
@@ -439,90 +439,90 @@ sources:
     snippet: HTTP request header exposes a request’s destination to a server
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 34
+      line: 33
   - label: sec_fetch_dest_value_valid (2)
     section: § 2.1
     snippet: If r’s destination is the empty string, set header’s value to the string "empty"
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 102
+      line: 101
   - label: sec_fetch_dest_value_valid (3)
     section: § 2.1
     snippet: In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 97
+      line: 96
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 91
+      line: 90
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 92
+      line: 91
   - label: sec_fetch_dest_value_valid (4)
     section: § 2.1
     snippet: It is a Structured Field whose value MUST be a token.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 66
+      line: 65
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 79
+      line: 78
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 63
+      line: 62
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 76
+      line: 75
   - label: sec_fetch_dest_value_valid (5)
     section: § 2.1
     snippet: Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch].
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 98
+      line: 97
   - label: sec_fetch_mode_value_valid
     section: § 2.2
     snippet: HTTP request header exposes a request’s mode to a server
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 31
+      line: 30
   - label: sec_fetch_mode_value_valid (2)
     section: § 2.2
     snippet: Valid Sec-Fetch-Mode values include "cors", "navigate", "no-cors", "same-origin", and "websocket".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 92
+      line: 91
   - label: sec_fetch_site_value_valid
     section: § 2.3
     snippet: HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 31
+      line: 30
   - label: sec_fetch_site_value_valid (2)
     section: § 2.3
     snippet: It is a Structured Field whose value is a token.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 64
+      line: 63
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 77
+      line: 76
   - label: sec_fetch_site_value_valid (3)
     section: § 2.3
     snippet: Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 93
+      line: 92
   - label: sec_fetch_user_value_valid
     snippet: 'Sec-Fetch-User = sf-boolean Note: The header is delivered only for navigation requests, and only when its value is true.'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 75
+      line: 74
   - label: sec_fetch_user_value_valid (2)
     section: § 2.4
     snippet: HTTP request header exposes whether or not a navigation request was triggered by user activation.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 31
+      line: 30
   - label: sec_fetch_user_value_valid (3)
     section: § 2.4
     snippet: It is a Structured Field whose value is a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 63
+      line: 62
 - label: Resource Timing
   url: https://www.w3.org/TR/resource-timing/
   type: text/html
@@ -531,31 +531,31 @@ sources:
     snippet: Timing-Allow-Origin = 1#( origin-or-null / wildcard )
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 59
+      line: 58
   - label: timing_allow_origin_valid (2)
     section: § 3.5.2
     snippet: Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 28
+      line: 27
   - label: timing_allow_origin_valid (3)
     section: § 3.5.2
     snippet: 'The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 71
+      line: 70
   - label: timing_allow_origin_valid (4)
     section: § 3.5.2
     snippet: The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 42
+      line: 41
   - label: timing_allow_origin_valid (5)
     section: § 3.5.2
     snippet: The sender MAY generate multiple Timing-Allow-Origin header fields.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 41
+      line: 40
 - label: Server Timing
   url: https://www.w3.org/TR/server-timing/
   type: text/html
@@ -565,7 +565,7 @@ sources:
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 365
+      line: 364
   - label: server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
@@ -577,25 +577,25 @@ sources:
     snippet: All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 493
+      line: 492
   - label: server_timing_header_syntax (3)
     section: § 2
     snippet: If any server-timing-param-name is specified more than once, only the first instance is to be considered, even if the server-timing-param is incomplete or invalid.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 492
+      line: 491
   - label: server_timing_header_syntax (4)
     section: § 2
     snippet: 'See [RFC7230] for definitions of #, *, OWS, token, and quoted-string.'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 336
+      line: 335
   - label: Server-Timing grammar
     section: § 2
     snippet: 'Server-Timing = #server-timing-metric'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 335
+      line: 334
   - label: server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
@@ -613,55 +613,55 @@ sources:
     snippet: To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 491
+      line: 490
   - label: server_timing_header_syntax (8)
     section: § 2
     snippet: User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 512
+      line: 511
   - label: server-timing-metric grammar
     section: § 2
     snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 364
+      line: 363
   - label: server-timing-param grammar
     section: § 2
     snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 437
+      line: 436
   - label: server-timing-param-name grammar
     section: § 2
     snippet: server-timing-param-name = token
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 438
+      line: 437
   - label: server-timing-param-value grammar
     section: § 2
     snippet: server-timing-param-value = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 542
+      line: 541
   - label: server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 610
+      line: 609
   - label: server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 609
+      line: 608
   - label: server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 593
+      line: 592
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -671,33 +671,33 @@ sources:
     snippet: Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 331
+      line: 330
   - label: permissions_policy_directives_valid (2)
     section: § 5.2
     snippet: Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 95
+      line: 94
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 315
+      line: 314
   - label: permissions_policy_directives_valid (3)
     section: § 5.2
     snippet: The Member Names must be Tokens.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 423
+      line: 422
   - label: permissions_policy_directives_valid (4)
     section: § 5.2
     snippet: 'The Member Values represent allowlists, and must be one of:'
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 314
+      line: 313
   - label: permissions_policy_directives_valid (5)
     section: § 6.1
     snippet: The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 99
+      line: 98
 - label: draft-ietf-httpbis-rfc6265bis
   url: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis
   type: text/html
@@ -707,31 +707,31 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 125
+      line: 124
   - label: cookie_attribute_consistent (2)
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 262
+      line: 261
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_same_site_enforced.rs
-      line: 133
+      line: 132
   - label: cookie_same_site_enforced (2)
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is something other than these three known keywords, the attribute's value will be subject to a default enforcement mode that is equivalent to "Lax".
     cited_by:
     - file: lint-http-rules/src/rules/cookie_same_site_enforced.rs
-      line: 125
+      line: 124
   - label: cookie_same_site_enforced (3)
     section: § 4.1.2.7
     snippet: If the value is "Lax", the cookie will be sent with same-site requests, and with "cross-site" top-level navigations, as described in Section 5.6.7.1.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_same_site_enforced.rs
-      line: 147
+      line: 146
 - label: draft-thomson-hybi-http-timeout-03
   url: https://www.ietf.org/archive/id/draft-thomson-hybi-http-timeout-03.txt
   type: text/plain
@@ -761,7 +761,7 @@ sources:
     snippet: Indicates the character encoding standard used. The value is case insensitive but lowercase is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/charset_present.rs
-      line: 85
+      line: 84
 - label: MDN X-XSS-Protection
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection
   fragments:
@@ -769,22 +769,22 @@ sources:
     snippet: Disables XSS filtering.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 67
+      line: 66
   - label: x_xss_protection_value_valid (2)
     snippet: Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 73
+      line: 72
   - label: x_xss_protection_value_valid (3)
     snippet: Even though this feature can protect users of older web browsers that don't support CSP, in some cases, X-XSS-Protection can create XSS vulnerabilities in otherwise safe websites.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 66
+      line: 65
   - label: x_xss_protection_value_valid (4)
     snippet: response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when they detected reflected cross-site scripting
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 29
+      line: 28
 - label: RFC 1035
   url: https://www.rfc-editor.org/rfc/rfc1035.txt
   type: text/plain
@@ -826,19 +826,19 @@ sources:
     snippet: These values are not case sensitive
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 69
+      line: 68
   - label: content_transfer_encoding_valid (2)
     section: § 6.1
     snippet: mechanism := "7bit" / "8bit" / "binary" / "quoted-printable" / "base64" / ietf-token / x-token
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 42
+      line: 41
   - label: content_transfer_encoding_valid (3)
     section: § 6.3
     snippet: Implementors may, if necessary, define private Content-Transfer-Encoding values, but must use an x-token, which is a name prefixed by "X-", to indicate its non-standard status
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 68
+      line: 67
 - label: RFC 2046
   url: https://www.rfc-editor.org/rfc/rfc2046.txt
   type: text/plain
@@ -848,111 +848,111 @@ sources:
     snippet: All subtypes of "multipart" must use this syntax.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 179
+      line: 178
   - label: multipart_boundary_syntax (2)
     section: § 5.1.1
     snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 375
+      line: 374
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 42
+      line: 40
   - label: multipart_boundary_syntax (3)
     section: § 5.1.1
     snippet: The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 376
+      line: 375
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 205
+      line: 204
   - label: multipart_boundary_syntax (4)
     section: § 5.1.1
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 244
+      line: 243
   - label: multipart_boundary_syntax (5)
     section: § 5.1.1
     snippet: The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 335
+      line: 334
   - label: multipart_boundary_syntax (6)
     section: § 5.1.1
     snippet: bchars := bcharsnospace / " "
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 296
+      line: 295
   - label: multipart_boundary_syntax (7)
     section: § 5.1.1
     snippet: bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 297
+      line: 296
   - label: multipart_boundary_syntax (8)
     section: § 5.1.1
     snippet: boundary := 0*69<bchars> bcharsnospace
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 334
+      line: 333
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 356
+      line: 355
   - label: multipart_content_type_and_body_consistent
     section: § 5.1.1
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 251
+      line: 250
   - label: multipart_content_type_and_body_consistent (2)
     section: § 5.1.1
     snippet: Boundary string comparisons must compare the boundary value with the beginning of each candidate line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 250
+      line: 249
   - label: multipart_content_type_and_body_consistent (3)
     section: § 5.1.1
     snippet: Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 263
+      line: 262
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 333
+      line: 332
   - label: multipart_content_type_and_body_consistent (4)
     section: § 5.1.1
     snippet: The boundary delimiter MUST occur at the beginning of a line, i.e., following a CRLF, and the initial CRLF is considered to be attached to the boundary delimiter line rather than part of the preceding part.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 225
+      line: 224
   - label: multipart_content_type_and_body_consistent (5)
     section: § 5.1.1
     snippet: The boundary delimiter line following the last body part is a distinguished delimiter that indicates that no further body parts will follow.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 318
+      line: 317
   - label: multipart_content_type_and_body_consistent (6)
     section: § 5.1.1
     snippet: The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 319
+      line: 318
   - label: multipart_content_type_and_body_consistent (7)
     section: § 5.1.1
     snippet: close-delimiter := delimiter "--"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 262
+      line: 261
   - label: multipart_content_type_and_body_consistent (8)
     section: § 5.1.1
     snippet: dash-boundary := "--" boundary
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 204
+      line: 203
   - label: multipart_content_type_and_body_consistent (9)
     section: § 5.1.1
     snippet: implementations must ignore anything that appears before the first boundary delimiter line or after the last one.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 298
+      line: 297
 - label: RFC 2068
   url: https://www.rfc-editor.org/rfc/rfc2068.txt
   type: text/plain
@@ -1076,7 +1076,7 @@ sources:
     snippet: This MUST be specified if a qop directive is sent (see above), and MUST NOT be specified if the server did not send a qop directive in the WWW-Authenticate header field.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 112
+      line: 111
 - label: RFC 3230
   url: https://www.rfc-editor.org/rfc/rfc3230.txt
   type: text/plain
@@ -1086,13 +1086,13 @@ sources:
     snippet: All digest-algorithm values are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 102
+      line: 101
   - label: digest_header_syntax (2)
     section: § 4.1.1
     snippet: digest-algorithm = token
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 101
+      line: 100
 - label: RFC 3986
   url: https://www.rfc-editor.org/rfc/rfc3986.txt
   type: text/plain
@@ -1102,9 +1102,9 @@ sources:
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 169
+      line: 168
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 200
+      line: 199
   - label: host_and_authority_consistent
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1140,7 +1140,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1045
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 142
+      line: 141
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
     section: § 3.2.2
     snippet: This is the only place where square bracket characters are allowed in the URI syntax.
@@ -1158,9 +1158,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 339
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 118
+      line: 117
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 109
+      line: 107
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 2.1
     snippet: A percent-encoded octet is encoded as a character triplet, consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value.
@@ -1174,7 +1174,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 72
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 108
+      line: 106
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 2.1
     snippet: If two URIs differ only in the case of hexadecimal digits used in percent-encoded octets, they are equivalent.
@@ -1222,13 +1222,13 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 102
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 55
+      line: 54
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 205
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 544
+      line: 542
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 106
+      line: 105
   - label: lint-http-rules/src/helpers/uri.rs (9)
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
@@ -1286,9 +1286,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 942
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 928
+      line: 926
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 218
+      line: 217
   - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
@@ -1348,9 +1348,9 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 204
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 107
+      line: 105
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 479
+      line: 475
   - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
@@ -1366,7 +1366,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 51
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 393
+      line: 391
   - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
@@ -1380,7 +1380,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 138
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 105
+      line: 103
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 48
   - label: lint-http-rules/src/helpers/uri.rs (25)
@@ -1390,7 +1390,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 139
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 219
+      line: 218
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 91
   - label: lint-http-rules/src/helpers/uri.rs (26)
@@ -1414,7 +1414,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 65
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 94
+      line: 92
   - label: lint-http-rules/src/helpers/uri.rs (27)
     section: § 5.2.3
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
@@ -1466,7 +1466,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 767
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 241
+      line: 240
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 154
   - label: lint-http-rules/src/helpers/uri.rs (35)
@@ -1476,9 +1476,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 466
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 240
+      line: 239
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 196
+      line: 195
   - label: lint-http-rules/src/helpers/uri.rs (36)
     section: § 6.2.2.2
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
@@ -1496,27 +1496,27 @@ sources:
     snippet: URI-reference = URI / relative-ref
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 72
+      line: 71
   - label: location_header_uri_valid (2)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 128
+      line: 127
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 145
+      line: 144
   - label: referer_uri_valid
     section: § 3.2.1
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 250
+      line: 249
   - label: referer_uri_valid (2)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 201
+      line: 200
   - label: request_target_no_fragment
     section: § 2.2
     snippet: If data for a URI component would conflict with a reserved character's purpose as a delimiter, then the conflicting data must be percent-encoded before the URI is formed.
@@ -1528,7 +1528,7 @@ sources:
     snippet: URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 93
+      line: 91
   - label: request_target_no_fragment (2)
     section: § 3.5
     snippet: A fragment identifier component is indicated by the presence of a number sign ("#") character and terminated by the end of the URI.
@@ -1540,19 +1540,19 @@ sources:
     snippet: the fragment identifier is separated from the rest of the URI prior to a dereference, and thus the identifying information within the fragment itself is dereferenced solely by the user agent, regardless of the URI scheme
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 113
+      line: 111
   - label: request_uri_percent_encoding_valid
     section: § 2
     snippet: The ABNF notation defines its terminal values to be non-negative integers (codepoints) based on the US-ASCII coded character set [ASCII].
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 110
+      line: 108
   - label: request_uri_percent_encoding_valid (2)
     section: § 2
     snippet: the integer values used by the ABNF must be mapped back to their corresponding characters via US-ASCII in order to complete the syntax rules.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 111
+      line: 109
   - label: request_uri_percent_encoding_valid (3)
     section: § 2.4
     snippet: Because the percent ("%") character serves as the indicator for percent-encoded octets, it must be percent-encoded as "%25" for that octet to be used as data within a URI.
@@ -1570,7 +1570,7 @@ sources:
     snippet: query       = *( pchar / "/" / "?" )
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 106
+      line: 104
   - label: well_known_uri_syntax
     section: § 3.3
     snippet: The path is terminated by the first question mark ("?") or number sign ("#") character, or by the end of the URI.
@@ -1588,7 +1588,7 @@ sources:
     snippet: segment-nz    = 1*pchar
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 255
+      line: 254
 - label: RFC 4647
   url: https://www.rfc-editor.org/rfc/rfc4647.txt
   type: text/plain
@@ -1598,7 +1598,7 @@ sources:
     snippet: A basic language range differs from the language tags defined in [RFC4646] only in that there is no requirement that it be "well-formed" or be validated against the IANA Language Subtag Registry.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 51
+      line: 49
   - label: lint-http-rules/src/helpers/language.rs
     section: § 2.1
     snippet: language-range   = (1*8ALPHA *("-" 1*8alphanum)) / "*"
@@ -1606,7 +1606,7 @@ sources:
     - file: lint-http-rules/src/helpers/language.rs
       line: 74
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 131
+      line: 129
 - label: RFC 4648
   url: https://www.rfc-editor.org/rfc/rfc4648.txt
   type: text/plain
@@ -1668,7 +1668,7 @@ sources:
     snippet: It is therefore incumbent upon implementations to conform to the syntax of addresses for the context in which they are used.
     cited_by:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 145
+      line: 142
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 3.2.1
     snippet: quoted-pair = ("\" (VCHAR / WSP)) / obs-qp
@@ -1784,7 +1784,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 34
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 162
+      line: 159
   - label: lint-http-rules/src/helpers/mailbox.rs (20)
     section: § 3.4
     snippet: mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list
@@ -1792,7 +1792,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 35
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 163
+      line: 160
   - label: lint-http-rules/src/helpers/mailbox.rs (21)
     section: § 3.4
     snippet: name-addr = [display-name] angle-addr
@@ -1812,7 +1812,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 52
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 144
+      line: 141
   - label: lint-http-rules/src/helpers/mailbox.rs (24)
     section: § 3.4.1
     snippet: The locally interpreted string is either a quoted-string or a dot-atom.
@@ -1856,7 +1856,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 37
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 177
+      line: 174
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.txt
   type: text/plain
@@ -1900,17 +1900,17 @@ sources:
     snippet: Can be specified using a 415 (Unsupported Media Type) response when the client sends a patch document format that the server does not support for the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 252
+      line: 249
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 210
+      line: 208
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 98
+      line: 96
   - label: accept_patch_header_valid (2)
     section: § 2.2
     snippet: Such a response SHOULD include an Accept-Patch response header as described in Section 3.1 to notify the client what patch document media types are supported.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 253
+      line: 250
   - label: accept_patch_header_valid (3)
     section: § 3
     snippet: A server can advertise its support for the PATCH method by adding it to the listing of allowed methods in the "Allow" OPTIONS response header defined in HTTP/1.1.
@@ -1922,7 +1922,7 @@ sources:
     snippet: The PATCH method MAY appear in the "Allow" header even if the Accept-Patch header is absent, in which case the list of allowed patch documents is not advertised.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 299
+      line: 295
   - label: Accept-Patch grammar
     section: § 3.1
     snippet: Accept-Patch = "Accept-Patch" ":" 1#media-type
@@ -1936,7 +1936,7 @@ sources:
     snippet: Accept-Patch SHOULD appear in the OPTIONS response for any resource that supports the use of the PATCH method.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 298
+      line: 294
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 51
   - label: accept_patch_header_valid (6)
@@ -1952,9 +1952,9 @@ sources:
     snippet: The presence of the Accept-Patch header in response to any method is an implicit indication that PATCH is allowed on the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 231
+      line: 229
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 171
+      line: 169
   - label: accept_patch_header_valid (8)
     section: § 3.1
     snippet: This specification introduces a new response header Accept-Patch used to specify the patch document formats accepted by the server.
@@ -1966,7 +1966,7 @@ sources:
     snippet: The presence of a specific patch document format in this header indicates that that specific format is allowed on the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 179
+      line: 177
   - label: patch_partial_update
     section: § 2
     snippet: Note that entity-headers contained in the request apply only to the contained patch document and MUST NOT be applied to the resource being modified.
@@ -1978,25 +1978,25 @@ sources:
     snippet: Servers MUST ensure that a received patch document is appropriate for the type of resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 97
+      line: 95
   - label: patch_partial_update (3)
     section: § 2
     snippet: The PATCH method requests that a set of changes described in the request entity be applied to the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 51
+      line: 49
   - label: patch_partial_update (4)
     section: § 2
     snippet: The set of changes is represented in a format called a "patch document" identified by a media type.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 96
+      line: 94
   - label: patch_partial_update (5)
     section: § 2
     snippet: Therefore, there is no single default patch document format that implementations are required to support.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 84
+      line: 82
 - label: RFC 6265
   url: https://www.rfc-editor.org/rfc/rfc6265.txt
   type: text/plain
@@ -2006,79 +2006,79 @@ sources:
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 62
+      line: 61
   - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 186
+      line: 185
   - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 102
+      line: 101
   - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 89
+      line: 88
   - label: cookie_attribute_consistent (5)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 158
+      line: 157
   - label: cookie_attribute_consistent (6)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 159
+      line: 158
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_matching.rs
-      line: 102
+      line: 101
   - label: cookie_domain_matching (2)
     section: § 5.4
     snippet: The request-uri's path path-matches the cookie's path.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_matching.rs
-      line: 116
+      line: 115
   - label: cookie_domain_valid
     section: § 5.2.3
     snippet: If the attribute-value is empty, the behavior is undefined.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 50
+      line: 49
   - label: cookie_domain_valid (2)
     section: § 5.2.3
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 65
+      line: 64
   - label: cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 130
+      line: 129
   - label: cookie_lifecycle (2)
     section: § 5.3
     snippet: The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 186
+      line: 185
   - label: cookie_lifecycle (3)
     section: § 5.4
     snippet: Cookies with longer paths are listed before cookies with shorter paths.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 89
+      line: 88
   - label: lint-http-rules/src/helpers/cookie.rs
     section: § 4.1.1
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'
@@ -2128,7 +2128,7 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 197
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 56
+      line: 55
   - label: lint-http-rules/src/helpers/cookie.rs (6)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.
@@ -2156,11 +2156,11 @@ sources:
     snippet: content-disposition = "Content-Disposition" ":" disposition-type *( ";" disposition-parm )
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_parameter_valid.rs
-      line: 35
+      line: 34
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 41
+      line: 40
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 123
+      line: 122
   - label: content_disposition_token_valid
     section: § 1
     snippet: This document does not apply to Content-Disposition header fields appearing in payload bodies transmitted over HTTP, such as when using the media type "multipart/form-data" ([RFC2388]).
@@ -2178,25 +2178,25 @@ sources:
     snippet: Note that due to the rules for implied linear whitespace (Section 2.1 of [RFC2616]), OPTIONAL whitespace can appear between words (token or quoted-string) and separator characters.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 54
+      line: 53
   - label: content_disposition_token_valid (4)
     section: § 4.1
     snippet: disp-ext-type       = token
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 71
+      line: 70
   - label: content_disposition_token_valid (5)
     section: § 4.1
     snippet: disposition-type = "inline" | "attachment" | disp-ext-type
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 56
+      line: 55
   - label: content_disposition_token_valid (6)
     section: § 4.2
     snippet: Unknown or unhandled disposition types SHOULD be handled by recipients the same way as "attachment" (see also [RFC2183], Section 2.8).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 72
+      line: 71
 - label: RFC 6335
   url: https://www.rfc-editor.org/rfc/rfc6335.txt
   type: text/plain
@@ -2434,13 +2434,13 @@ sources:
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 208
+      line: 207
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 209
+      line: 208
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 65
   - label: Sec-WebSocket-Protocol
@@ -2848,37 +2848,37 @@ sources:
     snippet: The client MUST implement CSRF protection for its redirection URI.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 75
+      line: 74
   - label: oauth2_code_flow (2)
     section: § 10.12
     snippet: The client SHOULD utilize the "state" request parameter to deliver this value
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 76
+      line: 75
   - label: oauth2_code_flow (3)
     section: § 4.1.1
     snippet: RECOMMENDED.  An opaque value used by the client to maintain state between the request and callback.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 74
+      line: 73
   - label: oauth2_code_flow (4)
     section: § 4.1.1
     snippet: REQUIRED.  Value MUST be set to "code".
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 66
+      line: 65
   - label: oauth2_code_flow (5)
     section: § 4.1.2
     snippet: REQUIRED if the "state" parameter was present in the client authorization request.  The exact value received from the client.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 99
+      line: 98
   - label: oauth2_code_flow (6)
     section: § 4.1.2
     snippet: REQUIRED.  The authorization code generated by the authorization server.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 94
+      line: 93
 - label: RFC 6750
   url: https://www.rfc-editor.org/rfc/rfc6750.txt
   type: text/plain
@@ -2888,7 +2888,7 @@ sources:
     snippet: credentials = "Bearer" 1*SP b64token
     cited_by:
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 46
+      line: 45
   - label: bearer b64token grammar
     section: § 2.1
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
@@ -2904,37 +2904,37 @@ sources:
     snippet: All directives MUST appear only once in an STS header field.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 188
+      line: 187
   - label: strict_transport_security_valid (2)
     section: § 6.1
     snippet: UAs MUST ignore any STS header field containing directives, or other header field value data, that does not conform to the syntax defined in this specification.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 31
+      line: 30
   - label: strict_transport_security_valid (3)
     section: § 6.1
     snippet: directive-name            = token
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 77
+      line: 76
   - label: strict_transport_security_valid (4)
     section: § 6.1
     snippet: directive-value           = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 161
+      line: 160
   - label: strict_transport_security_valid (5)
     section: § 6.1.1
     snippet: The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 90
+      line: 89
   - label: strict_transport_security_valid (6)
     section: § 6.1.2
     snippet: The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 134
+      line: 133
 - label: RFC 6838
   url: https://www.rfc-editor.org/rfc/rfc6838.txt
   type: text/plain
@@ -2950,7 +2950,7 @@ sources:
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1007
+      line: 1005
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 123
   - label: link_header_valid (2)
@@ -2958,7 +2958,7 @@ sources:
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1008
+      line: 1006
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 136
   - label: link_header_valid (3)
@@ -2966,13 +2966,13 @@ sources:
     snippet: restricted-name-chars = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "-" / "^" / "_"
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1009
+      line: 1007
   - label: link_header_valid (4)
     section: § 4.2
     snippet: restricted-name-chars =/ "+" ; Characters after last plus always ; specify a structured syntax suffix
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1011
+      line: 1009
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 131
   - label: link_header_valid (5)
@@ -2980,13 +2980,13 @@ sources:
     snippet: restricted-name-chars =/ "." ; Characters before first dot always ; specify a facet name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1010
+      line: 1008
   - label: link_header_valid (6)
     section: § 4.2
     snippet: type-name = restricted-name subtype-name = restricted-name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 984
+      line: 982
   - label: media_type_suffix_valid
     section: § 4.2.8
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
@@ -3007,9 +3007,9 @@ sources:
     snippet: The Content-MD5 header field has been removed because it was inconsistently implemented with respect to partial responses.
     cited_by:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
-      line: 47
+      line: 46
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 508
+      line: 507
 - label: RFC 7234
   url: https://www.rfc-editor.org/rfc/rfc7234.txt
   type: text/plain
@@ -3019,7 +3019,7 @@ sources:
     snippet: Warning = 1#warning-value
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 316
+      line: 312
   - label: warning_header_syntax (2)
     section: § 5.5
     snippet: Warning header fields can in general be applied to any message, however some warn-codes are specific to caches and can only be applied to response messages.
@@ -3031,39 +3031,39 @@ sources:
     snippet: Warnings are assigned three digit warn-codes.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 356
+      line: 352
   - label: warning_header_syntax (4)
     section: § 5.5
     snippet: warn-agent = ( uri-host [ ":" port ] ) / pseudonym
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 458
+      line: 454
   - label: warning_header_syntax (5)
     section: § 5.5
     snippet: warn-code = 3DIGIT warn-agent = ( uri-host [ ":" port ] ) / pseudonym
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 355
+      line: 351
   - label: warning_header_syntax (6)
     section: § 5.5
     snippet: warn-date = DQUOTE HTTP-date DQUOTE
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 417
+      line: 413
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 506
+      line: 502
   - label: warning_header_syntax (7)
     section: § 5.5
     snippet: warn-text = quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 393
+      line: 389
   - label: warning_header_syntax (8)
     section: § 5.5
     snippet: warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 349
+      line: 345
 - label: RFC 7239
   url: https://www.rfc-editor.org/rfc/rfc7239.txt
   type: text/plain
@@ -3079,7 +3079,7 @@ sources:
     snippet: '"Forwarded" is only for use in HTTP requests and is not to be used in HTTP responses.'
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 329
+      line: 327
   - label: forwarded_header_valid (3)
     section: § 4
     snippet: Each parameter MUST NOT occur more than once per field-value.
@@ -3163,13 +3163,13 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 99
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 311
+      line: 309
   - label: forwarded_header_valid (13)
     section: § 8.2
     snippet: This header field should never be copied into response messages by origin servers or intermediaries, as it can reveal the whole proxy chain to the client.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 330
+      line: 328
   - label: forwarded_header_valid (14)
     section: § 9
     snippet: New parameters and their values MUST conform with the forwarded-pair as defined in ABNF in Section 4.
@@ -3285,9 +3285,9 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 36
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 220
+      line: 218
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 221
+      line: 220
   - label: prefer_header_and_preference_applied (3)
     section: § 2
     snippet: If a server supports the optional application of a preference that might result in a variance to a cache's handling of a response entity, a Vary header field MUST be included in the response listing the Prefer header field regardless of whether the client actually used Prefer in the request.
@@ -3301,7 +3301,7 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 148
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 144
+      line: 143
   - label: prefer_header_and_preference_applied (4)
     section: § 3
     snippet: The Preference-Applied response header MAY be included within a response message as an indication as to which Prefer tokens were honored by the server and applied to the processing of a request.
@@ -3311,7 +3311,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 112
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 239
+      line: 238
   - label: prefer_header_and_preference_applied (5)
     section: § 3
     snippet: applied-pref = token [ BWS "=" BWS word ]
@@ -3319,7 +3319,7 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 160
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 192
+      line: 191
   - label: prefer_header_and_preference_applied (6)
     section: § 4.1
     snippet: the server can honor the "respond-async" preference by returning a 202 (Accepted) response.
@@ -3363,13 +3363,13 @@ sources:
     snippet: '*( OWS ";" [ OWS parameter ] )'
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 183
+      line: 181
   - label: prefer_header_valid (2)
     section: § 2
     snippet: A client MAY use multiple instances of the Prefer header field in a single message, or it MAY use a single Prefer header field with multiple comma-separated preference tokens.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 128
+      line: 126
   - label: prefer_header_valid (3)
     section: § 2
     snippet: A server that does not recognize or is unable to comply with particular preference tokens in the Prefer header field of a request MUST ignore those tokens and continue processing instead of signaling an error.
@@ -3381,7 +3381,7 @@ sources:
     snippet: An optional set of parameters can be specified for any preference token.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 249
+      line: 247
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 73
   - label: prefer_header_valid (5)
@@ -3389,17 +3389,17 @@ sources:
     snippet: Empty or zero-length values on both the preference token and within parameters are equivalent to no value being specified at all.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 217
+      line: 215
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 22
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 226
+      line: 225
   - label: prefer_header_valid (6)
     section: § 2
     snippet: If any preference is specified more than once, only the first instance is to be considered.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 287
+      line: 285
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 89
   - label: prefer_header_valid (7)
@@ -3407,7 +3407,7 @@ sources:
     snippet: If multiple Prefer header fields are used, it is equivalent to a single Prefer header field with the comma-separated concatenation of all of the tokens.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 129
+      line: 127
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 41
   - label: prefer_header_valid (8)
@@ -3415,7 +3415,7 @@ sources:
     snippet: Prefer     = "Prefer" ":" 1#preference
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 137
+      line: 135
   - label: prefer_header_valid (9)
     section: § 2
     snippet: The Prefer request header field is used to indicate that particular server behaviors are preferred by the client but are not required for successful completion of the request.
@@ -3427,19 +3427,19 @@ sources:
     snippet: To avoid any possible ambiguity, individual preference tokens SHOULD NOT appear multiple times within a single request.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 286
+      line: 284
   - label: prefer_header_valid (11)
     section: § 2
     snippet: parameter  = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 248
+      line: 246
   - label: prefer_header_valid (12)
     section: § 2
     snippet: preference = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 182
+      line: 180
   - label: prefer_header_valid (13)
     section: § 4
     snippet: The following subsections define an initial set of preferences.
@@ -3457,7 +3457,7 @@ sources:
     snippet: The "return=minimal" and "return=representation" preferences are mutually exclusive directives.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 288
+      line: 286
   - label: prefer_header_valid (16)
     section: § 4.2
     snippet: return = "return" BWS "=" BWS ("representation" / "minimal")
@@ -3475,7 +3475,7 @@ sources:
     snippet: The "handling=strict" and "handling=lenient" preferences are mutually exclusive directives.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 289
+      line: 287
   - label: prefer_header_valid (19)
     section: § 4.4
     snippet: handling = "handling" BWS "=" BWS ("strict" / "lenient")
@@ -3487,7 +3487,7 @@ sources:
     snippet: The syntax of the Preference-Applied header differs from that of the Prefer header in that parameters are not included.
     cited_by:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 184
+      line: 183
 - label: RFC 7301
   url: https://www.rfc-editor.org/rfc/rfc7301.txt
   type: text/plain
@@ -3543,13 +3543,13 @@ sources:
     snippet: The media types application/xml or text/xml, or a more specific media type (see Section 9.6), SHOULD be used.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 80
+      line: 79
   - label: problem_details_content_type (2)
     section: § 9.2
     snippet: The registration information for text/xml is in all respects the same as that given for application/xml above (Section 9.1), except that the "Type name" is "text".
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 81
+      line: 80
 - label: RFC 7578
   url: https://www.rfc-editor.org/rfc/rfc7578.txt
   type: text/plain
@@ -3559,13 +3559,13 @@ sources:
     snippet: The Content-Disposition header field MUST also contain an additional parameter of "name"; the value of the "name" parameter is the original field name from the form
     cited_by:
     - file: lint-http-rules/src/rules/form_data_content_disposition_valid.rs
-      line: 63
+      line: 62
   - label: form_data_content_disposition_valid (2)
     section: § 4.2
     snippet: where the disposition type is "form-data".
     cited_by:
     - file: lint-http-rules/src/rules/form_data_content_disposition_valid.rs
-      line: 54
+      line: 53
 - label: RFC 7616
   url: https://www.rfc-editor.org/rfc/rfc7616.txt
   type: text/plain
@@ -3575,49 +3575,49 @@ sources:
     snippet: A case-insensitive flag indicating that the previous request from the client was rejected because the nonce value was stale.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 253
+      line: 252
   - label: digest_auth_nonce_handling (2)
     section: § 3.3
     snippet: A string of data, specified by the server, that SHOULD be returned by the client unchanged in the Authorization header field of subsequent requests
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 182
+      line: 181
   - label: digest_auth_nonce_handling (3)
     section: § 3.3
     snippet: The nonce is opaque to the client.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 136
+      line: 135
   - label: digest_auth_nonce_handling (4)
     section: § 3.4
     snippet: if the same nc value is seen twice, then the request is a replay.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 241
+      line: 240
   - label: digest_auth_valid
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 151
+      line: 150
   - label: digest_auth_valid (2)
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 150
+      line: 149
   - label: digest_auth_valid (3)
     section: § 3.4
     snippet: If a parameter or its value is improper, or required parameters are missing, the proper response is a 4xx error code.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 61
+      line: 60
   - label: cnonce
     section: § 3.4
     snippet: This parameter MUST be used by all implementations.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 111
+      line: 110
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 3.5
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
@@ -3633,7 +3633,7 @@ sources:
     snippet: The value is computed based on user-id and password as defined below.
     cited_by:
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 46
+      line: 45
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 2
     snippet: The user-id and password MUST NOT contain any control characters
@@ -3681,7 +3681,7 @@ sources:
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 259
+      line: 258
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 219
   - label: alt_svc_h3_advertisement_valid (3)
@@ -3711,7 +3711,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 37
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 258
+      line: 257
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 218
   - label: alt_svc_h3_advertisement_valid (6)
@@ -3719,13 +3719,13 @@ sources:
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 284
+      line: 283
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 457
+      line: 455
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
@@ -3737,7 +3737,7 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 442
+      line: 440
   - label: alt_svc_header_syntax (4)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
@@ -3919,17 +3919,17 @@ sources:
     snippet: Clients SHOULD NOT issue a conditional request during the response's freshness lifetime (e.g., upon a reload) unless explicitly overridden by the user (e.g., a force reload).
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 107
+      line: 106
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 105
+      line: 104
   - label: immutable_cache_never_stale (2)
     section: § 2
     snippet: The immutable extension only applies during the freshness lifetime of the stored response.
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 108
+      line: 107
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 104
+      line: 103
 - label: RFC 8259
   url: https://www.rfc-editor.org/rfc/rfc8259.txt
   type: text/plain
@@ -3939,21 +3939,21 @@ sources:
     snippet: The media type for JSON text is application/json.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 79
+      line: 78
   - label: problem_details_structure_valid
     section: § 2
     snippet: A JSON text is a serialized value.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 132
+      line: 131
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 161
+      line: 160
   - label: problem_details_structure_valid (2)
     section: § 8.1
     snippet: JSON text exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 162
+      line: 161
 - label: RFC 8288
   url: https://www.rfc-editor.org/rfc/rfc8288.txt
   type: text/plain
@@ -3963,49 +3963,49 @@ sources:
     snippet: 'This document uses the Augmented Backus-Naur Form (ABNF) [RFC5234] notation of [RFC7230], including the #rule, and explicitly includes the following rules from it'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 673
+      line: 671
   - label: link_header_valid (2)
     section: § 1.2
     snippet: The requirements regarding conformance and error handling highlighted in [RFC7230], Section 2.5 apply to this document.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 473
+      line: 471
   - label: link_header_valid (3)
     section: § 2.1.1
     snippet: Registered relation type names MUST conform to the reg-rel-type rule (see Section 3.3) and MUST be compared character by character in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 796
+      line: 794
   - label: link_header_valid (4)
     section: § 2.1.2
     snippet: When extension relation types are compared, they MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion, character by character.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 918
+      line: 916
   - label: link_header_valid (5)
     section: § 2.2
     snippet: The names of target attributes SHOULD conform to the token rule, but SHOULD NOT include any of the characters "%", "'", or "*", for portability across serialisations and MUST be compared in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 696
+      line: 694
   - label: link_header_valid (6)
     section: § 3
     snippet: Individual link-params specify their syntax in terms of the value after any necessary unquoting
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 672
+      line: 670
   - label: link_header_valid (7)
     section: § 3
     snippet: 'Link       = #link-value link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 475
+      line: 473
   - label: link_header_valid (8)
     section: § 3
     snippet: Note that any link-param can be generated with values using either the token or the quoted-string syntax; therefore, recipients MUST be able to parse both forms.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 671
+      line: 669
   - label: link_header_valid (9)
     section: § 3
     snippet: The Link header field provides a means for serialising one or more links into HTTP headers.
@@ -4017,121 +4017,121 @@ sources:
     snippet: link-param = token BWS [ "=" BWS ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 670
+      line: 668
   - label: link_header_valid (11)
     section: § 3
     snippet: link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 543
+      line: 541
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 604
+      line: 602
   - label: link_header_valid (12)
     section: § 3.1
     snippet: Each link-value conveys one target IRI as a URI-Reference (after conversion to one, if necessary; see [RFC3987], Section 3.1) inside angle brackets ("<>").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 632
+      line: 630
   - label: link_header_valid (13)
     section: § 3.3
     snippet: Note that extension relation types are REQUIRED to be absolute URIs in Link header fields and MUST be quoted when they contain characters not allowed in tokens
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 917
+      line: 915
   - label: link_header_valid (14)
     section: § 3.3
     snippet: The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 596
+      line: 594
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 863
+      line: 861
   - label: link_header_valid (15)
     section: § 3.3
     snippet: The rel parameter can, however, contain multiple link relation types.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 879
+      line: 877
   - label: link_header_valid (16)
     section: § 3.3
     snippet: The relation type of a link conveyed in the Link header field is conveyed in the "rel" parameter's value.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 862
+      line: 860
   - label: link_header_valid (17)
     section: § 3.3
     snippet: ext-rel-type   = URI ; Section 3 of [RFC3986]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 916
+      line: 914
   - label: link_header_valid (18)
     section: § 3.3
     snippet: reg-rel-type   = LOALPHA *( LOALPHA / DIGIT / "." / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 915
+      line: 913
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 961
+      line: 959
   - label: link_header_valid (19)
     section: § 3.3
     snippet: relation-type  = reg-rel-type / ext-rel-type
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 914
+      line: 912
   - label: link_header_valid (20)
     section: § 3.3
     snippet: relation-type *( 1*SP relation-type )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 878
+      line: 876
   - label: link_header_valid (21)
     section: § 3.4.1
     snippet: Its value MUST be quoted if it contains a semicolon (";") or comma (",").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 774
+      line: 772
   - label: link_header_valid (22)
     section: § 3.4.1
     snippet: 'The ABNF for the hreflang parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 742
+      line: 740
   - label: link_header_valid (23)
     section: § 3.4.1
     snippet: 'The ABNF for the media parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 773
+      line: 771
   - label: link_header_valid (24)
     section: § 3.4.1
     snippet: 'The ABNF for the type parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 753
+      line: 751
   - label: link_header_valid (25)
     section: § 3.4.1
     snippet: The title attribute MUST NOT appear more than once in a given link; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 598
+      line: 596
   - label: link_header_valid (26)
     section: § 3.4.1
     snippet: The title* link-param MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 599
+      line: 597
   - label: link_header_valid (27)
     section: § 3.4.1
     snippet: The type attribute MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 600
+      line: 598
   - label: link_header_valid (28)
     section: § 3.4.1
     snippet: There MUST NOT be more than one media attribute in a link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 597
+      line: 595
 - label: RFC 8297
   url: https://www.rfc-editor.org/rfc/rfc8297.txt
   type: text/plain
@@ -4189,7 +4189,7 @@ sources:
     snippet: In particular, an HTTP/1.1 client that mishandles an informational response as a final response is likely to consider all responses to the succeeding requests sent over the same connection to be part of the final response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 127
+      line: 123
 - label: RFC 8441
   url: https://www.rfc-editor.org/rfc/rfc8441.txt
   type: text/plain
@@ -4199,13 +4199,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 202
+      line: 196
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 203
+      line: 197
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -4311,9 +4311,9 @@ sources:
     snippet: The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future.
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 123
+      line: 122
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 34
+      line: 33
 - label: RFC 8615
   url: https://www.rfc-editor.org/rfc/rfc8615.txt
   type: text/plain
@@ -4323,13 +4323,13 @@ sources:
     snippet: Furthermore, defining well-known locations usurps the origin's control over its own URI space [RFC7320].
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 225
+      line: 224
   - label: well_known_uri_syntax (2)
     section: § 1
     snippet: To address these uses, this memo reserves a path prefix in HTTP, HTTPS, WebSocket (WS), and Secure WebSocket (WSS) URIs for these "well-known locations", "/.well-known/".
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 237
+      line: 236
   - label: well_known_uri_syntax (3)
     section: § 1
     snippet: Well-known URIs can also be used with other URI schemes, but only when those schemes' definitions explicitly allow it.
@@ -4347,7 +4347,7 @@ sources:
     snippet: Also, this specification does not define a format or media type for the resource located at "/.well-known/", and clients should not expect a resource to exist at that location.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 256
+      line: 255
   - label: well_known_uri_syntax (6)
     section: § 3
     snippet: Applications that wish to mint new well-known URIs MUST register them, following the procedures in Section 5.1, subject to the following requirements.
@@ -4359,25 +4359,25 @@ sources:
     snippet: For example, "/.well-known/example" is a well-known URI, whereas "/foo/.well-known/example" is not.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 224
+      line: 223
   - label: well_known_uri_syntax (8)
     section: § 3
     snippet: Registered names MUST conform to the "segment-nz" production in [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 254
+      line: 253
   - label: well_known_uri_syntax (9)
     section: § 3
     snippet: Registrations MAY also contain additional information, such as the syntax of additional path components, query strings, and/or fragment identifiers to be appended to the well-known URI
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 270
+      line: 269
   - label: well_known_uri_syntax (10)
     section: § 3
     snippet: This means they cannot contain the "/" character.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 269
+      line: 268
   - label: well_known_uri_syntax (11)
     section: § 3
     snippet: This specification updates the "http" [RFC7230] and "https" [RFC7230] schemes to support well-known URIs.
@@ -4389,7 +4389,7 @@ sources:
     snippet: Well-known URIs are rooted in the top of the path's hierarchy; they are not well-known by definition in other parts of the path.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 223
+      line: 222
   - label: well_known_uri_syntax (13)
     section: § 5.2
     snippet: If a URI scheme explicitly has been specified to use well-known URIs as per Section 3, the value changes to a reference to that specification.
@@ -4451,53 +4451,53 @@ sources:
     snippet: A user agent cannot rely on proactive negotiation preferences being consistently honored, since the origin server might not implement proactive negotiation for the requested resource or might decide that sending a response that doesn't conform to the user agent's preferences is better than sending a 406 (Not Acceptable) response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 44
+      line: 42
   - label: accept_and_content_type_negotiation (2)
     section: § 12.4.1
     snippet: For each of the content negotiation fields, a request that does not contain the field implies that the sender has no preference on that dimension of negotiation.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 84
+      line: 82
   - label: accept_and_content_type_negotiation (3)
     section: § 12.4.1
     snippet: If a content negotiation header field is present in a request and none of the available representations for the response can be considered acceptable according to it, the origin server can either honor the header field by sending a 406 (Not Acceptable) response or disregard the header field by treating the response as if it is not subject to content negotiation for that request header field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 43
+      line: 41
   - label: accept_and_content_type_negotiation (4)
     section: § 12.4.2
     snippet: If no "q" parameter is present, the default weight is 1.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 178
+      line: 176
   - label: accept_and_content_type_negotiation (5)
     section: § 12.4.2
     snippet: The weight is normalized to a real number in the range 0 through 1, where 0.001 is the least preferred and 1 is the most preferred; a value of 0 means "not acceptable".
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 177
+      line: 175
   - label: accept_and_content_type_negotiation (6)
     section: § 12.5.1
     snippet: 'Accept = #( media-range [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 54
+      line: 52
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 36
+      line: 35
   - label: accept_and_content_type_negotiation (7)
     section: § 12.5.1
     snippet: If more than one media range applies to a given type, the most specific reference has precedence.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 202
+      line: 200
   - label: accept_and_content_type_negotiation (8)
     section: § 12.5.1
     snippet: Recipients SHOULD process any parameter named "q" as weight, regardless of parameter ordering.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 154
+      line: 152
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 271
+      line: 270
   - label: accept_and_content_type_negotiation (9)
     section: § 12.5.1
     snippet: The "Accept" header field can be used by user agents to specify their preferences regarding response media types.
@@ -4511,67 +4511,67 @@ sources:
     snippet: The asterisk "*" character is used to group media types into ranges, with "*/*" indicating all media types and "type/*" indicating all subtypes of that type.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 143
+      line: 141
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 99
+      line: 98
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 244
+      line: 242
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 191
+      line: 189
   - label: accept_and_content_type_negotiation (11)
     section: § 12.5.1
     snippet: The media-range can include media type parameters that are applicable to that range.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 201
+      line: 199
   - label: accept_and_content_type_negotiation (12)
     section: § 12.5.1
     snippet: media-range    = ( "*/*" / ( type "/" "*" ) / ( type "/" subtype ) ) parameters
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 142
+      line: 140
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 98
+      line: 97
   - label: accept_and_content_type_negotiation (13)
     section: § 15.5.7
     snippet: The 406 (Not Acceptable) status code indicates that the target resource does not have a current representation that would be acceptable to the user agent
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 76
+      line: 74
   - label: accept_and_content_type_negotiation (14)
     section: § 8.3
     snippet: Recipients often attempt to handle this error by using the last syntactically valid member of the list, leading to potential interoperability and security issues if different implementations have different error handling behaviors.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 65
+      line: 63
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 58
+      line: 56
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 140
+      line: 138
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 49
+      line: 48
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 79
+      line: 78
   - label: accept_encoding_parameter_valid
     section: § 12.4.2
     snippet: The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 133
+      line: 131
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 270
+      line: 269
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 83
+      line: 82
   - label: accept_encoding_parameter_valid (2)
     section: § 12.4.2
     snippet: weight = OWS ";" OWS "q=" qvalue
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 38
+      line: 36
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 37
+      line: 36
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 123
+      line: 121
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 88
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -4581,33 +4581,33 @@ sources:
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 37
+      line: 35
   - label: accept_encoding_parameter_valid (4)
     section: § 12.5.3
     snippet: An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 70
+      line: 68
   - label: accept_encoding_parameter_valid (5)
     section: § 12.5.3
     snippet: An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 48
+      line: 46
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 53
+      line: 51
   - label: accept_encoding_parameter_valid (6)
     section: § 12.5.3
     snippet: Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 108
+      line: 106
   - label: accept_encoding_parameter_valid (7)
     section: § 12.5.3
     snippet: The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 69
+      line: 67
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 110
   - label: accept_encoding_parameter_valid (8)
@@ -4623,7 +4623,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 19
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 45
+      line: 43
   - label: accept_encoding_parameter_valid (10)
     section: § 12.5.3
     snippet: When the Accept-Encoding header field is present in a response, it indicates what content codings the resource was willing to accept in the associated request.
@@ -4635,45 +4635,45 @@ sources:
     snippet: content-coding   = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 68
+      line: 66
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 50
+      line: 48
   - label: accept_encoding_present
     section: § 12.5.3
     snippet: 'Accept-Encoding = #( codings [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 47
+      line: 45
   - label: accept_encoding_present (2)
     section: § 12.5.3
     snippet: If no Accept-Encoding header field is in the request, any content coding is considered acceptable by the user agent.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 46
+      line: 44
   - label: accept_encoding_present (3)
     section: § 12.5.3
     snippet: If the representation has no content coding, then it is acceptable by default unless specifically excluded by the Accept-Encoding header field stating either "identity;q=0" or "*;q=0" without a more specific entry for "identity".
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 100
+      line: 98
   - label: accept_encoding_present (4)
     section: § 9.3.6
     snippet: Any 2xx (Successful) response indicates that the sender (and all inbound proxies) will switch to tunnel mode immediately after the response header section; data received after that header section is from the server identified by the request target.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 33
+      line: 31
   - label: accept_encoding_present (5)
     section: § 9.3.6
     snippet: The CONNECT method requests that the recipient establish a tunnel to the destination origin server identified by the request target and, if successful, thereafter restrict its behavior to blind forwarding of data, in both directions, until the tunnel is closed.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 32
+      line: 30
   - label: accept_header_media_type_syntax
     section: § 12.4.2
     snippet: A sender of qvalue MUST NOT generate more than three digits after the decimal point.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 279
+      line: 278
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 292
   - label: accept_header_media_type_syntax (2)
@@ -4681,19 +4681,19 @@ sources:
     snippet: Each media-range might be followed by optional applicable media type parameters (e.g., charset), followed by an optional "q" parameter for indicating a relative weight (Section 12.4.2).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 37
+      line: 36
   - label: accept_header_media_type_syntax (3)
     section: § 12.5.1
     snippet: Senders using weights SHOULD send "q" last (after all media-range parameters).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 199
+      line: 198
   - label: accept_header_media_type_syntax (4)
     section: § 12.5.1
     snippet: The accept extension grammar (accept-params, accept-ext) has been removed because it had a complicated definition, was not being used in practice, and is more easily deployed through new header fields.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 198
+      line: 197
   - label: accept_header_media_type_syntax (5)
     section: § 12.5.1
     snippet: When sent by a server in a response, Accept provides information about which content types are preferred in the content of a subsequent request to the same resource.
@@ -4705,11 +4705,11 @@ sources:
     snippet: Tokens are short textual identifiers that do not include whitespace or delimiters.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 83
+      line: 82
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 244
+      line: 243
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 71
+      line: 70
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 81
   - label: accept_header_media_type_syntax (7)
@@ -4717,7 +4717,7 @@ sources:
     snippet: media-type = type "/" subtype parameters type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 128
+      line: 127
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 42
   - label: accept_language_weight_valid
@@ -4725,13 +4725,13 @@ sources:
     snippet: 'Accept-Language = #( language-range [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 36
+      line: 35
   - label: accept_language_weight_valid (2)
     section: § 12.5.4
     snippet: Each language-range can be given an associated quality value representing an estimate of the user's preference for the languages specified by that range, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 64
+      line: 63
   - label: accept_language_weight_valid (3)
     section: § 12.5.4
     snippet: The "Accept-Language" header field can be used by user agents to indicate the set of natural languages that are preferred in the response.
@@ -4751,19 +4751,19 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 46
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 161
+      line: 158
   - label: accept_patch_header_valid (2)
     section: § 15.5.16
     snippet: If the problem was caused by an unsupported content coding, the Accept-Encoding response header field (Section 12.5.3) ought to be used
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 255
+      line: 252
   - label: accept_patch_header_valid (3)
     section: § 15.5.16
     snippet: The format problem might be due to the request's indicated Content-Type or Content-Encoding, or as a result of inspecting the data directly.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 254
+      line: 251
   - label: accept_patch_header_valid (4)
     section: § 5.6.1.2
     snippet: 'Empty elements do not contribute to the count of elements present.  A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism.'
@@ -4779,11 +4779,11 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 153
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 147
+      line: 145
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 155
+      line: 154
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 317
+      line: 313
   - label: accept_patch_header_valid (6)
     section: § 9.1
     snippet: The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names.
@@ -4791,7 +4791,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 188
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 241
+      line: 238
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 74
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -4803,81 +4803,81 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 186
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 84
+      line: 82
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 125
+      line: 123
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 50
+      line: 48
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 31
+      line: 29
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 81
+      line: 80
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 191
+      line: 192
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 171
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 75
+      line: 73
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 70
+      line: 69
     - file: lint-http-rules/src/rules/status_3xx_vs_request_method.rs
-      line: 93
+      line: 91
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 47
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 78
+      line: 76
   - label: accept_patch_header_valid (7)
     section: § 9.3.7
     snippet: An OPTIONS request with an asterisk ("*") as the request target (Section 7.1) applies to the server in general rather than to a specific resource.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 300
+      line: 296
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 129
+      line: 127
   - label: accept_ranges_and_206_consistent
     section: § 14
     snippet: Range requests are an OPTIONAL feature of HTTP, designed so that recipients not implementing this feature (or not supporting it for the target resource) can respond as if it is a normal GET request without impacting interoperability.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 54
+      line: 52
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 109
+      line: 107
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 53
+      line: 52
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 38
+      line: 37
   - label: accept_ranges_and_206_consistent (2)
     section: § 14.2
     snippet: If all of the preconditions are true, the server supports the Range header field for the target resource, the received Range field-value contains a valid ranges-specifier with a range-unit supported for that target resource, and that ranges-specifier is satisfiable with respect to the selected representation, the server SHOULD send a 206 (Partial Content) response with content containing one or more partial representations that correspond to the satisfiable range-spec(s) requested.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 106
+      line: 104
   - label: accept_ranges_and_206_consistent (3)
     section: § 14.3
     snippet: A client MAY generate range requests regardless of having received an Accept-Ranges field.  The information only provides advice for the sake of improving performance and reducing unnecessary network transfers.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 55
+      line: 53
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 110
+      line: 108
   - label: accept_ranges_and_206_consistent (4)
     section: § 14.3
     snippet: A server that does not support any kind of range request for the target resource MAY send
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 71
+      line: 69
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 118
+      line: 116
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 125
+      line: 124
   - label: accept_ranges_and_206_consistent (5)
     section: § 14.3
     snippet: The "Accept-Ranges" field in a response indicates whether an upstream server supports range requests for the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 31
+      line: 29
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 95
+      line: 93
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 23
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
@@ -4887,29 +4887,29 @@ sources:
     snippet: to advise the client not to attempt a range request on the same request path.  The range unit "none" is reserved for this purpose.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 72
+      line: 70
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 92
+      line: 90
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 126
+      line: 125
   - label: accept_ranges_and_206_consistent (7)
     section: § 14.3
     snippet: to indicate that it supports byte range requests for that target resource, thereby encouraging its use by the client for future partial requests on the same request path.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 56
+      line: 54
   - label: accept_ranges_and_206_consistent (8)
     section: § 15.3.7
     snippet: 'A server that generates a 206 response MUST generate the following header fields, in addition to those required in the subsections below, if the field would have been sent in a 200 (OK) response to the same request: Date, Cache-Control, ETag, Expires, Content-Location, and Vary.'
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 57
+      line: 55
   - label: accept_ranges_and_206_consistent (9)
     section: § 15.3.7
     snippet: The 206 (Partial Content) status code indicates that the server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 37
+      line: 35
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 139
   - label: accept_ranges_on_partial_content
@@ -4917,37 +4917,37 @@ sources:
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 83
+      line: 81
   - label: accept_ranges_on_partial_content (2)
     section: § 14.2
     snippet: An origin server MUST ignore a Range header field that contains a range unit it does not understand.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 142
+      line: 140
   - label: accept_ranges_on_partial_content (3)
     section: § 14.2
     snippet: The "Range" header field on a GET request modifies the method semantics to request transfer of only one or more subranges of the selected representation data (Section 8.1), rather than the entire selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 82
+      line: 80
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 20
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 86
+      line: 85
   - label: accept_ranges_on_partial_content (4)
     section: § 14.3
     snippet: Conversely, a client MUST NOT assume that receiving an Accept-Ranges field means that future range requests will return partial responses.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 163
+      line: 161
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 167
+      line: 166
   - label: accept_ranges_on_partial_content (5)
     section: § 15.3.7
     snippet: A client MUST inspect a 206 response's Content-Type and Content-Range field(s) to determine what parts are enclosed and whether additional requests are needed.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 164
+      line: 162
   - label: accept_ranges_on_partial_content (6)
     section: § A
     snippet: Range = ranges-specifier
@@ -4961,25 +4961,25 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 37
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 311
+      line: 310
   - label: acceptable-ranges grammar
     section: § 14.3
     snippet: acceptable-ranges = 1#range-unit
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 94
+      line: 93
   - label: accept_ranges_values_valid
     section: § 16.5.1
     snippet: The "HTTP Range Unit Registry" defines the namespace for the range unit names and refers to their corresponding specifications.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 165
+      line: 164
   - label: tchar grammar
     section: § 5.6.2
     snippet: tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 72
+      line: 71
   - label: allow_header_method_tokens_valid
     section: § 10.2
     snippet: The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources.
@@ -4993,7 +4993,7 @@ sources:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 103
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
-      line: 76
+      line: 74
   - label: allow_header_method_tokens_valid (2)
     section: § 10.2.1
     snippet: An empty Allow field value indicates that the resource allows no methods, which might occur in a 405 response if the resource has been temporarily disabled by configuration.
@@ -5003,7 +5003,7 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 43
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 123
+      line: 120
   - label: allow_header_method_tokens_valid (3)
     section: § 10.2.1
     snippet: The purpose of this field is strictly to inform the recipient of valid request methods associated with the resource.
@@ -5017,43 +5017,43 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 172
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 170
+      line: 169
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 305
+      line: 304
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 111
+      line: 108
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 21
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 153
+      line: 149
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 430
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 474
+      line: 472
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 73
+      line: 72
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 229
+      line: 227
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 165
+      line: 164
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 101
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 171
+      line: 172
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 195
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 212
+      line: 210
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 305
+      line: 301
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 109
+      line: 107
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 50
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 101
+      line: 99
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 303
+      line: 299
   - label: Allow grammar, sender-expanded
     section: § A
     snippet: Allow = [ method *( OWS "," OWS method ) ]
@@ -5069,7 +5069,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 164
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 135
+      line: 138
   - label: alt_svc_header_syntax
     section: § 3.7
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
@@ -5099,61 +5099,61 @@ sources:
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 91
+      line: 90
   - label: authentication_challenge_valid (2)
     section: § 11.5
     snippet: Recipients might have to support both token and quoted-string syntax for maximum interoperability with existing clients that have been accepting both notations for a long time.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 61
+      line: 60
   - label: authentication_challenge_valid (3)
     section: § 11.5
     snippet: These realms allow the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme and/or authorization database.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 90
+      line: 89
   - label: authentication_failure_loop
     section: § 15.5.2
     snippet: If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_failure_loop.rs
-      line: 57
+      line: 56
   - label: authentication_failure_loop (2)
     section: § 15.5.2
     snippet: The 401 (Unauthorized) status code indicates that the request has not been applied because it lacks valid authentication credentials for the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_failure_loop.rs
-      line: 30
+      line: 29
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 72
+      line: 70
   - label: authorization_credentials_present
     section: § 11.6.2
     snippet: Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested
     cited_by:
     - file: lint-http-rules/src/rules/authorization_credentials_present.rs
-      line: 34
+      line: 33
   - label: cache_coherence
     section: § 15.4.5
     snippet: there is no need for the server to transfer a representation of the target resource because the request indicates that the client, which made the request conditional, already has a valid representation
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 42
+      line: 41
   - label: cache_coherence (2)
     section: § 6.6.1
     snippet: The "Date" header field represents the date and time at which the message was originated
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 67
+      line: 66
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 45
+      line: 44
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 64
+      line: 63
   - label: cache_coherence (3)
     section: § 8.8.2
     snippet: The "Last-Modified" header field in a response provides a timestamp indicating the date and time at which the origin server believes the selected representation was last modified
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 54
+      line: 53
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 33
   - label: cache_validation_chain
@@ -5161,27 +5161,27 @@ sources:
     snippet: The "If-None-Match" header field makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource, when the field value is "*"
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 62
+      line: 61
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 100
+      line: 99
   - label: cached_validators_reused
     section: § 13.1.2
     snippet: When a client desires to update one or more stored responses that have entity tags, the client SHOULD generate an If-None-Match header field containing a list of those entity tags when making a GET request
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
-      line: 66
+      line: 64
   - label: cached_validators_reused (2)
     section: § 13.1.3
     snippet: 'If-Modified-Since is typically used for two distinct purposes: 1) to allow efficient updates of a cached representation that does not have an entity tag'
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
-      line: 67
+      line: 65
   - label: charset_present
     section: § 8.3.2
     snippet: HTTP uses "charset" names to indicate or negotiate the character encoding scheme
     cited_by:
     - file: lint-http-rules/src/rules/charset_present.rs
-      line: 48
+      line: 47
   - label: charset_registered
     section: § 8.3
     snippet: 'The "Content-Type" header field indicates the media type of the associated representation: either the representation enclosed in the message content or the selected representation, as determined by the message semantics.'
@@ -5215,21 +5215,21 @@ sources:
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 90
+      line: 88
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 159
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 70
+      line: 69
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 10.1.4
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 91
+      line: 89
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 140
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 52
+      line: 51
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 8.4
     snippet: An origin server MAY respond with a status code of 415 (Unsupported Media Type) if a representation in the request message has a content coding that is not acceptable.
@@ -5241,9 +5241,9 @@ sources:
     snippet: 'Content-Encoding = #content-coding'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 49
+      line: 47
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 33
+      line: 32
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 95
   - label: compression_and_transfer_encoding_consistent (5)
@@ -5251,25 +5251,25 @@ sources:
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 145
+      line: 143
   - label: compression_and_transfer_encoding_consistent (6)
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 138
+      line: 136
   - label: compression_and_transfer_encoding_consistent (7)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 122
+      line: 120
   - label: compression_and_transfer_encoding_consistent (8)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 69
+      line: 67
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 149
   - label: conditional_headers_consistent
@@ -5277,57 +5277,57 @@ sources:
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 39
+      line: 38
   - label: conditional_headers_consistent (2)
     section: § 13.1.3
     snippet: A recipient MUST ignore the If-Modified-Since header field if the received field value is not a valid HTTP-date, the field value has more than one member, or if the request method is neither GET nor HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 104
+      line: 103
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 126
+      line: 125
   - label: conditional_headers_consistent (3)
     section: § 13.1.4
     snippet: A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 50
+      line: 49
   - label: conditional_headers_consistent (4)
     section: § 13.1.4
     snippet: A recipient MUST ignore the If-Unmodified-Since header field if the received field value is not a valid HTTP-date (including when the field value appears to be a list of dates).
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 105
+      line: 104
   - label: conditional_headers_consistent (5)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 76
+      line: 75
   - label: conditional_headers_consistent (6)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 62
+      line: 61
   - label: conditional_request_handling
     section: § 13.1.2
     snippet: An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 97
+      line: 96
   - label: conditional_request_handling (2)
     section: § 13.1.3
     snippet: An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 131
+      line: 130
   - label: conditional_request_handling (3)
     section: § 13.2.2
     snippet: When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 132
+      line: 131
   - label: connection_header_tokens_valid
     section: § 7.6.1
     snippet: A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content.  For example, Cache-Control is never appropriate as a connection option (Section 5.2 of [CACHING]).
@@ -5341,7 +5341,7 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 23
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 84
+      line: 83
   - label: connection_header_tokens_valid (2)
     section: § 7.6.1
     snippet: The "Connection" header field allows the sender to list desired control options for the current connection.
@@ -5351,7 +5351,7 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 131
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 197
+      line: 196
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 32
   - label: Connection grammar, sender-expanded
@@ -5365,15 +5365,15 @@ sources:
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 151
+      line: 150
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 85
+      line: 84
   - label: content_encoding_and_type_consistent
     section: § 15.4.5
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 108
+      line: 107
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"
@@ -5397,105 +5397,105 @@ sources:
     snippet: The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_valid.rs
-      line: 32
+      line: 31
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 185
+      line: 184
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 103
+      line: 102
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 145
+      line: 144
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 109
+      line: 108
   - label: content_location_and_uri_consistent
     section: § 4.1
     snippet: A "partial-URI" rule is defined for protocol elements that can contain a relative URI but not a fragment component.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 167
+      line: 166
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 198
+      line: 197
   - label: content_location_and_uri_consistent (2)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 168
+      line: 167
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 199
+      line: 198
   - label: content_location_and_uri_consistent (3)
     section: § 8.7
     snippet: Content-Location = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 54
+      line: 53
   - label: content_location_and_uri_consistent (4)
     section: § 8.7
     snippet: For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 273
+      line: 272
   - label: content_location_and_uri_consistent (5)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its field value refers to a URI that differs from the target URI, then the origin server claims that the URI is an identifier for a different resource corresponding to the enclosed representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 272
+      line: 271
   - label: content_location_and_uri_consistent (6)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its value refers (after conversion to absolute form) to a URI that is the same as the target URI, then the recipient MAY consider the content to be a current representation of that resource at the time indicated by the message origination date.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 186
+      line: 185
   - label: content_location_and_uri_consistent (7)
     section: § 8.7
     snippet: In the latter case (Section 4), the referenced URI is relative to the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 213
+      line: 212
   - label: content_location_and_uri_consistent (8)
     section: § 8.7
     snippet: Such a claim can only be trusted if both identifiers share the same resource owner, which cannot be programmatically determined via HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 274
+      line: 273
   - label: content_location_and_uri_consistent (9)
     section: § 8.7
     snippet: The "Content-Location" header field references a URI that can be used as an identifier for a specific resource corresponding to the representation in this message's content.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 41
+      line: 40
   - label: content_location_and_uri_consistent (10)
     section: § 8.7
     snippet: The field value is either an absolute-URI or a partial-URI.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 117
+      line: 116
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 166
+      line: 165
   - label: content_type_present
     section: § 15.3.6
     snippet: Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 41
+      line: 40
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 69
+      line: 68
   - label: content_type_present (2)
     section: § 8.3
     snippet: A sender that generates a message containing content SHOULD generate a Content-Type header field in that message unless the intended media type of the enclosed representation is unknown to the sender.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 101
+      line: 100
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 64
+      line: 62
   - label: content_type_present (3)
     section: § 8.3
     snippet: Content-Type = media-type
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 102
+      line: 101
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 56
+      line: 54
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 35
   - label: content_type_present (4)
@@ -5503,27 +5503,27 @@ sources:
     snippet: If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([RFC2046], Section 4.5.1) or examine the data to determine its type.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 108
+      line: 107
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 99
+      line: 97
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 88
+      line: 87
   - label: content_type_present (5)
     section: § 8.3
     snippet: This "MIME sniffing" risks drawing incorrect conclusions about the data, which might expose the user to additional security risks (e.g., "privilege escalation").
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 109
+      line: 108
   - label: content_type_present (6)
     section: § 9.3.2
     snippet: The HEAD method is identical to GET except that the server MUST NOT send content in the response.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 52
+      line: 51
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 207
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 74
+      line: 73
   - label: content_type_registered
     section: § 8.3.1
     snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
@@ -5535,9 +5535,9 @@ sources:
     snippet: Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 57
+      line: 55
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 139
+      line: 137
   - label: context_fields_direction
     section: § 10.1
     snippet: The request header fields below provide additional information about the request context, including information about the user, user agent, and resource behind the request.
@@ -5551,7 +5551,7 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 55
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 395
+      line: 393
   - label: context_fields_direction (2)
     section: § 10.1.1
     snippet: The "Expect" header field in a request indicates a certain set of behaviors (expectations) that need to be supported by the server in order to properly handle this request.
@@ -5567,7 +5567,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 16
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 52
+      line: 50
   - label: context_fields_direction (4)
     section: § 10.1.3
     snippet: The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled).
@@ -5587,7 +5587,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 362
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 396
+      line: 394
   - label: context_fields_direction (6)
     section: § 10.1.5
     snippet: The "User-Agent" header field contains information about the user agent originating the request
@@ -5605,9 +5605,9 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 47
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 70
+      line: 69
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
-      line: 99
+      line: 97
   - label: context_fields_direction (8)
     section: § 10.2.3
     snippet: Servers send the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request.
@@ -5615,11 +5615,11 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 48
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 27
+      line: 26
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
-      line: 67
+      line: 65
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
-      line: 91
+      line: 89
   - label: context_fields_direction (9)
     section: § 10.2.4
     snippet: The "Server" header field contains information about the software used by the origin server to handle the request
@@ -5631,7 +5631,7 @@ sources:
     snippet: An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1).
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 93
+      line: 92
   - label: early_data_header_safe_method
     section: § 16.1.1
     snippet: 'HTTP method registrations MUST include the following fields:'
@@ -5671,19 +5671,19 @@ sources:
     snippet: An origin server SHOULD send Last-Modified for any selected representation for which a last modification date can be reasonably and consistently determined
     cited_by:
     - file: lint-http-rules/src/rules/etag_or_last_modified_present.rs
-      line: 36
+      line: 35
   - label: etag_or_last_modified_present (2)
     section: § 8.8.3.1
     snippet: An origin server SHOULD send an ETag for any selected representation for which detection of changes can be reasonably and consistently determined
     cited_by:
     - file: lint-http-rules/src/rules/etag_or_last_modified_present.rs
-      line: 37
+      line: 36
   - label: etag_syntax
     section: § 8.8.3
     snippet: The "ETag" field in a response provides the current entity tag for the selected representation, as determined at the conclusion of handling the request.
     cited_by:
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 30
+      line: 29
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 34
   - label: expect_header_valid
@@ -5691,25 +5691,25 @@ sources:
     snippet: A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 127
+      line: 126
   - label: expect_header_valid (2)
     section: § 10.1.1
     snippet: A client MUST NOT generate a 100-continue expectation in a request that does not include content.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 126
+      line: 125
   - label: expect_header_valid (3)
     section: § 10.1.1
     snippet: A client that receives a 417 (Expectation Failed) status code in response to a request containing a 100-continue expectation SHOULD repeat that request without a 100-continue expectation, since the 417 response merely indicates that the response chain does not support expectations (e.g., it passes through an HTTP/1.0 server).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 145
+      line: 144
   - label: expect_header_valid (4)
     section: § 10.1.1
     snippet: A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 168
+      line: 167
   - label: expect_header_valid (5)
     section: § 10.1.1
     snippet: The Expect field value is case-insensitive.
@@ -5717,7 +5717,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 19
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 92
+      line: 91
   - label: expect_header_valid (6)
     section: § 10.1.1
     snippet: The only expectation defined by this specification is "100-continue" (with no defined parameters).
@@ -5729,25 +5729,25 @@ sources:
     snippet: expectation = token [ "=" ( token / quoted-string ) parameters ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 304
+      line: 303
   - label: expect_header_valid (8)
     section: § 15.5.18
     snippet: The 417 (Expectation Failed) status code indicates that the expectation given in the request's Expect header field (Section 10.1.1) could not be met by at least one of the inbound servers.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 144
+      line: 143
   - label: expect_header_valid (9)
     section: § 5.6.6
     snippet: '|  *Note:* Parameters do not allow whitespace (not even "bad" |  whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 444
+      line: 443
   - label: expect_header_valid (10)
     section: § A
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 80
+      line: 79
   - label: expect_header_valid (11)
     section: § B.3
     snippet: List-based grammar for Expect has been restored for compatibility with RFC 2616.
@@ -5759,7 +5759,7 @@ sources:
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 415
+      line: 414
   - label: extension_headers_registered
     section: § 16.3
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
@@ -5801,7 +5801,7 @@ sources:
     snippet: The address ought to be machine-usable, as defined by "mailbox" in Section 3.4 of [RFC5322]
     cited_by:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 53
+      line: 51
   - label: head_response_headers_match_get
     section: § 12.5.5
     snippet: A Vary field value is either the wildcard member "*" or a list of request field names, known as the selecting header fields, that might have had a role in selecting the representation for this response.
@@ -5821,7 +5821,7 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 236
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 36
+      line: 34
   - label: head_response_headers_match_get (4)
     section: § 15.3.1
     snippet: The content sent in a 200 response depends on the request method.
@@ -5835,9 +5835,9 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 128
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 55
+      line: 54
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 81
+      line: 80
   - label: head_response_headers_match_get (6)
     section: § 8.8
     snippet: In responses to safe requests, validator fields describe the selected representation chosen by the origin server while handling the response.
@@ -5881,13 +5881,13 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 202
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 67
+      line: 66
   - label: field-name grammar
     section: § A
     snippet: field-name = token field-value = *field-content
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 142
+      line: 140
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 81
   - label: host_and_authority_consistent
@@ -5921,33 +5921,33 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 49
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 274
+      line: 273
   - label: host_header
     section: § 7.2
     snippet: A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 58
+      line: 57
   - label: http2_pseudo_headers_valid
     section: § 7.1
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 241
+      line: 235
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 127
+      line: 122
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 259
+      line: 255
   - label: http2_pseudo_headers_valid (2)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 242
+      line: 236
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 128
+      line: 123
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 230
+      line: 226
   - label: http2_pseudo_headers_valid (3)
     section: § 9.3.6
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
@@ -5971,49 +5971,49 @@ sources:
     snippet: 'If-Match = "*" / #entity-tag'
     cited_by:
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 53
+      line: 52
   - label: if_match_etag_syntax (2)
     section: § 8.8.3
     snippet: etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text
     cited_by:
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 77
+      line: 76
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 78
+      line: 77
   - label: if_modified_since_date_syntax
     section: § 13.1.3
     snippet: If-Modified-Since = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 64
+      line: 63
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 39
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 76
+      line: 75
   - label: if_modified_since_date_syntax (2)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 65
+      line: 64
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 65
+      line: 64
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 45
+      line: 44
   - label: if_none_match_etag_syntax
     section: § 13.1.2
     snippet: 'If-None-Match = "*" / #entity-tag'
     cited_by:
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 54
+      line: 53
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 99
+      line: 98
   - label: if_unmodified_since_date_syntax
     section: § 13.1.4
     snippet: If-Unmodified-Since = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 64
+      line: 63
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 40
   - label: keep_alive_header_valid
@@ -6027,7 +6027,7 @@ sources:
     snippet: 'Content-Language = #language-tag'
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 98
+      line: 96
   - label: language_tag_syntax (2)
     section: § 8.5
     snippet: The "Content-Language" header field describes the natural language(s) of the intended audience for the representation.
@@ -6039,43 +6039,43 @@ sources:
     snippet: A language tag, as defined in [RFC5646], identifies a natural language spoken, written, or otherwise conveyed by human beings for communication of information to other human beings.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 53
+      line: 51
   - label: language_tag_syntax (4)
     section: § 8.5.1
     snippet: HTTP uses language tags within the Accept-Language and Content-Language header fields.  Accept-Language uses the broader language-range production defined in Section 12.5.4, whereas Content-Language uses the language-tag production defined below.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 50
+      line: 48
   - label: last_modified_rfc1123_syntax
     section: § 8.8.2
     snippet: Last-Modified = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 44
+      line: 43
   - label: link_header_valid
     section: § 5.6.3
     snippet: A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 688
+      line: 686
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 204
+      line: 202
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 270
+      line: 268
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 210
+      line: 209
   - label: link_header_valid (2)
     section: § 5.6.3
     snippet: A sender MUST NOT generate BWS in messages.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 687
+      line: 685
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 203
+      line: 201
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 269
+      line: 267
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 209
+      line: 208
   - label: lint-http-core/src/http_date.rs
     section: § 5.6.7
     snippet: A recipient that parses a timestamp value in an HTTP field MUST accept all three HTTP-date formats.
@@ -6089,7 +6089,7 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 80
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 526
+      line: 522
   - label: lint-http-core/src/http_date.rs (3)
     section: § 5.6.7
     snippet: HTTP-date = IMF-fixdate / obs-date
@@ -6109,13 +6109,13 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 82
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 67
+      line: 66
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 67
+      line: 66
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 47
+      line: 46
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 548
+      line: 544
   - label: lint-http-core/src/http_transaction.rs
     section: § 15
     snippet: 'A single request can have multiple associated responses: zero or more "interim" (non-final) responses with status codes in the "informational" (1xx) range, followed by exactly one "final" response with a status code in one of the other ranges.'
@@ -6143,7 +6143,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 155
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 89
+      line: 87
   - label: lint-http-core/src/http_version.rs (3)
     section: § 2.5
     snippet: The first digit (major version) indicates the messaging syntax, whereas the second digit (minor version) indicates the highest minor version within that major version to which the sender is conformant (able to understand for future communication).
@@ -6163,9 +6163,9 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 42
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 129
+      line: 127
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 172
+      line: 170
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
     section: § 11.7.2
     snippet: Unlike Authorization, the Proxy-Authorization header field applies only to the next inbound proxy that demanded authentication using the Proxy-Authenticate header field.
@@ -6227,9 +6227,9 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket.rs
       line: 144
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
-      line: 63
+      line: 57
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 54
+      line: 53
   - label: lint-http-rules/src/helpers/accept_ranges.rs
     section: § 14.1
     snippet: All range unit names are case-insensitive and ought to be registered within the "HTTP Range Unit Registry", as defined in Section 16.5.1.
@@ -6243,13 +6243,13 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 47
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 164
+      line: 163
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 323
+      line: 322
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 54
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 223
+      line: 222
   - label: lint-http-rules/src/helpers/accept_ranges.rs (2)
     section: § 14.1
     snippet: Range units are intended to be extensible, as described in Section 16.5.
@@ -6259,9 +6259,9 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 80
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 277
+      line: 276
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 224
+      line: 223
   - label: Accept-Ranges grammar
     section: § 14.3
     snippet: Accept-Ranges     = acceptable-ranges acceptable-ranges = 1#range-unit
@@ -6275,7 +6275,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 61
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 166
+      line: 165
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 49
   - label: lint-http-rules/src/helpers/accept_ranges.rs (4)
@@ -6287,13 +6287,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 552
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 61
+      line: 59
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 51
+      line: 50
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 278
+      line: 277
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 54
+      line: 53
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 252
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -6303,7 +6303,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 145
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 54
+      line: 53
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
     section: § 5.6.1.2
     snippet: In contrast, the following values would be invalid, since at least one non-empty element is required by the example-list production
@@ -6311,7 +6311,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 118
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 285
+      line: 284
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 125
   - label: lint-http-rules/src/helpers/auth.rs
@@ -6323,11 +6323,11 @@ sources:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
       line: 92
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 30
+      line: 29
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 39
+      line: 38
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 35
+      line: 34
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 11.3
     snippet: 'challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
@@ -6359,13 +6359,13 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 81
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 297
+      line: 296
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 146
+      line: 144
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 154
+      line: 153
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 241
+      line: 240
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -6397,7 +6397,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 49
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 93
+      line: 91
   - label: lint-http-rules/src/helpers/content_range.rs (2)
     section: § 14.1.1
     snippet: 'The range unit name determines what kinds of range-spec are applicable to its own specifiers.  Hence, the following grammar is generic: each range unit is expected to specify requirements on when int-range, suffix-range, and other-range are allowed.'
@@ -6405,7 +6405,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 51
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 225
+      line: 224
   - label: ranges-specifier grammar
     section: § 14.1.1
     snippet: ranges-specifier = range-unit "=" range-set
@@ -6413,7 +6413,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 50
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 90
+      line: 89
   - label: lint-http-rules/src/helpers/content_range.rs (3)
     section: § 14.1.2
     snippet: In the byte-range syntax, first-pos, last-pos, and suffix-length are expressed as decimal number of octets.  Since there is no predefined limit to the length of content, recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows.
@@ -6421,7 +6421,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 197
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 376
+      line: 375
   - label: lint-http-rules/src/helpers/content_range.rs (4)
     section: § 14.4
     snippet: A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value.
@@ -6473,21 +6473,21 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 69
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 110
+      line: 109
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 433
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 477
+      line: 475
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 247
+      line: 246
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 330
+      line: 329
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 234
+      line: 232
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 305
+      line: 301
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 11.6.3
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
@@ -6507,9 +6507,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1841
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 171
+      line: 169
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 121
+      line: 120
   - label: Vary grammar
     section: § 12.5.5
     snippet: 'Vary = #( "*" / field-name )'
@@ -6517,7 +6517,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1113
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 37
+      line: 36
   - label: If-None-Match weak comparison
     section: § 13.1.2
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
@@ -6557,17 +6557,17 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1639
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 36
+      line: 35
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 36
+      line: 35
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 64
+      line: 63
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 215
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 73
+      line: 68
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 77
+      line: 76
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6581,11 +6581,11 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 78
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 407
+      line: 405
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 240
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 179
+      line: 178
   - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
@@ -6593,9 +6593,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 180
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 93
+      line: 92
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 81
+      line: 80
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 330
   - label: lint-http-rules/src/helpers/headers.rs (9)
@@ -6613,37 +6613,37 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 101
+      line: 100
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 125
+      line: 124
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 59
+      line: 57
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 40
+      line: 39
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 81
+      line: 80
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 217
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 76
+      line: 75
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 34
+      line: 33
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 43
+      line: 42
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 40
+      line: 39
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 40
+      line: 39
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 40
+      line: 39
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 248
+      line: 246
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 77
+      line: 76
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 41
-    - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
       line: 40
+    - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+      line: 39
   - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
@@ -6659,19 +6659,19 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 56
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 99
+      line: 96
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 243
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 113
+      line: 112
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 88
+      line: 87
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 138
+      line: 137
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 122
+      line: 121
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 126
+      line: 125
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 49
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -6687,23 +6687,23 @@ sources:
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 251
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 86
+      line: 85
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 84
+      line: 82
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 203
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 49
+      line: 48
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 72
-    - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 156
-    - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 50
-    - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 180
-    - file: lint-http-rules/src/rules/user_agent_token_valid.rs
       line: 70
+    - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
+      line: 154
+    - file: lint-http-rules/src/rules/server_header_product_valid.rs
+      line: 49
+    - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
+      line: 179
+    - file: lint-http-rules/src/rules/user_agent_token_valid.rs
+      line: 69
   - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 5.5
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
@@ -6711,9 +6711,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1637
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 124
+      line: 123
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 250
+      line: 248
   - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.5
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
@@ -6721,7 +6721,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1638
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 251
+      line: 249
   - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 5.5
     snippet: field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
@@ -6739,53 +6739,53 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 92
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 301
+      line: 300
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 92
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 458
+      line: 456
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 115
+      line: 114
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 116
+      line: 115
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 64
+      line: 63
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 70
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 96
+      line: 95
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 235
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 82
+      line: 81
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 83
+      line: 82
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 493
+      line: 491
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 134
+      line: 133
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 159
+      line: 157
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 167
+      line: 166
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 250
+      line: 249
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 347
+      line: 346
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 73
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 77
+      line: 76
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 73
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 151
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 59
+      line: 58
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 259
+      line: 257
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 329
+      line: 325
   - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -6793,15 +6793,15 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 551
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 49
+      line: 47
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 50
+      line: 49
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 43
+      line: 42
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 432
+      line: 430
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 485
+      line: 483
   - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
@@ -6811,7 +6811,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 589
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 175
+      line: 174
   - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
@@ -6823,7 +6823,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 82
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 54
+      line: 53
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 46
   - label: lint-http-rules/src/helpers/headers.rs (20)
@@ -6839,17 +6839,17 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 288
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 142
+      line: 141
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 118
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 380
+      line: 379
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 245
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 184
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 212
+      line: 210
   - label: OWS grammar
     section: § 5.6.3
     snippet: OWS            = *( SP / HTAB )
@@ -6867,31 +6867,31 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2040
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 64
+      line: 63
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 298
+      line: 297
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 33
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 68
+      line: 66
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 99
+      line: 97
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 109
+      line: 108
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 44
+      line: 43
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 44
+      line: 43
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 124
+      line: 122
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 242
+      line: 241
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 463
+      line: 462
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 160
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 71
+      line: 70
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 66
   - label: lint-http-rules/src/helpers/headers.rs (21)
@@ -6923,7 +6923,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 343
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 527
+      line: 523
   - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
@@ -6935,9 +6935,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1477
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 421
+      line: 419
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 564
+      line: 562
   - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
@@ -6955,7 +6955,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 115
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 312
+      line: 311
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 316
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6963,7 +6963,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 342
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 34
+      line: 33
   - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
@@ -6971,11 +6971,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2330
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 155
+      line: 153
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 126
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 213
+      line: 212
   - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
@@ -6985,7 +6985,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2065
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 380
+      line: 379
   - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 5.6.6
     snippet: parameter-name  = token
@@ -6997,9 +6997,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2247
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 243
+      line: 242
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 381
+      line: 380
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
@@ -7007,13 +7007,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2261
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 290
+      line: 289
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 132
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 382
+      line: 381
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 219
+      line: 218
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
   - label: lint-http-rules/src/helpers/headers.rs (30)
@@ -7025,11 +7025,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2110
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 63
+      line: 62
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 379
+      line: 378
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 203
+      line: 202
   - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
@@ -7055,7 +7055,7 @@ sources:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 103
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 34
+      line: 32
   - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
@@ -7065,25 +7065,25 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 44
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 68
+      line: 66
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 36
+      line: 35
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 169
+      line: 168
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 125
+      line: 122
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 89
+      line: 88
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 34
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 212
+      line: 211
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 95
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 46
+      line: 45
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 56
+      line: 55
   - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
@@ -7097,9 +7097,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2192
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 203
+      line: 201
     - file: lint-http-rules/src/rules/charset_present.rs
-      line: 40
+      line: 39
     - file: lint-http-rules/src/rules/content_type_registered.rs
       line: 101
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7107,13 +7107,13 @@ sources:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 149
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 180
+      line: 179
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 58
+      line: 57
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 93
+      line: 92
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 73
   - label: lint-http-rules/src/helpers/headers.rs (37)
@@ -7159,11 +7159,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1961
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 57
+      line: 56
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 54
+      line: 53
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 55
+      line: 54
   - label: entity-tag grammar
     section: § 8.8.3
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
@@ -7183,7 +7183,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 33
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 54
+      line: 52
   - label: lint-http-rules/src/helpers/product.rs
     section: § 10.1.5
     snippet: The User-Agent field value consists of one or more product identifiers, each followed by zero or more comments (Section 5.6.5), which together identify the user agent software and its significant subproducts.
@@ -7191,9 +7191,9 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 87
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 53
+      line: 52
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 38
+      line: 37
   - label: lint-http-rules/src/helpers/product.rs (2)
     section: § 10.2.4
     snippet: Each product identifier consists of a name and optional version, as defined in Section 10.1.5.
@@ -7213,7 +7213,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 103
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 340
+      line: 338
   - label: lint-http-rules/src/helpers/product.rs (5)
     section: § 5.6.3
     snippet: The RWS rule is used when at least one linear whitespace octet is required to separate field tokens.
@@ -7221,7 +7221,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 102
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 339
+      line: 337
   - label: lint-http-rules/src/helpers/product.rs (6)
     section: § A
     snippet: Server = product *( RWS ( product / comment ) )
@@ -7255,9 +7255,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 381
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 161
+      line: 160
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 111
+      line: 109
   - label: Host grammar
     section: § 7.2
     snippet: Host = uri-host [ ":" port ]
@@ -7267,7 +7267,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 161
+      line: 160
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 112
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -7281,7 +7281,7 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 216
+      line: 210
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -7293,31 +7293,31 @@ sources:
     snippet: A Location field value cannot | allow a list of members because the comma list separator is a | valid data character within a URI-reference.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 94
+      line: 93
   - label: location_header_uri_valid (2)
     section: § 10.2.2
     snippet: If an invalid | message is sent with multiple Location field lines, a recipient | along the path might combine those field lines into one value.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 95
+      line: 94
   - label: Location grammar
     section: § 10.2.2
     snippet: Location = URI-reference
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 71
+      line: 70
   - label: location_header_uri_valid (3)
     section: § 16.3.2.2
     snippet: because URIs can include commas, it is not possible to reliably distinguish between a single value that includes a comma from two values
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 96
+      line: 95
   - label: location_header_uri_valid (4)
     section: § 5.5
     snippet: Fields that expect to contain a comma within a member, such as within an HTTP-date or URI-reference element, ought to be defined with delimiters around that element to distinguish any comma within that data from potential list separators.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 93
+      line: 92
   - label: location_on_redirect_present
     section: § 10.2.2
     snippet: For 201 (Created) responses, the Location value refers to the primary resource created by the request.
@@ -7325,7 +7325,7 @@ sources:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
       line: 28
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 76
+      line: 74
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 88
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -7335,7 +7335,7 @@ sources:
     snippet: For 3xx (Redirection) responses, the Location value refers to the preferred target resource for automatically redirecting the request.
     cited_by:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
-      line: 112
+      line: 111
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -7347,7 +7347,7 @@ sources:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
       line: 27
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 62
+      line: 60
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 89
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -7357,13 +7357,13 @@ sources:
     snippet: If a Location header field (Section 10.2.2) is provided, the user agent MAY automatically redirect its request to the URI referenced by the Location field value, even if the specific status code is not understood.
     cited_by:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
-      line: 121
+      line: 120
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 78
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/status_3xx_vs_request_method.rs
-      line: 80
+      line: 78
   - label: location_on_redirect_present (5)
     section: § 15.4.1
     snippet: For request methods other than HEAD, the server SHOULD generate content in the 300 response containing a list of representation metadata and URI reference(s) from which the user or user agent can choose the one most preferred.
@@ -7417,25 +7417,25 @@ sources:
     snippet: A recipient MAY ignore a Max-Forwards header field received with any other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 46
+      line: 45
   - label: max_forwards_numeric (2)
     section: § 7.6.2
     snippet: Each intermediary that receives a TRACE or OPTIONS request containing a Max-Forwards header field MUST check and update its value prior to forwarding the request.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 129
+      line: 128
   - label: max_forwards_numeric (3)
     section: § 7.6.2
     snippet: If the received value is zero (0), the intermediary MUST NOT forward the request; instead, the intermediary MUST respond as the final recipient.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 130
+      line: 129
   - label: Max-Forwards grammar
     section: § 7.6.2
     snippet: Max-Forwards = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 98
+      line: 97
   - label: max_forwards_numeric (4)
     section: § 7.6.2
     snippet: The "Max-Forwards" header field provides a mechanism with the TRACE (Section 9.3.8) and OPTIONS (Section 9.3.7) request methods to limit the number of times that the request is forwarded by proxies.
@@ -7447,57 +7447,57 @@ sources:
     snippet: The Max-Forwards value is a decimal integer indicating the remaining number of times this request message can be forwarded.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 128
+      line: 127
   - label: max_forwards_numeric (6)
     section: § 9.3.7
     snippet: A proxy MUST NOT generate a Max-Forwards header field while forwarding a request unless that request was received with a Max-Forwards field.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 131
+      line: 130
   - label: multipart_boundary_syntax
     section: § 5.6.6
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 242
+      line: 241
   - label: multipart_boundary_syntax (2)
     section: § 5.6.6
     snippet: Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 298
+      line: 297
   - label: multipart_boundary_syntax (3)
     section: § 5.6.6
     snippet: The quoted and unquoted values are equivalent.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 243
+      line: 242
   - label: multipart_boundary_syntax (4)
     section: § 8.3.3
     snippet: All multipart types share a common syntax, as defined in Section 5.1.1 of [RFC2046], and include a boundary parameter as part of the media type value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 178
+      line: 177
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 40
+      line: 38
   - label: multipart_content_type_and_body_consistent
     section: § 8.3.3
     snippet: HTTP message framing does not use the multipart boundary as an indicator of message body length, though it might be used by implementations that generate or process the content.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 41
+      line: 39
   - label: multipart_content_type_and_body_consistent (2)
     section: § 8.3.3
     snippet: The message body is itself a protocol element; a sender MUST generate only CRLF to represent line breaks between body parts.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 226
+      line: 225
   - label: no_body_for_1xx_204_304
     section: § 15.3.5
     snippet: A 204 response is terminated by the end of the header section; it cannot contain content or trailers.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 55
+      line: 54
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 27
   - label: no_body_for_1xx_204_304 (2)
@@ -7505,37 +7505,37 @@ sources:
     snippet: A 304 response is terminated by the end of the header section; it cannot contain content or trailers.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 56
+      line: 55
   - label: no_body_for_1xx_204_304 (3)
     section: § 6.4
     snippet: This abstract definition of content reflects the data after it has been extracted from the message framing.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 79
+      line: 78
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 171
+      line: 170
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 130
+      line: 129
   - label: no_body_for_1xx_204_304 (4)
     section: § 6.4.1
     snippet: All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include content.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 49
+      line: 48
   - label: no_body_for_1xx_204_304 (5)
     section: § 8.6
     snippet: A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 15.4.5); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a 200 (OK) response to the same request.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 143
+      line: 142
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 56
+      line: 55
   - label: no_body_for_1xx_204_304 (6)
     section: § 8.6
     snippet: A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 132
+      line: 131
   - label: no_connection_specific_fields
     section: § 7.6.1
     snippet: 'This includes but is not limited to:'
@@ -7565,15 +7565,15 @@ sources:
     snippet: An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 145
+      line: 143
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 92
+      line: 90
   - label: options_method_capabilities (2)
     section: § 15.3
     snippet: The 2xx (Successful) class of status code indicates that the client's request was successfully received, understood, and accepted.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 136
+      line: 134
   - label: options_method_capabilities (3)
     section: § 9.3.7
     snippet: A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type.
@@ -7581,7 +7581,7 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 65
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 98
+      line: 96
   - label: options_method_capabilities (4)
     section: § 9.3.7
     snippet: A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification.
@@ -7589,37 +7589,37 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 42
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 146
+      line: 144
   - label: options_method_capabilities (5)
     section: § 9.3.7
     snippet: If the request target is not an asterisk, the OPTIONS request applies to the options that are available when communicating with the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 130
+      line: 128
   - label: options_method_capabilities (6)
     section: § 9.3.7
     snippet: The OPTIONS method requests information about the communication options available for the target resource, at either the origin server or an intervening intermediary.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 83
+      line: 81
   - label: patch_method_content_type_match
     section: § 12.3
     snippet: When content negotiation preferences are sent in a server's response, the listed preferences are called "request content negotiation" because they intend to influence selection of an appropriate content for subsequent requests to that resource.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 208
+      line: 206
   - label: patch_method_content_type_match (2)
     section: § 12.4.3
     snippet: If no wildcard is present, values that are not explicitly mentioned in the field are considered unacceptable.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 209
+      line: 207
   - label: patch_method_content_type_match (3)
     section: § 12.4.3
     snippet: Most of these header fields, where indicated, define a wildcard value ("*") to select unspecified values.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 190
+      line: 188
   - label: patch_method_content_type_match (4)
     section: § 8.3.1
     snippet: The presence or absence of a parameter might be significant to the processing of a media type, depending on its definition within the media type registry.
@@ -7631,23 +7631,23 @@ sources:
     snippet: Similarly, Section 3.1 of [RFC5789] defines the "Accept-Patch" response header field, which allows discovery of which content types are accepted in PATCH requests.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 85
+      line: 83
   - label: post_creates_resource
     section: § 15.3.2
     snippet: The 201 (Created) status code indicates that the request has been fulfilled and has resulted in one or more new resources being created.
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 50
+      line: 48
   - label: post_creates_resource (2)
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"; see Section 16.3.1.
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 61
+      line: 59
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 174
+      line: 173
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 205
+      line: 204
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 98
   - label: post_creates_resource (3)
@@ -7655,13 +7655,13 @@ sources:
     snippet: An origin server indicates response semantics by choosing an appropriate status code depending on the result of processing the POST request; almost all of the status codes defined by this specification could be received in a response to POST (the exceptions being 206 (Partial Content), 304 (Not Modified), and 416 (Range Not Satisfiable)).
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 39
+      line: 37
   - label: post_creates_resource (4)
     section: § 9.3.3
     snippet: If one or more resources has been created on the origin server as a result of successfully processing a POST request, the origin server SHOULD send a 201 (Created) response containing a Location header field that provides an identifier for the primary resource created (Section 10.2.2) and a representation that describes the status of the request while referring to the new resource(s).
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 75
+      line: 73
   - label: prefer_header_and_preference_applied
     section: § 9.1
     snippet: The method token is case-sensitive
@@ -7703,7 +7703,7 @@ sources:
     snippet: The "Content-Encoding" header field indicates what content codings have been applied to the representation, beyond those inherent in the media type, and thus what decoding mechanisms have to be applied in order to obtain data in the media type referenced by the Content-Type header field.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 115
+      line: 114
   - label: proxy_connection_discouraged
     section: § 7.6.1
     snippet: Note that some versions of HTTP prohibit the use of fields for such information, and therefore do not allow the Connection field.
@@ -7815,113 +7815,113 @@ sources:
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 107
+      line: 106
   - label: range_header_syntax (2)
     section: § 14.1.1
     snippet: An int-range is invalid if the last-pos value is present and less than the first-pos.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 349
+      line: 348
   - label: int-range position grammar
     section: § 14.1.1
     snippet: first-pos     = 1*DIGIT last-pos      = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 305
+      line: 304
   - label: int-range grammar
     section: § 14.1.1
     snippet: int-range     = first-pos "-" [ last-pos ]
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 325
+      line: 324
   - label: other-range grammar
     section: § 14.1.1
     snippet: other-range   = 1*( %x21-2B / %x2D-7E )
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 55
+      line: 54
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 266
+      line: 265
   - label: range-set grammar
     section: § 14.1.1
     snippet: range-set        = 1#range-spec
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 230
+      line: 229
   - label: suffix-length grammar
     section: § 14.1.1
     snippet: suffix-length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 309
+      line: 308
   - label: suffix-range grammar
     section: § 14.1.1
     snippet: suffix-range  = "-" suffix-length
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 308
+      line: 307
   - label: range_header_syntax (3)
     section: § 14.1.2
     snippet: A client can limit the number of bytes requested without knowing the size of the selected representation.  If the last-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 341
+      line: 340
   - label: range_header_syntax (4)
     section: § 14.1.2
     snippet: A client can refer to the last N bytes (N > 0) of the selected representation using a suffix-range.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 313
+      line: 312
   - label: range_header_syntax (5)
     section: § 14.1.2
     snippet: Each byte range is expressed as an integer range at some offset, relative to either the beginning (int-range) or end (suffix-range) of the representation data.  Byte ranges do not use the other-range specifier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 300
+      line: 299
   - label: range_header_syntax (6)
     section: § 14.1.2
     snippet: 'For a GET request, a valid bytes range-spec is satisfiable if it is either:'
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 132
+      line: 131
   - label: range_header_syntax (7)
     section: § 14.1.2
     snippet: The "bytes" range unit is used to express subranges of a representation data's octet sequence.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 278
+      line: 277
   - label: a bytes range-set the section prints with a leading space
     section: § 14.1.2
     snippet: bytes= 0-999, 4500-5499, -1000
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 227
+      line: 226
   - label: range_header_syntax (8)
     section: § 14.2
     snippet: A client that is requesting multiple ranges SHOULD list those ranges in ascending order (the order in which they would typically be received in a complete representation) unless there is a specific need to request a later part earlier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 134
+      line: 133
   - label: range_header_syntax (9)
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.  For this specification, GET is the only method for which range handling is defined.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 133
+      line: 132
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 80
+      line: 79
   - label: range_header_syntax (10)
     section: § 14.2
     snippet: An origin server MUST ignore a Range header field that contains a range unit it does not understand.  A proxy MAY discard a Range header field that contains a range unit it does not understand.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 226
+      line: 225
   - label: Range grammar
     section: § 14.2
     snippet: Range = ranges-specifier
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 89
+      line: 88
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 37
   - label: range_request_and_caching
@@ -7929,43 +7929,43 @@ sources:
     snippet: A valid entity-tag can be distinguished from a valid HTTP-date by examining the first three characters for a DQUOTE.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 186
+      line: 185
   - label: range_request_and_caching (2)
     section: § 13.1.5
     snippet: Note that the If-Range comparison is by exact match, including when the validator is an HTTP-date, and so it differs from the "earlier than or equal to" comparison used when evaluating an If-Unmodified-Since conditional.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 207
+      line: 206
   - label: range_request_and_caching (3)
     section: § 13.1.5
     snippet: Range header field containing an HTTP-date unless the client has no entity tag for the corresponding representation and the date is a strong validator in the sense defined by Section 8.8.2.2.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 197
+      line: 196
   - label: range_request_and_caching (4)
     section: § 15.3.7.3
     snippet: A client that has received multiple partial responses to GET requests on a target resource MAY combine those responses into a larger continuous range if they share the same strong validator.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 93
+      line: 92
   - label: range_request_and_caching (5)
     section: § 15.3.7.3
     snippet: These ranges can only be safely combined if they all have in common the same strong validator (Section 8.8.1).
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 134
+      line: 133
   - label: redirect_chain_valid
     section: § 10.2.2
     snippet: If the Location value provided in a 3xx (Redirection) response does not have a fragment component, a user agent MUST process the redirection as if the value inherits the fragment component of the URI reference used to generate the target URI (i.e., the redirection inherits the original reference's fragment, if any).
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 171
+      line: 170
   - label: redirect_chain_valid (2)
     section: § 10.2.2
     snippet: When it has the form of a relative reference ([URI], Section 4.2), the final value is computed by resolving it against the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 162
+      line: 161
   - label: redirect_chain_valid (3)
     section: § 15
     snippet: However, a client MUST understand the class of any status code, as indicated by the first digit, and treat an unrecognized status code as being equivalent to the x00 status code of that class.
@@ -7975,13 +7975,13 @@ sources:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 44
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 67
+      line: 65
   - label: redirect_chain_valid (4)
     section: § 15.4
     snippet: A client SHOULD detect and intervene in cyclical redirections (i.e., "infinite" redirection loops).
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 235
+      line: 234
   - label: redirect_chain_valid (5)
     section: § 15.4.1
     snippet: the target resource has more than one representation, each with its own more specific identifier
@@ -8043,7 +8043,7 @@ sources:
     snippet: The type of relationship is defined by the combination of request method and status code semantics.
     cited_by:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
-      line: 83
+      line: 81
   - label: redirect_status_and_location_valid (2)
     section: § 15
     snippet: A client that receives a response with an invalid status code SHOULD process the response as if it had a 5xx (Server Error) status code.
@@ -8051,25 +8051,25 @@ sources:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 53
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 79
+      line: 77
   - label: referer_uri_valid
     section: § 10.1.3
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 197
+      line: 196
   - label: referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 326
+      line: 325
   - label: referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 146
+      line: 145
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
@@ -8081,49 +8081,49 @@ sources:
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 331
+      line: 330
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 144
+      line: 143
   - label: referer_uri_valid (5)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 272
+      line: 271
   - label: referer_uri_valid (6)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 329
+      line: 328
   - label: referer_uri_valid (7)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 328
+      line: 327
   - label: referer_uri_valid (8)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 273
+      line: 272
   - label: referer_uri_valid (9)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 330
+      line: 329
   - label: referer_uri_valid (10)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 327
+      line: 326
   - label: request_method_token_valid
     section: § 9.1
     snippet: All such methods ought to be registered within the "Hypertext Transfer Protocol (HTTP) Method Registry", as described in Section 16.1.
@@ -8135,13 +8135,13 @@ sources:
     snippet: An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 199
+      line: 200
   - label: request_method_token_valid (3)
     section: § 9.1
     snippet: By convention, standardized methods are defined in all-uppercase US-ASCII letters.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 192
+      line: 193
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
@@ -8153,7 +8153,7 @@ sources:
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 237
+      line: 233
   - label: request_target_form_valid (2)
     section: § 7.1
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
@@ -8169,7 +8169,7 @@ sources:
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 229
+      line: 225
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
@@ -8181,19 +8181,19 @@ sources:
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 91
+      line: 89
   - label: request_target_no_fragment (2)
     section: § 4.2.5
     snippet: They are distinguished by use of the ABNF rule for elements where fragment is allowed; otherwise, a specific rule that excludes fragments is used.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 92
+      line: 90
   - label: request_target_no_fragment (3)
     section: § 7.1
     snippet: The target URI excludes the reference's fragment component, if any, since fragment identifiers are reserved for client-side processing
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 112
+      line: 110
   - label: request_target_no_fragment (4)
     section: § 7.1
     snippet: To perform an action on a "target resource", the client sends a request message containing enough components of its parsed target URI to enable recipients to identify that same resource.
@@ -8215,7 +8215,7 @@ sources:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
       line: 58
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 83
+      line: 81
   - label: request_version_method_valid (2)
     section: § 9.3.1
     snippet: Although request message framing is independent of the method used, content received in a GET request has no generally defined semantics, cannot alter the meaning or target of the request
@@ -8227,25 +8227,25 @@ sources:
     snippet: An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 114
+      line: 112
   - label: request_version_method_valid (4)
     section: § 9.3.2
     snippet: A client SHOULD NOT generate content in a HEAD request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 85
+      line: 83
   - label: request_version_method_valid (5)
     section: § 9.3.5
     snippet: A client SHOULD NOT generate content in a DELETE request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 87
+      line: 85
   - label: request_version_method_valid (6)
     section: § 9.3.6
     snippet: A CONNECT request message does not have content.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 93
+      line: 91
   - label: request_version_method_valid (7)
     section: § 9.3.6
     snippet: The interpretation of data sent after the header section of the CONNECT request message is specific to the version of HTTP in use.
@@ -8257,19 +8257,19 @@ sources:
     snippet: As a result, a sender MUST NOT forward a message with a Content-Length header field value that is known to be incorrect.
     cited_by:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 134
+      line: 133
   - label: retry_after_date_or_delay
     section: § 10.2.3
     snippet: A delay-seconds value is a non-negative decimal integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 61
+      line: 60
   - label: retry_after_date_or_delay (2)
     section: § 10.2.3
     snippet: Retry-After = HTTP-date / delay-seconds
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 44
+      line: 43
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 43
   - label: retry_after_status_valid
@@ -8301,19 +8301,19 @@ sources:
     snippet: newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 52
+      line: 51
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 49
+      line: 48
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 49
+      line: 48
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 49
+      line: 48
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 44
+      line: 43
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 50
-    - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
       line: 49
+    - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+      line: 48
   - label: server_header_product_valid
     section: § 10.2.4
     snippet: An origin server MAY generate a Server header field in its responses.
@@ -8325,15 +8325,15 @@ sources:
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers)
     cited_by:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 45
+      line: 44
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 65
+      line: 64
   - label: hash rule expansion
     section: § 5.6.1
     snippet: '#element => [ 1#element ]'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 329
+      line: 328
   - label: singleton_fields_not_repeated
     section: § 10.1.5
     snippet: User-Agent = product *( RWS ( product / comment ) )
@@ -8369,7 +8369,7 @@ sources:
     snippet: 'such as an ABNF rule of #(values) defined in Section 5.6.1'
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 249
+      line: 247
   - label: singleton_fields_not_repeated (6)
     section: § 6.6.1
     snippet: The "Date" header field represents the date and time at which the message was originated, having the same semantics as the Origination Date Field (orig-date) defined in Section 3.6.1 of [RFC5322].
@@ -8381,61 +8381,61 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 48
+      line: 47
   - label: status_101_switching_protocols (2)
     section: § 15.2.2
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 148
+      line: 147
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 189
+      line: 188
   - label: status_101_switching_protocols (3)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 135
+      line: 134
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 176
+      line: 175
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 203
+      line: 202
   - label: status_101_switching_protocols (4)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 78
+      line: 77
   - label: status_101_switching_protocols (5)
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 165
+      line: 164
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 105
+      line: 101
   - label: status_103_early_hints_before_final (2)
     section: § 15.2
     snippet: The 1xx (Informational) class of status code indicates an interim response for communicating connection status or request progress prior to completing the requested action and sending a final response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 126
+      line: 122
   - label: status_200_vs_204_body_consistent
     section: § 15.3.1
     snippet: Aside from responses to CONNECT, a 200 response is expected to contain message content unless the message framing explicitly indicates that the content has zero length.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 62
+      line: 61
   - label: status_200_vs_204_body_consistent (2)
     section: § 15.3.1
     snippet: For CONNECT, there is no content because the successful result is a tunnel, which begins immediately after the 200 response header section.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 90
+      line: 89
   - label: status_200_vs_204_body_consistent (3)
     section: § 15.3.1
     snippet: If some aspect of the request indicates a preference for no content upon success, the origin server ought to send a 204 (No Content) response instead.
@@ -8447,7 +8447,7 @@ sources:
     snippet: The 200 (OK) status code indicates that the request has succeeded.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 61
+      line: 60
   - label: status_200_vs_204_body_consistent (5)
     section: § 15.3.5
     snippet: The 204 (No Content) status code indicates that the server has successfully fulfilled the request and that there is no additional content to send in the response content.
@@ -8459,13 +8459,13 @@ sources:
     snippet: 2xx (Successful) responses to a CONNECT request method (Section 9.3.6) switch the connection to tunnel mode instead of having content.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 91
+      line: 90
   - label: status_200_vs_204_body_consistent (7)
     section: § 6.4.1
     snippet: Responses to the HEAD request method (Section 9.3.2) never include content; the associated response header fields indicate only what their values would have been if the request method had been GET (Section 9.3.1).
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 75
+      line: 74
   - label: status_3xx_vs_request_method
     section: § 15.4
     snippet: 307 | (Temporary Redirect) and 308 (Permanent Redirect) [RFC7538] | were later added to unambiguously indicate method-preserving | redirects, and status codes 301 and 302 have been adjusted to | allow a POST request to be redirected as GET.
@@ -8489,39 +8489,39 @@ sources:
     snippet: If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field.
     cited_by:
     - file: lint-http-rules/src/rules/status_3xx_vs_request_method.rs
-      line: 102
+      line: 100
   - label: status_405_allow_valid
     section: § 10.2.1
     snippet: The actual set of allowed methods is defined by the origin server at the time of each request.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 162
+      line: 159
   - label: status_405_allow_valid (2)
     section: § 15.5.6
     snippet: The 405 (Method Not Allowed) status code indicates that the method received in the request-line is known by the origin server but not supported by the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 160
+      line: 157
   - label: status_405_allow_valid (3)
     section: § 15.5.6
     snippet: The origin server MUST generate an Allow header field in a 405 response containing a list of the target resource's currently supported methods.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 124
+      line: 121
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 159
+      line: 156
   - label: status_405_allow_valid (4)
     section: § 9.1
     snippet: However, the set of allowed methods can change dynamically.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 163
+      line: 160
   - label: status_426_upgrade_valid
     section: § 15.5.22
     snippet: The 426 (Upgrade Required) status code indicates that the server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 125
+      line: 124
   - label: status_426_upgrade_valid (2)
     section: § 15.5.22
     snippet: The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 7.8).
@@ -8541,25 +8541,25 @@ sources:
     snippet: A server that sends a 426 (Upgrade Required) response MUST send an Upgrade header field to indicate the acceptable protocols, in order of descending preference.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 124
+      line: 123
   - label: status_and_caching_semantics
     section: § 15.1
     snippet: Responses with status codes that are defined as heuristically cacheable (e.g., 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, and 501 in this specification) can be reused by a cache with heuristic expiration unless otherwise indicated by the method definition or explicit cache controls
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 36
+      line: 35
   - label: status_code_semantics
     section: § 11.6.1
     snippet: A proxy forwarding a response MUST NOT modify any WWW-Authenticate header fields in that response.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 80
+      line: 78
   - label: status_code_semantics (2)
     section: § 11.6.1
     snippet: A server MAY generate a WWW-Authenticate header field in other response messages to indicate that supplying credentials (or different credentials) might affect the response.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 120
+      line: 118
   - label: status_code_semantics (3)
     section: § 11.6.1
     snippet: Furthermore, the header field itself can occur multiple times.
@@ -8571,17 +8571,17 @@ sources:
     snippet: The "WWW-Authenticate" response header field indicates the authentication scheme(s) and parameters applicable to the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 66
+      line: 64
     - file: lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
-      line: 34
+      line: 33
   - label: status_code_semantics (5)
     section: § 11.7.1
     snippet: A proxy MUST send at least one Proxy-Authenticate header field in each 407 (Proxy Authentication Required) response that it generates.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 68
+      line: 66
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 131
+      line: 129
   - label: status_code_semantics (6)
     section: § 11.7.1
     snippet: Note that the parsing considerations for WWW-Authenticate apply to this header field as well; see Section 11.6.1 for details.
@@ -8593,71 +8593,71 @@ sources:
     snippet: The "Proxy-Authenticate" header field consists of at least one challenge that indicates the authentication scheme(s) and parameters applicable to the proxy for this request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 67
+      line: 65
   - label: status_code_semantics (8)
     section: § 15.5.2
     snippet: The server generating a 401 response MUST send a WWW-Authenticate header field (Section 11.6.1) containing at least one challenge applicable to the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 81
+      line: 79
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 101
+      line: 99
   - label: status_code_semantics (9)
     section: § 15.5.8
     snippet: The 407 (Proxy Authentication Required) status code is similar to 401 (Unauthorized), but it indicates that the client needs to authenticate itself in order to use a proxy for this request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 122
+      line: 120
   - label: status_code_semantics (10)
     section: § 15.5.8
     snippet: The proxy MUST send a Proxy-Authenticate header field (Section 11.7.1) containing a challenge applicable to that proxy for the request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 130
+      line: 128
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 147
+      line: 145
   - label: status_code_semantics (11)
     section: § A
     snippet: Proxy-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 146
+      line: 144
   - label: status_code_semantics (12)
     section: § A
     snippet: WWW-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 100
+      line: 98
   - label: status_code_valid_range
     section: § 15
     snippet: All valid status codes are within the range of 100 to 599, inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 57
+      line: 55
   - label: status_code_valid_range (2)
     section: § 15
     snippet: Implementations often use three-digit integer values outside of that range (i.e., 600..999) for internal communication of non-HTTP status (e.g., library errors).
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 91
+      line: 89
   - label: status_code_valid_range (3)
     section: § 15
     snippet: Values outside the range 100..599 are invalid.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 58
+      line: 56
   - label: status_code_valid_range (4)
     section: § 15.1
     snippet: All such status codes ought to be registered within the "Hypertext Transfer Protocol (HTTP) Status Code Registry", as described in Section 16.2.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 68
+      line: 66
   - label: status_code_valid_range (5)
     section: § 16.2.2
     snippet: New status codes are required to fall under one of the categories defined in Section 15.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 59
+      line: 57
   - label: te_header_valid
     section: § 10.1.4
     snippet: A sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
@@ -8697,7 +8697,7 @@ sources:
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 87
+      line: 86
   - label: trace_method_echo
     section: § 11.6.2
     snippet: Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested.
@@ -8715,7 +8715,7 @@ sources:
     snippet: A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response.
     cited_by:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 103
+      line: 101
   - label: trace_method_echo (4)
     section: § 9.3.8
     snippet: A client MUST NOT send content in a TRACE request.
@@ -8723,7 +8723,7 @@ sources:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 61
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 87
+      line: 85
   - label: trace_method_echo (5)
     section: § 9.3.8
     snippet: For example, it would be foolish for a user agent to send stored user credentials (Section 11) or cookies [COOKIE] in a TRACE request.
@@ -8741,7 +8741,7 @@ sources:
     snippet: A sender that intends to generate one or more trailer fields in a message SHOULD generate a Trailer header field in the header section of that message to indicate which fields might be present in the trailers.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 260
+      line: 259
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 96
   - label: trailer_fields_valid (3)
@@ -8749,7 +8749,7 @@ sources:
     snippet: When a field aside from Connection is used to supply control information for or about the current connection, the sender MUST list the corresponding field name within the Connection header field.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 239
+      line: 238
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 42
   - label: trailer_header_valid
@@ -8809,7 +8809,7 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 136
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 248
+      line: 246
   - label: upgrade_header_syntax (3)
     section: § 7.8
     snippet: A client MAY send a list of protocol names in the Upgrade header field of a request to invite the server to switch to one or more of the named protocols, in order of descending preference, before sending the final response.
@@ -8827,7 +8827,7 @@ sources:
     snippet: A user agent SHOULD send a User-Agent header field in each request unless specifically configured not to do so.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 40
+      line: 39
   - label: user_agent_present (2)
     section: § 3.5
     snippet: The term "user agent" refers to any of the various client programs that initiate a request.
@@ -8839,73 +8839,73 @@ sources:
     snippet: A sender SHOULD NOT generate information in product-version that is not a version identifier
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 49
+      line: 48
   - label: user_agent_token_valid (2)
     section: § 10.1.5
     snippet: A sender SHOULD limit generated product identifiers to what is necessary to identify the product; a sender MUST NOT generate advertising or other nonessential information within the product identifier.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 48
+      line: 47
   - label: user_agent_token_valid (3)
     section: § 10.1.5
     snippet: A user agent SHOULD NOT generate a User-Agent header field containing needlessly fine-grained detail and SHOULD limit the addition of subproducts by third parties.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 50
+      line: 49
   - label: vary_header_valid
     section: § 12.5.5
     snippet: The "Vary" header field in a response describes what parts of a request message, aside from the method and target URI, might have influenced the origin server's process for selecting the content of this response.
     cited_by:
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 32
+      line: 31
   - label: via_header_syntax
     section: § 4.1
     snippet: port = <port, see [URI], Section 3.2.3>
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 392
+      line: 390
   - label: via_header_syntax (2)
     section: § 5.6.3
     snippet: OWS = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 200
+      line: 198
   - label: via_header_syntax (3)
     section: § 7.6.3
     snippet: A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 34
+      line: 32
   - label: via_header_syntax (4)
     section: § 7.6.3
     snippet: A sender MAY generate comments to identify the software of each recipient, analogous to the User-Agent and Server header fields.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 420
+      line: 418
   - label: via_header_syntax (5)
     section: § 7.6.3
     snippet: An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message and MAY send a Via header field in forwarded response messages.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 43
+      line: 41
   - label: via_header_syntax (6)
     section: § 7.6.3
     snippet: For brevity, the protocol-name is omitted when the received protocol is HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 312
+      line: 310
   - label: via_header_syntax (7)
     section: § 7.6.3
     snippet: However, comments in Via are optional, and a recipient MAY remove them prior to forwarding the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 421
+      line: 419
   - label: via_header_syntax (8)
     section: § 7.6.3
     snippet: However, if the real host is considered to be sensitive information, a sender MAY replace it with a pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 370
+      line: 368
   - label: via_header_syntax (9)
     section: § 7.6.3
     snippet: The "Via" header field indicates the presence of intermediate protocols and recipients between the user agent and the server (on requests) or between the origin server and the client (on responses)
@@ -8917,53 +8917,53 @@ sources:
     snippet: The received-by portion is normally the host and optional port number of a recipient server or client that subsequently forwarded the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 369
+      line: 367
   - label: via_header_syntax (11)
     section: § 7.6.3
     snippet: 'Via = #( received-protocol RWS received-by [ RWS comment ] )'
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 247
+      line: 245
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 303
+      line: 301
   - label: via_header_syntax (12)
     section: § 7.6.3
     snippet: received-by = pseudonym [ ":" port ] pseudonym = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 367
+      line: 365
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 484
+      line: 480
   - label: via_header_syntax (13)
     section: § 7.6.3
     snippet: received-protocol = [ protocol-name "/" ] protocol-version
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 309
+      line: 307
   - label: via_header_syntax (14)
     section: § 7.8
     snippet: protocol-name = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 310
+      line: 308
   - label: via_header_syntax (15)
     section: § 7.8
     snippet: protocol-version = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 311
+      line: 309
   - label: via_header_syntax (16)
     section: § B.2
     snippet: For simplicity, we have removed uri-host from the received-by production because it can be encompassed by the existing grammar for pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 368
+      line: 366
   - label: warning_header_syntax
     section: § 5.6.7
     snippet: Prior to 1995, there were three different formats commonly used by servers to communicate timestamps.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 547
+      line: 543
 - label: RFC 9111
   url: https://www.rfc-editor.org/rfc/rfc9111.txt
   type: text/plain
@@ -8973,17 +8973,17 @@ sources:
     snippet: If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648 (2^31) or the greatest positive integer it can conveniently represent.
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 57
+      line: 56
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 297
+      line: 296
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 167
+      line: 166
   - label: age_header_numeric (2)
     section: § 5.1
     snippet: Although it is defined as a singleton header field, a cache encountering a message with a list-based Age field value SHOULD use the first member of the field value, discarding subsequent ones.
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 36
+      line: 35
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 45
   - label: age_header_numeric (3)
@@ -8993,29 +8993,29 @@ sources:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 17
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 73
+      line: 72
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 77
+      line: 76
   - label: age_header_numeric (4)
     section: § 5.1
     snippet: The Age field value is a non-negative integer, representing time in seconds
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 56
+      line: 55
   - label: alt_svc_h3_advertisement_valid
     section: § 1.2.2
     snippet: The delta-seconds rule specifies a non-negative integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 286
+      line: 285
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 152
+      line: 151
   - label: delta-seconds
     section: § 1.2.2
     snippet: delta-seconds  = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 285
+      line: 284
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
       line: 596
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
@@ -9025,157 +9025,157 @@ sources:
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 106
+      line: 105
   - label: cache_control_and_pragma_consistent
     section: § 5.4
     snippet: However, support for Cache-Control is now widespread.  As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
-      line: 70
+      line: 69
   - label: cache_control_and_pragma_consistent (2)
     section: § 5.4
     snippet: The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
-      line: 30
+      line: 29
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 36
+      line: 35
   - label: cache_control_directive_valid
     section: § 5.2
     snippet: The "Cache-Control" header field is used to list directives for caches along the request/response chain.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 27
+      line: 26
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 27
+      line: 26
   - label: cache_control_directive_valid (2)
     section: § 5.2
     snippet: cache-directive = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 122
+      line: 121
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 124
+      line: 123
   - label: cache_control_directive_valid (3)
     section: § 5.2.2.7
     snippet: If a qualified private response directive is present, with an argument that lists one or more field names
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 174
+      line: 173
   - label: cache_control_present
     section: § 4.2.2
     snippet: Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_present.rs
-      line: 34
+      line: 33
   - label: cache_validation_chain
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 133
+      line: 132
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 171
+      line: 170
   - label: cache_validation_chain (2)
     section: § 4.3.1
     snippet: MUST send the relevant entity tags (using If-Match, If-None-Match, or If-Range) if the entity tags were provided in the stored response(s) being validated.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 92
+      line: 91
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 155
+      line: 154
   - label: cache_validation_chain (3)
     section: § 4.3.1
     snippet: SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 98
+      line: 97
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 128
+      line: 127
   - label: caching_directive_interaction
     section: § 4.2.1
     snippet: 'When there is more than one value present for a given directive (e.g., two Expires header field lines or multiple Cache-Control: max-age directives), either the first occurrence should be used or the response should be considered stale.'
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 131
+      line: 130
   - label: caching_directive_interaction (2)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 117
+      line: 116
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 149
+      line: 148
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 175
+      line: 174
   - label: caching_directive_interaction (3)
     section: § 5.2.2.7
     snippet: The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user).
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 98
+      line: 97
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 86
+      line: 85
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 123
+      line: 122
   - label: caching_directive_interaction (4)
     section: § 5.2.2.9
     snippet: The public response directive indicates that a cache MAY store the response even if it would otherwise be prohibited, subject to the constraints defined in Section 3.
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 97
+      line: 96
   - label: expires_and_cache_control_consistent
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 146
+      line: 145
   - label: expires_and_cache_control_consistent (2)
     section: § 5.3
     snippet: A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired").
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 106
+      line: 105
   - label: expires_and_cache_control_consistent (3)
     section: § 5.3
     snippet: If a response includes a Cache-Control header field with the max-age directive (Section 5.2.2.1), a recipient MUST ignore the Expires header field.
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 145
+      line: 144
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 163
+      line: 162
   - label: expires_and_cache_control_consistent (4)
     section: § 5.3
     snippet: The Expires field value is an HTTP-date timestamp, as defined in Section 5.6.7 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 38
+      line: 37
   - label: immutable_cache_never_stale
     section: § 5.2
     snippet: Cache directives are identified by a token, to be compared case-insensitively
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 195
+      line: 194
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 204
+      line: 203
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 159
+      line: 158
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 258
+      line: 257
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 54
+      line: 53
   - label: immutable_cache_never_stale (2)
     section: § 5.2.2.4
     snippet: the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 182
+      line: 181
   - label: immutable_cache_never_stale (3)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 181
+      line: 180
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 4.1
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
@@ -9183,9 +9183,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1116
     - file: lint-http-rules/src/rules/vary_and_cache_consistent.rs
-      line: 45
+      line: 44
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 171
+      line: 170
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
@@ -9203,107 +9203,107 @@ sources:
     snippet: A "fresh" response is one whose age has not yet exceeded its freshness lifetime
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 108
+      line: 107
   - label: max_age_directive_valid (2)
     section: § 4.2
     snippet: When a response is fresh, it can be used to satisfy subsequent requests without contacting the origin server, thereby improving efficiency
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 116
+      line: 115
   - label: max_age_directive_valid (3)
     section: § 4.3
     snippet: it can use the conditional request mechanism
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 136
+      line: 135
   - label: max_age_directive_valid (4)
     section: § 5.2.2.1
     snippet: The max-age response directive indicates that the response is to be considered stale after its age is greater than the specified number of seconds.
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 107
+      line: 106
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 54
+      line: 53
   - label: must_revalidate_enforced
     section: § 4.2
     snippet: A "fresh" response is one whose age has not yet exceeded its freshness lifetime. Conversely, a "stale" response is one where it has.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 107
+      line: 106
   - label: must_revalidate_enforced (2)
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 99
+      line: 98
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 81
+      line: 80
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 39
+      line: 38
     - file: lint-http-rules/src/rules/s_max_age_enforced.rs
-      line: 90
+      line: 89
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 57
+      line: 56
   - label: must_revalidate_enforced (3)
     section: § 5.2.2.2
     snippet: The must-revalidate response directive indicates that once the response has become stale, a cache MUST NOT reuse that response to satisfy another request until it has been successfully validated by the origin, as defined by Section 4.3.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 113
+      line: 112
   - label: no_cache_revalidation
     section: § 5.2.2.4
     snippet: The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 85
+      line: 84
   - label: no_cache_revalidation (2)
     section: § 5.2.2.4
     snippet: The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request
     cited_by:
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 156
+      line: 155
   - label: pragma_token_valid
     section: § 5.4
     snippet: As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 63
+      line: 62
   - label: range_request_and_caching
     section: § 3.3
     snippet: A cache MAY complete a stored incomplete response by making a subsequent range request (Section 14.2 of [HTTP]) and combining the successful response with the stored response, as defined in Section 3.4.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 92
+      line: 91
   - label: range_request_and_caching (2)
     section: § 3.4
     snippet: A cache MAY combine these ranges into a single stored response, and reuse that response to satisfy later requests, if they all share the same strong validator
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 135
+      line: 134
   - label: range_request_and_caching (3)
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields.  These contain validator metadata sourced from a stored response(s) that has the same URI.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 108
+      line: 107
   - label: range_request_and_caching (4)
     section: § 4.3.1
     snippet: MAY send the Last-Modified value (using If-Unmodified-Since or If-Range) if the request is for a subrange, a single stored response is being validated, and that response contains only a Last-Modified value (not an entity tag).
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 129
+      line: 128
   - label: range_request_and_caching (5)
     section: § 4.3.1
     snippet: Typically, this will include only the stored response(s) that has the same cache key, although a cache is allowed to validate a response that it cannot choose with the request header fields it is sending
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 109
+      line: 108
   - label: s_max_age_enforced
     section: § 5.2.2.10
     snippet: The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires header field.
     cited_by:
     - file: lint-http-rules/src/rules/s_max_age_enforced.rs
-      line: 99
+      line: 98
   - label: singleton_fields_not_repeated
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server.
@@ -9317,25 +9317,25 @@ sources:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 46
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 75
+      line: 74
   - label: status_and_caching_semantics
     section: § 3
     snippet: A cache MUST NOT store a response to a request unless
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 86
+      line: 85
   - label: status_and_caching_semantics (2)
     section: § 5.2.2.10
     snippet: The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 55
+      line: 54
   - label: vary_header_cache_valid
     section: § 4.1
     snippet: the cache MUST NOT use that stored response without revalidation unless all the presented request header fields nominated by that Vary field value match those fields in the original request
     cited_by:
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 192
+      line: 191
 - label: RFC 9112
   url: https://www.rfc-editor.org/rfc/rfc9112.txt
   type: text/plain
@@ -9347,19 +9347,19 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 21
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 180
+      line: 179
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 121
+      line: 119
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 100
+      line: 98
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 53
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -9367,87 +9367,87 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 302
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 76
+      line: 75
   - label: compression_and_transfer_encoding_consistent (4)
     section: § 7.2
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 131
+      line: 129
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 7.3
     snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 130
+      line: 128
   - label: content_length_vs_transfer_encoding
     section: § 6.2
     snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 28
+      line: 27
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 75
+      line: 74
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 125
+      line: 124
   - label: content_length_vs_transfer_encoding (2)
     section: § 6.3
     snippet: An intermediary that chooses to forward the message MUST first remove the received Content-Length field and process the Transfer-Encoding
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 37
+      line: 36
   - label: content_length_vs_transfer_encoding (3)
     section: § 6.3
     snippet: If a message is received with both a Transfer-Encoding and a Content-Length header field, the Transfer-Encoding overrides the Content-Length.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 36
+      line: 35
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 183
+      line: 182
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 58
+      line: 57
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 120
+      line: 119
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 106
+      line: 105
   - label: content_transfer_encoding_valid
     section: § B.5
     snippet: HTTP does not use the Content-Transfer-Encoding field of MIME.
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 84
+      line: 83
   - label: content_transfer_encoding_valid (2)
     section: § B.5
     snippet: Proxies and gateways from MIME-compliant protocols to HTTP need to remove any Content-Transfer-Encoding prior to delivering the response message to an HTTP client.
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 85
+      line: 84
   - label: content_type_present
     section: § 6.3
     snippet: Any 2xx (Successful) response to a CONNECT request implies that the connection will become a tunnel immediately after the empty line that concludes the header fields.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 57
+      line: 56
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 109
+      line: 108
   - label: content_type_present (2)
     section: § 6.3
     snippet: Any response to a HEAD request and any response with a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status code is always terminated by the first empty line after the header fields, regardless of the header fields present in the message, and thus cannot contain a message body or trailer section.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 33
+      line: 32
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 62
+      line: 61
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 50
+      line: 49
   - label: content_type_present (3)
     section: § 6.3
     snippet: Otherwise, this is a response message without a declared message body length, so the message body length is determined by the number of octets received prior to the server closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 79
+      line: 78
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 140
+      line: 139
   - label: head_response_headers_match_get
     section: § 6.1
     snippet: This indication is not required, however, because any recipient on the response chain (including the origin server) can remove transfer codings when they are not needed.
@@ -9461,9 +9461,9 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 266
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 173
+      line: 172
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 214
+      line: 213
   - label: host_and_authority_consistent
     section: § 3.2.2
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
@@ -9475,19 +9475,19 @@ sources:
     snippet: A client MUST send a Host header field (Section 7.2 of [HTTP]) in all HTTP/1.1 request messages.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 59
+      line: 58
   - label: host_header (2)
     section: § 3.2
     snippet: If the authority component is missing or undefined for the target URI, then a client MUST send a Host header field with an empty field value.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 116
+      line: 115
   - label: host_header (3)
     section: § 3.2
     snippet: If the target URI includes an authority component, then a client MUST send a field value for Host that is identical to that authority component, excluding any userinfo subcomponent and its "@" delimiter (Section 4.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 125
+      line: 124
   - label: authority-form
     section: § 3.2.3
     snippet: authority-form = uri-host ":" port
@@ -9501,11 +9501,11 @@ sources:
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 154
+      line: 150
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 110
+      line: 108
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 100
+      line: 98
   - label: http_version_syntax (2)
     section: § 3
     snippet: A request-line begins with a method token, followed by a single space (SP), the request-target, and another single space (SP), and ends with the protocol version.
@@ -9523,11 +9523,11 @@ sources:
     snippet: field-line   = field-name ":" OWS field-value OWS
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 66
+      line: 65
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 66
+      line: 65
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 46
+      line: 45
   - label: HTTP-version
     section: § 2.3
     snippet: HTTP-version  = HTTP-name "/" DIGIT "." DIGIT
@@ -9539,7 +9539,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 159
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 90
+      line: 88
   - label: lint-http-core/src/http_version.rs
     section: § 2.3
     snippet: HTTP-version is case-sensitive.
@@ -9555,7 +9555,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 63
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 145
+      line: 141
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 158
   - label: HTTP-name
@@ -9571,7 +9571,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 48
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 41
+      line: 40
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
@@ -9579,7 +9579,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 387
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 77
+      line: 76
   - label: request-target forms
     section: § 3.2
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
@@ -9611,33 +9611,33 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 384
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 86
+      line: 84
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 223
+      line: 222
   - label: no_body_for_1xx_204_304
     section: § 6.1
     snippet: A server MUST NOT send a Transfer-Encoding header field in any response with a status code of 1xx (Informational) or 204 (No Content).
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 172
+      line: 171
   - label: post_creates_resource
     section: § 3.3
     snippet: Otherwise, the target URI's combined path and query component is the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 87
+      line: 85
   - label: problem_details_structure_valid
     section: § 6.3
     snippet: If a valid Content-Length header field is present without Transfer-Encoding, its decimal value defines the expected message body length in octets.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 184
+      line: 183
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 53
+      line: 52
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 121
+      line: 120
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 108
+      line: 107
   - label: proxy_connection_discouraged
     section: § C.2.2
     snippet: As a result, clients are encouraged not to send the Proxy-Connection header field in any requests.
@@ -9649,47 +9649,47 @@ sources:
     snippet: One attempted solution was the introduction of a Proxy-Connection header field, targeted specifically at proxies.  In practice, this was also unworkable, because proxies are often deployed in multiple layers, bringing about the same problem discussed above.
     cited_by:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 84
+      line: 79
   - label: redirect_chain_valid
     section: § 3.3
     snippet: Otherwise, if the request is received over a secured connection, the target URI's scheme is "https"; if not, the scheme is "http".
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 224
+      line: 223
   - label: request_body_length_accuracy
     section: § 6.2
     snippet: For messages that do include content, the Content-Length field value provides the framing information necessary for determining where the data (and message) ends.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 86
+      line: 85
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 135
+      line: 134
   - label: request_body_length_accuracy (2)
     section: § 6.2
     snippet: When a message does not have a Transfer-Encoding header field, a Content-Length header field (Section 8.6 of [HTTP]) can provide the anticipated size, as a decimal number of octets, for potential content.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 74
+      line: 73
   - label: request_body_length_accuracy (3)
     section: § 6.3
     snippet: If a Transfer-Encoding header field is present and the chunked transfer coding (Section 7.1) is the final encoding, the message body length is determined by reading and decoding the chunked data until the transfer coding indicates the data is complete.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 59
+      line: 58
   - label: request_body_length_accuracy (4)
     section: § 6.3
     snippet: If the sender closes the connection or the recipient times out before the indicated number of octets are received, the recipient MUST consider the message to be incomplete and close the connection.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 87
+      line: 86
   - label: request_body_length_accuracy (5)
     section: § 6.3
     snippet: The length of a message body is determined by one of the following (in order of precedence)
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 46
+      line: 45
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 39
+      line: 38
   - label: request_target_form_valid
     section: § 3.2
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
@@ -9707,9 +9707,9 @@ sources:
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 213
+      line: 211
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 306
+      line: 302
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
@@ -9721,7 +9721,7 @@ sources:
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 297
+      line: 293
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
@@ -9729,19 +9729,19 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 62
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 96
+      line: 94
   - label: request_target_form_valid (6)
     section: § 3.2.2
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 299
+      line: 295
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 298
+      line: 294
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
@@ -9749,45 +9749,45 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 63
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 95
+      line: 93
   - label: request_target_form_valid (8)
     section: § 3.2.3
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 238
+      line: 234
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 270
+      line: 266
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 283
+      line: 279
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 246
+      line: 242
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 239
+      line: 235
   - label: request_target_form_valid (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 260
+      line: 256
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 261
+      line: 257
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
@@ -9799,25 +9799,25 @@ sources:
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
     cited_by:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 110
+      line: 109
   - label: status_code_valid_range
     section: § 4
     snippet: A client SHOULD ignore the reason-phrase content because it is not a reliable channel for information
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 37
+      line: 35
   - label: status_code_valid_range (2)
     section: § 4
     snippet: The status-code element is a 3-digit integer code describing the result of the server's attempt to understand and satisfy the client's corresponding request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 99
+      line: 97
   - label: status_code_valid_range (3)
     section: § 4
     snippet: status-code    = 3DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 80
+      line: 78
   - label: te_header_valid
     section: § 7.3
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
@@ -9905,25 +9905,25 @@ sources:
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 115
+      line: 114
   - label: transfer_encoding_chunked_final (2)
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 131
+      line: 130
   - label: transfer_encoding_chunked_final (3)
     section: § 9.6
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 151
+      line: 150
   - label: transfer_encoding_chunked_final (4)
     section: § 9.6
     snippet: The "close" connection option is defined as a signal that the sender will close this connection after completion of the response.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 85
+      line: 84
 - label: RFC 9113
   url: https://www.rfc-editor.org/rfc/rfc9113.txt
   type: text/plain
@@ -9933,7 +9933,7 @@ sources:
     snippet: HTTP/2 implementations SHOULD validate field names and values according to their definitions in Sections 5.1 and 5.5 of [HTTP], respectively, and treat messages that contain prohibited characters as malformed
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 131
+      line: 129
   - label: host_and_authority_consistent
     section: § 8.3.1
     snippet: A request in asterisk form (for OPTIONS) includes the value '*' for the ":path" pseudo-header field.
@@ -9941,7 +9941,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 202
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 240
+      line: 234
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 160
   - label: host_and_authority_consistent (2)
@@ -9949,13 +9949,13 @@ sources:
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 327
+      line: 325
   - label: host_and_authority_consistent (3)
     section: § 8.3.1
     snippet: An origin server can apply any normalization method, whereas other servers MUST perform scheme-based normalization (see Section 6.2.3 of [RFC3986]) of the two fields.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 305
+      line: 303
   - label: host_and_authority_consistent (4)
     section: § 8.3.1
     snippet: Clients MUST NOT generate a request with a Host header field that differs from the ":authority" pseudo-header field.
@@ -9963,7 +9963,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 142
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 326
+      line: 324
   - label: host_and_authority_consistent (5)
     section: § 8.3.1
     snippet: The ":authority" pseudo-header field conveys the authority portion (Section 3.2 of [RFC3986]) of the target URI (Section 7.1 of [HTTP]).
@@ -9971,13 +9971,13 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 185
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 280
+      line: 274
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 304
+      line: 302
   - label: http2_pseudo_headers_valid
     section: § 8.2.1
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
@@ -9995,19 +9995,19 @@ sources:
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 321
+      line: 315
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 285
+      line: 279
   - label: http2_pseudo_headers_valid (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 256
+      line: 250
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
@@ -10015,37 +10015,37 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 160
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 136
+      line: 139
   - label: http2_pseudo_headers_valid (7)
     section: § 8.3.1
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 279
+      line: 273
   - label: http2_pseudo_headers_valid (8)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 255
+      line: 249
   - label: http2_pseudo_headers_valid (9)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 371
+      line: 365
   - label: http2_pseudo_headers_valid (10)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 372
+      line: 366
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 208
+      line: 202
   - label: http2_pseudo_headers_valid (12)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
@@ -10059,7 +10059,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 20
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 207
+      line: 201
   - label: http2_pseudo_headers_valid (14)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
@@ -10083,7 +10083,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 71
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 146
+      line: 142
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 8.3.2
     snippet: HTTP/2 responses implicitly have a protocol version of "2.0".
@@ -10105,7 +10105,7 @@ sources:
     snippet: An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 182
+      line: 181
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 150
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -10153,7 +10153,7 @@ sources:
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 97
+      line: 95
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 41
   - label: status_101_switching_protocols
@@ -10161,7 +10161,7 @@ sources:
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 98
+      line: 97
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.txt
   type: text/plain
@@ -10171,7 +10171,7 @@ sources:
     snippet: An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 132
+      line: 131
   - label: extension_headers_registered
     section: § 4.2
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
@@ -10179,21 +10179,21 @@ sources:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 206
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 117
+      line: 115
   - label: header_field_names_token_valid
     section: § 4.2
     snippet: Properties of HTTP field names and values are discussed in more detail in Section 5.1 of [HTTP]
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 132
+      line: 130
   - label: host_and_authority_consistent
     section: § 4.3.1
     snippet: If both fields are present, they MUST contain the same value.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 306
+      line: 304
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 328
+      line: 326
   - label: host_and_authority_consistent (2)
     section: § 4.3.1
     snippet: If the :scheme pseudo-header field identifies a scheme that has a mandatory authority component (including "http" and "https"), the request MUST contain either an :authority pseudo-header field or a Host header field.
@@ -10201,15 +10201,15 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 216
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 269
+      line: 267
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 156
+      line: 151
   - label: host_and_authority_consistent (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 270
+      line: 268
   - label: http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
@@ -10253,39 +10253,39 @@ sources:
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 42
+      line: 37
   - label: http3_pseudo_headers_valid (2)
     section: § 4.3.1
     snippet: The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 180
+      line: 175
   - label: http3_pseudo_headers_valid (3)
     section: § 4.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 141
+      line: 136
   - label: http3_pseudo_headers_valid (4)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 215
+      line: 210
   - label: http3_pseudo_headers_valid (5)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 216
+      line: 211
   - label: http3_pseudo_headers_valid (6)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 58
+      line: 53
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 107
+      line: 102
   - label: http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document
@@ -10327,9 +10327,9 @@ sources:
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
-      line: 48
+      line: 42
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 115
+      line: 114
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 61
   - label: lint-http-core/src/http_version.rs
@@ -10341,7 +10341,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 76
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 147
+      line: 143
   - label: lint-http-core/src/http_version.rs (2)
     section: § 4.3.1
     snippet: HTTP/3 requests implicitly have a protocol version of "3.0".
@@ -10399,13 +10399,13 @@ sources:
     snippet: Interim responses do not contain content or trailer sections.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 187
+      line: 186
   - label: no_body_for_1xx_204_304 (2)
     section: § 4.1
     snippet: Transfer codings (see Section 7 of [HTTP/1.1]) are not defined for HTTP/3; the Transfer-Encoding header field MUST NOT be used.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 183
+      line: 182
   - label: no_connection_specific_fields
     section: § 4.2
     snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
@@ -10459,7 +10459,7 @@ sources:
     snippet: '":method":  Contains the HTTP method (Section 9 of [HTTP])'
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 137
+      line: 140
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
@@ -10471,7 +10471,7 @@ sources:
     snippet: Contains the path and query parts of the target URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 98
+      line: 96
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
       line: 42
 - label: RFC 9218
@@ -10483,19 +10483,19 @@ sources:
     snippet: the server is expected to control the cacheability or the applicability of the cached response by using header fields that control the caching behavior (e.g., Cache-Control, Vary)
     cited_by:
     - file: lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
-      line: 70
+      line: 69
   - label: priority_header_syntax
     section: § 4
     snippet: For both the Priority header field and the PRIORITY_UPDATE frame, the set of priority parameters is encoded as a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 245
+      line: 243
   - label: priority_header_syntax (2)
     section: § 4
     snippet: Receivers parse the Dictionary as described in Section 4.2 of [STRUCTURED-FIELDS].
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 246
+      line: 244
   - label: priority_header_syntax (3)
     section: § 4
     snippet: When receiving an HTTP request that does not carry these priority parameters, a server SHOULD act as if their default values were specified.
@@ -10507,43 +10507,43 @@ sources:
     snippet: Where the Dictionary is successfully parsed, this document places the additional requirement that unknown priority parameters, priority parameters with out-of-range values, or values of unexpected types MUST be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 284
+      line: 282
   - label: priority_header_syntax (5)
     section: § 4.1
     snippet: The urgency (u) parameter value is Integer (see Section 3.3.1 of [STRUCTURED-FIELDS]), between 0 and 7 inclusive, in descending order of priority.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 298
+      line: 296
   - label: priority_header_syntax (6)
     section: § 4.1
     snippet: between 0 and 7 inclusive, in descending order of priority. The default is 3.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 320
+      line: 318
   - label: priority_header_syntax (7)
     section: § 4.2
     snippet: The default value of the incremental parameter is false (0).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 332
+      line: 330
   - label: priority_header_syntax (8)
     section: § 4.2
     snippet: The incremental (i) parameter value is Boolean (see Section 3.3.6 of [STRUCTURED-FIELDS]).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 329
+      line: 327
   - label: priority_header_syntax (9)
     section: § 4.3
     snippet: Since unknown priority parameters are ignored, new priority parameters should not change the interpretation of, or modify, the urgency (see Section 4.1) or incremental (see Section 4.2) priority parameters in a way that is not backwards compatible or fallback safe.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 351
+      line: 349
   - label: priority_header_syntax (10)
     section: § 4.3.1
     snippet: New priority parameters can be defined by registering them in the "HTTP Priority" registry.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 350
+      line: 348
   - label: priority_header_syntax (11)
     section: § 5
     snippet: The Priority HTTP header field is a Dictionary that carries priority parameters (see Section 4).
@@ -10581,65 +10581,65 @@ sources:
     snippet: If the response is still a representation of a resource, for example, it's often preferable to describe the relevant details in that application's format.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 85
+      line: 84
   - label: problem_details_content_type (2)
     section: § 1
     snippet: Problem details can be used with any HTTP status code, but they most naturally fit the semantics of 4xx and 5xx responses.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 35
+      line: 34
   - label: problem_details_content_type (3)
     section: § 1
     snippet: This specification's aim is to define common error formats for applications that need one so that they aren't required to define their own or, worse, tempted to redefine the semantics of existing HTTP status codes.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 98
+      line: 97
   - label: problem_details_content_type (4)
     section: § 3
     snippet: When serialized in a JSON document, that format is identified with the "application/problem+json" media type.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 65
+      line: 64
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 102
+      line: 101
   - label: problem_details_content_type (5)
     section: § 4
     snippet: Problem details are intended to avoid the necessity of establishing new "fault" or "error" document formats, not to replace existing domain-specific formats.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 86
+      line: 85
   - label: problem_details_content_type (6)
     section: § B
     snippet: The media type for this format is "application/problem+xml".
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 66
+      line: 65
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 103
+      line: 102
   - label: problem_details_structure_valid
     section: § 3
     snippet: The canonical model for problem details is a JSON [JSON] object.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 150
+      line: 149
   - label: problem_details_structure_valid (2)
     section: § 3.1
     snippet: Problem detail objects can have the following members.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 145
+      line: 144
   - label: problem_details_structure_valid (3)
     section: § 3.1.1
     snippet: When this member is not present, its value is assumed to be "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 146
+      line: 145
   - label: problem_details_structure_valid (4)
     section: § 4.2.1
     snippet: Consequently, any problem details object not carrying an explicit "type" member implicitly uses this URI.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 147
+      line: 146
 - label: RFC 9530
   url: https://www.rfc-editor.org/rfc/rfc9530.txt
   type: text/plain
@@ -10649,44 +10649,44 @@ sources:
     snippet: The Content-Digest HTTP field can be used in requests and responses
     cited_by:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
-      line: 30
+      line: 29
   - label: digest_header_syntax
     snippet: This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 254
+      line: 253
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 286
+      line: 285
   - label: digest_header_syntax (2)
     section: § 2
     snippet: 'It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 127
+      line: 126
   - label: digest_header_syntax (3)
     section: § 2
     snippet: key conveys the hashing algorithm (see Section 5) used to compute the digest;
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 147
+      line: 146
   - label: digest_header_syntax (4)
     section: § 2
     snippet: value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 159
+      line: 158
   - label: digest_header_syntax (5)
     section: § 4
     snippet: 'Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 190
+      line: 189
   - label: digest_header_syntax (6)
     section: § 4
     snippet: value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 214
+      line: 213
 - label: RFC 9651
   url: https://www.rfc-editor.org/rfc/rfc9651.txt
   type: text/plain
@@ -10696,9 +10696,9 @@ sources:
     snippet: their serialization in textual HTTP fields is similar to that of Integers, distinguished from them with a leading "@".
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 67
+      line: 66
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 62
+      line: 61
   - label: lint-http-rules/src/helpers/structured_fields.rs
     section: § 3.1.2
     snippet: Note that parameters are ordered, and parameter keys cannot contain uppercase letters.
@@ -10742,7 +10742,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 414
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 43
+      line: 42
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 89
   - label: lint-http-rules/src/helpers/structured_fields.rs (8)
@@ -10856,7 +10856,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 481
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 304
+      line: 302
   - label: lint-http-rules/src/helpers/structured_fields.rs (26)
     section: § 4.2.2
     snippet: No structured data has been found; return dictionary (which is empty).
@@ -10864,7 +10864,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 457
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 69
+      line: 68
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 294
   - label: lint-http-rules/src/helpers/structured_fields.rs (27)
@@ -10910,7 +10910,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 619
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 378
+      line: 377
   - label: lint-http-rules/src/helpers/structured_fields.rs (34)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not lcalpha or "*", fail parsing.
@@ -10918,7 +10918,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 225
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 358
+      line: 357
   - label: lint-http-rules/src/helpers/structured_fields.rs (35)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not one of lcalpha, DIGIT, "_", "-", ".", or "*", return output_string.
@@ -11064,23 +11064,23 @@ sources:
     snippet: As with Lists, an empty Dictionary is represented by omitting the entire field.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 70
+      line: 69
   - label: permissions_policy_directives_valid (2)
     section: § 3.2
     snippet: Member keys cannot contain uppercase characters.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 316
+      line: 315
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 424
+      line: 423
   - label: permissions_policy_directives_valid (3)
     section: § 4.2
     snippet: If parsing fails, either the entire field value MUST be ignored (i.e., treated as if the field were not present in the section), or alternatively the complete HTTP message MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 91
+      line: 90
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 253
+      line: 251
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 119
   - label: permissions_policy_directives_valid (4)
@@ -11088,7 +11088,7 @@ sources:
     snippet: When generating input_bytes, parsers MUST combine all field lines in the same section (header or trailer) that case-insensitively match the field name into one comma-separated field-value, as per Section 5.2 of [HTTP]; this assures that the entire field value is processed correctly.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 35
+      line: 34
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 61
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
@@ -11100,15 +11100,15 @@ sources:
     snippet: Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 235
+      line: 234
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 266
+      line: 264
   - label: priority_header_syntax
     section: § 3.3.1
     snippet: While it is possible to serialize Integers with leading zeros (e.g., "0002", "-01") and signed zero ("-0"), these distinctions may not be preserved by implementations.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 299
+      line: 297
   - label: structured_headers_valid
     snippet: This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,
     cited_by:
@@ -11153,20 +11153,20 @@ sources:
     snippet: The Deprecation HTTP response header field allows a server to communicate to a client application that the resource in the context of the message will be or has been deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 27
+      line: 26
   - label: deprecation_header_syntax (2)
     section: § 2.1
     snippet: Deprecation is an Item Structured Header Field; its value MUST be a Date as per Section 3.3.7 of [RFC9651].
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 39
+      line: 38
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 66
+      line: 65
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 61
+      line: 60
   - label: sunset_and_deprecation_consistent
     section: § 4
     snippet: The timestamp given in the Sunset HTTP header field MUST NOT be earlier than the one given in the Deprecation header field.
     cited_by:
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 101
+      line: 100


### PR DESCRIPTION
check_transaction takes a RuleContext. The engine prepares every enabled rule once at construction — severity resolved, custom sections parsed into each rule's own typed state behind dyn Any — and dispatch borrows that into a two-word context per transaction. The hundred and seventy severity-only rules lose their per-transaction parse line; the sixteen with options of their own move the parse into prepare and downcast it back at the check; twelve that handed the parsed config to helper functions now hand those helpers the severity itself.

validate is gone from both traits: validation is successful preparation, so the hook that answered Ok(()) is replaced by the one that answers with the values, and the same parse cannot run twice. The comments that argued about where in each rule the config read belonged go with the read.

A catalogue-wide test prepares every registered rule under the shipped example config — the startup-time replacement for the coverage the per-transaction .ok()? parses used to get incidentally, and the check no per-rule test has to remember.
