### PR TITLE
Each message of an exchange answers for itself

### DIFF
--- a/lint-http-rules/src/rules/accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -31,136 +31,155 @@ impl Rule for AcceptRangesValuesValid {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Vec<Violation> {
-        // Single-finding body behind an Option: `?` ends it early, and the
-        // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            let resp = tx.response.as_ref()?;
+        let Some(resp) = tx.response.as_ref() else {
+            return Vec::new();
+        };
 
-            // Both of the sections the field is defined for, and every line inside
-            // each of them. This used to be one `get_header_str` on the header
-            // section, which reads the *first* line of it: a response advertising
-            // `bytes` on one line and `none` on the next was read as advertising
-            // `bytes`, and a response advertising anything at all in its trailer
-            // section was read as advertising nothing.
-            //
-            // The lines of one section are joined and the sections are not. Appending
-            // a field line to the one before it is defined within a field section --
-            // a trailer is a separate section arriving after the content -- so what
-            // is measured against the list production is each section's own value.
-            //
-            // A response carrying no `Accept-Ranges` at all reaches none of this and
-            // is not a finding: the loop runs over nothing. The whole feature is
-            // optional, and a server is under no obligation to say anything about it.
-            //
-            // cite(RFC 9110 § 14): "Range requests are an OPTIONAL feature of HTTP, designed so that recipients not implementing this feature (or not supporting it for the target resource) can respond as if it is a normal GET request without impacting interoperability."
-            let mut units: Vec<String> = Vec::new();
-            for section in crate::helpers::accept_ranges::field_sections(resp) {
-                let mut lines: Vec<&str> = Vec::new();
-                for hv in section.get_all("accept-ranges").iter() {
-                    // `to_str` refuses every octet outside visible US-ASCII, and the
-                    // whole of this field is built from `token`, whose characters
-                    // are a subset of that -- so the refusal is never a false alarm
-                    // here and no other rule owns the field's syntax to report it.
-                    // The line used to be handed to a reader that folds an absent
-                    // field into an unreadable one, so the rule said nothing at all
-                    // about a value no production admits.
-                    //
-                    // What makes it a finding is not that the value failed to be
-                    // UTF-8: a `0xC3 0xA9` that decodes to a perfectly good `é` is
-                    // refused as readily as a lone `0xFF`, and neither octet is one
-                    // a range unit name is allowed to be built from.
-                    //
-                    // cite(RFC 9110 § 5.6.2): "Tokens are short textual identifiers that do not include whitespace or delimiters."
-                    // cite(RFC 9110 § 5.6.2, label: tchar grammar): "tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters"
-                    let Ok(value) = hv.to_str() else {
-                        return Some(self.violation(ctx.severity, "Accept-Ranges holds an octet no range-unit admits: a range unit name is a token, whose characters are all visible US-ASCII".into()));
-                    };
-                    lines.push(value.trim());
-                }
-                if lines.is_empty() {
-                    continue;
-                }
+        // Two kinds of finding, and they nest: each field section is its own
+        // list to measure, so a malformed one is its own finding, while the
+        // `none`-beside-a-unit contradiction below is asked of the response
+        // as a whole and stays one finding however many units it names.
+        let mut out: Vec<Violation> = Vec::new();
 
-                // Comma SP, in the order the lines arrived, because that is the
-                // value a recipient acts on. The field's definition allows it: the
-                // exception in the sentence below turns on whether the field is a
-                // comma-separated list, and `acceptable-ranges = 1#range-unit` is
-                // one -- so several lines here are not a duplication to report but a
-                // single list to read.
+        // Both of the sections the field is defined for, and every line inside
+        // each of them. This used to be one `get_header_str` on the header
+        // section, which reads the *first* line of it: a response advertising
+        // `bytes` on one line and `none` on the next was read as advertising
+        // `bytes`, and a response advertising anything at all in its trailer
+        // section was read as advertising nothing.
+        //
+        // The lines of one section are joined and the sections are not. Appending
+        // a field line to the one before it is defined within a field section --
+        // a trailer is a separate section arriving after the content -- so what
+        // is measured against the list production is each section's own value.
+        //
+        // A response carrying no `Accept-Ranges` at all reaches none of this and
+        // is not a finding: the loop runs over nothing. The whole feature is
+        // optional, and a server is under no obligation to say anything about it.
+        //
+        // cite(RFC 9110 § 14): "Range requests are an OPTIONAL feature of HTTP, designed so that recipients not implementing this feature (or not supporting it for the target resource) can respond as if it is a normal GET request without impacting interoperability."
+        let mut units: Vec<String> = Vec::new();
+        for section in crate::helpers::accept_ranges::field_sections(resp) {
+            let mut lines: Vec<&str> = Vec::new();
+            // Set where this section cannot be read as a list at all. What
+            // follows is then skipped *for this section only* — the other
+            // section is a separate value and answers for itself, which is
+            // what returning at the first defect used to prevent: a header
+            // section holding an octet no range-unit admits hid a trailer
+            // section that was not `1#range-unit` either.
+            let mut unreadable = false;
+            for hv in section.get_all("accept-ranges").iter() {
+                // `to_str` refuses every octet outside visible US-ASCII, and the
+                // whole of this field is built from `token`, whose characters
+                // are a subset of that -- so the refusal is never a false alarm
+                // here and no other rule owns the field's syntax to report it.
+                // The line used to be handed to a reader that folds an absent
+                // field into an unreadable one, so the rule said nothing at all
+                // about a value no production admits.
                 //
-                // cite(RFC 9110 § 5.3): "A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP."
-                // cite(RFC 9110 § 14.3, label: acceptable-ranges grammar): "acceptable-ranges = 1#range-unit"
-                let value = lines.join(", ");
-
-                if let Err(e) = read_units(&value, &mut units) {
-                    return Some(self.violation(
-                        ctx.severity,
-                        format!("Invalid Accept-Ranges field value '{}': {}", value, e),
-                    ));
-                }
+                // What makes it a finding is not that the value failed to be
+                // UTF-8: a `0xC3 0xA9` that decodes to a perfectly good `é` is
+                // refused as readily as a lone `0xFF`, and neither octet is one
+                // a range unit name is allowed to be built from.
+                //
+                // cite(RFC 9110 § 5.6.2): "Tokens are short textual identifiers that do not include whitespace or delimiters."
+                // cite(RFC 9110 § 5.6.2, label: tchar grammar): "tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters"
+                let Ok(value) = hv.to_str() else {
+                    out.push(self.violation(ctx.severity, "Accept-Ranges holds an octet no range-unit admits: a range unit name is a token, whose characters are all visible US-ASCII".into()));
+                    unreadable = true;
+                    break;
+                };
+                lines.push(value.trim());
+            }
+            if unreadable || lines.is_empty() {
+                continue;
             }
 
-            // `none` says the server supports no kind of range request at all, so a
-            // field that lists it beside a unit it does support says both. Nothing
-            // forbids the combination -- the description used to claim a MUST NOT
-            // that no sentence of § 14.3 states -- but a client cannot act on both
-            // halves, and one of the two is what it will act on.
+            // Comma SP, in the order the lines arrived, because that is the
+            // value a recipient acts on. The field's definition allows it: the
+            // exception in the sentence below turns on whether the field is a
+            // comma-separated list, and `acceptable-ranges = 1#range-unit` is
+            // one -- so several lines here are not a duplication to report but a
+            // single list to read.
             //
-            // The old check counted the list's elements instead of looking at them,
-            // so `Accept-Ranges: none, none` was reported for combining `none` with
-            // other range-units when there was no other range-unit.
-            //
-            // What the second sentence buys is the condition travelling with the
-            // MAY -- "does not support any kind of range request" -- which is the
-            // state a server is in when it sends this name, and not the state of one
-            // listing a unit beside it. The third says the name means nothing else.
-            //
-            // The question is asked of the response rather than of a field value,
-            // because a header section advertising `bytes` and a trailer section
-            // advertising `none` are two well-formed lists and one contradiction.
-            //
-            // cite(RFC 9110 § 14.3): "A server that does not support any kind of range request for the target resource MAY send"
-            // cite(RFC 9110 § 14.3): "to advise the client not to attempt a range request on the same request path.  The range unit "none" is reserved for this purpose."
-            let mut others: Vec<&str> = Vec::new();
-            for unit in units.iter().map(String::as_str) {
-                // A unit named twice is named once in the message: the finding is
-                // about which units sit beside `none`, and repeating one of them
-                // says nothing further about that.
-                if unit != "none" && !others.contains(&unit) {
-                    others.push(unit);
-                }
+            // cite(RFC 9110 § 5.3): "A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP."
+            // cite(RFC 9110 § 14.3, label: acceptable-ranges grammar): "acceptable-ranges = 1#range-unit"
+            let value = lines.join(", ");
+
+            // Read into a scratch list and adopt it only where the whole
+            // section parsed. A section that is not `1#range-unit` is not a
+            // list a recipient acts on, so the names in front of the defect
+            // must not go on to answer the `none` question below — that
+            // would measure a contradiction out of text nobody honours.
+            let mut section_units: Vec<String> = Vec::new();
+            match read_units(&value, &mut section_units) {
+                Ok(()) => units.append(&mut section_units),
+                Err(e) => out.push(self.violation(
+                    ctx.severity,
+                    format!("Invalid Accept-Ranges field value '{}': {}", value, e),
+                )),
             }
-            if units.iter().any(|u| u == "none") && !others.is_empty() {
-                return Some(self.violation(ctx.severity, format!(
+        }
+
+        // `none` says the server supports no kind of range request at all, so a
+        // field that lists it beside a unit it does support says both. Nothing
+        // forbids the combination -- the description used to claim a MUST NOT
+        // that no sentence of § 14.3 states -- but a client cannot act on both
+        // halves, and one of the two is what it will act on.
+        //
+        // The old check counted the list's elements instead of looking at them,
+        // so `Accept-Ranges: none, none` was reported for combining `none` with
+        // other range-units when there was no other range-unit.
+        //
+        // What the second sentence buys is the condition travelling with the
+        // MAY -- "does not support any kind of range request" -- which is the
+        // state a server is in when it sends this name, and not the state of one
+        // listing a unit beside it. The third says the name means nothing else.
+        //
+        // The question is asked of the response rather than of a field value,
+        // because a header section advertising `bytes` and a trailer section
+        // advertising `none` are two well-formed lists and one contradiction.
+        //
+        // cite(RFC 9110 § 14.3): "A server that does not support any kind of range request for the target resource MAY send"
+        // cite(RFC 9110 § 14.3): "to advise the client not to attempt a range request on the same request path.  The range unit "none" is reserved for this purpose."
+        let mut others: Vec<&str> = Vec::new();
+        for unit in units.iter().map(String::as_str) {
+            // A unit named twice is named once in the message: the finding is
+            // about which units sit beside `none`, and repeating one of them
+            // says nothing further about that.
+            if unit != "none" && !others.contains(&unit) {
+                others.push(unit);
+            }
+        }
+        if units.iter().any(|u| u == "none") && !others.is_empty() {
+            out.push(self.violation(ctx.severity, format!(
                         "Accept-Ranges advertises '{}' beside 'none', which is reserved for advising that no kind of range request is supported: the field says both that this resource supports range requests and that it does not (advice: nothing forbids it)",
                         others.join("', '")
                     )));
-            }
+        }
 
-            // Three things a well-formed `Accept-Ranges` can still be, none of them
-            // reported here, all of them named so the silence is not read as an
-            // oversight.
-            //
-            // *A unit nobody registered* is not a finding. The modal is "ought to
-            // be", which is weaker than SHOULD, and this rule holds no copy of the
-            // registry to check a name against in any case -- the registry is where
-            // the check would have to live, and adding a name to it is IETF Review.
-            //
-            // *In a trailer section rather than a header section* is a preference
-            // stated with its own reason and no modal at all. A response advertising
-            // after its content is doing what the field permits.
-            //
-            // *A promise the next request will be honoured* is the one thing this
-            // field explicitly does not make, and the sentence saying so is addressed
-            // to the client. Nothing in it measures the response that carried it.
-            //
-            // cite(RFC 9110 § 14.1): "All range unit names are case-insensitive and ought to be registered within the "HTTP Range Unit Registry", as defined in Section 16.5.1."
-            // cite(RFC 9110 § 16.5.1): "The "HTTP Range Unit Registry" defines the namespace for the range unit names and refers to their corresponding specifications."
-            // cite(RFC 9110 § 14.3): "The Accept-Ranges field MAY be sent in a trailer section, but is preferred to be sent as a header field because the information is particularly useful for restarting large information transfers that have failed in mid-content (before the trailer section is received)."
-            // cite(RFC 9110 § 14.3): "Conversely, a client MUST NOT assume that receiving an Accept-Ranges field means that future range requests will return partial responses."
-            None
-        };
-        Vec::from_iter(finding())
+        // Three things a well-formed `Accept-Ranges` can still be, none of them
+        // reported here, all of them named so the silence is not read as an
+        // oversight.
+        //
+        // *A unit nobody registered* is not a finding. The modal is "ought to
+        // be", which is weaker than SHOULD, and this rule holds no copy of the
+        // registry to check a name against in any case -- the registry is where
+        // the check would have to live, and adding a name to it is IETF Review.
+        //
+        // *In a trailer section rather than a header section* is a preference
+        // stated with its own reason and no modal at all. A response advertising
+        // after its content is doing what the field permits.
+        //
+        // *A promise the next request will be honoured* is the one thing this
+        // field explicitly does not make, and the sentence saying so is addressed
+        // to the client. Nothing in it measures the response that carried it.
+        //
+        // cite(RFC 9110 § 14.1): "All range unit names are case-insensitive and ought to be registered within the "HTTP Range Unit Registry", as defined in Section 16.5.1."
+        // cite(RFC 9110 § 16.5.1): "The "HTTP Range Unit Registry" defines the namespace for the range unit names and refers to their corresponding specifications."
+        // cite(RFC 9110 § 14.3): "The Accept-Ranges field MAY be sent in a trailer section, but is preferred to be sent as a header field because the information is particularly useful for restarting large information transfers that have failed in mid-content (before the trailer section is received)."
+        // cite(RFC 9110 § 14.3): "Conversely, a client MUST NOT assume that receiving an Accept-Ranges field means that future range requests will return partial responses."
+        out
     }
 
     fn title(&self) -> Option<&'static str> {
@@ -335,6 +354,17 @@ mod tests {
     fn judge(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {
         let rule = AcceptRangesValuesValid;
         crate::test_helpers::run_rule(
+            &rule,
+            tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+    }
+
+    /// Every finding, for the tests that are about there being more than one.
+    fn judge_all(tx: &crate::http_transaction::HttpTransaction) -> Vec<Violation> {
+        let rule = AcceptRangesValuesValid;
+        crate::test_helpers::run_rule_all(
             &rule,
             tx,
             &crate::transaction_history::TransactionHistory::empty(),
@@ -554,6 +584,56 @@ mod tests {
     fn missing_response_returns_none() {
         let tx = crate::test_helpers::make_test_transaction();
         assert!(judge(&tx).is_none());
+    }
+
+    /// Each field section is its own list, so each malformed one is its own
+    /// finding. The header section holds an octet no `token` admits and the
+    /// trailer section has an empty element; returning at the first left the
+    /// second unsaid.
+    #[test]
+    fn a_malformed_section_does_not_hide_the_other() {
+        let tx = advertising(&[
+            (Section::Header, b"by\xffes"),
+            (Section::Trailer, b"bytes,,none"),
+        ]);
+        let all = judge_all(&tx);
+        assert_eq!(all.len(), 2, "{all:?}");
+        assert!(
+            all[0].message.contains("no range-unit admits"),
+            "{}",
+            all[0].message
+        );
+        assert!(all[1].message.contains("is empty"), "{}", all[1].message);
+    }
+
+    /// The names in front of a defect are not a list a recipient acts on, so
+    /// they do not go on to answer the `none` question: this trailer section
+    /// fails `1#range-unit`, and the `bytes` inside it must not be read as
+    /// sitting beside the header section's `none`.
+    #[test]
+    fn a_malformed_section_contributes_no_units_to_the_contradiction() {
+        let tx = advertising(&[
+            (Section::Header, b"none"),
+            (Section::Trailer, b"bytes,,pages"),
+        ]);
+        let all = judge_all(&tx);
+        assert_eq!(all.len(), 1, "{all:?}");
+        assert!(all[0].message.contains("is empty"), "{}", all[0].message);
+    }
+
+    /// The contradiction is one finding however many units it names: one
+    /// response coding both answers at once, which is the single thing a client
+    /// cannot act on.
+    #[test]
+    fn units_beside_none_stay_one_finding() {
+        let tx = advertising(&[(Section::Header, b"bytes, pages, none")]);
+        let all = judge_all(&tx);
+        assert_eq!(all.len(), 1, "{all:?}");
+        assert!(
+            all[0].message.contains("beside 'none'"),
+            "{}",
+            all[0].message
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
+++ b/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -29,152 +29,149 @@ impl Rule for CompressionAndTransferEncodingConsistent {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Vec<Violation> {
-        // Single-finding body behind an Option: `?` ends it early, and the
-        // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            // Both fields are lists whose members a sender may spread over several
-            // field lines, and there the resemblance ends: their grammars differ in
-            // a way that decides how each is split.
+        // Both fields are lists whose members a sender may spread over several
+        // field lines, and there the resemblance ends: their grammars differ in
+        // a way that decides how each is split.
+        //
+        // Values are decoded from the raw octets rather than read through
+        // `to_str`, which refuses everything outside visible US-ASCII and used
+        // to drop the whole field line. Neither coding name can contain such an
+        // octet -- both are `token` -- so one appearing where a name belongs
+        // simply fails to match anything, which is the right outcome; dropping
+        // the line instead hid every *other* name on it.
+        let decode = crate::helpers::headers::field_line_as_written;
+
+        let check = |headers: &hyper::HeaderMap, side: &str| -> Option<Violation> {
+            // `content-coding` is a bare `token` with no parameters, so every comma
+            // is a separator and there is no quoting to respect.
+            // cite(RFC 9110 § 8.4): "Content-Encoding = #content-coding"
+            // cite(RFC 9110 § 8.4.1): "content-coding   = token"
+            let mut ce_set = std::collections::HashSet::new();
+            for hv in headers.get_all("content-encoding").iter() {
+                let s = decode(hv);
+                for part in crate::helpers::headers::list_members(&s) {
+                    // Nothing in this field's grammar sits behind a `;`, so this
+                    // strips something that cannot legally be there. It is kept as
+                    // a deliberate tolerance: a sender writing `gzip;q=1.0` here
+                    // has produced one malformed token, and reading the name out of
+                    // it keeps this advisory useful on a value that
+                    // `content_encoding_registered` is already
+                    // reporting as malformed. It cannot invent an overlap -- the
+                    // text before the `;` is text the sender wrote.
+                    // The trim is `OWS`, not `str::trim`: the value is read one
+                    // `char` per octet, so %xA0 reaches here as U+00A0 —
+                    // `char::is_whitespace` admits it and no `token` does, and
+                    // taking it would turn a name no production writes into
+                    // `gzip`.
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                    // cite(RFC 9110 § 8.4.1): "All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry","
+                    let token = crate::helpers::headers::trim_ows(part.split(';').next().unwrap())
+                        .to_ascii_lowercase();
+                    if token.is_empty() {
+                        continue;
+                    }
+                    ce_set.insert(token);
+                }
+            }
+
+            // `transfer-coding` does carry parameters, and a parameter value may be
+            // a `quoted-string` holding a comma, so this split has to respect them.
             //
-            // Values are decoded from the raw octets rather than read through
-            // `to_str`, which refuses everything outside visible US-ASCII and used
-            // to drop the whole field line. Neither coding name can contain such an
-            // octet -- both are `token` -- so one appearing where a name belongs
-            // simply fails to match anything, which is the right outcome; dropping
-            // the line instead hid every *other* name on it.
-            let decode = crate::helpers::headers::field_line_as_written;
-
-            let check = |headers: &hyper::HeaderMap, side: &str| -> Option<Violation> {
-                // `content-coding` is a bare `token` with no parameters, so every comma
-                // is a separator and there is no quoting to respect.
-                // cite(RFC 9110 § 8.4): "Content-Encoding = #content-coding"
-                // cite(RFC 9110 § 8.4.1): "content-coding   = token"
-                let mut ce_set = std::collections::HashSet::new();
-                for hv in headers.get_all("content-encoding").iter() {
-                    let s = decode(hv);
-                    for part in crate::helpers::headers::list_members(&s) {
-                        // Nothing in this field's grammar sits behind a `;`, so this
-                        // strips something that cannot legally be there. It is kept as
-                        // a deliberate tolerance: a sender writing `gzip;q=1.0` here
-                        // has produced one malformed token, and reading the name out of
-                        // it keeps this advisory useful on a value that
-                        // `content_encoding_registered` is already
-                        // reporting as malformed. It cannot invent an overlap -- the
-                        // text before the `;` is text the sender wrote.
-                        // The trim is `OWS`, not `str::trim`: the value is read one
-                        // `char` per octet, so %xA0 reaches here as U+00A0 —
-                        // `char::is_whitespace` admits it and no `token` does, and
-                        // taking it would turn a name no production writes into
-                        // `gzip`.
-                        // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
-                        // cite(RFC 9110 § 8.4.1): "All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry","
-                        let token =
-                            crate::helpers::headers::trim_ows(part.split(';').next().unwrap())
-                                .to_ascii_lowercase();
-                        if token.is_empty() {
-                            continue;
-                        }
-                        ce_set.insert(token);
+            // No unbalanced-quote guard, unlike the two sibling rules on these
+            // fields. Quoting that never closes swallows the rest of the value
+            // into one member, and the name this reads off it is still the name
+            // in front of the first `;` -- a name the sender wrote. Later names
+            // are lost, so the only thing at risk is a finding, never a false
+            // one, and this rule reports nothing about the malformed value
+            // anyway. Do not "harmonise" a decline into this loop: it would
+            // trade a missed advisory for nothing.
+            // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
+            // cite(RFC 9110 § 10.1.4): "transfer-parameter = token BWS "=" BWS ( token / quoted-string )"
+            let mut te_set = std::collections::HashSet::new();
+            for hv in headers.get_all("transfer-encoding").iter() {
+                let s = decode(hv);
+                for part in crate::helpers::headers::split_commas_respecting_quotes(&s) {
+                    // `OWS` for the same reason as the `Content-Encoding` loop
+                    // above, and this production prints it: the whitespace around
+                    // the `;` is `OWS` and nothing wider.
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                    // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
+                    let token = crate::helpers::headers::trim_ows(part.split(';').next().unwrap())
+                        .to_ascii_lowercase();
+                    if token.is_empty() {
+                        continue;
                     }
+                    te_set.insert(token);
                 }
+            }
 
-                // `transfer-coding` does carry parameters, and a parameter value may be
-                // a `quoted-string` holding a comma, so this split has to respect them.
-                //
-                // No unbalanced-quote guard, unlike the two sibling rules on these
-                // fields. Quoting that never closes swallows the rest of the value
-                // into one member, and the name this reads off it is still the name
-                // in front of the first `;` -- a name the sender wrote. Later names
-                // are lost, so the only thing at risk is a finding, never a false
-                // one, and this rule reports nothing about the malformed value
-                // anyway. Do not "harmonise" a decline into this loop: it would
-                // trade a missed advisory for nothing.
-                // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
-                // cite(RFC 9110 § 10.1.4): "transfer-parameter = token BWS "=" BWS ( token / quoted-string )"
-                let mut te_set = std::collections::HashSet::new();
-                for hv in headers.get_all("transfer-encoding").iter() {
-                    let s = decode(hv);
-                    for part in crate::helpers::headers::split_commas_respecting_quotes(&s) {
-                        // `OWS` for the same reason as the `Content-Encoding` loop
-                        // above, and this production prints it: the whitespace around
-                        // the `;` is `OWS` and nothing wider.
-                        // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
-                        // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
-                        let token =
-                            crate::helpers::headers::trim_ows(part.split(';').next().unwrap())
-                                .to_ascii_lowercase();
-                        if token.is_empty() {
-                            continue;
-                        }
-                        te_set.insert(token);
-                    }
-                }
+            // If either header is absent or no valid tokens present, nothing to check
+            if ce_set.is_empty() || te_set.is_empty() {
+                return None;
+            }
 
-                // If either header is absent or no valid tokens present, nothing to check
-                if ce_set.is_empty() || te_set.is_empty() {
-                    return None;
-                }
+            // The comparison, and the whole premise of the rule -- which had no
+            // citation of any kind, and a user-facing message pointing at
+            // § 5.3, "Field Order".
+            //
+            // The two fields address different layers, and both specifications
+            // say so in mirrored sentences:
+            // cite(RFC 9112 § 6.1): "Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation."
+            // cite(RFC 9110 § 8.4): "Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition."
+            //
+            // **Nothing forbids naming the same coding at both layers.** It
+            // means the representation was coded and then coded again in
+            // transit, which is well defined rather than ambiguous: the two
+            // namespaces may share a name only where the transformation is
+            // identical, and the compression transfer codings are defined by
+            // the algorithm of the content coding they are named after.
+            // cite(RFC 9112 § 7.3): "Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2."
+            // cite(RFC 9112 § 7.2): "The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:"
+            //
+            // § 8.4 goes further and contemplates a coding applied twice,
+            // declining to forbid it and remarking only on how odd it would be.
+            // That sentence is about an encoding inherent in the media type
+            // rather than about Transfer-Encoding, so it does not govern this
+            // check -- but it settles the modal, which is what was in doubt.
+            // cite(RFC 9110 § 8.4): "Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation."
+            //
+            // So the finding is advisory, and the message now says what is
+            // unusual rather than implying something was broken.
+            //
+            // Content-Encoding is taken at its word -- nothing here decodes a
+            // body -- and § 8.4 is what makes that reading fair.
+            // cite(RFC 9110 § 8.4): "If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied."
+            let mut overlap: Vec<String> = ce_set
+                .intersection(&te_set)
+                .map(|s| s.to_string())
+                .collect();
+            overlap.sort();
 
-                // The comparison, and the whole premise of the rule -- which had no
-                // citation of any kind, and a user-facing message pointing at
-                // § 5.3, "Field Order".
-                //
-                // The two fields address different layers, and both specifications
-                // say so in mirrored sentences:
-                // cite(RFC 9112 § 6.1): "Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation."
-                // cite(RFC 9110 § 8.4): "Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition."
-                //
-                // **Nothing forbids naming the same coding at both layers.** It
-                // means the representation was coded and then coded again in
-                // transit, which is well defined rather than ambiguous: the two
-                // namespaces may share a name only where the transformation is
-                // identical, and the compression transfer codings are defined by
-                // the algorithm of the content coding they are named after.
-                // cite(RFC 9112 § 7.3): "Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2."
-                // cite(RFC 9112 § 7.2): "The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:"
-                //
-                // § 8.4 goes further and contemplates a coding applied twice,
-                // declining to forbid it and remarking only on how odd it would be.
-                // That sentence is about an encoding inherent in the media type
-                // rather than about Transfer-Encoding, so it does not govern this
-                // check -- but it settles the modal, which is what was in doubt.
-                // cite(RFC 9110 § 8.4): "Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation."
-                //
-                // So the finding is advisory, and the message now says what is
-                // unusual rather than implying something was broken.
-                //
-                // Content-Encoding is taken at its word -- nothing here decodes a
-                // body -- and § 8.4 is what makes that reading fair.
-                // cite(RFC 9110 § 8.4): "If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied."
-                let mut overlap: Vec<String> = ce_set
-                    .intersection(&te_set)
-                    .map(|s| s.to_string())
-                    .collect();
-                overlap.sort();
-
-                if !overlap.is_empty() {
-                    return Some(self.violation(ctx.severity, format!(
+            if !overlap.is_empty() {
+                return Some(self.violation(ctx.severity, format!(
                         "Compression coding(s) '{}' appear in both Content-Encoding and Transfer-Encoding of the {}; the representation is coded once and then coded again in transit, which is decodable but almost never intended",
                         overlap.join(", "),
                         side
                     )));
-                }
-
-                None
-            };
-
-            if let Some(v) = check(&tx.request.headers, "request") {
-                return Some(v);
-            }
-            if let Some(resp) = &tx.response {
-                if let Some(v) = check(&resp.headers, "response") {
-                    return Some(v);
-                }
             }
 
             None
         };
-        Vec::from_iter(finding())
+
+        // One finding per side, and both sides are answered. The overlap a
+        // side has is one observation about one message — a representation
+        // coded once and coded again in transit is a single contradiction,
+        // however many codings it names, which is why the message lists them
+        // together — but the request and the response are two messages with
+        // two representations, and the finding already names which. Stopping
+        // at the request's overlap hid the response's.
+        let mut out = Vec::new();
+        out.extend(check(&tx.request.headers, "request"));
+        if let Some(resp) = &tx.response {
+            out.extend(check(&resp.headers, "response"));
+        }
+
+        out
     }
 
     fn description(&self) -> &'static str {
@@ -639,6 +636,46 @@ mod tests {
         ]);
         crate::rules::validate_rules(&cfg)?;
         Ok(())
+    }
+
+    /// Two messages, two representations, two findings. The overlap on one side
+    /// stays one finding however many codings it names — a representation coded
+    /// and coded again is a single contradiction — but the request's overlap
+    /// used to hide the response's.
+    #[test]
+    fn each_side_of_the_exchange_is_its_own_finding() {
+        let rule = CompressionAndTransferEncodingConsistent;
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(
+            200,
+            &[
+                ("content-encoding", "br"),
+                ("transfer-encoding", "br, chunked"),
+            ],
+        );
+        tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[
+            ("content-encoding", "gzip, deflate"),
+            ("transfer-encoding", "gzip, deflate, chunked"),
+        ]);
+
+        let all = crate::test_helpers::run_rule_all(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        assert_eq!(all.len(), 2, "{all:?}");
+        // One message per side, and the two overlapping codings of the request
+        // are named together in the request's.
+        assert!(
+            all[0].message.contains("'deflate, gzip'") && all[0].message.contains("request"),
+            "{}",
+            all[0].message
+        );
+        assert!(
+            all[1].message.contains("'br'") && all[1].message.contains("response"),
+            "{}",
+            all[1].message
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -22,201 +22,202 @@ impl Rule for TransferEncodingChunkedFinal {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Vec<Violation> {
-        // Single-finding body behind an Option: `?` ends it early, and the
-        // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            // Collect the coding names in wire order across every field line.
-            //
-            // `None` means the value could not be read as a list at all: quoting
-            // that never closes leaves every later comma inside it, and an order
-            // derived from members that cannot be delimited would be a guess.
-            // Unlike the ordering questions below, that one has an owner --
-            // `transfer_coding_registered` reports a malformed
-            // `Transfer-Encoding` -- so declining here loses nothing.
-            // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
-            let collect = |headers: &hyper::HeaderMap| -> Option<Vec<String>> {
-                let mut codings: Vec<String> = Vec::new();
-                for hv in headers.get_all(hyper::header::TRANSFER_ENCODING).iter() {
-                    // Decoded from the raw octets. `to_str` refuses everything
-                    // outside visible US-ASCII, and a single such byte -- legal in
-                    // this grammar only inside a `quoted-string` in a parameter
-                    // value, which this rule never reads -- used to drop the whole
-                    // field line. Dropping a line here does not merely miss a
-                    // finding: it silently reorders the sequence this rule exists
-                    // to judge, because the codings on that line are the ones
-                    // between the lines that remain.
-                    let val = crate::helpers::headers::field_line_as_written(hv);
-                    if !crate::helpers::headers::quoting_is_balanced(&val) {
-                        return None;
-                    }
-                    // Quote-aware: a comma inside a transfer-parameter's
-                    // quoted-string value is not a list separator.
-                    // cite(RFC 9110 § 10.1.4): "transfer-parameter = token BWS "=" BWS ( token / quoted-string )"
-                    for part in crate::helpers::headers::split_commas_respecting_quotes(&val) {
-                        // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
-                        if part.is_empty() {
-                            continue;
-                        }
-                        // The name, not the member. The old code pushed the whole
-                        // member, so `chunked;ext=1` never equalled `"chunked"` and
-                        // a parameterised chunked in a non-final position was
-                        // invisible to every check below -- the one place where
-                        // being lax about parameters changes the answer rather than
-                        // just the message. Whether the parameter should be there at
-                        // all is `transfer_coding_registered`'s finding.
-                        // The trim is `OWS` because that is the whitespace the
-                        // production prints around the `;`. `str::trim` would take
-                        // more, and on a value read one `char` per octet there is
-                        // more to take: %xA0 arrives as U+00A0, which
-                        // `char::is_whitespace` admits and no `token` does.
-                        // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
-                        // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
-                        let name =
-                            crate::helpers::headers::trim_ows(part.split(';').next().unwrap());
-                        if name.is_empty() {
-                            continue;
-                        }
-                        // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
-                        codings.push(name.to_ascii_lowercase());
-                    }
-                }
-                Some(codings)
-            };
-
-            // Whether the message announces that the connection ends with it.
-            // cite(RFC 9110 § 7.6.1): "Connection        = #connection-option connection-option = token"
-            // cite(RFC 9112 § 9.6): "The "close" connection option is defined as a signal that the sender will close this connection after completion of the response."
-            let announces_close = |headers: &hyper::HeaderMap| -> bool {
-                headers.get_all("connection").iter().any(|hv| {
-                    let val = crate::helpers::headers::field_line_as_written(hv);
-                    // Bound rather than returned directly: the iterator borrows
-                    // `val`, and as a tail expression it outlives it. Not a style
-                    // choice -- inlining it does not compile.
-                    let found = crate::helpers::headers::list_members(&val)
-                        .any(|opt| opt.eq_ignore_ascii_case("close"));
-                    found
-                })
-            };
-
-            let check = |headers: &hyper::HeaderMap, is_request: bool| -> Option<Violation> {
-                let codings = collect(headers)?;
-
-                if codings.is_empty() {
+        // Collect the coding names in wire order across every field line.
+        //
+        // `None` means the value could not be read as a list at all: quoting
+        // that never closes leaves every later comma inside it, and an order
+        // derived from members that cannot be delimited would be a guess.
+        // Unlike the ordering questions below, that one has an owner --
+        // `transfer_coding_registered` reports a malformed
+        // `Transfer-Encoding` -- so declining here loses nothing.
+        // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
+        let collect = |headers: &hyper::HeaderMap| -> Option<Vec<String>> {
+            let mut codings: Vec<String> = Vec::new();
+            for hv in headers.get_all(hyper::header::TRANSFER_ENCODING).iter() {
+                // Decoded from the raw octets. `to_str` refuses everything
+                // outside visible US-ASCII, and a single such byte -- legal in
+                // this grammar only inside a `quoted-string` in a parameter
+                // value, which this rule never reads -- used to drop the whole
+                // field line. Dropping a line here does not merely miss a
+                // finding: it silently reorders the sequence this rule exists
+                // to judge, because the codings on that line are the ones
+                // between the lines that remain.
+                let val = crate::helpers::headers::field_line_as_written(hv);
+                if !crate::helpers::headers::quoting_is_balanced(&val) {
                     return None;
                 }
+                // Quote-aware: a comma inside a transfer-parameter's
+                // quoted-string value is not a list separator.
+                // cite(RFC 9110 § 10.1.4): "transfer-parameter = token BWS "=" BWS ( token / quoted-string )"
+                for part in crate::helpers::headers::split_commas_respecting_quotes(&val) {
+                    // cite(RFC 9110 § 5.6.1.2): "Empty elements do not contribute to the count of elements present."
+                    if part.is_empty() {
+                        continue;
+                    }
+                    // The name, not the member. The old code pushed the whole
+                    // member, so `chunked;ext=1` never equalled `"chunked"` and
+                    // a parameterised chunked in a non-final position was
+                    // invisible to every check below -- the one place where
+                    // being lax about parameters changes the answer rather than
+                    // just the message. Whether the parameter should be there at
+                    // all is `transfer_coding_registered`'s finding.
+                    // The trim is `OWS` because that is the whitespace the
+                    // production prints around the `;`. `str::trim` would take
+                    // more, and on a value read one `char` per octet there is
+                    // more to take: %xA0 arrives as U+00A0, which
+                    // `char::is_whitespace` admits and no `token` does.
+                    // cite(RFC 9110 § 10.1.4): "transfer-coding    = token *( OWS ";" OWS transfer-parameter )"
+                    // cite(RFC 9110 § 5.6.3, label: OWS grammar): "OWS            = *( SP / HTAB )"
+                    let name = crate::helpers::headers::trim_ows(part.split(';').next().unwrap());
+                    if name.is_empty() {
+                        continue;
+                    }
+                    // cite(RFC 9112 § 7): "All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3."
+                    codings.push(name.to_ascii_lowercase());
+                }
+            }
+            Some(codings)
+        };
 
-                // This sentence was cited on the collection loop from the day the
-                // rule was written, and nothing implemented it. `chunked, chunked`
-                // did produce a finding -- the position check below sees the
-                // *first* one is not last -- but it said "chunked must be the final
-                // coding" about a value whose final coding is chunked. The right
-                // answer for the wrong reason, and unreadable to anyone trying to
-                // fix it. Counted here, ahead of the position check, so the more
-                // specific defect wins -- and ahead of the response's close
-                // exemption, because this sentence offers no alternative. Nothing
-                // in § 6.1 lets a closed connection excuse chunking twice.
-                // cite(RFC 9112 § 6.1): "A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed)."
-                let chunked_count = codings.iter().filter(|c| *c == "chunked").count();
-                if chunked_count > 1 {
-                    return Some(self.violation(
-                        ctx.severity,
-                        format!(
-                            "The chunked transfer coding must not be applied more than once: \
+        // Whether the message announces that the connection ends with it.
+        // cite(RFC 9110 § 7.6.1): "Connection        = #connection-option connection-option = token"
+        // cite(RFC 9112 § 9.6): "The "close" connection option is defined as a signal that the sender will close this connection after completion of the response."
+        let announces_close = |headers: &hyper::HeaderMap| -> bool {
+            headers.get_all("connection").iter().any(|hv| {
+                let val = crate::helpers::headers::field_line_as_written(hv);
+                // Bound rather than returned directly: the iterator borrows
+                // `val`, and as a tail expression it outlives it. Not a style
+                // choice -- inlining it does not compile.
+                let found = crate::helpers::headers::list_members(&val)
+                    .any(|opt| opt.eq_ignore_ascii_case("close"));
+                found
+            })
+        };
+
+        let check = |headers: &hyper::HeaderMap, is_request: bool| -> Option<Violation> {
+            let codings = collect(headers)?;
+
+            if codings.is_empty() {
+                return None;
+            }
+
+            // This sentence was cited on the collection loop from the day the
+            // rule was written, and nothing implemented it. `chunked, chunked`
+            // did produce a finding -- the position check below sees the
+            // *first* one is not last -- but it said "chunked must be the final
+            // coding" about a value whose final coding is chunked. The right
+            // answer for the wrong reason, and unreadable to anyone trying to
+            // fix it. Counted here, ahead of the position check, so the more
+            // specific defect wins -- and ahead of the response's close
+            // exemption, because this sentence offers no alternative. Nothing
+            // in § 6.1 lets a closed connection excuse chunking twice.
+            // cite(RFC 9112 § 6.1): "A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed)."
+            let chunked_count = codings.iter().filter(|c| *c == "chunked").count();
+            if chunked_count > 1 {
+                return Some(self.violation(
+                    ctx.severity,
+                    format!(
+                        "The chunked transfer coding must not be applied more than once: \
                              codings found '{}'",
-                            codings.join(", ")
-                        ),
-                    ));
-                }
+                        codings.join(", ")
+                    ),
+                ));
+            }
 
-                // § 6.1 gives a response two ways to satisfy the same requirement,
-                // and the rule knew only one of them:
-                // cite(RFC 9112 § 6.1): "If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection."
-                //
-                // So `Transfer-Encoding: chunked, gzip` on a response was reported
-                // as a violation of a requirement the sender may have met the other
-                // way -- and it is coherent: gzip applied *after* chunked means the
-                // message is not chunk-framed on the wire, which is exactly when
-                // closing the connection is the framing.
-                //
-                // The transaction records no connection teardown, so the second
-                // alternative is read from the announcement instead. **That
-                // inference rests on a SHOULD, not a MUST**, and the residue is
-                // stated rather than hidden: a response that closes without saying
-                // so is reported here, wrongly, and is also disregarding § 9.6.
-                // Narrowing further would mean dropping the response side
-                // altogether, which costs more than this tolerance does.
-                //
-                // It guards only what follows. The duplication MUST NOT above has
-                // no second alternative, and an earlier draft of this exemption sat
-                // in front of it -- so a response could chunk twice and be excused
-                // by announcing a close.
-                // cite(RFC 9112 § 9.6): "A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection."
-                if !is_request && announces_close(headers) {
-                    return None;
-                }
+            // § 6.1 gives a response two ways to satisfy the same requirement,
+            // and the rule knew only one of them:
+            // cite(RFC 9112 § 6.1): "If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection."
+            //
+            // So `Transfer-Encoding: chunked, gzip` on a response was reported
+            // as a violation of a requirement the sender may have met the other
+            // way -- and it is coherent: gzip applied *after* chunked means the
+            // message is not chunk-framed on the wire, which is exactly when
+            // closing the connection is the framing.
+            //
+            // The transaction records no connection teardown, so the second
+            // alternative is read from the announcement instead. **That
+            // inference rests on a SHOULD, not a MUST**, and the residue is
+            // stated rather than hidden: a response that closes without saying
+            // so is reported here, wrongly, and is also disregarding § 9.6.
+            // Narrowing further would mean dropping the response side
+            // altogether, which costs more than this tolerance does.
+            //
+            // It guards only what follows. The duplication MUST NOT above has
+            // no second alternative, and an earlier draft of this exemption sat
+            // in front of it -- so a response could chunk twice and be excused
+            // by announcing a close.
+            // cite(RFC 9112 § 9.6): "A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection."
+            if !is_request && announces_close(headers) {
+                return None;
+            }
 
-                // If 'chunked' appears anywhere other than the final coding it's a violation
-                if let Some(pos) = codings.iter().position(|c| c == "chunked") {
-                    if pos != codings.len() - 1 {
-                        return Some(self.violation(ctx.severity, format!(
+            // If 'chunked' appears anywhere other than the final coding it's a violation
+            if let Some(pos) = codings.iter().position(|c| c == "chunked") {
+                if pos != codings.len() - 1 {
+                    return Some(self.violation(ctx.severity, format!(
                             "Transfer-Encoding 'chunked' must be the final coding: codings found '{}'",
                             codings.join(", ")
                         )));
-                    }
                 }
-
-                // The rule was named for where `chunked` goes when it is present,
-                // and so only ever asked that. § 6.1 states the requirement the
-                // other way round -- it is about what must be there at all -- and
-                // that half went unchecked, so a request reading
-                //
-                //     Transfer-Encoding: gzip
-                //
-                // passed. It applies a transfer coding other than chunked and never
-                // frames the result, which is the case the sentence exists for.
-                // (A test asserted this was fine.)
-                // cite(RFC 9112 § 6.1): "If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed."
-                //
-                // Requests only. The response form of the sentence offers a second
-                // way to satisfy it, handled below.
-                if is_request
-                    && codings.iter().any(|c| c != "chunked")
-                    && codings.last().map(String::as_str) != Some("chunked")
-                {
-                    return Some(self.violation(ctx.severity, format!(
-                            "A request that applies any transfer coding other than chunked must apply \
-                             chunked as the final coding: codings found '{}'",
-                            codings.join(", ")
-                        )));
-                }
-
-                None
-            };
-
-            if let Some(v) = check(&tx.request.headers, true) {
-                return Some(v);
             }
 
-            if let Some(resp) = &tx.response {
-                // All three of § 6.1's requirements speak of a coding *applied to*
-                // content or to a message body. In these two responses there is no
-                // body for one to have been applied to, and the field means
-                // something else entirely -- what the origin would have done for an
-                // unconditional GET. Judging the sequence for how it frames a body
-                // that does not exist would report an advisory value for failing at
-                // a job it was never doing.
-                // cite(RFC 9112 § 6.1): "Transfer-Encoding MAY be sent in a response to a HEAD request or in a 304 (Not Modified) response (Section 15.4.5 of [HTTP]) to a GET request, neither of which includes a message body, to indicate that the origin server would have applied a transfer coding to the message body if the request had been an unconditional GET."
-                let bodiless = tx.request.method.eq_ignore_ascii_case("HEAD") || resp.status == 304;
-                if !bodiless {
-                    if let Some(v) = check(&resp.headers, false) {
-                        return Some(v);
-                    }
-                }
+            // The rule was named for where `chunked` goes when it is present,
+            // and so only ever asked that. § 6.1 states the requirement the
+            // other way round -- it is about what must be there at all -- and
+            // that half went unchecked, so a request reading
+            //
+            //     Transfer-Encoding: gzip
+            //
+            // passed. It applies a transfer coding other than chunked and never
+            // frames the result, which is the case the sentence exists for.
+            // (A test asserted this was fine.)
+            // cite(RFC 9112 § 6.1): "If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed."
+            //
+            // Requests only. The response form of the sentence offers a second
+            // way to satisfy it, handled below.
+            if is_request
+                && codings.iter().any(|c| c != "chunked")
+                && codings.last().map(String::as_str) != Some("chunked")
+            {
+                return Some(self.violation(
+                    ctx.severity,
+                    format!(
+                        "A request that applies any transfer coding other than chunked must apply \
+                             chunked as the final coding: codings found '{}'",
+                        codings.join(", ")
+                    ),
+                ));
             }
 
             None
         };
-        Vec::from_iter(finding())
+
+        // Two messages, two findings. `check` answers for one message and
+        // deliberately answers once — the three requirements are ordered so
+        // the most specific one wins for a single coding sequence — but the
+        // request's sequence and the response's are separate sequences
+        // framing separate bodies. Reporting only the first meant a request
+        // that applied a coding and never framed the result concealed a
+        // response that chunked twice.
+        let mut out = Vec::new();
+        out.extend(check(&tx.request.headers, true));
+
+        if let Some(resp) = &tx.response {
+            // All three of § 6.1's requirements speak of a coding *applied to*
+            // content or to a message body. In these two responses there is no
+            // body for one to have been applied to, and the field means
+            // something else entirely -- what the origin would have done for an
+            // unconditional GET. Judging the sequence for how it frames a body
+            // that does not exist would report an advisory value for failing at
+            // a job it was never doing.
+            // cite(RFC 9112 § 6.1): "Transfer-Encoding MAY be sent in a response to a HEAD request or in a 304 (Not Modified) response (Section 15.4.5 of [HTTP]) to a GET request, neither of which includes a message body, to indicate that the origin server would have applied a transfer coding to the message body if the request had been an unconditional GET."
+            let bodiless = tx.request.method.eq_ignore_ascii_case("HEAD") || resp.status == 304;
+            if !bodiless {
+                out.extend(check(&resp.headers, false));
+            }
+        }
+
+        out
     }
 
     fn title(&self) -> Option<&'static str> {
@@ -860,6 +861,36 @@ mod tests {
             &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
         );
         assert!(v.is_none(), "{v:?}");
+    }
+
+    /// One coding sequence still gets one finding — the three requirements are
+    /// ordered so the most specific wins — but the request's sequence and the
+    /// response's are two sequences framing two bodies, and each answers for
+    /// itself. The request here never frames its content; the response chunks
+    /// twice. Reporting only the first hid the second.
+    #[test]
+    fn each_side_of_the_exchange_is_its_own_finding() {
+        let rule = TransferEncodingChunkedFinal;
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(
+            200,
+            &[("transfer-encoding", "chunked, chunked")],
+        );
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("transfer-encoding", "gzip")]);
+
+        let all = crate::test_helpers::run_rule_all(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        );
+        assert_eq!(all.len(), 2, "{all:?}");
+        assert!(all[0].message.contains("must apply"), "{}", all[0].message);
+        assert!(
+            all[1].message.contains("more than once"),
+            "{}",
+            all[1].message
+        );
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4637,7 +4637,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 69
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 51
+      line: 48
   - label: accept_encoding_present
     section: § 12.5.3
     snippet: 'Accept-Encoding = #( codings [ weight ] )'
@@ -4709,7 +4709,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 228
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 73
+      line: 85
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 75
   - label: accept_header_media_type_syntax (7)
@@ -4843,7 +4843,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 110
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 55
+      line: 60
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 40
   - label: accept_ranges_and_206_consistent (2)
@@ -4869,7 +4869,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 119
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 122
+      line: 143
   - label: accept_ranges_and_206_consistent (5)
     section: § 14.3
     snippet: The "Accept-Ranges" field in a response indicates whether an upstream server supports range requests for the target resource.
@@ -4891,7 +4891,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 93
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 123
+      line: 144
   - label: accept_ranges_and_206_consistent (7)
     section: § 14.3
     snippet: to indicate that it supports byte range requests for that target resource, thereby encouraging its use by the client for future partial requests on the same request path.
@@ -4941,7 +4941,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 156
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 160
+      line: 181
   - label: accept_ranges_on_partial_content (5)
     section: § 15.3.7
     snippet: A client MUST inspect a 206 response's Content-Type and Content-Range field(s) to determine what parts are enclosed and whether additional requests are needed.
@@ -4961,25 +4961,25 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 37
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 306
+      line: 325
   - label: acceptable-ranges grammar
     section: § 14.3
     snippet: acceptable-ranges = 1#range-unit
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 92
+      line: 106
   - label: accept_ranges_values_valid
     section: § 16.5.1
     snippet: The "HTTP Range Unit Registry" defines the namespace for the range unit names and refers to their corresponding specifications.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 158
+      line: 179
   - label: tchar grammar
     section: § 5.6.2
     snippet: tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 74
+      line: 86
   - label: allow_header_method_tokens_valid
     section: § 10.2
     snippet: The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources.
@@ -5215,21 +5215,21 @@ sources:
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 92
+      line: 88
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 121
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 72
+      line: 69
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 10.1.4
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 93
+      line: 89
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 102
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 54
+      line: 51
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 8.4
     snippet: An origin server MAY respond with a status code of 415 (Unsupported Media Type) if a representation in the request message has a content coding that is not acceptable.
@@ -5241,7 +5241,7 @@ sources:
     snippet: 'Content-Encoding = #content-coding'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 50
+      line: 47
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
       line: 35
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
@@ -5251,25 +5251,25 @@ sources:
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 148
+      line: 143
   - label: compression_and_transfer_encoding_consistent (6)
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 141
+      line: 136
   - label: compression_and_transfer_encoding_consistent (7)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 125
+      line: 120
   - label: compression_and_transfer_encoding_consistent (8)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 70
+      line: 67
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 97
   - label: conditional_headers_consistent
@@ -5341,7 +5341,7 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 23
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 87
+      line: 83
   - label: connection_header_tokens_valid (2)
     section: § 7.6.1
     snippet: The "Connection" header field allows the sender to list desired control options for the current connection.
@@ -6243,9 +6243,9 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 47
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 157
+      line: 178
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 318
+      line: 337
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 54
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6259,7 +6259,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 80
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 272
+      line: 291
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 224
   - label: Accept-Ranges grammar
@@ -6275,7 +6275,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 61
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 159
+      line: 180
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 49
   - label: lint-http-rules/src/helpers/accept_ranges.rs (4)
@@ -6291,7 +6291,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 53
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 273
+      line: 292
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
       line: 57
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -6303,7 +6303,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 107
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 56
+      line: 53
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
     section: § 5.6.1.2
     snippet: In contrast, the following values would be invalid, since at least one non-empty element is required by the example-list production
@@ -6311,7 +6311,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 118
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 280
+      line: 299
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 125
   - label: lint-http-rules/src/helpers/auth.rs
@@ -6359,7 +6359,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 75
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 292
+      line: 311
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 141
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -6593,7 +6593,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 180
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 91
+      line: 105
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 81
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6739,7 +6739,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 86
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 296
+      line: 315
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 86
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6869,13 +6869,13 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 67
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 293
+      line: 312
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 33
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 69
+      line: 66
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 101
+      line: 97
     - file: lint-http-rules/src/rules/host_header.rs
       line: 105
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
@@ -6891,7 +6891,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 122
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 73
+      line: 70
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 66
   - label: lint-http-rules/src/helpers/headers.rs (21)
@@ -6963,7 +6963,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 305
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 36
+      line: 33
   - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
@@ -9347,19 +9347,19 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 21
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 178
+      line: 174
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 124
+      line: 119
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 102
+      line: 98
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 39
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -9367,19 +9367,19 @@ sources:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 266
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 79
+      line: 75
   - label: compression_and_transfer_encoding_consistent (4)
     section: § 7.2
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 134
+      line: 129
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 7.3
     snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 133
+      line: 128
   - label: content_length_vs_transfer_encoding
     section: § 6.2
     snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
@@ -9463,7 +9463,7 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 171
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 208
+      line: 213
   - label: host_and_authority_consistent
     section: § 3.2.2
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
@@ -9905,25 +9905,25 @@ sources:
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 118
+      line: 114
   - label: transfer_encoding_chunked_final (2)
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 133
+      line: 129
   - label: transfer_encoding_chunked_final (3)
     section: § 9.6
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 153
+      line: 149
   - label: transfer_encoding_chunked_final (4)
     section: § 9.6
     snippet: The "close" connection option is defined as a signal that the sender will close this connection after completion of the response.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 88
+      line: 84
 - label: RFC 9113
   url: https://www.rfc-editor.org/rfc/rfc9113.txt
   type: text/plain


### PR DESCRIPTION
Three rules judged the request, then the response, and returned at the first finding — so a defect on one side concealed a defect on the other. The two messages are two messages: transfer_encoding_chunked_final judges two coding sequences framing two bodies, and compression_and_transfer_encoding_consistent two representations, each already naming the side it describes.

accept_ranges_values_valid does the same across field sections rather than across the exchange. Its header section and trailer section are separately `1#range-unit` — RFC 9110 §14.3 lets the field arrive in either — so each malformed one is its own finding. A section that fails now also contributes no range units to the `none`-beside-a-unit question: the names in front of the defect are not a list a recipient acts on, and measuring a contradiction out of text nobody honours would invent one.

What stays folded stays folded, and this is the judgment the audit's list of ten needs per rule. One coding sequence still yields one finding, because the three requirements are ordered so the most specific wins. One side's overlapping codings are named together, because coding a representation and coding it again is one contradiction however many names it takes. `none` beside two units is one response saying both things at once.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
