### PR TITLE
Nine copies of one list parser become one function

### DIFF
--- a/apycite.toml
+++ b/apycite.toml
@@ -51,7 +51,7 @@ label = "{path}"
 # reason this widening is allowed to happen. Widening to a non-empty baseline
 # would have traded "every file in scope is cited" for "every file in scope is
 # cited eventually", and there is no second mechanism to hold the difference.
-# 221 files, 210 cited, 11 excluded below, 0 to migrate.
+# 222 files, 210 cited, 12 excluded below, 0 to migrate.
 #
 # `lint-http-core` and `lint-http-proxy` are deliberately still out of scope, and
 # not because their cites do not work — they do, and both crates carry some. It is
@@ -84,9 +84,17 @@ baseline = "specs/ratchet.txt"
 # query is a URI prefix filter, so no part of `scheme + host + port` is ever
 # parsed or compared. Real origin matching lives in
 # `rules/origin_matching_for_cors.rs`, and is cited there.
+#
+# `helpers/rule_config.rs` parses the shared `allowed`/`headers` array shape out
+# of TOML — configuration plumbing, enforcing no sentence of any specification.
+# The one normative fact near it, that each rule's entries are matched
+# case-insensitively, is a per-registry claim and is cited in each rule's
+# `prepare` beside the call, which is exactly why the fold's justification did
+# not move here with the parser.
 exclude = [
     "lint-http-rules/src/rules/mod.rs",
     "lint-http-rules/src/helpers/mod.rs",
+    "lint-http-rules/src/helpers/rule_config.rs",
     "lint-http-rules/src/queries/*.rs",
     "lint-http-rules/src/engine.rs",
     "lint-http-rules/src/lib.rs",

--- a/lint-http-rules/src/helpers/mod.rs
+++ b/lint-http-rules/src/helpers/mod.rs
@@ -50,6 +50,7 @@ pub mod ipv6;
 pub mod language;
 pub mod mailbox;
 pub mod product;
+pub mod rule_config;
 pub mod status;
 pub mod structured_fields;
 pub mod token;

--- a/lint-http-rules/src/helpers/rule_config.rs
+++ b/lint-http-rules/src/helpers/rule_config.rs
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The shared shape of a configured list of case-insensitive names.
+//!
+//! Nine rules configure themselves with a required array of strings whose
+//! entries are matched case-insensitively against the wire — seven under the
+//! key `allowed`, two under the key `headers` — and each had grown its own
+//! copy of the same parser, differing only in the key and the noun its error
+//! messages named. The parser moves here; the key and the *nouns* stay with
+//! the rules (`key`/`what`/`example` below), and so do the citations that
+//! justify each rule's case-fold, because which sentence licenses folding
+//! `GZIP` to `gzip` is a per-registry fact, not a property of this function.
+//!
+//! What deliberately does **not** share this parser: `alt_svc_protocol_registered`.
+//! ALPN protocol names are opaque byte strings identified by their exact
+//! octets, so its list is stored as written and each entry is validated —
+//! same TOML shape, different question.
+
+use crate::config::Config;
+
+/// A rule's resolved `allowed` list, entries folded to lowercase once at
+/// prepare time so the comparison site folds only the wire value.
+#[derive(Debug)]
+pub struct AllowedList {
+    pub allowed: Vec<String>,
+}
+
+/// A rule's resolved `headers` list — field names to check, folded once at
+/// prepare time (field names are case-insensitive, RFC 9110 §5.1; the cite
+/// lives with each rule that relies on it).
+#[derive(Debug)]
+pub struct HeaderNameList {
+    pub headers: Vec<String>,
+}
+
+/// Parse the required `key` array out of `[rules.<rule_id>]`, folding each
+/// entry to lowercase. `what` names the entries in error messages
+/// ("acceptable charset names"); `example` shows a valid array
+/// ("['utf-8','iso-8859-1']").
+pub fn parse_lowercased_list(
+    cfg: &Config,
+    rule_id: &str,
+    key: &str,
+    what: &str,
+    example: &str,
+) -> anyhow::Result<Vec<String>> {
+    let rule_cfg = cfg.get_rule_config(rule_id).ok_or_else(|| {
+        anyhow::anyhow!(
+            "rule '{}' requires configuration and a named '{}' array listing {}. Example in config_example.toml",
+            rule_id,
+            key,
+            what
+        )
+    })?;
+
+    let table = rule_cfg
+        .as_table()
+        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
+
+    let list_val = table.get(key).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Rule '{}' requires a '{}' array listing {} (e.g., {})",
+            rule_id,
+            key,
+            what,
+            example
+        )
+    })?;
+
+    let arr = list_val.as_array().ok_or_else(|| {
+        anyhow::anyhow!("'{}' must be an array of strings (e.g., {})", key, example)
+    })?;
+
+    // No sentence forbids an empty array. It is refused because the rule it
+    // configures would then report every message it reads, which is a broken
+    // linter rather than a deployment that accepts nothing.
+    if arr.is_empty() {
+        return Err(anyhow::anyhow!("'{}' array cannot be empty", key));
+    }
+
+    let mut out = Vec::new();
+    for (i, item) in arr.iter().enumerate() {
+        let s = item.as_str().ok_or_else(|| {
+            anyhow::anyhow!("'{}' array item at index {} must be a string", key, i)
+        })?;
+        out.push(s.to_ascii_lowercase());
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with(rule: &str, value: toml::Value) -> Config {
+        let mut cfg = Config::default();
+        cfg.rules.insert(rule.to_string(), value);
+        cfg
+    }
+
+    fn table_with_allowed(value: toml::Value) -> toml::Value {
+        let mut table = toml::map::Map::new();
+        table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        table.insert(
+            "severity".to_string(),
+            toml::Value::String("warn".to_string()),
+        );
+        table.insert("allowed".to_string(), value);
+        toml::Value::Table(table)
+    }
+
+    fn parse(cfg: &Config) -> anyhow::Result<Vec<String>> {
+        parse_lowercased_list(
+            cfg,
+            "some_rule",
+            "allowed",
+            "acceptable widgets",
+            "['a','b']",
+        )
+    }
+
+    #[test]
+    fn entries_fold_to_lowercase_once() {
+        let cfg = cfg_with(
+            "some_rule",
+            table_with_allowed(toml::Value::Array(vec![
+                toml::Value::String("UTF-8".to_string()),
+                toml::Value::String("gzip".to_string()),
+            ])),
+        );
+        let list = parse(&cfg).unwrap();
+        assert_eq!(list, vec!["utf-8".to_string(), "gzip".to_string()]);
+    }
+
+    #[test]
+    fn missing_rule_table_names_the_what() {
+        let err = parse(&Config::default()).unwrap_err().to_string();
+        assert!(err.contains("requires configuration"), "{err}");
+        assert!(err.contains("acceptable widgets"), "{err}");
+    }
+
+    #[test]
+    fn non_table_config_is_refused() {
+        let cfg = cfg_with("some_rule", toml::Value::Boolean(true));
+        let err = parse(&cfg).unwrap_err().to_string();
+        assert!(err.contains("must be a table"), "{err}");
+    }
+
+    #[test]
+    fn missing_key_shows_the_key_and_example() {
+        let mut table = toml::map::Map::new();
+        table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        let cfg = cfg_with("some_rule", toml::Value::Table(table));
+        let err = parse(&cfg).unwrap_err().to_string();
+        assert!(err.contains("requires a 'allowed' array"), "{err}");
+        assert!(err.contains("['a','b']"), "{err}");
+    }
+
+    #[test]
+    fn a_different_key_is_read_and_named() {
+        let mut table = toml::map::Map::new();
+        table.insert(
+            "headers".to_string(),
+            toml::Value::Array(vec![toml::Value::String("ETag".to_string())]),
+        );
+        let cfg = cfg_with("some_rule", toml::Value::Table(table));
+        let list =
+            parse_lowercased_list(&cfg, "some_rule", "headers", "field names", "['etag']").unwrap();
+        assert_eq!(list, vec!["etag".to_string()]);
+
+        let err = parse_lowercased_list(&cfg, "some_rule", "allowed", "widgets", "['a']")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("'allowed'"), "{err}");
+    }
+
+    #[test]
+    fn non_array_value_is_refused() {
+        let cfg = cfg_with(
+            "some_rule",
+            table_with_allowed(toml::Value::String("gzip".to_string())),
+        );
+        let err = parse(&cfg).unwrap_err().to_string();
+        assert!(err.contains("must be an array of strings"), "{err}");
+    }
+
+    #[test]
+    fn empty_array_is_refused() {
+        let cfg = cfg_with("some_rule", table_with_allowed(toml::Value::Array(vec![])));
+        let err = parse(&cfg).unwrap_err().to_string();
+        assert!(err.contains("cannot be empty"), "{err}");
+    }
+
+    #[test]
+    fn non_string_item_is_refused_by_index() {
+        let cfg = cfg_with(
+            "some_rule",
+            table_with_allowed(toml::Value::Array(vec![
+                toml::Value::String("ok".to_string()),
+                toml::Value::Integer(3),
+            ])),
+        );
+        let err = parse(&cfg).unwrap_err().to_string();
+        assert!(err.contains("index 1"), "{err}");
+    }
+}

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -5,57 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct AuthSchemeConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<AuthSchemeConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config.get_rule_config(rule_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "rule '{}' requires configuration and a named 'allowed' array listing acceptable auth-schemes. Example in config_example.toml",
-            rule_id
-        )
-    })?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires an 'allowed' array listing allowed auth-schemes (e.g., ['Basic','Bearer'])",
-            rule_id
-        )
-    })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'allowed' must be an array of strings (e.g., ['Basic','Bearer'])")
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(AuthSchemeConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 pub struct AuthSchemeRegistered;
 
 impl Rule for AuthSchemeRegistered {
@@ -68,13 +17,20 @@ impl Rule for AuthSchemeRegistered {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "acceptable auth-schemes",
+            "['Basic','Bearer']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -84,7 +40,7 @@ impl Rule for AuthSchemeRegistered {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &AuthSchemeConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
         // Helper to check a single scheme token against allowed list
         let check_scheme =
             |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {
@@ -93,7 +49,7 @@ impl Rule for AuthSchemeRegistered {
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(scheme) {
                     return Some(Violation {
                         rule: "auth_scheme_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid character '{}' in {} auth-scheme", c, hdr_name),
                     });
                 }
@@ -108,7 +64,7 @@ impl Rule for AuthSchemeRegistered {
                 if !allowed.contains(&scheme.to_ascii_lowercase()) {
                     return Some(Violation {
                         rule: "auth_scheme_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Unrecognized auth-scheme '{}' in {}", scheme, hdr_name),
                     });
                 }
@@ -123,7 +79,7 @@ impl Rule for AuthSchemeRegistered {
                     Err(_) => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: "WWW-Authenticate header contains non-UTF8 value".into(),
                         })
                     }
@@ -145,7 +101,7 @@ impl Rule for AuthSchemeRegistered {
                     Err(e) => {
                         return Some(Violation {
                             rule: self.id().into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!("Invalid WWW-Authenticate header: {}", e),
                         })
                     }
@@ -160,7 +116,7 @@ impl Rule for AuthSchemeRegistered {
                 if let Err(e) = crate::helpers::auth::validate_authorization_syntax(v) {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid Authorization header: {}", e),
                     });
                 }
@@ -172,7 +128,7 @@ impl Rule for AuthSchemeRegistered {
             } else {
                 return Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: "Authorization header contains non-UTF8 value".into(),
                 });
             }
