### PR TITLE
A finding can carry the sentence it enforces, and the outputs show it

### DIFF
--- a/lint-http-core/src/lint.rs
+++ b/lint-http-core/src/lint.rs
@@ -10,12 +10,68 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A structured reference to the specification text a finding enforces.
+///
+/// Owned strings, unlike the rule metadata this is built from: a finding
+/// round-trips through serde (captures are re-read by `lint <captures>` and
+/// by capture seeding), and `&'static str` cannot come back out of a file.
+/// The allocation happens only on the rare finding path.
+///
+/// Deliberately absent: the quoted sentence. The verbatim text lives in the
+/// `// cite` comment at the enforcing statement, where it is verified against
+/// the published document — copying it here would create a second, unverified
+/// copy that can drift. `spec + section + url` is enough to open the exact
+/// text.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SpecCitation {
+    /// The document, in the vocabulary `specs/sources.yaml` uses: `"RFC 9110"`.
+    pub spec: String,
+    /// The section within it: `"7.2"`. `None` when the reference names the
+    /// document as a whole.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    /// Where to read it.
+    pub url: String,
+}
+
+impl std::fmt::Display for SpecCitation {
+    /// `RFC 9110 §7.2 <url>` — the form the text report and logs append to a
+    /// cited finding.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.section {
+            Some(section) => write!(f, "{} §{} {}", self.spec, section, self.url),
+            None => write!(f, "{} {}", self.spec, self.url),
+        }
+    }
+}
+
 /// Represents a single rule violation detected by the linter.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Violation {
     pub rule: String,
     pub severity: Severity,
     pub message: String,
+    /// The specification text this finding enforces, when the rule attached
+    /// one at the violation site. Serde-defaulted both ways: captures written
+    /// before the field existed read back as `None`, and an un-cited finding
+    /// serializes exactly as it always has.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cite: Option<SpecCitation>,
+}
+
+impl Violation {
+    /// Construct an un-cited finding. Rule code goes through the `Rule` /
+    /// `ProtocolRule` `violation()` helpers instead (which fill `rule` from
+    /// the rule itself); this constructor serves the callers that have only a
+    /// rule *name* — fixtures, replay tooling, tests.
+    pub fn new(rule: impl Into<String>, severity: Severity, message: impl Into<String>) -> Self {
+        Self {
+            rule: rule.into(),
+            severity,
+            message: message.into(),
+            cite: None,
+        }
+    }
 }
 
 /// Severity level for a rule violation. Ordered by increasing severity
@@ -26,4 +82,50 @@ pub enum Severity {
     Info,
     Warn,
     Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A capture line written before the `cite` field existed still parses,
+    /// and an un-cited finding still serializes byte-identically to what that
+    /// older line held — the capture format is unchanged until a rule
+    /// actually cites.
+    #[test]
+    fn legacy_capture_line_round_trips_without_cite() {
+        let legacy = r#"{"rule":"host_header","severity":"warn","message":"m"}"#;
+        let v: Violation = serde_json::from_str(legacy).expect("pre-cite line parses");
+        assert!(v.cite.is_none());
+        assert_eq!(serde_json::to_string(&v).expect("serializes"), legacy);
+    }
+
+    #[test]
+    fn cited_finding_round_trips_with_its_citation() {
+        let v = Violation {
+            cite: Some(SpecCitation {
+                spec: "RFC 9110".to_string(),
+                section: Some("7.2".to_string()),
+                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2".to_string(),
+            }),
+            ..Violation::new("host_header", Severity::Warn, "m")
+        };
+        let json = serde_json::to_string(&v).expect("serializes");
+        assert!(json.contains("\"cite\""));
+        let back: Violation = serde_json::from_str(&json).expect("parses");
+        assert_eq!(back.cite, v.cite);
+    }
+
+    #[test]
+    fn sectionless_citation_omits_the_section_key() {
+        let c = SpecCitation {
+            spec: "Fetch".to_string(),
+            section: None,
+            url: "https://fetch.spec.whatwg.org/".to_string(),
+        };
+        let json = serde_json::to_string(&c).expect("serializes");
+        assert!(!json.contains("section"));
+        let back: SpecCitation = serde_json::from_str(&json).expect("parses");
+        assert_eq!(back, c);
+    }
 }

