### PR TITLE
The first rule to answer with more than one finding

### DIFF
--- a/lint-http-rules/src/rules/structured_headers_valid.rs
+++ b/lint-http-rules/src/rules/structured_headers_valid.rs
@@ -118,33 +118,24 @@ impl Rule for StructuredHeadersValid {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Vec<Violation> {
-        // Single-finding body behind an Option: `?` ends it early, and the
-        // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            let config: &crate::helpers::rule_config::HeaderNameList = ctx.state();
-            // cite(RFC 9651): "This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,"
-            for hdr in &config.headers {
-                // The two sections are joined separately, never across the pair: the
-                // sentence cited on `check_section` gathers the lines "in the same
-                // section", so a request's field and a response's field of the same
-                // name are two field values, not one.
-                if let Some(v) =
-                    self.check_section(&tx.request.headers, hdr, "request", ctx.severity)
-                {
-                    return Some(v);
-                }
-                if let Some(resp) = &tx.response {
-                    if let Some(v) =
-                        self.check_section(&resp.headers, hdr, "response", ctx.severity)
-                    {
-                        return Some(v);
-                    }
-                }
+        let config: &crate::helpers::rule_config::HeaderNameList = ctx.state();
+        // Every configured field is judged, and every failing one is its own
+        // finding: the fields are independent — §4.2 parses each field value
+        // on its own — so stopping at the first failure reported one defect
+        // and silently swallowed the rest of the configured list.
+        // cite(RFC 9651): "This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,"
+        let mut out = Vec::new();
+        for hdr in &config.headers {
+            // The two sections are joined separately, never across the pair: the
+            // sentence cited on `check_section` gathers the lines "in the same
+            // section", so a request's field and a response's field of the same
+            // name are two field values, not one.
+            out.extend(self.check_section(&tx.request.headers, hdr, "request", ctx.severity));
+            if let Some(resp) = &tx.response {
+                out.extend(self.check_section(&resp.headers, hdr, "response", ctx.severity));
             }
-
-            None
-        };
-        Vec::from_iter(finding())
+        }
+        out
     }
 
     fn description(&self) -> &'static str {
@@ -1253,5 +1244,27 @@ mod tests {
         .expect("should report");
         assert!(v.message.contains("outside ASCII"), "{}", v.message);
         assert!(!v.message.contains("UTF-8"), "{}", v.message);
+    }
+
+    /// Two configured fields, both malformed, are two findings — the split
+    /// the Vec return exists for. Asserted through the all-findings helper;
+    /// the single-finding tests above still read the first.
+    #[test]
+    fn each_failing_configured_field_is_its_own_finding() {
+        let cfg = make_cfg_with_headers(&["x-first", "x-second"]);
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
+            ("x-first", "\"unterminated"),
+            ("x-second", "\"also unterminated"),
+        ]);
+        let all = crate::test_helpers::run_rule_all(
+            &StructuredHeadersValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        );
+        assert_eq!(all.len(), 2, "{all:?}");
+        assert!(all[0].message.contains("x-first"), "{}", all[0].message);
+        assert!(all[1].message.contains("x-second"), "{}", all[1].message);
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -10752,7 +10752,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 452
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 248
+      line: 239
   - label: lint-http-rules/src/helpers/structured_fields.rs (9)
     section: § 4.2
     snippet: The parsing algorithms for both types allow tab characters, since these might be used to combine field lines by some implementations.
@@ -10866,7 +10866,7 @@ sources:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 72
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 256
+      line: 247
   - label: lint-http-rules/src/helpers/structured_fields.rs (27)
     section: § 4.2.3
     snippet: Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
@@ -11111,37 +11111,37 @@ sources:
     snippet: This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 125
+      line: 126
   - label: structured_headers_valid (2)
     section: § 4.2
     snippet: Given an array of bytes as input_bytes that represent the chosen field's field-value (which is empty if that field is not present) and field_type (one of "dictionary", "list", or "item"), return the parsed field value.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 236
+      line: 227
   - label: structured_headers_valid (3)
     section: § 4.2
     snippet: If field_type is "dictionary", let output be the result of running Parsing a Dictionary (Section 4.2.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 268
+      line: 259
   - label: structured_headers_valid (4)
     section: § 4.2
     snippet: If field_type is "item", let output be the result of running Parsing an Item (Section 4.2.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 261
+      line: 252
   - label: structured_headers_valid (5)
     section: § 4.2
     snippet: If field_type is "list", let output be the result of running Parsing a List (Section 4.2.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 263
+      line: 254
   - label: structured_headers_valid (6)
     section: § 4.2.1
     snippet: No structured data has been found; return members (which is empty).
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 255
+      line: 246
 - label: RFC 9745
   url: https://www.rfc-editor.org/rfc/rfc9745.txt
   type: text/plain


### PR DESCRIPTION
structured_headers_valid judged its configured fields in a loop and returned at the first failure, so one malformed field silently swallowed every defect after it in the configured list. The fields are independent — RFC 9651 §4.2 parses each field value on its own — so each failing field is now its own finding, which is what the vector return exists for.

One rule, deliberately: the audit called out ten rules for folding defects into one message, but the fold is not one thing. Where a message names several values in one sentence about one contradiction, that is one finding and stays one; each of the remaining rules gets read before it gets split.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