@@ -438,7 +394,7 @@ mod tests {
         // Missing table
         let mut cfg = crate::config::Config::default();
         crate::test_helpers::enable_rule(&mut cfg, "auth_scheme_registered");
-        assert!(parse_allowed_config(&cfg, "auth_scheme_registered").is_err());
+        assert!(AuthSchemeRegistered.prepare(&cfg).is_err());
 
         // Not a table
         let mut cfg2 = crate::config::Config::default();
@@ -447,7 +403,7 @@ mod tests {
             "auth_scheme_registered".into(),
             toml::Value::String("invalid".into()),
         );
-        assert!(parse_allowed_config(&cfg2, "auth_scheme_registered").is_err());
+        assert!(AuthSchemeRegistered.prepare(&cfg2).is_err());
 
         // allowed not array
         let mut cfg3 = crate::config::Config::default();
@@ -462,7 +418,7 @@ mod tests {
                 t
             }),
         );
-        assert!(parse_allowed_config(&cfg3, "auth_scheme_registered").is_err());
+        assert!(AuthSchemeRegistered.prepare(&cfg3).is_err());
 
         // empty allowed array
         let mut cfg4 = crate::config::Config::default();
@@ -477,7 +433,7 @@ mod tests {
                 t
             }),
         );
-        assert!(parse_allowed_config(&cfg4, "auth_scheme_registered").is_err());
+        assert!(AuthSchemeRegistered.prepare(&cfg4).is_err());
 
         // non-string item
         let mut cfg5 = crate::config::Config::default();
@@ -495,7 +451,7 @@ mod tests {
                 t
             }),
         );
-        assert!(parse_allowed_config(&cfg5, "auth_scheme_registered").is_err());
+        assert!(AuthSchemeRegistered.prepare(&cfg5).is_err());
 
         // normalization to lowercase
         let mut cfg6 = crate::config::Config::default();
@@ -516,7 +472,9 @@ mod tests {
                 t
             }),
         );
