### PR TITLE
Two requirements in one rule are two findings

### DIFF
--- a/lint-http-rules/src/rules/options_method_capabilities.rs
+++ b/lint-http-rules/src/rules/options_method_capabilities.rs
@@ -73,97 +73,101 @@ impl Rule for OptionsMethodCapabilities {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Vec<Violation> {
-        // Single-finding body behind an Option: `?` ends it early, and the
-        // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            // Two sentences meet at this gate and both are load-bearing: the first
-            // is why the rule looks at OPTIONS at all, the second is why the
-            // comparison is exact. `options` is not the OPTIONS method, and a method
-            // this specification does not define has no capability-advertising
-            // semantics for a response to be measured against.
-            // cite(RFC 9110 § 9.3.7): "The OPTIONS method requests information about the communication options available for the target resource, at either the origin server or an intervening intermediary."
-            // cite(RFC 9110 § 9.1): "The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names."
-            if tx.request.method != "OPTIONS" {
-                return None;
-            }
+        // Two sentences meet at this gate and both are load-bearing: the first
+        // is why the rule looks at OPTIONS at all, the second is why the
+        // comparison is exact. `options` is not the OPTIONS method, and a method
+        // this specification does not define has no capability-advertising
+        // semantics for a response to be measured against.
+        // cite(RFC 9110 § 9.3.7): "The OPTIONS method requests information about the communication options available for the target resource, at either the origin server or an intervening intermediary."
+        // cite(RFC 9110 § 9.1): "The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names."
+        if tx.request.method != "OPTIONS" {
+            return Vec::new();
+        }
 
-            // Content, not framing: the shared measurement reads § 6.4's octet
-            // stream, so a chunked OPTIONS whose only chunk is the terminator
-            // carries none, and an OPTIONS carrying an HTTP/2 DATA frame — which
-            // declares no framing field at all — does.
-            //
-            // Absence is the finding here and nothing else is. The sentence asks for
-            // a *valid* field, and a value that is empty or is not a media type is
-            // `content_type_valid`'s — confirmed by running it, not by
-            // reading it.
-            // cite(RFC 9110 § 9.3.7): "A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type."
-            if let Some(evidence) = crate::helpers::headers::content_evidence(
-                &tx.request.headers,
-                tx.request.body_length,
-            ) {
-                if !tx.request.headers.contains_key("content-type") {
-                    return Some(self.violation(ctx.severity, format!(
+        // Two requirements, one on each message, and a single exchange can
+        // break both: § 9.3.7 asks the client to label content it sends and
+        // asks the server to advertise something back. Returning at the
+        // request's finding hid the response's, and the `?` below discarded
+        // the request's outright whenever no response was captured — the
+        // request had already broken its sentence by then.
+        let mut out = Vec::new();
+
+        // Content, not framing: the shared measurement reads § 6.4's octet
+        // stream, so a chunked OPTIONS whose only chunk is the terminator
+        // carries none, and an OPTIONS carrying an HTTP/2 DATA frame — which
+        // declares no framing field at all — does.
+        //
+        // Absence is the finding here and nothing else is. The sentence asks for
+        // a *valid* field, and a value that is empty or is not a media type is
+        // `content_type_valid`'s — confirmed by running it, not by
+        // reading it.
+        // cite(RFC 9110 § 9.3.7): "A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type."
+        if let Some(evidence) =
+            crate::helpers::headers::content_evidence(&tx.request.headers, tx.request.body_length)
+        {
+            if !tx.request.headers.contains_key("content-type") {
+                out.push(self.violation(ctx.severity, format!(
                             "OPTIONS request carries content ({evidence}) with no Content-Type header field; RFC 9110 § 9.3.7 says a client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type"
                         )));
-                }
             }
+        }
 
-            let resp = tx.response.as_ref()?;
+        let Some(resp) = tx.response.as_ref() else {
+            return out;
+        };
 
-            // An asterisk target names no resource, and the SHOULD below asks for
-            // headers "applicable to the target resource". There is nothing for such
-            // a response to advertise: `Allow` lists the methods of a target
-            // resource this request does not have.
-            //
-            // This reaches the asterisk over HTTP/1.1 only, and the limit is in the
-            // capture rather than here: `proxy/http3.rs` records
-            // `req.uri().to_string()` of a URI the h3 crate rebuilds from `:scheme`,
-            // `:authority` and `:path`, so a `:path` of `*` is recorded as
-            // `https://example.com*` — a string that does not even reparse to the
-            // same target (the authority swallows the asterisk). Widening the
-            // comparison would be guessing; recovering the form needs the capture to
-            // keep it. Stated in `description()` because it costs an operator a
-            // finding.
-            // cite(RFC 9110 § 9.3.7): "An OPTIONS request with an asterisk ("*") as the request target (Section 7.1) applies to the server in general rather than to a specific resource."
-            // cite(RFC 9110 § 9.3.7): "If the request target is not an asterisk, the OPTIONS request applies to the options that are available when communicating with the target resource."
-            if tx.request.uri == "*" {
-                return None;
-            }
+        // An asterisk target names no resource, and the SHOULD below asks for
+        // headers "applicable to the target resource". There is nothing for such
+        // a response to advertise: `Allow` lists the methods of a target
+        // resource this request does not have.
+        //
+        // This reaches the asterisk over HTTP/1.1 only, and the limit is in the
+        // capture rather than here: `proxy/http3.rs` records
+        // `req.uri().to_string()` of a URI the h3 crate rebuilds from `:scheme`,
+        // `:authority` and `:path`, so a `:path` of `*` is recorded as
+        // `https://example.com*` — a string that does not even reparse to the
+        // same target (the authority swallows the asterisk). Widening the
+        // comparison would be guessing; recovering the form needs the capture to
+        // keep it. Stated in `description()` because it costs an operator a
+        // finding.
+        // cite(RFC 9110 § 9.3.7): "An OPTIONS request with an asterisk ("*") as the request target (Section 7.1) applies to the server in general rather than to a specific resource."
+        // cite(RFC 9110 § 9.3.7): "If the request target is not an asterisk, the OPTIONS request applies to the options that are available when communicating with the target resource."
+        if tx.request.uri == "*" {
+            return out;
+        }
 
-            // "Successful" is the name of the 2xx class, so that is the range.
-            // cite(RFC 9110 § 15.3): "The 2xx (Successful) class of status code indicates that the client's request was successfully received, understood, and accepted."
-            if !(200..300).contains(&resp.status) {
-                return None;
-            }
+        // "Successful" is the name of the 2xx class, so that is the range.
+        // cite(RFC 9110 § 15.3): "The 2xx (Successful) class of status code indicates that the client's request was successfully received, understood, and accepted."
+        if !(200..300).contains(&resp.status) {
+            return out;
+        }
 
-            // The SHOULD is about the class, not about `Allow`: asking for that
-            // field by name would report a server exercising § 10.2.1's MAY, and the
-            // one response where `Allow` is required is a 405, which is not 2xx and
-            // is `status_405_allow_valid`'s.
-            // cite(RFC 9110 § 10.2.1): "An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response."
-            // cite(RFC 9110 § 9.3.7): "A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification."
-            if !ADVERTISED_CAPABILITIES
-                .iter()
-                .any(|(lowercase, _, in_trailers)| {
-                    resp.headers.contains_key(*lowercase)
-                        || (*in_trailers
-                            && resp
-                                .trailers
-                                .as_ref()
-                                .is_some_and(|t| t.contains_key(*lowercase)))
-                })
-            {
-                let named: Vec<&str> = ADVERTISED_CAPABILITIES.iter().map(|(_, n, _)| *n).collect();
-                return Some(self.violation(ctx.severity, format!(
+        // The SHOULD is about the class, not about `Allow`: asking for that
+        // field by name would report a server exercising § 10.2.1's MAY, and the
+        // one response where `Allow` is required is a 405, which is not 2xx and
+        // is `status_405_allow_valid`'s.
+        // cite(RFC 9110 § 10.2.1): "An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response."
+        // cite(RFC 9110 § 9.3.7): "A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification."
+        if !ADVERTISED_CAPABILITIES
+            .iter()
+            .any(|(lowercase, _, in_trailers)| {
+                resp.headers.contains_key(*lowercase)
+                    || (*in_trailers
+                        && resp
+                            .trailers
+                            .as_ref()
+                            .is_some_and(|t| t.contains_key(*lowercase)))
+            })
+        {
+            let named: Vec<&str> = ADVERTISED_CAPABILITIES.iter().map(|(_, n, _)| *n).collect();
+            out.push(self.violation(ctx.severity, format!(
                         "Successful OPTIONS response ({}) carries none of {}; RFC 9110 § 9.3.7 says a server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource",
                         resp.status,
                         named.join(", ")
                     )));
-            }
+        }
 
-            None
-        };
-        Vec::from_iter(finding())
+        out
     }
 
     fn title(&self) -> Option<&'static str> {
@@ -292,6 +296,64 @@ mod tests {
             trailers: None,
         });
         tx
+    }
+
+    fn run_all(tx: &crate::http_transaction::HttpTransaction) -> Vec<Violation> {
+        let rule = OptionsMethodCapabilities;
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        crate::test_helpers::run_rule_all(
+            &rule,
+            tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+    }
+
+    /// § 9.3.7 asks the client to label the content it sends and asks the
+    /// server to advertise something back. One exchange can break both, and
+    /// each is its own finding.
+    #[test]
+    fn an_unlabelled_request_and_a_silent_response_are_two_findings() {
+        let tx = make_tx(
+            "OPTIONS",
+            "/r",
+            &[("host", "example.com"), ("content-length", "4")],
+            Some(4),
+            Some((200, &[][..])),
+        );
+        let all = run_all(&tx);
+        assert_eq!(all.len(), 2, "{all:?}");
+        assert!(
+            all[0].message.contains("no Content-Type"),
+            "{}",
+            all[0].message
+        );
+        assert!(
+            all[1].message.contains("carries none of"),
+            "{}",
+            all[1].message
+        );
+    }
+
+    /// The request had already broken its sentence when it was sent, so the
+    /// finding does not depend on a response arriving — which is what reading
+    /// the response with `?` used to make it do.
+    #[test]
+    fn an_unlabelled_request_is_reported_without_a_response() {
+        let tx = make_tx(
+            "OPTIONS",
+            "/r",
+            &[("host", "example.com"), ("content-length", "4")],
+            Some(4),
+            None,
+        );
+        let all = run_all(&tx);
+        assert_eq!(all.len(), 1, "{all:?}");
+        assert!(
+            all[0].message.contains("no Content-Type"),
+            "{}",
+            all[0].message
+        );
     }
 
     fn run(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {

--- a/lint-http-rules/src/rules/trace_method_echo.rs
+++ b/lint-http-rules/src/rules/trace_method_echo.rs
@@ -69,52 +69,58 @@ impl Rule for TraceMethodEcho {
         _history: &crate::transaction_history::TransactionHistory,
         ctx: &crate::rules::RuleContext<'_>,
     ) -> Vec<Violation> {
-        // Single-finding body behind an Option: `?` ends it early, and the
-        // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            // Matched exactly, never case-folded: `trace` is not the TRACE method,
-            // and § 9.3.8 says nothing about it. A method this specification does
-            // not define has no loop-back semantics for content to be measured
-            // against.
-            // cite(RFC 9110 § 9.1): "The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names."
-            if tx.request.method != "TRACE" {
-                return None;
-            }
+        // Matched exactly, never case-folded: `trace` is not the TRACE method,
+        // and § 9.3.8 says nothing about it. A method this specification does
+        // not define has no loop-back semantics for content to be measured
+        // against.
+        // cite(RFC 9110 § 9.1): "The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names."
+        if tx.request.method != "TRACE" {
+            return Vec::new();
+        }
 
-            // Content, not framing: the shared measurement reads § 6.4's octet
-            // stream, so a chunked TRACE whose only chunk is the terminator carries
-            // nothing to report, and a TRACE carrying an HTTP/2 DATA frame — which
-            // declares no framing field at all — does.
-            // cite(RFC 9110 § 9.3.8): "A client MUST NOT send content in a TRACE request."
-            if let Some(evidence) = crate::helpers::headers::content_evidence(
-                &tx.request.headers,
-                tx.request.body_length,
-            ) {
-                return Some(self.violation(ctx.severity, format!(
+        // Two requirements, and one request can break both. § 9.3.8 states
+        // them as two sentences addressed to the same client: one about
+        // sending content, one about the fields sent beside it. A TRACE
+        // carrying a body *and* an Authorization header disobeys both, and
+        // returning at the content said only half of it — the fix for the
+        // half reported would have revealed the other.
+        let mut out = Vec::new();
+
+        // Content, not framing: the shared measurement reads § 6.4's octet
+        // stream, so a chunked TRACE whose only chunk is the terminator carries
+        // nothing to report, and a TRACE carrying an HTTP/2 DATA frame — which
+        // declares no framing field at all — does.
+        // cite(RFC 9110 § 9.3.8): "A client MUST NOT send content in a TRACE request."
+        if let Some(evidence) =
+            crate::helpers::headers::content_evidence(&tx.request.headers, tx.request.body_length)
+        {
+            out.push(self.violation(ctx.severity, format!(
                         "TRACE request carries content ({evidence}); RFC 9110 § 9.3.8 says a client MUST NOT send content in a TRACE request"
                     )));
-            }
+        }
 
-            // The response is a loop-back of this request, so a field is disclosed
-            // by having been sent — which is why the finding is about the request
-            // and does not wait for the response to arrive.
-            // cite(RFC 9110 § 9.3.8): "A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response."
-            let present: Vec<&str> = SENSITIVE_FIELDS
-                .iter()
-                .filter(|(lowercase, _)| carries_a_value(&tx.request.headers, lowercase))
-                .map(|(_, name)| *name)
-                .collect();
+        // The response is a loop-back of this request, so a field is disclosed
+        // by having been sent — which is why the finding is about the request
+        // and does not wait for the response to arrive.
+        // cite(RFC 9110 § 9.3.8): "A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response."
+        let present: Vec<&str> = SENSITIVE_FIELDS
+            .iter()
+            .filter(|(lowercase, _)| carries_a_value(&tx.request.headers, lowercase))
+            .map(|(_, name)| *name)
+            .collect();
 
-            if !present.is_empty() {
-                return Some(self.violation(ctx.severity, format!(
+        // One finding for the whole set, not one per field: the sentence is
+        // about the request the client generated, and every named field is
+        // disclosed by the same loop-back. Naming them together is what an
+        // operator acts on — this request must not have been sent as it was.
+        if !present.is_empty() {
+            out.push(self.violation(ctx.severity, format!(
                         "TRACE request carries {}; RFC 9110 § 9.3.8 says a client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response, and names credentials and cookies as its example",
                         present.join(", ")
                     )));
-            }
+        }
 
-            None
-        };
-        Vec::from_iter(finding())
+        out
     }
 
     fn title(&self) -> Option<&'static str> {
@@ -211,6 +217,63 @@ mod tests {
         tx.request.headers = crate::test_helpers::make_headers_from_pairs(&headers);
         tx.request.body_length = body_length;
         tx
+    }
+
+    fn check_all(tx: &crate::http_transaction::HttpTransaction) -> Vec<Violation> {
+        let rule = TraceMethodEcho;
+        crate::test_helpers::run_rule_all(
+            &rule,
+            tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+    }
+
+    /// § 9.3.8's two sentences are two findings, and one request can break
+    /// both: this one carries a body *and* the credentials the section names as
+    /// its example of what the loop-back would disclose. Reporting the content
+    /// alone left the disclosure to be discovered by fixing the body.
+    #[test]
+    fn content_and_a_disclosed_field_are_two_findings() {
+        let all = check_all(&make_tx(
+            "TRACE",
+            vec![
+                ("content-length", "4"),
+                ("authorization", "Basic dXNlcjpwYXNz"),
+            ],
+            Some(4),
+        ));
+        assert_eq!(all.len(), 2, "{all:?}");
+        assert!(
+            all[0].message.contains("MUST NOT send content"),
+            "{}",
+            all[0].message
+        );
+        assert!(
+            all[1].message.contains("Authorization"),
+            "{}",
+            all[1].message
+        );
+    }
+
+    /// The disclosure finding stays one however many fields it names: the
+    /// sentence is about the request the client generated, and all three travel
+    /// back in the same loop-back.
+    #[test]
+    fn every_disclosed_field_is_named_in_one_finding() {
+        let all = check_all(&make_tx(
+            "TRACE",
+            vec![
+                ("authorization", "Basic dXNlcjpwYXNz"),
+                ("proxy-authorization", "Basic dXNlcjpwYXNz"),
+                ("cookie", "session=8f1c2b"),
+            ],
+            Some(0),
+        ));
+        assert_eq!(all.len(), 1, "{all:?}");
+        for named in ["Authorization", "Proxy-Authorization", "Cookie"] {
+            assert!(all[0].message.contains(named), "{}", all[0].message);
+        }
     }
 
     fn check(tx: &crate::http_transaction::HttpTransaction) -> Option<Violation> {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4803,7 +4803,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 190
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 85
+      line: 82
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 126
     - file: lint-http-rules/src/rules/patch_partial_update.rs
@@ -4825,7 +4825,7 @@ sources:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 47
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 79
+      line: 76
   - label: accept_patch_header_valid (7)
     section: § 9.3.7
     snippet: An OPTIONS request with an asterisk ("*") as the request target (Section 7.1) applies to the server in general rather than to a specific resource.
@@ -4833,7 +4833,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 289
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 127
+      line: 133
   - label: accept_ranges_and_206_consistent
     section: § 14
     snippet: Range requests are an OPTIONAL feature of HTTP, designed so that recipients not implementing this feature (or not supporting it for the target resource) can respond as if it is a normal GET request without impacting interoperability.
@@ -7565,7 +7565,7 @@ sources:
     snippet: An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 143
+      line: 149
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 93
   - label: options_method_capabilities (2)
@@ -7573,7 +7573,7 @@ sources:
     snippet: The 2xx (Successful) class of status code indicates that the client's request was successfully received, understood, and accepted.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 134
+      line: 140
   - label: options_method_capabilities (3)
     section: § 9.3.7
     snippet: A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type.
@@ -7581,7 +7581,7 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 65
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 99
+      line: 104
   - label: options_method_capabilities (4)
     section: § 9.3.7
     snippet: A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification.
@@ -7589,19 +7589,19 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 42
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 144
+      line: 150
   - label: options_method_capabilities (5)
     section: § 9.3.7
     snippet: If the request target is not an asterisk, the OPTIONS request applies to the options that are available when communicating with the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 128
+      line: 134
   - label: options_method_capabilities (6)
     section: § 9.3.7
     snippet: The OPTIONS method requests information about the communication options available for the target resource, at either the origin server or an intervening intermediary.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 84
+      line: 81
   - label: patch_method_content_type_match
     section: § 12.3
     snippet: When content negotiation preferences are sent in a server's response, the listed preferences are called "request content negotiation" because they intend to influence selection of an appropriate content for subsequent requests to that resource.
@@ -8715,7 +8715,7 @@ sources:
     snippet: A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response.
     cited_by:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 101
+      line: 105
   - label: trace_method_echo (4)
     section: § 9.3.8
     snippet: A client MUST NOT send content in a TRACE request.
@@ -8723,7 +8723,7 @@ sources:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 61
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 88
+      line: 93
   - label: trace_method_echo (5)
     section: § 9.3.8
     snippet: For example, it would be foolish for a user agent to send stored user credentials (Section 11) or cookies [COOKIE] in a TRACE request.


### PR DESCRIPTION
trace_method_echo and options_method_capabilities each enforce two sentences of their section, and each returned at the first — so an exchange breaking both disclosed only one, and the second was found by fixing the first. A TRACE carrying a body and an Authorization header now reports both; an OPTIONS request that sends content unlabelled and draws a response advertising nothing reports both.

options_method_capabilities also read `tx.response` with `?` after judging the request, so a captured OPTIONS request with content and no Content-Type went unreported whenever no response was captured. The client had already broken that sentence when it sent the message; nothing about it waits for an answer.

Both folds inside those findings stay folded. The sensitive fields of a TRACE are named together because one loop-back discloses all of them and the request must not have been sent as it was, and the three capability fields are one sentence's worth of "nothing recognizable was advertised".

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