--- a/lint-http-proxy/src/capture.rs
+++ b/lint-http-proxy/src/capture.rs
@@ -442,11 +442,11 @@ mod tests {
         let mut req_headers = HeaderMap::new();
         req_headers.insert("x-test", "1".parse()?);
 
-        let violations = vec![crate::lint::Violation {
-            rule: "r1".into(),
-            severity: crate::lint::Severity::Warn,
-            message: "m".into(),
-        }];
+        let violations = vec![crate::lint::Violation::new(
+            "r1",
+            crate::lint::Severity::Warn,
+            "m",
+        )];
 
         // Build a minimal transaction using helper
         use crate::http_transaction::TimingInfo;

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -461,13 +461,19 @@ fn render_lint_report(
                     }
                 }
                 for v in block.violations() {
-                    writeln!(
+                    write!(
                         out,
                         "  {:<5} {}  {}",
                         severity_label(v.severity),
                         v.rule,
                         v.message
                     )?;
+                    // The specification text the finding enforces, when the
+                    // rule attached one at the violation site.
+                    if let Some(cite) = &v.cite {
+                        write!(out, "  [{cite}]")?;
+                    }
+                    writeln!(out)?;
                 }
             }
             let total: usize = findings.iter().map(|f| f.violations().len()).sum();
@@ -939,11 +945,11 @@ severity = "warn"
     }
 
     fn sample_violation() -> lint::Violation {
-        lint::Violation {
-            rule: "cache_control_present".to_string(),
-            severity: lint::Severity::Warn,
-            message: "missing Cache-Control".to_string(),
-        }
+        lint::Violation::new(
+            "cache_control_present",
+            lint::Severity::Warn,
+            "missing Cache-Control",
+        )
     }
 
     fn sample_findings() -> Vec<FindingsBlock> {
@@ -979,6 +985,30 @@ severity = "warn"
         let out = render_lint_report(&findings, 1, 0, OutputFormat::Json)?;
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&out)?;
         assert!(parsed[0]["status"].is_null());
+        Ok(())
+    }
+
+    #[test]
+    fn render_lint_report_text_appends_the_citation_when_present() -> anyhow::Result<()> {
+        let mut v = sample_violation();
+        v.cite = Some(lint::SpecCitation {
+            spec: "RFC 9111".to_string(),
+            section: Some("5.2".to_string()),
+            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2".to_string(),
+        });
+        let findings = vec![FindingsBlock::HttpTransaction(TransactionFindings {
+            method: "GET".to_string(),
+            uri: "http://example.test/".to_string(),
+            status: Some(200),
+            violations: vec![v, sample_violation()],
+        })];
+        let out = render_lint_report(&findings, 1, 0, OutputFormat::Text)?;
+        assert!(
+            out.contains("[RFC 9111 §5.2 https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2]"),
+            "{out}"
+        );
+        // The un-cited finding's line is unchanged — no empty bracket.
+        assert!(!out.contains("[]"), "{out}");
         Ok(())
     }
 

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -297,12 +297,22 @@ fn emit_h3_protocol_event(
     };
     let violations = shared.protocol_event_pipeline().commit(&pe);
     for v in &violations {
-        warn!(
-            rule = %v.rule,
-            severity = ?v.severity,
-            "H3 protocol violation: {}",
-            v.message
-        );
+        if let Some(cite) = &v.cite {
+            warn!(
+                rule = %v.rule,
+                severity = ?v.severity,
+                cite = %cite,
+                "H3 protocol violation: {}",
+                v.message
+            );
+        } else {
+            warn!(
+                rule = %v.rule,
+                severity = ?v.severity,
+                "H3 protocol violation: {}",
+                v.message
+            );
+        }
     }
 }
 

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -143,6 +143,19 @@ pub struct SpecRef {
     pub note: &'static str,
 }
 
+impl SpecRef {
+    /// This reference as an owned, serializable [`crate::lint::SpecCitation`]
+    /// — what a finding carries. The `note` stays behind: it is rule-scoped
+    /// prose for the docs, not part of locating the text.
+    pub fn citation(&self) -> crate::lint::SpecCitation {
+        crate::lint::SpecCitation {
+            spec: self.spec.to_string(),
+            section: self.section.map(str::to_string),
+            url: self.url.to_string(),
+        }
+    }
+}
+
 impl std::fmt::Display for SpecRef {
     /// The markdown bullet body the docs render. One spelling now, derived —
     /// which is what retires the format drift rather than merely tidying it.
@@ -220,6 +233,29 @@ pub trait Rule: Send + Sync {
             rule: self.id().into(),
             severity,
             message,
+            cite: None,
+        }
+    }
+
+    /// Build one of this rule's findings, carrying the specification text it
+    /// enforces. `spec` must be one of the rule's own [`Rule::specifications`]
+    /// — a finding may only cite a reference its rule declares, which also
+    /// keeps the docs' Specifications section covering every citable target.
+    /// Checked in debug builds, so the whole test suite enforces it.
+    ///
+    /// Attachment is per violation site and opt-in, never derived from the
+    /// rule: the median rule declares several references, and a wrong
+    /// citation is worse than none. The `// cite` comment beside the call is
+    /// the reviewer's oracle that the right one was named.
+    fn cited(&self, spec: &SpecRef, severity: crate::lint::Severity, message: String) -> Violation {
+        debug_assert!(
+            self.specifications().contains(spec),
+            "{}: a finding may only cite a spec the rule declares",
+            self.id()
+        );
+        Violation {
+            cite: Some(spec.citation()),
+            ..self.violation(severity, message)
         }
     }
 