-        let parsed = parse_allowed_config(&cfg6, "auth_scheme_registered").unwrap();
+        let parsed = AuthSchemeRegistered.prepare(&cfg6).unwrap();
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert_eq!(
             parsed.allowed,
             vec!["basic".to_string(), "bearer".to_string()]

--- a/lint-http-rules/src/rules/charset_registered.rs
+++ b/lint-http-rules/src/rules/charset_registered.rs
@@ -5,61 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct CharsetConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<CharsetConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config.get_rule_config(rule_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "rule '{}' requires configuration and a named 'allowed' array listing acceptable charset names. Example in config_example.toml",
-            rule_id
-        )
-    })?;
-
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires an 'allowed' array listing allowed character set names (e.g., ['utf-8','iso-8859-1'])",
-            rule_id
-        )
-    })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'allowed' must be an array of strings (e.g., ['utf-8','iso-8859-1'])")
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    // Entries are folded once here rather than at every comparison, which is
-    // sound because the matching itself is defined to ignore case.
-    // cite(RFC 9110 § 8.3.2): "In both cases, charset names are matched case-insensitively."
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(CharsetConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 pub struct CharsetRegistered;
 
 impl Rule for CharsetRegistered {
@@ -76,13 +21,24 @@ impl Rule for CharsetRegistered {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        // Entries are folded once at prepare time rather than at every
+        // comparison, which is sound because the matching itself is defined to
+        // ignore case.
+        // cite(RFC 9110 § 8.3.2): "In both cases, charset names are matched case-insensitively."
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "acceptable charset names",
+            "['utf-8','iso-8859-1']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -92,7 +48,7 @@ impl Rule for CharsetRegistered {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &CharsetConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
         use crate::helpers::headers::parse_media_type;
 
         let check_header = |which: &str, val: &str| -> Option<Violation> {
@@ -133,7 +89,7 @@ impl Rule for CharsetRegistered {
                         if value.is_empty() {
                             return Some(Violation {
                                 rule: CharsetRegistered.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Invalid Content-Type in {}: empty 'charset' parameter",
                                     which
@@ -154,7 +110,7 @@ impl Rule for CharsetRegistered {
                                 Err(e) => {
                                     return Some(Violation {
                                         rule: CharsetRegistered.id().into(),
-                                        severity: config.severity,
+                                        severity: ctx.severity,
                                         message: format!(
                                             "Invalid Content-Type in {}: 'charset' quoted-string invalid: {}",
                                             which, e
@@ -183,7 +139,7 @@ impl Rule for CharsetRegistered {
                             if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
                                 return Some(Violation {
                                     rule: CharsetRegistered.id().into(),
-                                    severity: config.severity,
+                                    severity: ctx.severity,
                                     message: format!(
                                         "Invalid Content-Type in {}: charset contains invalid character '{}'",
                                         which, c
@@ -196,7 +152,7 @@ impl Rule for CharsetRegistered {
                         if value.is_empty() {
                             return Some(Violation {
                                 rule: CharsetRegistered.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Invalid Content-Type in {}: empty 'charset' parameter",
                                     which
@@ -215,7 +171,7 @@ impl Rule for CharsetRegistered {
                         if !config.allowed.contains(&value.to_ascii_lowercase()) {
                             return Some(Violation {
                                 rule: CharsetRegistered.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Unrecognized charset '{}' in {} header",
                                     value, which
@@ -645,7 +601,7 @@ mod tests {
     #[test]
     fn parse_config_requires_allowed_array() {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&["charset_registered"]);
-        let res = parse_allowed_config(&cfg, "charset_registered");
+        let res = CharsetRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -664,7 +620,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "charset_registered");
+        let res = CharsetRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -686,7 +642,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "charset_registered");
+        let res = CharsetRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -704,7 +660,7 @@ mod tests {
                 t
             }),
         );
-        let res = parse_allowed_config(&cfg, "charset_registered");
+        let res = CharsetRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -716,7 +672,7 @@ mod tests {
             "charset_registered".into(),
             toml::Value::String("not-a-table".into()),
         );
-        let res = parse_allowed_config(&cfg, "charset_registered");
+        let res = CharsetRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -833,7 +789,7 @@ mod tests {
     #[test]
     fn parse_allowed_config_missing_rule_errors() {
         let cfg = crate::config::Config::default();
-        let res = parse_allowed_config(&cfg, "charset_registered");
+        let res = CharsetRegistered.prepare(&cfg);
         assert!(res.is_err());
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("requires configuration") || msg.contains("missing"));
@@ -841,7 +797,6 @@ mod tests {
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = CharsetRegistered;
         let mut full_cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["charset_registered"]);
         full_cfg.rules.insert(
@@ -858,7 +813,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_allowed_config(&full_cfg, rule.id())?;
+        let arc = CharsetRegistered.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::AllowedList =
+            arc.state.downcast_ref().expect("allowed list state");
         assert!(arc.allowed.contains(&"utf-8".to_string()));
         Ok(())
     }

--- a/lint-http-rules/src/rules/content_encoding_registered.rs
+++ b/lint-http-rules/src/rules/content_encoding_registered.rs
@@ -5,59 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct ContentEncodingConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<ContentEncodingConfig> {
-    // Base required fields (enabled + severity)
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    // Allowed list is REQUIRED for this rule. It must be an array of strings.
-    let rule_cfg = config.get_rule_config(rule_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "rule '{}' requires configuration and a named 'allowed' array listing acceptable content-codings. Example in config_example.toml",
-            rule_id
-        )
-    })?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires an 'allowed' array listing allowed content-coding tokens (e.g., ['gzip','br','deflate'])",
-            rule_id
-        )
-    })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'allowed' must be an array of strings (e.g., ['gzip','br'])")
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(ContentEncodingConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 pub struct ContentEncodingRegistered;
 
 impl Rule for ContentEncodingRegistered {
@@ -70,13 +17,20 @@ impl Rule for ContentEncodingRegistered {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "acceptable content-coding tokens",
+            "['gzip','br','deflate']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -86,7 +40,7 @@ impl Rule for ContentEncodingRegistered {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &ContentEncodingConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
         // Helper to check a single header value against allowed list
         // `is_accept` distinguishes the two grammars. They are not the same vocabulary:
         // Content-Encoding is a list of plain content-codings, while Accept-Encoding
@@ -113,7 +67,7 @@ impl Rule for ContentEncodingRegistered {
                     }
                     return Some(Violation {
                             rule: "content_encoding_registered".into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "'*' is not a content-coding and is only meaningful in Accept-Encoding, not in {}",
                                 hdr_name
@@ -127,7 +81,7 @@ impl Rule for ContentEncodingRegistered {
                 if !is_accept && token.eq_ignore_ascii_case("identity") {
                     return Some(Violation {
                             rule: "content_encoding_registered".into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "'identity' is reserved for Accept-Encoding and SHOULD NOT be sent in {}",
                                 hdr_name
@@ -138,7 +92,7 @@ impl Rule for ContentEncodingRegistered {
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
                     return Some(Violation {
                         rule: "content_encoding_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!("Invalid token '{}' in {} header", c, hdr_name),
                     });
                 }
@@ -150,7 +104,7 @@ impl Rule for ContentEncodingRegistered {
                 if !allowed.contains(&token.to_ascii_lowercase()) {
                     return Some(Violation {
                         rule: "content_encoding_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Unrecognized content-coding '{}' in {} header",
                             token, hdr_name
@@ -359,7 +313,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&cfg, "content_encoding_registered")?;
+        let parsed = ContentEncodingRegistered.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert_eq!(parsed.allowed, vec!["x-custom".to_string()]);
         Ok(())
     }
@@ -380,7 +336,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "content_encoding_registered");
+        let res = ContentEncodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -403,7 +359,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "content_encoding_registered");
+        let res = ContentEncodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -413,7 +369,7 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "content_encoding_registered",
         ]);
-        let res = parse_allowed_config(&cfg, "content_encoding_registered");
+        let res = ContentEncodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -421,7 +377,7 @@ mod tests {
     fn parse_allowed_config_missing_rule_errors() {
         // If the entire rule is not present in the config, parsing should fail
         let cfg = crate::config::Config::default();
-        let res = parse_allowed_config(&cfg, "content_encoding_registered");
+        let res = ContentEncodingRegistered.prepare(&cfg);
         assert!(res.is_err());
         let msg = res.unwrap_err().to_string();
         // Different helper functions compose different error strings; accept either form.
@@ -451,7 +407,7 @@ mod tests {
             "content_encoding_registered".into(),
             toml::Value::String("not-a-table".into()),
         );
-        let res = parse_allowed_config(&cfg, "content_encoding_registered");
+        let res = ContentEncodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -471,7 +427,7 @@ mod tests {
                 t
             }),
         );
-        let res = parse_allowed_config(&cfg, "content_encoding_registered");
+        let res = ContentEncodingRegistered.prepare(&cfg);
         assert!(res.is_err());
         let msg = res.unwrap_err().to_string();
         assert!(msg.contains("'allowed' must be an array"));
@@ -479,7 +435,6 @@ mod tests {
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = ContentEncodingRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "content_encoding_registered",
         ]);
@@ -497,7 +452,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_allowed_config(&full_cfg, rule.id())?;
+        let arc = ContentEncodingRegistered.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::AllowedList =
+            arc.state.downcast_ref().expect("allowed list state");
         assert!(arc.allowed.contains(&"gzip".to_string()));
         Ok(())
     }
@@ -789,7 +746,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&cfg, "content_encoding_registered")?;
+        let parsed = ContentEncodingRegistered.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert_eq!(parsed.allowed, vec!["gzip".to_string()]);
         Ok(())
     }

--- a/lint-http-rules/src/rules/content_type_registered.rs
+++ b/lint-http-rules/src/rules/content_type_registered.rs
@@ -5,59 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct ContentTypeConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<ContentTypeConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config.get_rule_config(rule_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "rule '{}' requires configuration and a named 'allowed' array listing acceptable media-types or patterns. Example in config_example.toml",
-            rule_id
-        )
-    })?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires an 'allowed' array listing allowed media-types (e.g., ['text/plain','application/json','image/*','+json'])",
-            rule_id
-        )
-    })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!(
-            "'allowed' must be an array of strings (e.g., ['text/plain','application/json'])"
-        )
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(ContentTypeConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 pub struct ContentTypeRegistered;
 
 impl Rule for ContentTypeRegistered {
@@ -70,13 +17,20 @@ impl Rule for ContentTypeRegistered {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "acceptable media-types or patterns",
+            "['text/plain','application/json','image/*','+json']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -86,7 +40,7 @@ impl Rule for ContentTypeRegistered {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &ContentTypeConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
         let check_media_type =
             |hdr_name: &str, val: &str, allowed: &Vec<String>| -> Option<Violation> {
                 // Parse media-type; if it fails, let other rules (well-formed) report it.
@@ -145,7 +99,7 @@ impl Rule for ContentTypeRegistered {
 
                 Some(Violation {
                     rule: self.id().into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!("Unrecognized media type '{}' in {} header", full, hdr_name),
                 })
             };
@@ -389,7 +343,9 @@ mod tests {
                 t
             }),
         );
-        let parsed = parse_allowed_config(&cfg, "content_type_registered")?;
+        let parsed = ContentTypeRegistered.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert!(parsed.allowed.contains(&"image/*".to_string()));
         Ok(())
     }
@@ -464,7 +420,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&cfg, "content_type_registered")?;
+        let parsed = ContentTypeRegistered.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert!(parsed.allowed.contains(&"x-custom/type".to_string()));
         Ok(())
     }
@@ -484,7 +442,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "content_type_registered");
+        let res = ContentTypeRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -506,13 +464,12 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "content_type_registered");
+        let res = ContentTypeRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = ContentTypeRegistered;
         let mut full_cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["content_type_registered"]);
         full_cfg.rules.insert(
@@ -529,7 +486,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_allowed_config(&full_cfg, rule.id())?;
+        let arc = ContentTypeRegistered.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::AllowedList =
+            arc.state.downcast_ref().expect("allowed list state");
         assert!(arc.allowed.contains(&"text/plain".to_string()));
         Ok(())
     }

--- a/lint-http-rules/src/rules/extension_headers_registered.rs
+++ b/lint-http-rules/src/rules/extension_headers_registered.rs
@@ -5,64 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct ExtensionHeadersConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<ExtensionHeadersConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config.get_rule_config(rule_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "rule '{}' requires configuration and a named 'allowed' array listing the field names this deployment expects, in header and trailer sections alike. Example in config_example.toml",
-            rule_id
-        )
-    })?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires an 'allowed' array listing the field names this deployment expects (e.g., ['host','content-type','acme-request-id'])",
-            rule_id
-        )
-    })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'allowed' must be an array of strings (e.g., ['host','content-type'])")
-    })?;
-
-    // No sentence forbids an empty array. It is refused because the rule it
-    // configures would then report the first field of every message, which reads as
-    // a broken linter rather than as a deployment that accepts nothing.
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        // What the array lists is field names, and a field name means the same thing
-        // however it is spelled, so the configured spelling is folded here -- once per
-        // array rather than once per field of every message.
-        // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(ExtensionHeadersConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 pub struct ExtensionHeadersRegistered;
 
 impl Rule for ExtensionHeadersRegistered {
@@ -78,13 +20,24 @@ impl Rule for ExtensionHeadersRegistered {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        // What the array lists is field names, and a field name means the same
+        // thing however it is spelled, so the configured spelling is folded at
+        // prepare time -- once per array rather than once per field of every message.
+        // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "the field names this deployment expects, in header and trailer sections alike",
+            "['host','content-type']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -94,7 +47,7 @@ impl Rule for ExtensionHeadersRegistered {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &ExtensionHeadersConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
 
         // All four, in wire order, from the shared walk. A trailer field name is
         // a field name, so the allowlist reaches it on the same terms; a
@@ -102,7 +55,7 @@ impl Rule for ExtensionHeadersRegistered {
         // which sections exist at all is the framing's answer, not this rule's.
         // cite(RFC 9110 § 6.5): "Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields""
         for (section, headers) in crate::helpers::headers::transaction_field_sections(tx) {
-            if let Some(v) = check_section(section, headers, config) {
+            if let Some(v) = check_section(section, headers, config, ctx.severity) {
                 return Some(v);
             }
         }
@@ -194,7 +147,8 @@ impl Rule for ExtensionHeadersRegistered {
 fn check_section(
     section: &str,
     fields: &hyper::HeaderMap,
-    config: &ExtensionHeadersConfig,
+    config: &crate::helpers::rule_config::AllowedList,
+    severity: crate::lint::Severity,
 ) -> Option<Violation> {
     // `keys()` rather than `iter()`: what is being judged is the name, and a field
     // repeated across lines is one name that would otherwise be judged once per line.
@@ -214,7 +168,7 @@ fn check_section(
         // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
         return Some(Violation {
             rule: ExtensionHeadersRegistered.id().into(),
-            severity: config.severity,
+            severity,
             message: format!(
                 "Field name '{}' in the {} is not in the 'allowed' list for '{}'. That list is the rule's only authority: add the name to it if this deployment expects the field",
                 name.as_str(),
@@ -329,7 +283,7 @@ mod tests {
     #[test]
     fn parse_config_requires_allowed_array() {
         let cfg = crate::config::Config::default();
-        let res = parse_allowed_config(&cfg, "extension_headers_registered");
+        let res = ExtensionHeadersRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -349,7 +303,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "extension_headers_registered");
+        let res = ExtensionHeadersRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -372,7 +326,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "extension_headers_registered");
+        let res = ExtensionHeadersRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -392,7 +346,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "extension_headers_registered");
+        let res = ExtensionHeadersRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -406,7 +360,7 @@ mod tests {
             toml::Value::String("not a table".into()),
         );
 
-        let res = parse_allowed_config(&cfg, "extension_headers_registered");
+        let res = ExtensionHeadersRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -434,7 +388,6 @@ mod tests {
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = ExtensionHeadersRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "extension_headers_registered",
         ]);
@@ -452,7 +405,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_allowed_config(&full_cfg, rule.id())?;
+        let arc = ExtensionHeadersRegistered.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::AllowedList =
+            arc.state.downcast_ref().expect("allowed list state");
         assert!(arc.allowed.contains(&"host".to_string()));
         Ok(())
     }
@@ -515,7 +470,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&cfg, "extension_headers_registered")?;
+        let parsed = ExtensionHeadersRegistered.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert!(parsed.allowed.contains(&"x-custom".to_string()));
         Ok(())
     }

--- a/lint-http-rules/src/rules/head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/head_response_headers_match_get.rs
@@ -5,62 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct SemanticHeadResponseHeadersMatchGetConfig {
-    pub severity: crate::lint::Severity,
-    /// Lowercased header field-names that must match between a previous GET and a HEAD
-    pub headers: Vec<String>,
-}
-
-fn parse_headers_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<SemanticHeadResponseHeadersMatchGetConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config.get_rule_config(rule_id).ok_or_else(|| {
-        anyhow::anyhow!(
-            "rule '{}' requires configuration and a named 'headers' array listing header field-names to check. Example in config_example.toml",
-            rule_id
-        )
-    })?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let headers_val = table.get("headers").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires a 'headers' array listing header field-names to validate (e.g., ['etag','content-type','content-length'])",
-            rule_id
-        )
-    })?;
-
-    let arr = headers_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'headers' must be an array of strings (e.g., ['etag','content-type'])")
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'headers' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'headers' array item at index {} must be a string", i)
-        })?;
-        // The configured names are folded once here so the rest of the rule can
-        // compare them as strings; the fold is the field name's own rule, not a
-        // convenience.
-        // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(SemanticHeadResponseHeadersMatchGetConfig {
-        severity,
-        headers: out,
-    })
-}
-
 /// Whether a difference in *presence* of this field between the two responses
 /// is licensed, in either direction.
 ///
@@ -182,13 +126,24 @@ impl Rule for HeadResponseHeadersMatchGet {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_headers_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        // The configured names are folded once at prepare time so the rest of the
+        // rule can compare them as strings; the fold is the field name's own
+        // rule, not a convenience.
+        // cite(RFC 9110 § 5.1): "Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry""
+        let headers = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "headers",
+            "header field-names to check",
+            "['etag','content-type','content-length']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::HeaderNameList { headers }),
         })
     }
 
@@ -245,12 +200,12 @@ impl Rule for HeadResponseHeadersMatchGet {
 
         // Parse config only after the cheap method/response/history guards above —
         // non-HEAD transactions (the common case) skip the allocation entirely.
-        let config: &SemanticHeadResponseHeadersMatchGetConfig = ctx.state();
+        let config: &crate::helpers::rule_config::HeaderNameList = ctx.state();
 
         let report = |message: String| {
             Some(Violation {
                 rule: self.id().into(),
-                severity: config.severity,
+                severity: ctx.severity,
                 message,
             })
         };
@@ -768,7 +723,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_headers_config(&cfg, "head_response_headers_match_get")?;
+        let parsed = HeadResponseHeadersMatchGet.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::HeaderNameList =
+            parsed.state.downcast_ref().expect("header name list state");
         assert!(parsed.headers.contains(&"etag".to_string()));
         Ok(())
     }
@@ -1134,7 +1091,6 @@ mod tests {
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = HeadResponseHeadersMatchGet;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "head_response_headers_match_get",
         ]);
