### PR TITLE
The per-dispatch config layer has nothing left to hold up

### DIFF
--- a/lint-http-core/src/test_helpers.rs
+++ b/lint-http-core/src/test_helpers.rs
@@ -7,7 +7,7 @@
 //! Helper functions for constructing test fixtures (HTTP transactions,
 //! configurations) that depend only on core types. Used across this crate's
 //! tests and — via the `test-utils` feature — by downstream crates. Fixtures
-//! that need rule-layer types (e.g. `make_test_rule_config`) live in the rules
+//! that need rule-layer types (e.g. `run_rule`) live in the rules
 //! crate's own `test_helpers`.
 
 use crate::state::ClientIdentifier;

--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -54,11 +54,11 @@ impl PreparedEngine {
     /// Validate the config, then intersect the catalogue's precomputed scope
     /// views with `cfg.is_enabled`, once.
     ///
-    /// **This is the only place `enabled` is read, and it is why the per-rule
-    /// reading went.** Each rule's `parse_rule_config` used to ask the same
-    /// question again on every transaction and discard the answer; the flag is
-    /// decided here, when the engine is built, and a rule that is not in one of
-    /// these three vectors is never dispatched.
+    /// **This is the only place `enabled` is read.** The flag is decided here,
+    /// when the engine is built, and a rule that is not in one of these three
+    /// vectors is never dispatched; each rule's per-transaction config read
+    /// used to ask the same question again on every dispatch and discard the
+    /// answer.
     ///
     /// Construction runs [`crate::rules::validate_rules`] itself, so an engine
     /// cannot exist over a config whose rule tables were never checked. This
@@ -240,8 +240,8 @@ mod tests {
     #[test]
     fn construction_rejects_malformed_enabled_rule_config() {
         // An enabled rule whose table lacks `severity` used to be a lint-time
-        // silence (`parse_rule_config(...).ok()?`); construction now refuses
-        // the config outright.
+        // silence (a per-dispatch parse ending in `.ok()?`); construction now
+        // refuses the config outright.
         let mut cfg = Config::default();
         let mut table = toml::map::Map::new();
         table.insert("enabled".to_string(), toml::Value::Boolean(true));

--- a/lint-http-rules/src/rules/content_type_valid.rs
+++ b/lint-http-rules/src/rules/content_type_valid.rs
@@ -308,8 +308,7 @@ mod tests {
     #[case("text/plain; charset=", true)]
     #[case("text/plain; charset=\"\"", false)]
     fn content_type_parsing_cases(#[case] val: &str, #[case] expect_violation: bool) {
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let res = super::check_content_type("test", val, cfg.severity);
+        let res = super::check_content_type("test", val, crate::lint::Severity::Warn);
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", val);
         } else {
@@ -339,8 +338,7 @@ mod tests {
     #[case("text/plain; foo=\"a\\\"b\"", false)]
     #[case("text/plain; foo=\"\"", false)]
     fn extra_content_type_cases(#[case] val: &str, #[case] expect_violation: bool) {
-        let cfg = crate::test_helpers::make_test_rule_config();
-        let res = super::check_content_type("test", val, cfg.severity);
+        let res = super::check_content_type("test", val, crate::lint::Severity::Warn);
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", val);
         } else {

--- a/lint-http-rules/src/rules/header_field_names_token_valid.rs
+++ b/lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -261,8 +261,8 @@ mod tests {
         #[case] expect_violation: bool,
         #[case] expected_char: Option<char>,
     ) -> anyhow::Result<()> {
-        let cfg = &crate::test_helpers::make_test_rule_config();
-        let res = super::check_header_name("request header section", name, cfg.severity);
+        let res =
+            super::check_header_name("request header section", name, crate::lint::Severity::Warn);
 
         if expect_violation {
             assert!(res.is_some(), "expected violation for '{}'", name);

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -7,61 +7,6 @@ use crate::queries::QueryType;
 use linkme::distributed_slice;
 use std::sync::LazyLock;
 
-/// What a rule reads from its configuration **at lint time**, which is its
-/// severity and nothing else.
-///
-/// It carried an `enabled: bool` beside the severity, and no rule ever read it
-/// back: `PreparedEngine` partitions the catalogue with `Config::is_enabled`
-/// when it is built, so a disabled rule is never dispatched and the flag was
-/// discarded at all 174 `check_transaction` / `check_event` call sites. The
-/// question is answered before the rule runs, and asking it again cost a second
-/// hash of the rule id and a second table probe on the hottest path in the
-/// crate.
-///
-/// The *presence* of `enabled` is still required, and [`validate_rule_table`] is
-/// where that is asked — at startup, once per rule, rather than once per
-/// transaction per rule.
-#[derive(Debug, Clone)]
-pub struct RuleConfig {
-    pub severity: crate::lint::Severity,
-}
-
-/// Parse severity from config for a given rule.
-/// Returns RuleConfig with parsed severity. Fails if severity is not explicitly configured.
-///
-/// **What it costs, exactly.** One lookup of the rule id:
-/// [`get_rule_severity_required`] hashes `rule_id` against `Config::rules`,
-/// takes the value as a table and probes that table for `severity`. Thirteen
-/// rules that read this after their gates say why in the comment placing the
-/// call, and word it "several map probes plus a hash over the rule id"; **it
-/// used to be two hashes and is now one**, because the `enabled` lookup beside
-/// it was answering a question already decided. The call still belongs **after**
-/// whatever gate ends the rule: a version comparison or an event-kind
-/// discriminant is a few instructions against even one hash.
-///
-/// **Why the second lookup went, and where it went to.** Nothing at lint time
-/// read the flag — `PreparedEngine` partitions the catalogue with
-/// `Config::is_enabled` when it is built, so a disabled rule is never dispatched
-/// — and the only thing that lookup did on this path was make a rule whose table
-/// lacks `enabled` silent. That is a *validation* answer given at lint time, and
-/// [`validate_rule_table`] is where it belongs: the two `validate` defaults call
-/// it, `validate_rules` runs them at startup, and every binary entry point goes
-/// through `load_validated_config` first.
-///
-/// **The consequence, stated plainly, and it is narrower than it looks.** A rule
-/// whose table has a `severity` and no `enabled` used to be silent here and now
-/// returns its severity. Through `PreparedEngine` that changes nothing at all:
-/// `Config::is_enabled` reads a missing `enabled` as `false`, so such a rule is
-/// filtered out when the engine is built and this function is never reached for
-/// it — the lookup was dead *twice over* on that path. What changes is the
-/// answer for a caller invoking `check_transaction` directly, which is what the
-/// test suite does, and there the honest answer is the severity: whether the
-/// rule runs was that caller's decision, not this function's.
-pub fn parse_rule_config(cfg: &crate::config::Config, rule_id: &str) -> anyhow::Result<RuleConfig> {
-    let severity = get_rule_severity_required(cfg, rule_id)?;
-    Ok(RuleConfig { severity })
-}
-
 /// Both keys a rule's table must carry, checked once at startup.
 ///
 /// `enabled` must be present and a boolean, and `severity` present and one of
@@ -480,8 +425,8 @@ include!(concat!(env!("OUT_DIR"), "/rule_modules.rs"));
 // ── Protocol-level rule trait ──────────────────────────────────────────
 //
 // `ProtocolRule` mirrors `Rule` but operates on `ProtocolEvent` instead of
-// `HttpTransaction`.  It lives in the same module to share `RuleConfig`,
-// severity helpers, and the config TOML infrastructure.
+// `HttpTransaction`.  It lives in the same module to share `ResolvedRule`,
+// the severity helpers, and the config TOML infrastructure.
 
 /// A rule that evaluates protocol-level events (WebSocket frames, HTTP/3
 /// control frames, QUIC transport events) rather than HTTP transactions.
@@ -1390,44 +1335,24 @@ severity = "warn"
     }
 
     #[test]
-    fn parse_rule_config_success() -> anyhow::Result<()> {
-        let mut cfg = crate::config::Config::default();
-        let mut table = toml::map::Map::new();
-        table.insert("enabled".to_string(), toml::Value::Boolean(true));
-        table.insert("severity".to_string(), toml::Value::String("warn".into()));
-        cfg.rules
-            .insert("cache_control_present".into(), toml::Value::Table(table));
-
-        let rc = parse_rule_config(&cfg, "cache_control_present")?;
-        assert_eq!(rc.severity, crate::lint::Severity::Warn);
-
-        // The reading is the severity's, and the `enabled` key beside it is not
-        // read: a table carrying a severity and no `enabled` is a config a rule
-        // can be run under, and one `validate_rule_table` refuses.
+    fn a_severity_only_table_is_refused_and_never_dispatched() {
+        // A table carrying a severity and no `enabled` fails validation, and
+        // `is_enabled` reads the missing flag as `false` — so the rule is one
+        // `PreparedEngine` refuses to build over, and would never dispatch
+        // even if it did.
         let mut severity_only = crate::config::Config::default();
         let mut table = toml::map::Map::new();
         table.insert("severity".to_string(), toml::Value::String("error".into()));
         severity_only
             .rules
             .insert("cache_control_present".into(), toml::Value::Table(table));
-        assert_eq!(
-            parse_rule_config(&severity_only, "cache_control_present")?.severity,
-            crate::lint::Severity::Error
-        );
         assert!(validate_rule_table(&severity_only, "cache_control_present").is_err());
-
-        // And a table with neither is refused by both, because the severity is
-        // the reading lint time cannot do without.
-        let empty = crate::config::Config::default();
-        assert!(parse_rule_config(&empty, "cache_control_present").is_err());
-        assert!(validate_rule_table(&empty, "cache_control_present").is_err());
-
-        // And the reason dropping the flag is not an engine-visible change:
-        // `is_enabled` reads a missing `enabled` as `false`, so the rule whose
-        // severity is now readable is one `PreparedEngine` never dispatches. The
-        // lookup was dead twice over on that path.
         assert!(!severity_only.is_enabled("cache_control_present"));
-        Ok(())
+
+        // A table with neither key is refused too, because the severity is the
+        // reading dispatch cannot do without.
+        let empty = crate::config::Config::default();
+        assert!(validate_rule_table(&empty, "cache_control_present").is_err());
     }
 
     #[test]

--- a/lint-http-rules/src/test_helpers.rs
+++ b/lint-http-rules/src/test_helpers.rs
@@ -10,17 +10,6 @@
 
 pub use lint_http_core::test_helpers::*;
 
-/// Create a test rule configuration with `severity: Warn`.
-///
-/// It set an `enabled: true` beside the severity until the field went: whether a
-/// rule runs is `PreparedEngine`'s answer and never the rule's, so a value of
-/// this type says only how loud the finding is.
-pub fn make_test_rule_config() -> crate::rules::RuleConfig {
-    crate::rules::RuleConfig {
-        severity: crate::lint::Severity::Warn,
-    }
-}
-
 /// Prepare `rule` under `cfg`, then dispatch one transaction through it — the
 /// way the engine does, collapsed to one call for tests.
 ///


### PR DESCRIPTION
parse_rule_config, RuleConfig and the test fixture that built one are gone, along with the doc essays that argued about their cost and placement — an argument that no longer has a subject, since severity arrives resolved in every context. What survives is what prepare needs: the two required-key readers and validate_rule_table, now documented for the role they kept.