@@ -459,6 +495,29 @@ pub trait ProtocolRule: Send + Sync {
             rule: self.id().into(),
             severity,
             message,
+            cite: None,
+        }
+    }
+
+    /// Build one of this rule's findings, carrying the specification text it
+    /// enforces. `spec` must be one of the rule's own [`ProtocolRule::specifications`]
+    /// — a finding may only cite a reference its rule declares, which also
+    /// keeps the docs' Specifications section covering every citable target.
+    /// Checked in debug builds, so the whole test suite enforces it.
+    ///
+    /// Attachment is per violation site and opt-in, never derived from the
+    /// rule: the median rule declares several references, and a wrong
+    /// citation is worse than none. The `// cite` comment beside the call is
+    /// the reviewer's oracle that the right one was named.
+    fn cited(&self, spec: &SpecRef, severity: crate::lint::Severity, message: String) -> Violation {
+        debug_assert!(
+            self.specifications().contains(spec),
+            "{}: a finding may only cite a spec the rule declares",
+            self.id()
+        );
+        Violation {
+            cite: Some(spec.citation()),
+            ..self.violation(severity, message)
         }
     }
 
@@ -1349,6 +1408,37 @@ severity = "warn"
             .find(|r| r.id() == "host_header")
             .expect("host_header registered");
         assert!(rule.prepare(&cfg).is_err());
+    }
+
+    #[test]
+    fn cited_attaches_a_declared_spec() {
+        let rule = RULES
+            .iter()
+            .find(|r| r.id() == "host_header")
+            .expect("host_header registered");
+        let spec = &rule.specifications()[0];
+        let v = rule.cited(spec, crate::lint::Severity::Warn, "m".to_string());
+        let cite = v.cite.expect("citation attached");
+        assert_eq!(cite.spec, spec.spec);
+        assert_eq!(cite.section.as_deref(), spec.section);
+        assert_eq!(cite.url, spec.url);
+        assert_eq!(v.rule, "host_header");
+    }
+
+    #[test]
+    #[should_panic(expected = "may only cite a spec the rule declares")]
+    fn cited_refuses_a_spec_the_rule_does_not_declare() {
+        let rule = RULES
+            .iter()
+            .find(|r| r.id() == "host_header")
+            .expect("host_header registered");
+        let foreign = SpecRef {
+            spec: "RFC 0000",
+            section: None,
+            url: "https://example.com/",
+            note: "",
+        };
+        let _ = rule.cited(&foreign, crate::lint::Severity::Warn, "m".to_string());
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -10351,7 +10351,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 77
     - file: lint-http-proxy/src/proxy/http3.rs
-      line: 384
+      line: 394
   - label: lint-http-proxy/src/h3_instrument.rs
     section: § 6.2.1
     snippet: A control stream is indicated by a stream type of 0x00.


### PR DESCRIPTION
Violation gains cite: Option<SpecCitation> — spec, section, url as owned strings, because a finding round-trips through serde and 'static cannot come back out of a capture file. The verbatim quote deliberately stays in the // cite comment where it is verified; the citation is enough to open the exact text. Serde-defaulted both ways: a capture written before the field parses, an un-cited finding serializes byte-identically to what it wrote.

Attachment is per violation site and opt-in, through cited(): the spec must be one the rule declares — checked in debug builds, so the whole suite enforces it — because the median rule declares several references and a wrong citation is worse than none. violation() stays the un-cited path; Violation::new serves the callers that have only a rule name.

The text report appends [RFC x §y url] to a cited finding's line and nothing to the rest; the H3 warn loop gains a cite field the same way. JSONL, SSE and the JSON report get the field for free from serde.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