@@ -1152,7 +1108,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_headers_config(&full_cfg, rule.id())?;
+        let arc = HeadResponseHeadersMatchGet.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::HeaderNameList =
+            arc.state.downcast_ref().expect("header name list state");
         assert!(arc.headers.contains(&"etag".to_string()));
         Ok(())
     }
@@ -1173,7 +1131,7 @@ mod tests {
             }),
         );
 
-        let res = parse_headers_config(&cfg, "head_response_headers_match_get");
+        let res = HeadResponseHeadersMatchGet.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -1187,7 +1145,7 @@ mod tests {
             toml::Value::String("not a table".into()),
         );
 
-        let res = parse_headers_config(&cfg, "head_response_headers_match_get");
+        let res = HeadResponseHeadersMatchGet.prepare(&cfg);
         assert!(res.is_err());
     }
 

--- a/lint-http-rules/src/rules/media_type_suffix_valid.rs
+++ b/lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7,57 +7,6 @@ use crate::rules::Rule;
 
 pub struct MediaTypeSuffixValid;
 
-#[derive(Debug, Clone)]
-pub struct MessageMediaTypeSuffixConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<MessageMediaTypeSuffixConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config
-        .get_rule_config(rule_id)
-        .ok_or_else(|| anyhow::anyhow!("missing configuration for '{}'", rule_id))?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Rule '{}' requires an 'allowed' array listing known structured-syntax suffixes (e.g., ['json','xml'])",
-                    rule_id
-                )
-            })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'allowed' must be an array of strings (e.g., ['json','xml'])")
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    // Folded once here rather than at every comparison; the subtype a suffix
-    // lives in is case-insensitive, so the fold is the matching rule.
-    // cite(RFC 9110 § 8.3.1): "The type and subtype tokens are case-insensitive."
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(MessageMediaTypeSuffixConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 impl Rule for MediaTypeSuffixValid {
     fn id(&self) -> &'static str {
         "media_type_suffix_valid"
@@ -72,13 +21,24 @@ impl Rule for MediaTypeSuffixValid {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        // Entries are folded once at prepare time rather than at every comparison;
+        // the subtype a suffix lives in is case-insensitive, so the fold is the
+        // matching rule.
+        // cite(RFC 9110 § 8.3.1): "The type and subtype tokens are case-insensitive."
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "known structured-syntax suffixes",
+            "['json','xml']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -88,7 +48,7 @@ impl Rule for MediaTypeSuffixValid {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &MessageMediaTypeSuffixConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
         let check_media = |hdr_name: &str, val: &str| -> Option<Violation> {
             // A value that is not a media-type has no subtype to inspect, and
             // saying so is `content_type_valid`'s finding. The
@@ -137,7 +97,7 @@ impl Rule for MediaTypeSuffixValid {
                 if subtype.starts_with('+') {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Media type '{}/{}' in {} is a structured suffix with no base subtype name",
                             parsed.type_, parsed.subtype, hdr_name
@@ -155,7 +115,7 @@ impl Rule for MediaTypeSuffixValid {
                 if suffix.is_empty() {
                     return Some(Violation {
                         rule: self.id().into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Media type '{}/{}' in {} has empty structured suffix",
                             parsed.type_, parsed.subtype, hdr_name
@@ -179,7 +139,7 @@ impl Rule for MediaTypeSuffixValid {
                 if !config.allowed.contains(&suffix) {
                     return Some(Violation {
                                 rule: self.id().into(),
-                                severity: config.severity,
+                                severity: ctx.severity,
                                 message: format!(
                                     "Unrecognized structured syntax suffix '+{}' in media type '{}/{}' (header '{}')",
                                     suffix, parsed.type_, parsed.subtype, hdr_name
@@ -778,7 +738,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&cfg, "media_type_suffix_valid")?;
+        let parsed = MediaTypeSuffixValid.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert_eq!(parsed.allowed, vec!["ldjson".to_string()]);
         Ok(())
     }
@@ -798,7 +760,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "media_type_suffix_valid");
+        let res = MediaTypeSuffixValid.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -820,7 +782,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "media_type_suffix_valid");
+        let res = MediaTypeSuffixValid.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -828,13 +790,12 @@ mod tests {
     fn parse_config_requires_allowed_array() {
         let cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["media_type_suffix_valid"]);
-        let res = parse_allowed_config(&cfg, "media_type_suffix_valid");
+        let res = MediaTypeSuffixValid.prepare(&cfg);
         assert!(res.is_err());
     }
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = MediaTypeSuffixValid;
         let mut full_cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["media_type_suffix_valid"]);
         full_cfg.rules.insert(
@@ -851,7 +812,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_allowed_config(&full_cfg, rule.id())?;
+        let arc = MediaTypeSuffixValid.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::AllowedList =
+            arc.state.downcast_ref().expect("allowed list state");
         assert!(arc.allowed.contains(&"json".to_string()));
         Ok(())
     }

--- a/lint-http-rules/src/rules/structured_headers_valid.rs
+++ b/lint-http-rules/src/rules/structured_headers_valid.rs
@@ -8,60 +8,6 @@ use crate::rules::Rule;
 
 pub struct StructuredHeadersValid;
 
-#[derive(Debug, Clone)]
-pub struct MessageStructuredHeadersConfig {
-    pub severity: crate::lint::Severity,
-    pub headers: Vec<String>,
-}
-
-fn parse_headers_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<MessageStructuredHeadersConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    let rule_cfg = config
-        .get_rule_config(rule_id)
-        .ok_or_else(|| anyhow::anyhow!("missing configuration for '{}'", rule_id))?;
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let headers_val = table.get("headers").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires a 'headers' array listing header field-names to validate",
-            rule_id
-        )
-    })?;
-
-    let arr = headers_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!(
-            "'headers' must be an array of strings (e.g., ['Cache-Status','Proxy-Status'])"
-        )
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'headers' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'headers' array item at index {} must be a string", i)
-        })?;
-        // Folded once here so the lookups below are exact. The same sentence
-        // that makes a parser gather every line of a field says how it decides
-        // which lines belong to it.
-        // cite(RFC 9651 § 4.2): "When generating input_bytes, parsers MUST combine all field lines in the same section (header or trailer) that case-insensitively match the field name into one comma-separated field-value, as per Section 5.2 of [HTTP]; this assures that the entire field value is processed correctly."
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(MessageStructuredHeadersConfig {
-        severity,
-        headers: out,
-    })
-}
-
 impl StructuredHeadersValid {
     /// Judge one header field across one section, from its joined value.
     ///
@@ -78,7 +24,7 @@ impl StructuredHeadersValid {
         headers: &hyper::HeaderMap,
         hdr: &str,
         section: &str,
-        config: &MessageStructuredHeadersConfig,
+        severity: crate::lint::Severity,
     ) -> Option<Violation> {
         let mut lines: Vec<&str> = Vec::new();
         for hv in headers.get_all(hdr).iter() {
@@ -92,7 +38,7 @@ impl StructuredHeadersValid {
                     hdr,
                     section,
                     "contains a byte outside ASCII",
-                    config.severity,
+                    severity,
                 ));
             };
             lines.push(v);
@@ -101,7 +47,7 @@ impl StructuredHeadersValid {
             return None;
         }
         let msg = validate_structured_field(&lines.join(", "))?;
-        Some(self.parse_failure(hdr, section, &msg, config.severity))
+        Some(self.parse_failure(hdr, section, &msg, severity))
     }
 
     /// The finding, framed as what a recipient does about it.
@@ -149,13 +95,20 @@ impl Rule for StructuredHeadersValid {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_headers_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        let headers = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "headers",
+            "header field-names to validate",
+            "['Cache-Status','Proxy-Status']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::HeaderNameList { headers }),
         })
     }
 
@@ -165,18 +118,18 @@ impl Rule for StructuredHeadersValid {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &MessageStructuredHeadersConfig = ctx.state();
+        let config: &crate::helpers::rule_config::HeaderNameList = ctx.state();
         // cite(RFC 9651): "This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,"
         for hdr in &config.headers {
             // The two sections are joined separately, never across the pair: the
             // sentence cited on `check_section` gathers the lines "in the same
             // section", so a request's field and a response's field of the same
             // name are two field values, not one.
-            if let Some(v) = self.check_section(&tx.request.headers, hdr, "request", config) {
+            if let Some(v) = self.check_section(&tx.request.headers, hdr, "request", ctx.severity) {
                 return Some(v);
             }
             if let Some(resp) = &tx.response {
-                if let Some(v) = self.check_section(&resp.headers, hdr, "response", config) {
+                if let Some(v) = self.check_section(&resp.headers, hdr, "response", ctx.severity) {
                     return Some(v);
                 }
             }
@@ -423,7 +376,6 @@ mod tests {
 
     #[rstest]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = StructuredHeadersValid;
         let mut full_cfg =
             crate::test_helpers::make_test_config_with_enabled_rules(&["structured_headers_valid"]);
         full_cfg.rules.insert(
@@ -440,7 +392,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_headers_config(&full_cfg, rule.id())?;
+        let arc = StructuredHeadersValid.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::HeaderNameList =
+            arc.state.downcast_ref().expect("header name list state");
         assert!(arc.headers.contains(&"x-struct".to_string()));
         Ok(())
     }

--- a/lint-http-rules/src/rules/transfer_coding_registered.rs
+++ b/lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -5,61 +5,6 @@
 use crate::lint::Violation;
 use crate::rules::Rule;
 
-#[derive(Debug, Clone)]
-pub struct TransferCodingConfig {
-    pub severity: crate::lint::Severity,
-    pub allowed: Vec<String>,
-}
-
-fn parse_allowed_config(
-    config: &crate::config::Config,
-    rule_id: &str,
-) -> anyhow::Result<TransferCodingConfig> {
-    let severity = crate::rules::get_rule_severity_required(config, rule_id)?;
-
-    // get_rule_severity_required/required_enabled already asserts the rule config exists,
-    // so unwrap is safe here and avoids creating an unreachable error branch.
-    let rule_cfg = config
-        .get_rule_config(rule_id)
-        .expect("internal error: rule config missing after validation");
-    let table = rule_cfg
-        .as_table()
-        .ok_or_else(|| anyhow::anyhow!("Configuration for rule '{}' must be a table", rule_id))?;
-
-    let allowed_val = table.get("allowed").ok_or_else(|| {
-        anyhow::anyhow!(
-            "Rule '{}' requires an 'allowed' array listing allowed transfer-coding tokens (e.g., ['chunked','gzip','deflate'])",
-            rule_id
-        )
-    })?;
-
-    let arr = allowed_val.as_array().ok_or_else(|| {
-        anyhow::anyhow!("'allowed' must be an array of strings (e.g., ['chunked','gzip'])")
-    })?;
-
-    if arr.is_empty() {
-        return Err(anyhow::anyhow!("'allowed' array cannot be empty"));
-    }
-
-    let mut out = Vec::new();
-    for (i, item) in arr.iter().enumerate() {
-        let s = item.as_str().ok_or_else(|| {
-            anyhow::anyhow!("'allowed' array item at index {} must be a string", i)
-        })?;
-        // Folded once here so the comparison site can fold the wire value and
-        // be done. The fold is not a convenience: the names are defined to be
-        // case-insensitive, so `GZIP` in a config file and `gzip` on the wire
-        // are the same coding.
-        // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
-        out.push(s.to_ascii_lowercase());
-    }
-
-    Ok(TransferCodingConfig {
-        severity,
-        allowed: out,
-    })
-}
-
 /// Every coding RFC 9112 says defines no parameters. The first five are § 7.2's
 /// compression codings, defined there by reference to the content coding of the
 /// same name -- the two `x-` forms are named as alternates rather than as a
@@ -86,13 +31,25 @@ impl Rule for TransferCodingRegistered {
     }
 
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<crate::rules::ResolvedRule> {
-        let config = parse_allowed_config(cfg, self.id())?;
+        let severity = crate::rules::get_rule_severity_required(cfg, self.id())?;
+        // Entries are folded once at prepare time so the comparison site can fold
+        // the wire value and be done. The fold is not a convenience: the names are
+        // defined to be case-insensitive, so `GZIP` in a config file and `gzip` on
+        // the wire are the same coding.
+        // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
+        let allowed = crate::helpers::rule_config::parse_lowercased_list(
+            cfg,
+            self.id(),
+            "allowed",
+            "acceptable transfer-coding tokens",
+            "['chunked','gzip','deflate']",
+        )?;
         // The two standard keys, **after** this rule's own options, so a config
         // naming a bad option still fails on that option.
         crate::rules::validate_rule_table(cfg, self.id())?;
         Ok(crate::rules::ResolvedRule {
-            severity: config.severity,
-            state: Box::new(config),
+            severity,
+            state: Box::new(crate::helpers::rule_config::AllowedList { allowed }),
         })
     }
 
@@ -102,7 +59,7 @@ impl Rule for TransferCodingRegistered {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let config: &TransferCodingConfig = ctx.state();
+        let config: &crate::helpers::rule_config::AllowedList = ctx.state();
         // check a list-style header value (Transfer-Encoding or TE) against allowed list
         let check_value = |hdr_name: &str, val: &str, allowed: &[String]| -> Option<Violation> {
             // An odd number of unescaped DQUOTEs means the quoting never
@@ -122,7 +79,7 @@ impl Rule for TransferCodingRegistered {
             if !crate::helpers::headers::quoting_is_balanced(val) {
                 return Some(Violation {
                     rule: "transfer_coding_registered".into(),
-                    severity: config.severity,
+                    severity: ctx.severity,
                     message: format!(
                         "Unterminated quoted-string in {} header: '{}'",
                         hdr_name, val
@@ -185,7 +142,7 @@ impl Rule for TransferCodingRegistered {
                 if token.is_empty() {
                     return Some(Violation {
                         rule: "transfer_coding_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Missing transfer-coding name in {} header member '{}'",
                             hdr_name, part
@@ -195,7 +152,7 @@ impl Rule for TransferCodingRegistered {
                 if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
                     return Some(Violation {
                         rule: "transfer_coding_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         // The offending character alone does not locate itself
                         // on a field with several members -- `Invalid token
                         // '<'` says nothing about which coding carried it.
@@ -219,7 +176,7 @@ impl Rule for TransferCodingRegistered {
                 if hdr_name.eq_ignore_ascii_case("TE") && token.eq_ignore_ascii_case("chunked") {
                     return Some(Violation {
                         rule: "transfer_coding_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: "A client must not send the chunked transfer coding name in TE; \
                              chunked is always acceptable for HTTP/1.1 recipients"
                             .into(),
@@ -273,7 +230,7 @@ impl Rule for TransferCodingRegistered {
                         }
                         return Some(Violation {
                             rule: "transfer_coding_registered".into(),
-                            severity: config.severity,
+                            severity: ctx.severity,
                             message: format!(
                                 "Transfer-coding '{}' defines no parameters, but '{}' is \
                                  present in the {} header",
@@ -303,7 +260,7 @@ impl Rule for TransferCodingRegistered {
                 if !allowed.contains(&token.to_ascii_lowercase()) {
                     return Some(Violation {
                         rule: "transfer_coding_registered".into(),
-                        severity: config.severity,
+                        severity: ctx.severity,
                         message: format!(
                             "Unrecognized transfer-coding '{}' in {} header",
                             token, hdr_name
@@ -1069,7 +1026,9 @@ mod tests {
             }),
         );
 
-        let parsed = parse_allowed_config(&cfg, "transfer_coding_registered")?;
+        let parsed = TransferCodingRegistered.prepare(&cfg)?;
+        let parsed: &crate::helpers::rule_config::AllowedList =
+            parsed.state.downcast_ref().expect("allowed list state");
         assert_eq!(parsed.allowed, vec!["x-custom".to_string()]);
         Ok(())
     }
@@ -1090,7 +1049,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "transfer_coding_registered");
+        let res = TransferCodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -1113,7 +1072,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "transfer_coding_registered");
+        let res = TransferCodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -1122,13 +1081,12 @@ mod tests {
         let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "transfer_coding_registered",
         ]);
-        let res = parse_allowed_config(&cfg, "transfer_coding_registered");
+        let res = TransferCodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
     #[test]
     fn validate_parses_config() -> anyhow::Result<()> {
-        let rule = TransferCodingRegistered;
         let mut full_cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
             "transfer_coding_registered",
         ]);
@@ -1146,7 +1104,9 @@ mod tests {
             }),
         );
 
-        let arc = parse_allowed_config(&full_cfg, rule.id())?;
+        let arc = TransferCodingRegistered.prepare(&full_cfg)?;
+        let arc: &crate::helpers::rule_config::AllowedList =
+            arc.state.downcast_ref().expect("allowed list state");
         assert!(arc.allowed.contains(&"chunked".to_string()));
         Ok(())
     }
@@ -1264,7 +1224,7 @@ mod tests {
         ]);
         cfg.rules
             .insert("transfer_coding_registered".into(), toml::Value::Integer(1));
-        let res = parse_allowed_config(&cfg, "transfer_coding_registered");
+        let res = TransferCodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -1284,7 +1244,7 @@ mod tests {
             }),
         );
 
-        let res = parse_allowed_config(&cfg, "transfer_coding_registered");
+        let res = TransferCodingRegistered.prepare(&cfg);
         assert!(res.is_err());
     }
 
@@ -1325,7 +1285,7 @@ mod tests {
     fn parse_config_requires_named_rule_cfg() {
         // No rule entry present at all should produce an error stating configuration is required
         let cfg = crate::config::Config::default();
-        let res = parse_allowed_config(&cfg, "transfer_coding_registered");
+        let res = TransferCodingRegistered.prepare(&cfg);
         assert!(res.is_err());
         let e = res.unwrap_err();
         // Depending on which helper fails first the message may reference "missing configuration"

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2944,7 +2944,7 @@ sources:
     snippet: it specified a suffix (in that case, "+xml") to be appended to the base subtype name.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 139
+      line: 93
   - label: link_header_valid
     section: § 4.2
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
@@ -2952,7 +2952,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 1005
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 123
+      line: 83
   - label: link_header_valid (2)
     section: § 4.2
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
@@ -2960,7 +2960,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 1006
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 136
+      line: 96
   - label: link_header_valid (3)
     section: § 4.2
     snippet: restricted-name-chars = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "-" / "^" / "_"
@@ -2974,7 +2974,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 1009
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 131
+      line: 91
   - label: link_header_valid (5)
     section: § 4.2
     snippet: restricted-name-chars =/ "." ; Characters before first dot always ; specify a facet name
@@ -2992,13 +2992,13 @@ sources:
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
     cited_by:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 177
+      line: 137
   - label: media_type_suffix_valid (2)
     section: § 4.2.8
     snippet: By the same token, media types MUST NOT be given names incorporating suffixes for structured syntaxes they do not actually employ.
     cited_by:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 178
+      line: 138
 - label: RFC 7231
   url: https://www.rfc-editor.org/rfc/rfc7231.txt
   type: text/plain
@@ -4609,7 +4609,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 67
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 110
+      line: 64
   - label: accept_encoding_parameter_valid (8)
     section: § 12.5.3
     snippet: The field value is evaluated the same way as in a request.
@@ -4797,7 +4797,7 @@ sources:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 165
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 208
+      line: 163
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 203
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -5087,13 +5087,13 @@ sources:
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 106
+      line: 62
   - label: auth_scheme_registered (2)
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 107
+      line: 63
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -5187,11 +5187,11 @@ sources:
     snippet: 'The "Content-Type" header field indicates the media type of the associated representation: either the representation enclosed in the message content or the selected representation, as determined by the message semantics.'
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 73
+      line: 18
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 18
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 69
+      line: 18
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 20
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
@@ -5201,15 +5201,15 @@ sources:
     snippet: Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978].
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 213
+      line: 169
   - label: charset_registered (3)
     section: § 8.3.2
     snippet: In both cases, charset names are matched case-insensitively.
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 48
+      line: 28
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 214
+      line: 170
   - label: compression_and_transfer_encoding_consistent
     section: § 10.1.4
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
@@ -5217,7 +5217,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 88
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 159
+      line: 116
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 69
   - label: compression_and_transfer_encoding_consistent (2)
@@ -5227,7 +5227,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 89
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 140
+      line: 97
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 51
   - label: compression_and_transfer_encoding_consistent (3)
@@ -5245,7 +5245,7 @@ sources:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
       line: 32
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 95
+      line: 49
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 8.4
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
@@ -5271,7 +5271,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 67
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 149
+      line: 103
   - label: conditional_headers_consistent
     section: § 13.1.3
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
@@ -5379,19 +5379,19 @@ sources:
     snippet: codings = content-coding / "identity" / "*"
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 96
+      line: 50
   - label: content_encoding_registered (2)
     section: § 8.4
     snippet: Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included.
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 126
+      line: 80
   - label: content_encoding_registered (3)
     section: § 8.4.1
     snippet: content-coding = token
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 137
+      line: 91
   - label: content_length_valid
     section: § 8.6
     snippet: The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets.
@@ -5521,7 +5521,7 @@ sources:
     - file: lint-http-rules/src/rules/content_type_present.rs
       line: 51
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 207
+      line: 162
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 73
   - label: content_type_registered
@@ -5529,7 +5529,7 @@ sources:
     snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
     cited_by:
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 115
+      line: 69
   - label: content_type_valid
     section: § 8.3
     snippet: Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list.
@@ -5765,37 +5765,37 @@ sources:
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 193
+      line: 146
   - label: extension_headers_registered (2)
     section: § 16.3.2.1
     snippet: Field names ought not be prefixed with "X-"
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 155
+      line: 108
   - label: extension_headers_registered (3)
     section: § 5.1
     snippet: A proxy MUST forward unrecognized header fields unless the field name is listed in the Connection header field
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 191
+      line: 144
   - label: extension_headers_registered (4)
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 56
+      line: 27
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 214
+      line: 168
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 54
+      line: 133
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 316
+      line: 271
   - label: extension_headers_registered (5)
     section: § 5.1
     snippet: Other recipients SHOULD ignore unrecognized header and trailer fields
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 192
+      line: 145
   - label: from_header_email_syntax
     section: § 10.1.2
     snippet: The address ought to be machine-usable, as defined by "mailbox" in Section 3.4 of [RFC5322]
@@ -5807,19 +5807,19 @@ sources:
     snippet: A Vary field value is either the wildcard member "*" or a list of request field names, known as the selecting header fields, that might have had a role in selecting the representation for this response.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 315
+      line: 270
   - label: head_response_headers_match_get (2)
     section: § 12.5.5
     snippet: To inform cache recipients that they MUST NOT use this response to satisfy a later request unless the later request has the same values for the listed header fields as the original request
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 322
+      line: 277
   - label: head_response_headers_match_get (3)
     section: § 15
     snippet: The status code of a response is a three-digit integer code that describes the result of the request and the semantics of the response, including whether the request was successful and what content is enclosed (if any).
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 236
+      line: 191
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
       line: 34
   - label: head_response_headers_match_get (4)
@@ -5827,13 +5827,13 @@ sources:
     snippet: The content sent in a 200 response depends on the request method.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 161
+      line: 105
   - label: head_response_headers_match_get (5)
     section: § 8.6
     snippet: A server MAY send a Content-Length header field in a response to a HEAD request (Section 9.3.2); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a response if the same request had used the GET method.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 128
+      line: 72
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
       line: 54
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -5843,43 +5843,43 @@ sources:
     snippet: In responses to safe requests, validator fields describe the selected representation chosen by the origin server while handling the response.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 98
+      line: 42
   - label: head_response_headers_match_get (7)
     section: § 8.8.1
     snippet: A "strong validator" is representation metadata that changes value whenever a change occurs to the representation data that would be observable in the content of a 200 (OK) response to GET.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 99
+      line: 43
   - label: head_response_headers_match_get (8)
     section: § 8.8.2
     snippet: The "Last-Modified" header field in a response provides a timestamp indicating the date and time at which the origin server believes the selected representation was last modified, as determined at the conclusion of handling the request.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 100
+      line: 44
   - label: head_response_headers_match_get (9)
     section: § 9.2.1
     snippet: Of the request methods defined by this specification, the GET, HEAD, OPTIONS, and TRACE methods are defined to be safe.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 97
+      line: 41
   - label: head_response_headers_match_get (10)
     section: § 9.3.2
     snippet: However, a server MAY omit header fields for which a value is determined only while generating the content.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 75
+      line: 19
   - label: head_response_headers_match_get (11)
     section: § 9.3.2
     snippet: Such a response to GET might contain Content-Length and Vary fields, for example, that are not generated within a HEAD response.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 76
+      line: 20
   - label: head_response_headers_match_get (12)
     section: § 9.3.2
     snippet: The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 202
+      line: 157
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
       line: 66
   - label: field-name grammar
@@ -6301,7 +6301,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 145
+      line: 102
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 53
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
@@ -6321,7 +6321,7 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 213
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 92
+      line: 48
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
       line: 29
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -6537,7 +6537,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 342
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 76
+      line: 18
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 18
   - label: lint-http-rules/src/helpers/headers.rs (5)
@@ -6597,7 +6597,7 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 80
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 330
+      line: 287
   - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields.
@@ -6685,13 +6685,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 247
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 251
+      line: 207
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 85
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 82
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 203
+      line: 163
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 48
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
@@ -6847,7 +6847,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 245
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 184
+      line: 141
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 210
   - label: OWS grammar
@@ -6889,7 +6889,7 @@ sources:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 462
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 160
+      line: 117
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 70
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -6921,7 +6921,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 33
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 343
+      line: 300
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 523
   - label: lint-http-rules/src/helpers/headers.rs (25)
@@ -6959,9 +6959,9 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 316
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 121
+      line: 78
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 342
+      line: 299
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 33
   - label: lint-http-rules/src/helpers/headers.rs (27)
@@ -6973,7 +6973,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 153
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 126
+      line: 82
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 212
   - label: lint-http-rules/src/helpers/headers.rs (28)
@@ -7009,7 +7009,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 289
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 132
+      line: 88
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 381
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -7043,7 +7043,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 119
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 142
+      line: 86
   - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
@@ -7053,7 +7053,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 343
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 103
+      line: 56
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 32
   - label: lint-http-rules/src/helpers/headers.rs (34)
@@ -7101,11 +7101,11 @@ sources:
     - file: lint-http-rules/src/rules/charset_present.rs
       line: 39
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 101
+      line: 55
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 46
+      line: 28
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 149
+      line: 109
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 179
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -7133,7 +7133,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 105
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 107
+      line: 67
   - label: lint-http-rules/src/helpers/headers.rs (38)
     section: § 8.3.1
     snippet: type       = token subtype    = token
@@ -8671,7 +8671,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 26
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 377
+      line: 334
   - label: te_header_valid (3)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
@@ -8775,7 +8775,7 @@ sources:
     snippet: 'TE                 = #t-codings t-codings          = "trailers" / ( transfer-coding [ weight ] ) transfer-coding    = token *( OWS ";" OWS transfer-parameter ) transfer-parameter = token BWS "=" BWS ( token / quoted-string )'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 268
+      line: 225
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -9361,11 +9361,11 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 98
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 53
+      line: 39
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 218
+      line: 175
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 302
+      line: 259
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 75
   - label: compression_and_transfer_encoding_consistent (4)
@@ -9453,13 +9453,13 @@ sources:
     snippet: This indication is not required, however, because any recipient on the response chain (including the origin server) can remove transfer codings when they are not needed.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 267
+      line: 222
   - label: head_response_headers_match_get (2)
     section: § 6.1
     snippet: Transfer-Encoding MAY be sent in a response to a HEAD request or in a 304 (Not Modified) response (Section 15.4.5 of [HTTP]) to a GET request, neither of which includes a message body, to indicate that the origin server would have applied a transfer coding to the message body if the request had been an unconditional GET.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 266
+      line: 221
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 172
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -9831,7 +9831,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 48
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 376
+      line: 333
   - label: te_header_valid (3)
     section: § 7.4
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
@@ -9845,61 +9845,61 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 273
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 269
+      line: 226
   - label: transfer_coding_registered
     section: § 6.1
     snippet: A server that receives a request message with a transfer coding it does not understand SHOULD respond with 501 (Not Implemented).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 290
+      line: 247
   - label: transfer_coding_registered (2)
     section: § 6.1
     snippet: 'Transfer-Encoding = #transfer-coding'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 353
+      line: 310
   - label: transfer_coding_registered (3)
     section: § 7.1
     snippet: The chunked coding does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 242
+      line: 199
   - label: transfer_coding_registered (4)
     section: § 7.1
     snippet: Their presence SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 243
+      line: 200
   - label: transfer_coding_registered (5)
     section: § 7.2
     snippet: The compression codings do not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 233
+      line: 190
   - label: transfer_coding_registered (6)
     section: § 7.2
     snippet: The presence of parameters with any of these compression codings SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 234
+      line: 191
   - label: transfer_coding_registered (7)
     section: § 7.3
     snippet: The "HTTP Transfer Coding Registry" defines the namespace for transfer coding names.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 132
+      line: 89
   - label: transfer_coding_registered (8)
     section: § 7.4
     snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 215
+      line: 172
   - label: transfer_coding_registered (9)
     section: § 7.4
     snippet: The keyword "trailers" indicates that the sender will not discard trailer fields, as described in Section 6.5 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 169
+      line: 126
   - label: transfer_encoding_chunked_final
     section: § 6.1
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
@@ -10177,7 +10177,7 @@ sources:
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 206
+      line: 160
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 115
   - label: header_field_names_token_valid
@@ -10744,7 +10744,7 @@ sources:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 42
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 89
+      line: 35
   - label: lint-http-rules/src/helpers/structured_fields.rs (8)
     section: § 4.2
     snippet: Discard any leading SP characters from input_string.
@@ -10752,7 +10752,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 452
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 286
+      line: 239
   - label: lint-http-rules/src/helpers/structured_fields.rs (9)
     section: § 4.2
     snippet: The parsing algorithms for both types allow tab characters, since these might be used to combine field lines by some implementations.
@@ -10866,7 +10866,7 @@ sources:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 68
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 294
+      line: 247
   - label: lint-http-rules/src/helpers/structured_fields.rs (27)
     section: § 4.2.3
     snippet: Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
@@ -11082,7 +11082,7 @@ sources:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 251
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 119
+      line: 65
   - label: permissions_policy_directives_valid (4)
     section: § 4.2
     snippet: When generating input_bytes, parsers MUST combine all field lines in the same section (header or trailer) that case-insensitively match the field name into one comma-separated field-value, as per Section 5.2 of [HTTP]; this assures that the entire field value is processed correctly.
@@ -11092,9 +11092,7 @@ sources:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 61
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 55
-    - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 75
+      line: 21
   - label: permissions_policy_directives_valid (5)
     section: § 4.2.2
     snippet: Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored.
@@ -11113,37 +11111,37 @@ sources:
     snippet: This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 169
+      line: 122
   - label: structured_headers_valid (2)
     section: § 4.2
     snippet: Given an array of bytes as input_bytes that represent the chosen field's field-value (which is empty if that field is not present) and field_type (one of "dictionary", "list", or "item"), return the parsed field value.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 274
+      line: 227
   - label: structured_headers_valid (3)
     section: § 4.2
     snippet: If field_type is "dictionary", let output be the result of running Parsing a Dictionary (Section 4.2.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 306
+      line: 259
   - label: structured_headers_valid (4)
     section: § 4.2
     snippet: If field_type is "item", let output be the result of running Parsing an Item (Section 4.2.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 299
+      line: 252
   - label: structured_headers_valid (5)
     section: § 4.2
     snippet: If field_type is "list", let output be the result of running Parsing a List (Section 4.2.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 301
+      line: 254
   - label: structured_headers_valid (6)
     section: § 4.2.1
     snippet: No structured data has been found; return members (which is empty).
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 293
+      line: 246
 - label: RFC 9745
   url: https://www.rfc-editor.org/rfc/rfc9745.txt
   type: text/plain


### PR DESCRIPTION
Seven rules read a required 'allowed' array of case-insensitively matched names, two more read the same shape under 'headers', and each had grown its own copy of the parser — nine parsers and nine one-field config structs differing in the key and the noun their error messages named. The parser moves to helpers::rule_config::parse_lowercased_list; the key and the nouns stay with the rules, and so do the citations that justify each rule's case-fold, because which sentence licenses folding GZIP to gzip is a per-registry fact, not a property of the function.

alt_svc_protocol_registered deliberately keeps its own parser: ALPN protocol names are opaque byte strings identified by their exact octets, so its list is stored as written and each entry is validated — same TOML shape, different question.

The helper's error cases get one canonical test suite; the per-file parser tests now exercise the same paths through each rule's prepare.
