### PR TITLE
Every specification a rule declares has a name

### DIFF
--- a/lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
+++ b/lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
@@ -7,6 +7,47 @@ use crate::rules::Rule;
 
 pub struct AcceptAndContentTypeNegotiation;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_12_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.1",
+    note: "Absence: what a missing negotiation field means, and — the reason this rule is advisory — the origin server's explicit choice between sending 406 and disregarding the header entirely",
+};
+const RFC_9110_12_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
+    note: "Accept: the `#( media-range [ weight ] )` list, the three shapes a `media-range` takes and what the asterisk ranges over, the instruction to find `q` wherever it sits, and the media-range parameters this rule does not compare",
+};
+const RFC_9110_12_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
+    note: "Quality Values: `qvalue`, the meaning of a zero weight, and the default weight of 1 that a member with no readable `q` keeps",
+};
+const RFC_9110_12_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.1",
+    note: "Proactive negotiation: that a user agent cannot rely on its preferences being honoured, which is the same point as §12.4.1's from the client's side",
+};
+const RFC_9110_15_5_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.7",
+    note:
+        "406 (Not Acceptable): the status this rule suggests, and the one response it never reports",
+};
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "Content-Type: that recipients differ over which member of a duplicated field they act on, which is why a response with two Content-Type lines is not judged",
+};
+
 impl Rule for AcceptAndContentTypeNegotiation {
     fn id(&self) -> &'static str {
         "accept_and_content_type_negotiation"
@@ -246,42 +287,12 @@ impl Rule for AcceptAndContentTypeNegotiation {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.1",
-                note: "Absence: what a missing negotiation field means, and — the reason this rule is advisory — the origin server's explicit choice between sending 406 and disregarding the header entirely",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
-                note: "Accept: the `#( media-range [ weight ] )` list, the three shapes a `media-range` takes and what the asterisk ranges over, the instruction to find `q` wherever it sits, and the media-range parameters this rule does not compare",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
-                note: "Quality Values: `qvalue`, the meaning of a zero weight, and the default weight of 1 that a member with no readable `q` keeps",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.1",
-                note: "Proactive negotiation: that a user agent cannot rely on its preferences being honoured, which is the same point as §12.4.1's from the client's side",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.7",
-                note: "406 (Not Acceptable): the status this rule suggests, and the one response it never reports",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "Content-Type: that recipients differ over which member of a duplicated field they act on, which is why a response with two Content-Type lines is not judged",
-            },
+            RFC_9110_12_4_1,
+            RFC_9110_12_5_1,
+            RFC_9110_12_4_2,
+            RFC_9110_12_1,
+            RFC_9110_15_5_7,
+            RFC_9110_8_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct AcceptEncodingParameterValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_12_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
+    note: "Accept-Encoding: `#( codings [ weight ] )` — the production that says a coding may carry a weight and nothing else. Also the three `codings` alternatives, the meaning of an empty field value, and the meaning of the field in a response",
+};
+const RFC_9110_12_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
+    note: "Quality Values: the `weight` production this field admits, the `qvalue` its value must be, and the case-insensitive parameter name",
+};
+const RFC_9110_8_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
+    note: "Content Codings: `content-coding = token`, which is what the character check on each coding enforces",
+};
+const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
+    note: "Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore",
+};
+
 impl Rule for AcceptEncodingParameterValid {
     fn id(&self) -> &'static str {
         "accept_encoding_parameter_valid"
@@ -203,30 +231,10 @@ impl Rule for AcceptEncodingParameterValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
-                note: "Accept-Encoding: `#( codings [ weight ] )` — the production that says a coding may carry a weight and nothing else. Also the three `codings` alternatives, the meaning of an empty field value, and the meaning of the field in a response",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
-                note: "Quality Values: the `weight` production this field admits, the `qvalue` its value must be, and the case-insensitive parameter name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
-                note: "Content Codings: `content-coding = token`, which is what the character check on each coding enforces",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
-                note: "Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore",
-            },
+            RFC_9110_12_5_3,
+            RFC_9110_12_4_2,
+            RFC_9110_8_4_1,
+            RFC_9110_5_6_1_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/accept_encoding_present.rs
+++ b/lint-http-rules/src/rules/accept_encoding_present.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct AcceptEncodingPresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_12_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
+    note: "Accept-Encoding — the grammar, and the two sentences this rule had backwards: absence means every coding is acceptable, while an empty value means none is wanted",
+};
+const RFC_9110_9_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
+    note: "CONNECT — a tunnel rather than a representation, so nothing comes back for a content coding to apply to",
+};
+const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
+    note: "Why a field value of `,` lists no codings and reads as empty",
+};
+
 impl Rule for AcceptEncodingPresent {
     fn id(&self) -> &'static str {
         "accept_encoding_present"
@@ -107,26 +129,7 @@ impl Rule for AcceptEncodingPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
-                note: "Accept-Encoding — the grammar, and the two sentences this rule had backwards: absence means every coding is acceptable, while an empty value means none is wanted",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
-                note: "CONNECT — a tunnel rather than a representation, so nothing comes back for a content coding to apply to",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
-                note: "Why a field value of `,` lists no codings and reads as empty",
-            },
-        ]
+        &[RFC_9110_12_5_3, RFC_9110_9_3_6, RFC_9110_5_6_1_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct AcceptHeaderMediaTypeSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_12_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
+    note: "Accept: the `#( media-range [ weight ] )` list, the three shapes a `media-range` takes and what the asterisk ranges over, the removal of the extension parameters that once followed the weight, and the meaning of an Accept sent in a response",
+};
+const RFC_9110_12_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
+    note: "Quality Values: the `qvalue` production and its three-digit bound, and that the parameter name is matched case-insensitively",
+};
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "Media Type: `type` and `subtype` are both `token`, which is what the character checks enforce",
+};
+const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
+    note: "Parameters: the `name=value` grammar and the two alternatives a value may take. Its prohibition on whitespace around `=` is NOT enforced here",
+};
+const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
+    note: "Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore",
+};
+
 impl Rule for AcceptHeaderMediaTypeSyntax {
     fn id(&self) -> &'static str {
         "accept_header_media_type_syntax"
@@ -354,36 +388,11 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
-                note: "Accept: the `#( media-range [ weight ] )` list, the three shapes a `media-range` takes and what the asterisk ranges over, the removal of the extension parameters that once followed the weight, and the meaning of an Accept sent in a response",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
-                note: "Quality Values: the `qvalue` production and its three-digit bound, and that the parameter name is matched case-insensitively",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "Media Type: `type` and `subtype` are both `token`, which is what the character checks enforce",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-                note: "Parameters: the `name=value` grammar and the two alternatives a value may take. Its prohibition on whitespace around `=` is NOT enforced here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
-                note: "Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore",
-            },
+            RFC_9110_12_5_1,
+            RFC_9110_12_4_2,
+            RFC_9110_8_3_1,
+            RFC_9110_5_6_6,
+            RFC_9110_5_6_1_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/accept_language_weight_valid.rs
+++ b/lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct AcceptLanguageWeightValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_12_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.4",
+    note: "Accept-Language: `#( language-range [ weight ] )` — the production that says a range may carry a weight and nothing else. Note that, unlike Accept and Accept-Encoding, this section gives the field no meaning in a response",
+};
+const RFC_9110_12_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
+    note: "Quality Values: the `weight` production this field admits, the `qvalue` its value must be, and the case-insensitive parameter name",
+};
+const RFC_4647_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 4647",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc4647.html#section-2.1",
+    note: "Basic Language Range: where `language-range` is defined, by reference from RFC 9110. Its syntax is `language_tag_syntax`'s subject, not this rule's",
+};
+const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
+    note: "Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore",
+};
+
 impl Rule for AcceptLanguageWeightValid {
     fn id(&self) -> &'static str {
         "accept_language_weight_valid"
@@ -170,30 +198,10 @@ impl Rule for AcceptLanguageWeightValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.4",
-                note: "Accept-Language: `#( language-range [ weight ] )` — the production that says a range may carry a weight and nothing else. Note that, unlike Accept and Accept-Encoding, this section gives the field no meaning in a response",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
-                note: "Quality Values: the `weight` production this field admits, the `qvalue` its value must be, and the case-insensitive parameter name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 4647",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc4647.html#section-2.1",
-                note: "Basic Language Range: where `language-range` is defined, by reference from RFC 9110. Its syntax is `language_tag_syntax`'s subject, not this rule's",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
-                note: "Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore",
-            },
+            RFC_9110_12_5_4,
+            RFC_9110_12_4_2,
+            RFC_4647_2_1,
+            RFC_9110_5_6_1_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/accept_patch_header_valid.rs
+++ b/lint-http-rules/src/rules/accept_patch_header_valid.rs
@@ -185,6 +185,52 @@ fn allow_names_patch(headers: &hyper::HeaderMap) -> bool {
         .is_some_and(|value| value.split(',').any(|member| trim_ows(member) == "PATCH"))
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_5789_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
+    note: "The field: its grammar, its definition as a response header, its meaning in a response to any method, and the SHOULD that asks for it — in the OPTIONS response, not in the response to a PATCH. This reference said §2.2, which is Error Handling — and §2.2 turned out to hold a second SHOULD, listed below",
+};
+const RFC_5789_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3",
+    note: "Advertising support in OPTIONS — how a resource says it supports PATCH, which is the antecedent §3.1's SHOULD needs, and the sentence that leaves an Allow listing conforming without the field while naming what its absence costs",
+};
+const RFC_5789_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2.2",
+    note: "Error handling — the second SHOULD: a 415 answering a PATCH is told to carry the field, and what a 415 means is the whole of that requirement's condition",
+};
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "`media-type`, transcribed once in `helpers::headers` and shared with the Content-Type rule. It is where RFC 5789 §3.1's pointer at `[RFC2616], Section 3.7` resolves today; the obsolete name stays byte-exact inside the quote because it is the RFC's own wording",
+};
+const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
+    note: "The list construct expanded, and the worked example naming the values a `1#` production rejects for holding no non-empty member. §5.6.1.1 is the sender's half — the empty-member finding",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, which is why `PATCH` and `OPTIONS` are compared exactly and a `patch` request draws nothing from this rule",
+};
+const RFC_9110_10_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
+    note: "`Allow` — the value read to decide whether the OPTIONS response's resource supports PATCH. Its own grammar is `allow_header_method_tokens_valid`'s",
+};
+
 impl Rule for AcceptPatchHeaderValid {
     fn id(&self) -> &'static str {
         "accept_patch_header_valid"
@@ -310,48 +356,13 @@ impl Rule for AcceptPatchHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
-                note: "The field: its grammar, its definition as a response header, its meaning in a response to any method, and the SHOULD that asks for it — in the OPTIONS response, not in the response to a PATCH. This reference said §2.2, which is Error Handling — and §2.2 turned out to hold a second SHOULD, listed below",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3",
-                note: "Advertising support in OPTIONS — how a resource says it supports PATCH, which is the antecedent §3.1's SHOULD needs, and the sentence that leaves an Allow listing conforming without the field while naming what its absence costs",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2.2",
-                note: "Error handling — the second SHOULD: a 415 answering a PATCH is told to carry the field, and what a 415 means is the whole of that requirement's condition",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "`media-type`, transcribed once in `helpers::headers` and shared with the Content-Type rule. It is where RFC 5789 §3.1's pointer at `[RFC2616], Section 3.7` resolves today; the obsolete name stays byte-exact inside the quote because it is the RFC's own wording",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
-                note: "The list construct expanded, and the worked example naming the values a `1#` production rejects for holding no non-empty member. §5.6.1.1 is the sender's half — the empty-member finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, which is why `PATCH` and `OPTIONS` are compared exactly and a `patch` request draws nothing from this rule",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
-                note: "`Allow` — the value read to decide whether the OPTIONS response's resource supports PATCH. Its own grammar is `allow_header_method_tokens_valid`'s",
-            },
+            RFC_5789_3_1,
+            RFC_5789_3,
+            RFC_5789_2_2,
+            RFC_9110_8_3_1,
+            RFC_9110_5_6_1_2,
+            RFC_9110_9_1,
+            RFC_9110_10_2_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
+++ b/lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct AcceptRangesAnd206Consistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_14_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
+    note: "`Accept-Ranges`: `1#range-unit`, advertising which units a resource supports, or `none`. Sending it is not required — the section says so twice — and it MAY be sent in a trailer section",
+};
+const RFC_9110_15_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
+    note: "`206 Partial Content`: the server successfully fulfilling a range request, which is what makes `Accept-Ranges: none` in the same response a contradiction. The section also lists the header fields a 206 MUST carry, and `Accept-Ranges` is not among them. RFC 7233 §4.1 defined the status code; RFC 9110 obsoleted RFC 7233",
+};
+const RFC_9110_14_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
+    note: "`Range`: a 206 is the answer when the request's range unit is supported for the target resource, so the `Content-Range` unit is a unit the server supports",
+};
+const RFC_9110_14_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
+    note: "Range units: `range-unit = token`, one construct shared by `Accept-Ranges`, `Range` and `Content-Range`, and case-insensitive — which is why both sides of the comparison are folded",
+};
+
 impl Rule for AcceptRangesAnd206Consistent {
     fn id(&self) -> &'static str {
         "accept_ranges_and_206_consistent"
@@ -114,32 +142,7 @@ impl Rule for AcceptRangesAnd206Consistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
-                note: "`Accept-Ranges`: `1#range-unit`, advertising which units a resource supports, or `none`. Sending it is not required — the section says so twice — and it MAY be sent in a trailer section",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
-                note: "`206 Partial Content`: the server successfully fulfilling a range request, which is what makes `Accept-Ranges: none` in the same response a contradiction. The section also lists the header fields a 206 MUST carry, and `Accept-Ranges` is not among them. RFC 7233 §4.1 defined the status code; RFC 9110 obsoleted RFC 7233",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
-                note: "`Range`: a 206 is the answer when the request's range unit is supported for the target resource, so the `Content-Range` unit is a unit the server supports",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
-                note: "Range units: `range-unit = token`, one construct shared by `Accept-Ranges`, `Range` and `Content-Range`, and case-insensitive — which is why both sides of the comparison are folded",
-            },
-        ]
+        &[RFC_9110_14_3, RFC_9110_15_3_7, RFC_9110_14_2, RFC_9110_14_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
+++ b/lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
@@ -48,6 +48,34 @@ fn requested_unit(headers: &hyper::HeaderMap) -> Option<String> {
     Some(unit.to_ascii_lowercase())
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_14_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
+    note: "`Accept-Ranges`: advice, in the section's own words, about which range units a resource supports — or `none`, which advises against attempting a range request on the same request path. A client MAY send range requests regardless, and MUST NOT assume the field means future range requests will be answered with partial responses, which no parser can check",
+};
+const RFC_9110_14_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
+    note: "`Range`: `ranges-specifier`, and an origin server MUST ignore one whose range unit it does not understand — which is what a request in an unadvertised unit costs",
+};
+const RFC_9110_14_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
+    note: "Range units: `range-unit = token`, shared by `Accept-Ranges` and `Range`, and case-insensitive — which is why both sides of the comparison are folded",
+};
+const RFC_9110_15_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
+    note: "`206 Partial Content`: a client MUST inspect its `Content-Type` and `Content-Range`, which is not observable either. A 206 that advertised nothing is no longer reported here. RFC 7233 §4.1 defined the status code; RFC 9110 obsoleted RFC 7233",
+};
+
 impl Rule for AcceptRangesOnPartialContent {
     fn id(&self) -> &'static str {
         "accept_ranges_on_partial_content"
@@ -165,32 +193,7 @@ impl Rule for AcceptRangesOnPartialContent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
-                note: "`Accept-Ranges`: advice, in the section's own words, about which range units a resource supports — or `none`, which advises against attempting a range request on the same request path. A client MAY send range requests regardless, and MUST NOT assume the field means future range requests will be answered with partial responses, which no parser can check",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
-                note: "`Range`: `ranges-specifier`, and an origin server MUST ignore one whose range unit it does not understand — which is what a request in an unadvertised unit costs",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
-                note: "Range units: `range-unit = token`, shared by `Accept-Ranges` and `Range`, and case-insensitive — which is why both sides of the comparison are folded",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
-                note: "`206 Partial Content`: a client MUST inspect its `Content-Type` and `Content-Range`, which is not observable either. A 206 that advertised nothing is no longer reported here. RFC 7233 §4.1 defined the status code; RFC 9110 obsoleted RFC 7233",
-            },
-        ]
+        &[RFC_9110_14_3, RFC_9110_14_2, RFC_9110_14_1, RFC_9110_15_3_7]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -9,6 +9,46 @@ use crate::rules::Rule;
 /// reads it as one.
 pub struct AcceptRangesValuesValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_14_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
+    note: "`Accept-Ranges`: `acceptable-ranges = 1#range-unit`, sent in a response to indicate whether an upstream server supports range requests for the target resource. It grants a MAY to a server that \"does not support any kind of range request for the target resource\" to send `none`, and reserves that name for the purpose — the condition on the MAY is what makes `none` beside another unit worth reporting, and the absence of any prohibition is why the report is advice. The field MAY also be sent in a trailer section, which is where the second field section this rule reads comes from, and the preference for the header section carries no modal. The section's remaining sentences are addressed to clients: the field is advice a client MAY ignore, and a client MUST NOT read it as a promise about the next request",
+};
+const RFC_9110_14_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
+    note: "Range Units: `range-unit = token`, names case-insensitive, \"intended to be extensible\" — which is why no name is reported for being one this rule has not heard of. Registration is what names \"ought to be\" have, weaker than SHOULD, and this rule holds no registry to measure it with anyway",
+};
+const RFC_9110_16_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.5.1",
+    note: "The \"HTTP Range Unit Registry\", which holds `bytes` and `none` today and takes IETF Review to add to. Those two entries are the two this rule used to accept as though they were the grammar",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "Sender Requirements for the list construct: OWS on either side of each comma, and a sender MUST NOT generate empty list elements. §5.6.1.2 tells recipients the opposite — parse and ignore them — so the shared list reader, which drops them, cannot answer this rule's question, and a value with no non-empty element at all is among that section's own examples of an invalid `1#`",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "Tokens: `tchar` is \"any VCHAR, except delimiters\", so every character of a range unit name is visible US-ASCII. An octet outside that is reported for being outside the production and not for failing to decode as UTF-8, which refuses a perfectly good `é` for a reason that was never the point",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: multiple field lines of one name within a field section are combined in order, separated by comma SP, when the field's definition allows a comma-separated list — which `1#range-unit` is. So several `Accept-Ranges` lines are one list to read rather than a duplication to report, and the joining stops at the section boundary the sentence names",
+};
+
 impl Rule for AcceptRangesValuesValid {
     fn id(&self) -> &'static str {
         "accept_ranges_values_valid"
@@ -192,42 +232,12 @@ impl Rule for AcceptRangesValuesValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
-                note: "`Accept-Ranges`: `acceptable-ranges = 1#range-unit`, sent in a response to indicate whether an upstream server supports range requests for the target resource. It grants a MAY to a server that \"does not support any kind of range request for the target resource\" to send `none`, and reserves that name for the purpose — the condition on the MAY is what makes `none` beside another unit worth reporting, and the absence of any prohibition is why the report is advice. The field MAY also be sent in a trailer section, which is where the second field section this rule reads comes from, and the preference for the header section carries no modal. The section's remaining sentences are addressed to clients: the field is advice a client MAY ignore, and a client MUST NOT read it as a promise about the next request",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
-                note: "Range Units: `range-unit = token`, names case-insensitive, \"intended to be extensible\" — which is why no name is reported for being one this rule has not heard of. Registration is what names \"ought to be\" have, weaker than SHOULD, and this rule holds no registry to measure it with anyway",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.5.1",
-                note: "The \"HTTP Range Unit Registry\", which holds `bytes` and `none` today and takes IETF Review to add to. Those two entries are the two this rule used to accept as though they were the grammar",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "Sender Requirements for the list construct: OWS on either side of each comma, and a sender MUST NOT generate empty list elements. §5.6.1.2 tells recipients the opposite — parse and ignore them — so the shared list reader, which drops them, cannot answer this rule's question, and a value with no non-empty element at all is among that section's own examples of an invalid `1#`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "Tokens: `tchar` is \"any VCHAR, except delimiters\", so every character of a range unit name is visible US-ASCII. An octet outside that is reported for being outside the production and not for failing to decode as UTF-8, which refuses a perfectly good `é` for a reason that was never the point",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: multiple field lines of one name within a field section are combined in order, separated by comma SP, when the field's definition allows a comma-separated list — which `1#range-unit` is. So several `Accept-Ranges` lines are one list to read rather than a duplication to report, and the joining stops at the section boundary the sentence names",
-            },
+            RFC_9110_14_3,
+            RFC_9110_14_1,
+            RFC_9110_16_5_1,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct AccessControlAllowCredentialsWhenOrigin;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const MDN_ACCESS_CONTROL_ALLOW_CREDENTIALS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Access-Control-Allow-Credentials",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials",
+    note: "Access-Control-Allow-Credentials",
+};
+const MDN_ACCESS_CONTROL_ALLOW_ORIGIN: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Access-Control-Allow-Origin",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin",
+    note: "Access-Control-Allow-Origin",
+};
+const FETCH_4_10: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("4.10"),
+    url: "https://fetch.spec.whatwg.org/#concept-cors-check",
+    note: "Fetch CORS check — `*` succeeds only for non-credentialed requests, so `*` paired with `Access-Control-Allow-Credentials: true` can never authorize a credentialed request (the two cited steps)",
+};
+
 impl Rule for AccessControlAllowCredentialsWhenOrigin {
     fn id(&self) -> &'static str {
         "access_control_allow_credentials_when_origin"
@@ -99,24 +121,9 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "MDN Access-Control-Allow-Credentials",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials",
-                note: "Access-Control-Allow-Credentials",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Access-Control-Allow-Origin",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin",
-                note: "Access-Control-Allow-Origin",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("4.10"),
-                url: "https://fetch.spec.whatwg.org/#concept-cors-check",
-                note: "Fetch CORS check — `*` succeeds only for non-credentialed requests, so `*` paired with `Access-Control-Allow-Credentials: true` can never authorize a credentialed request (the two cited steps)",
-            },
+            MDN_ACCESS_CONTROL_ALLOW_CREDENTIALS,
+            MDN_ACCESS_CONTROL_ALLOW_ORIGIN,
+            FETCH_4_10,
         ]
     }
 

--- a/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct AccessControlAllowOriginValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const MDN_ACCESS_CONTROL_ALLOW_ORIGIN: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Access-Control-Allow-Origin",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin",
+    note: "Access-Control-Allow-Origin",
+};
+const FETCH_3_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("3.3.3"),
+    url: "https://fetch.spec.whatwg.org/#http-access-control-allow-origin",
+    note: "`Access-Control-Allow-Origin` carries one value: an echoed origin, `null`, or `*`",
+};
+const FETCH_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("3.2"),
+    url: "https://fetch.spec.whatwg.org/#origin-header",
+    note: "Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it; the host inside it is a `reg-name` or a bracketed `IP-literal`, so a character outside those productions or a malformed percent-encoding disqualifies it too; and `origin-or-null`'s `null` is case-sensitive",
+};
+const RFC_6454_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6454",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1",
+    note: "Historical origin syntax the non-`*` value is validated against — `serialized-origin = scheme \"://\" host [ \":\" port ]`, and `null` via origin-list-or-null; Fetch §3.2 supplants it",
+};
+
 impl Rule for AccessControlAllowOriginValid {
     fn id(&self) -> &'static str {
         "access_control_allow_origin_valid"
@@ -94,30 +122,10 @@ impl Rule for AccessControlAllowOriginValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "MDN Access-Control-Allow-Origin",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin",
-                note: "Access-Control-Allow-Origin",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("3.3.3"),
-                url: "https://fetch.spec.whatwg.org/#http-access-control-allow-origin",
-                note: "`Access-Control-Allow-Origin` carries one value: an echoed origin, `null`, or `*`",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("3.2"),
-                url: "https://fetch.spec.whatwg.org/#origin-header",
-                note: "Governing origin syntax: `serialized-origin` ends at its authority, so a path (not even a trailing slash), a query or a fragment all disqualify it; the host inside it is a `reg-name` or a bracketed `IP-literal`, so a character outside those productions or a malformed percent-encoding disqualifies it too; and `origin-or-null`'s `null` is case-sensitive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6454",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1",
-                note: "Historical origin syntax the non-`*` value is validated against — `serialized-origin = scheme \"://\" host [ \":\" port ]`, and `null` via origin-list-or-null; Fetch §3.2 supplants it",
-            },
+            MDN_ACCESS_CONTROL_ALLOW_ORIGIN,
+            FETCH_3_3_3,
+            FETCH_3_2,
+            RFC_6454_7_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/age_header_numeric.rs
+++ b/lint-http-rules/src/rules/age_header_numeric.rs
@@ -7,6 +7,16 @@ use crate::rules::Rule;
 
 pub struct AgeHeaderNumeric;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.1",
+    note: "`Age` field-value: delta-seconds (non-negative integer)",
+};
+
 impl Rule for AgeHeaderNumeric {
     fn id(&self) -> &'static str {
         "age_header_numeric"
@@ -84,12 +94,7 @@ impl Rule for AgeHeaderNumeric {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("5.1"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.1",
-            note: "`Age` field-value: delta-seconds (non-negative integer)",
-        }]
+        &[RFC_9111_5_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
+++ b/lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
@@ -152,6 +152,46 @@ impl AllowHeaderMethodTokensValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
+    note: "The field itself: its grammar, what the set of methods means, and the sentence that gives an empty field value a meaning rather than making it a defect",
+};
+const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not, and where `method = token` is quotable",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The sender's half of the list construct — the empty-member finding. The recipient's half (§5.6.1.2, parse and ignore them) is a different party's requirement, which is why the lenient list reader is not used here",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "`token = 1*tchar`, transcribed once in `helpers::token::is_tchar`, and the delimiter set that makes splitting this field on every comma exact",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "A field value excludes the whitespace around it, so a value that is only whitespace is the empty value — and `obs-text` is an octet field content admits, which is why the value is read as octets rather than through a UTF-8 decode",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sentence that makes a value outside its own grammar a violation, and the reason both halves of the exchange are measured: it addresses whoever generated the element",
+};
+
 impl Rule for AllowHeaderMethodTokensValid {
     fn id(&self) -> &'static str {
         "allow_header_method_tokens_valid"
@@ -235,42 +275,12 @@ impl Rule for AllowHeaderMethodTokensValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
-                note: "The field itself: its grammar, what the set of methods means, and the sentence that gives an empty field value a meaning rather than making it a defect",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("A"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-                note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not, and where `method = token` is quotable",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The sender's half of the list construct — the empty-member finding. The recipient's half (§5.6.1.2, parse and ignore them) is a different party's requirement, which is why the lenient list reader is not used here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "`token = 1*tchar`, transcribed once in `helpers::token::is_tchar`, and the delimiter set that makes splitting this field on every comma exact",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "A field value excludes the whitespace around it, so a value that is only whitespace is the empty value — and `obs-text` is an octet field content admits, which is why the value is read as octets rather than through a UTF-8 decode",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sentence that makes a value outside its own grammar a violation, and the reason both halves of the exchange are measured: it addresses whoever generated the element",
-            },
+            RFC_9110_10_2_1,
+            RFC_9110_A,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_5,
+            RFC_9110_2_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
+++ b/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
@@ -43,6 +43,35 @@ const MA: &str = "ma";
 /// not a spec limit — hence uncited (recorded in the audit ledger, §4.1).
 const MAX_REASONABLE_MA: u64 = 365 * 24 * 3600;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9114_3_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("3.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1.1",
+    note: "HTTP Alternative Services — advertising HTTP/3 via Alt-Svc using the \"h3\" ALPN token",
+};
+const RFC_7838_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
+    note: "Alt-Svc — the field's grammar, the `parameter` production, and the requirement that a recipient ignore a parameter name it does not know",
+};
+const RFC_7838_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1",
+    note:
+        "Caching Alt-Svc Header Field Values — what the `ma` parameter's delta-seconds value means",
+};
+const RFC_9111_1_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("1.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2",
+    note: "delta-seconds — the `1*DIGIT` production `ma` carries, and what a cache does with a value too large to represent",
+};
+
 impl Rule for AltSvcH3AdvertisementValid {
     fn id(&self) -> &'static str {
         "alt_svc_h3_advertisement_valid"
@@ -166,32 +195,7 @@ impl Rule for AltSvcH3AdvertisementValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("3.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-3.1.1",
-                note: "HTTP Alternative Services — advertising HTTP/3 via Alt-Svc using the \"h3\" ALPN token",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
-                note: "Alt-Svc — the field's grammar, the `parameter` production, and the requirement that a recipient ignore a parameter name it does not know",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1",
-                note: "Caching Alt-Svc Header Field Values — what the `ma` parameter's delta-seconds value means",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("1.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2",
-                note: "delta-seconds — the `1*DIGIT` production `ma` carries, and what a cache does with a value too large to represent",
-            },
-        ]
+        &[RFC_9114_3_1_1, RFC_7838_3, RFC_7838_3_1, RFC_9111_1_2_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -363,6 +363,58 @@ fn check_alt_value(member: &str) -> Option<String> {
     None
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7838_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
+    note: "The Alt-Svc HTTP Header Field: the field's grammar, the `clear` keyword, the three percent-encoding constraints on a protocol-id, and the prose requiring a colon and a port inside the alt-authority",
+};
+const RFC_7838_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1",
+    note: "Caching Alt-Svc Header Field Values: `persist = \"1\"` is the whole syntax of that parameter, and clients ignore any other value",
+};
+const RFC_7838_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-1.1",
+    note: "Notational Conventions: the field's terminals — `OWS`, `port`, `quoted-string`, `token`, `uri-host` — and the `#rule` extension are imported from RFC 7230, whose §3.2.3, §2.7, §3.2.6 and §7 are carried unchanged by RFC 9110 §5.6.3, §4.1, §5.6.4, §5.6.2 and §5.6.1",
+};
+const RFC_7838_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("8"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-8",
+    note: "Internationalization Considerations: an internationalized domain name in this field is written as A-labels",
+};
+const RFC_7838_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-2",
+    note: "Alternative Services Concepts: an alternative service is an ALPN protocol name, an RFC 3986 host and an RFC 3986 port, and the protocol name implies the transport the port is registered in",
+};
+const RFC_9110_5_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6",
+    note: "Common Rules for Defining Field Values: `token`, `quoted-string`, `OWS` and the `#rule` list construct this field's grammar is built from, and the sender's MUST NOT against empty list elements",
+};
+const RFC_3986_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2",
+    note: "Authority: `host` and `port`, the two productions the alt-authority's content is made of, and `pct-encoded` in §2.1",
+};
+const RFC_6335_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6335",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc6335.html#section-6",
+    note: "Port Number Ranges: the sixteen-bit namespace that bounds the port, and the reserved edge values that are not thereby invalid",
+};
+
 impl Rule for AltSvcHeaderSyntax {
     fn id(&self) -> &'static str {
         "alt_svc_header_syntax"
@@ -485,54 +537,14 @@ impl Rule for AltSvcHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
-                note: "The Alt-Svc HTTP Header Field: the field's grammar, the `clear` keyword, the three percent-encoding constraints on a protocol-id, and the prose requiring a colon and a port inside the alt-authority",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3.1",
-                note: "Caching Alt-Svc Header Field Values: `persist = \"1\"` is the whole syntax of that parameter, and clients ignore any other value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-1.1",
-                note: "Notational Conventions: the field's terminals — `OWS`, `port`, `quoted-string`, `token`, `uri-host` — and the `#rule` extension are imported from RFC 7230, whose §3.2.3, §2.7, §3.2.6 and §7 are carried unchanged by RFC 9110 §5.6.3, §4.1, §5.6.4, §5.6.2 and §5.6.1",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("8"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-8",
-                note: "Internationalization Considerations: an internationalized domain name in this field is written as A-labels",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-2",
-                note: "Alternative Services Concepts: an alternative service is an ALPN protocol name, an RFC 3986 host and an RFC 3986 port, and the protocol name implies the transport the port is registered in",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6",
-                note: "Common Rules for Defining Field Values: `token`, `quoted-string`, `OWS` and the `#rule` list construct this field's grammar is built from, and the sender's MUST NOT against empty list elements",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2",
-                note: "Authority: `host` and `port`, the two productions the alt-authority's content is made of, and `pct-encoded` in §2.1",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6335",
-                section: Some("6"),
-                url: "https://www.rfc-editor.org/rfc/rfc6335.html#section-6",
-                note: "Port Number Ranges: the sixteen-bit namespace that bounds the port, and the reserved edge values that are not thereby invalid",
-            },
+            RFC_7838_3,
+            RFC_7838_3_1,
+            RFC_7838_1_1,
+            RFC_7838_8,
+            RFC_7838_2,
+            RFC_9110_5_6,
+            RFC_3986_3_2,
+            RFC_6335_6,
         ]
     }
 

--- a/lint-http-rules/src/rules/alt_svc_protocol_registered.rs
+++ b/lint-http-rules/src/rules/alt_svc_protocol_registered.rs
@@ -191,6 +191,58 @@ fn shown_alpn_name(name: &[u8]) -> String {
 /// rule asks whether the name is one this deployment offers.
 pub struct AltSvcProtocolRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7838_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-2",
+    note: "Alternative Services Concepts: an alternative service is identified by an ALPN protocol name as per RFC 7301, a host and a port; §2.4 requires a client to treat a connection that does not negotiate the expected protocol as failed",
+};
+const RFC_7838_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7838",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
+    note: "The Alt-Svc HTTP Header Field: `protocol-id = token ; percent-encoded ALPN protocol name`, the escaping table that is its round trip, and the `clear` keyword",
+};
+const RFC_7301_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7301",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7301.html#section-3.1",
+    note: "The Application-Layer Protocol Negotiation Extension: protocol names are IANA-registered opaque byte strings, carried in a `ProtocolName` vector of at most 255 octets; §3.2 is the fatal alert a server sends when nothing is in common",
+};
+const RFC_7301_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7301",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc7301.html#section-6",
+    note: "IANA Considerations: the ALPN Protocol IDs registry, its Identification Sequence column, and its Expert Review policy — the reason the allowed list is configuration rather than a table compiled in here",
+};
+const RFC_8447_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8447",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8447.html#section-3",
+    note: "Adding \"TLS\" to Registry Names: the registry RFC 7301 §6 created is now \"TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs\"",
+};
+const IANA_TLS_ALPN_PROTOCOL_IDS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA TLS ALPN Protocol IDs",
+    section: None,
+    url: "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids",
+    note: "TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs: the registry an operator writes the allowed list from — nothing in this rule reads it",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "Tokens: `token = 1*tchar`, the production a `protocol-id` is, and §5.3's rule for combining a field spread over several lines",
+};
+const RFC_3986_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
+    note: "Percent-Encoding: `pct-encoded = \"%\" HEXDIG HEXDIG`, the triplet decoded back into an octet of the name",
+};
+
 impl Rule for AltSvcProtocolRegistered {
     fn id(&self) -> &'static str {
         "alt_svc_protocol_registered"
@@ -362,54 +414,14 @@ impl Rule for AltSvcProtocolRegistered {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-2",
-                note: "Alternative Services Concepts: an alternative service is identified by an ALPN protocol name as per RFC 7301, a host and a port; §2.4 requires a client to treat a connection that does not negotiate the expected protocol as failed",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7838",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7838.html#section-3",
-                note: "The Alt-Svc HTTP Header Field: `protocol-id = token ; percent-encoded ALPN protocol name`, the escaping table that is its round trip, and the `clear` keyword",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7301",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7301.html#section-3.1",
-                note: "The Application-Layer Protocol Negotiation Extension: protocol names are IANA-registered opaque byte strings, carried in a `ProtocolName` vector of at most 255 octets; §3.2 is the fatal alert a server sends when nothing is in common",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7301",
-                section: Some("6"),
-                url: "https://www.rfc-editor.org/rfc/rfc7301.html#section-6",
-                note: "IANA Considerations: the ALPN Protocol IDs registry, its Identification Sequence column, and its Expert Review policy — the reason the allowed list is configuration rather than a table compiled in here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8447",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8447.html#section-3",
-                note: "Adding \"TLS\" to Registry Names: the registry RFC 7301 §6 created is now \"TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs\"",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA TLS ALPN Protocol IDs",
-                section: None,
-                url: "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids",
-                note: "TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs: the registry an operator writes the allowed list from — nothing in this rule reads it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "Tokens: `token = 1*tchar`, the production a `protocol-id` is, and §5.3's rule for combining a field spread over several lines",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
-                note: "Percent-Encoding: `pct-encoded = \"%\" HEXDIG HEXDIG`, the triplet decoded back into an octet of the name",
-            },
+            RFC_7838_2,
+            RFC_7838_3,
+            RFC_7301_3_1,
+            RFC_7301_6,
+            RFC_8447_3,
+            IANA_TLS_ALPN_PROTOCOL_IDS,
+            RFC_9110_5_6_2,
+            RFC_3986_2_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct AuthSchemeRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_11_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.1",
+    note: "Authentication Scheme — `auth-scheme = token`, and where new schemes are registered",
+};
+const RFC_9110_16_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.4.1",
+    note: "Authentication Scheme Registry",
+};
+const IANA_HTTP_AUTHENTICATION_SCHEMES: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Authentication Schemes",
+    section: None,
+    url: "https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml",
+    note: "IANA HTTP Authentication Scheme Registry",
+};
+
 impl Rule for AuthSchemeRegistered {
     fn id(&self) -> &'static str {
         "auth_scheme_registered"
@@ -142,24 +164,9 @@ impl Rule for AuthSchemeRegistered {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.1",
-                note: "Authentication Scheme — `auth-scheme = token`, and where new schemes are registered",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.4.1",
-                note: "Authentication Scheme Registry",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Authentication Schemes",
-                section: None,
-                url: "https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml",
-                note: "IANA HTTP Authentication Scheme Registry",
-            },
+            RFC_9110_11_1,
+            RFC_9110_16_4_1,
+            IANA_HTTP_AUTHENTICATION_SCHEMES,
         ]
     }
 

--- a/lint-http-rules/src/rules/authentication_challenge_valid.rs
+++ b/lint-http-rules/src/rules/authentication_challenge_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct AuthenticationChallengeValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_11_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.5",
+    note: "Establishing a Protection Space (Realm)",
+};
+const RFC_9110_11_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
+    note: "WWW-Authenticate",
+};
+
 impl Rule for AuthenticationChallengeValid {
     fn id(&self) -> &'static str {
         "authentication_challenge_valid"
@@ -135,20 +151,7 @@ impl Rule for AuthenticationChallengeValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.5",
-                note: "Establishing a Protection Space (Realm)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
-                note: "WWW-Authenticate",
-            },
-        ]
+        &[RFC_9110_11_5, RFC_9110_11_6_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/authentication_failure_loop.rs
+++ b/lint-http-rules/src/rules/authentication_failure_loop.rs
@@ -9,6 +9,16 @@ use crate::rules::Rule;
 /// which indicates an authentication failure loop.
 pub struct AuthenticationFailureLoop;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+spec: "RFC 9110",
+section: Some("15.5.2"),
+url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.2",
+note: "401 Unauthorized — the status code this rule counts, and the SHOULD for a repeated challenge",
+        };
+
 impl Rule for AuthenticationFailureLoop {
     fn id(&self) -> &'static str {
         "authentication_failure_loop"
@@ -74,12 +84,7 @@ impl Rule for AuthenticationFailureLoop {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9110",
-            section: Some("15.5.2"),
-            url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.2",
-            note: "401 Unauthorized — the status code this rule counts, and the SHOULD for a repeated challenge",
-        }]
+        &[RFC_9110_15_5_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/authorization_credentials_present.rs
+++ b/lint-http-rules/src/rules/authorization_credentials_present.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct AuthorizationCredentialsPresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_11_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2",
+    note: "Authorization",
+};
+const RFC_7617: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7617",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc7617.html",
+    note: "Basic Authentication",
+};
+const RFC_6750: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6750",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc6750.html",
+    note: "The OAuth 2.0 Authorization Framework: Bearer Token Usage",
+};
+
 impl Rule for AuthorizationCredentialsPresent {
     fn id(&self) -> &'static str {
         "authorization_credentials_present"
@@ -59,26 +81,7 @@ impl Rule for AuthorizationCredentialsPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2",
-                note: "Authorization",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7617",
-                section: None,
-                url: "https://www.rfc-editor.org/rfc/rfc7617.html",
-                note: "Basic Authentication",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6750",
-                section: None,
-                url: "https://www.rfc-editor.org/rfc/rfc6750.html",
-                note: "The OAuth 2.0 Authorization Framework: Bearer Token Usage",
-            },
-        ]
+        &[RFC_9110_11_6_2, RFC_7617, RFC_6750]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/basic_auth_base64_valid.rs
+++ b/lint-http-rules/src/rules/basic_auth_base64_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct BasicAuthBase64Valid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7617_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7617",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7617.html#section-2",
+    note: "The Basic authentication scheme and the `user-pass` encoding (Base64)",
+};
+const RFC_4648_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 4648",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-4",
+    note: "Base64 encoding used for `token68`",
+};
+
 impl Rule for BasicAuthBase64Valid {
     fn id(&self) -> &'static str {
         "basic_auth_base64_valid"
@@ -73,20 +89,7 @@ impl Rule for BasicAuthBase64Valid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 7617",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7617.html#section-2",
-                note: "The Basic authentication scheme and the `user-pass` encoding (Base64)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 4648",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-4",
-                note: "Base64 encoding used for `token68`",
-            },
-        ]
+        &[RFC_7617_2, RFC_4648_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/bearer_token_syntax.rs
+++ b/lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct BearerTokenSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6750_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6750",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6750.html#section-2.1",
+    note: "Bearer credentials — `credentials = \"Bearer\" 1*SP b64token`; the Authorization header form and grammar for the Bearer scheme",
+};
+const RFC_9110_11_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2",
+    note: "token68 — the current auth framework's credential-token grammar, defined identically to RFC 6750's b64token; anchors the shape in a live spec (RFC 6750 references the obsolete RFC 2617). Replaces a stale RFC 7235 pointer.",
+};
+
 impl Rule for BearerTokenSyntax {
     fn id(&self) -> &'static str {
         "bearer_token_syntax"
@@ -70,20 +86,7 @@ impl Rule for BearerTokenSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6750",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6750.html#section-2.1",
-                note: "Bearer credentials — `credentials = \"Bearer\" 1*SP b64token`; the Authorization header form and grammar for the Bearer scheme",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2",
-                note: "token68 — the current auth framework's credential-token grammar, defined identically to RFC 6750's b64token; anchors the shape in a live spec (RFC 6750 references the obsolete RFC 2617). Replaces a stale RFC 7235 pointer.",
-            },
-        ]
+        &[RFC_6750_2_1, RFC_9110_11_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cache_coherence.rs
+++ b/lint-http-rules/src/rules/cache_coherence.rs
@@ -18,6 +18,34 @@ use crate::rules::Rule;
 /// secondary key, so URI identity is itself an approximation of the cache key.
 pub struct CacheCoherence;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.4",
+    note: "Serving Stale Responses — the MUST NOT this rule heuristically approximates",
+};
+const RFC_9110_8_8_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2",
+    note: "Last-Modified — the representation's modification time (preferred signal)",
+};
+const RFC_9110_6_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.1",
+    note: "Date — the message's origination time (coarser fallback signal)",
+};
+const RFC_9110_15_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
+    note: "304 Not Modified — conveys no representation, so it is skipped",
+};
+
 impl Rule for CacheCoherence {
     fn id(&self) -> &'static str {
         "cache_coherence"
@@ -129,30 +157,10 @@ impl Rule for CacheCoherence {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.4",
-                note: "Serving Stale Responses — the MUST NOT this rule heuristically approximates",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2",
-                note: "Last-Modified — the representation's modification time (preferred signal)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.1",
-                note: "Date — the message's origination time (coarser fallback signal)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
-                note: "304 Not Modified — conveys no representation, so it is skipped",
-            },
+            RFC_9111_4_2_4,
+            RFC_9110_8_8_2,
+            RFC_9110_6_6_1,
+            RFC_9110_15_4_5,
         ]
     }
 

--- a/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
+++ b/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
@@ -7,6 +7,16 @@ use crate::rules::Rule;
 
 pub struct CacheControlAndPragmaConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.4",
+    note: "`Pragma` and its relationship to `Cache-Control`",
+};
+
 impl Rule for CacheControlAndPragmaConsistent {
     fn id(&self) -> &'static str {
         "cache_control_and_pragma_consistent"
@@ -83,12 +93,7 @@ impl Rule for CacheControlAndPragmaConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("5.4"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.4",
-            note: "`Pragma` and its relationship to `Cache-Control`",
-        }]
+        &[RFC_9111_5_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cache_control_directive_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_directive_valid.rs
@@ -7,6 +7,16 @@ use crate::rules::Rule;
 
 pub struct CacheControlDirectiveValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2",
+    note: "Cache-Control directives and general directive syntax",
+};
+
 impl Rule for CacheControlDirectiveValid {
     fn id(&self) -> &'static str {
         "cache_control_directive_valid"
@@ -83,12 +93,7 @@ impl Rule for CacheControlDirectiveValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("5.2"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2",
-            note: "Cache-Control directives and general directive syntax",
-        }]
+        &[RFC_9111_5_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cache_control_present.rs
+++ b/lint-http-rules/src/rules/cache_control_present.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct CacheControlPresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.2",
+    note: "Calculating Heuristic Freshness — without an explicit expiration time a cache MAY guess one, which is what this rule asks the origin to avoid",
+};
+const RFC_9111_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2",
+    note: "Cache-Control — the header whose absence the rule reports",
+};
+
 impl Rule for CacheControlPresent {
     fn id(&self) -> &'static str {
         "cache_control_present"
@@ -61,20 +77,7 @@ impl Rule for CacheControlPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.2",
-                note: "Calculating Heuristic Freshness — without an explicit expiration time a cache MAY guess one, which is what this rule asks the origin to avoid",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2",
-                note: "Cache-Control — the header whose absence the rule reports",
-            },
-        ]
+        &[RFC_9111_4_2_2, RFC_9111_5_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -7,6 +7,16 @@ use crate::rules::Rule;
 
 pub struct CacheControlTokenValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2",
+    note: "Cache-Control directives and general directive syntax",
+};
+
 impl Rule for CacheControlTokenValid {
     fn id(&self) -> &'static str {
         "cache_control_token_valid"
@@ -83,12 +93,7 @@ impl Rule for CacheControlTokenValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("5.2"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2",
-            note: "Cache-Control directives and general directive syntax",
-        }]
+        &[RFC_9111_5_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/cache_validation_chain.rs
@@ -30,6 +30,28 @@ use crate::rules::Rule;
 /// is covered by the separate `cached_validators_reused` rule.
 pub struct CacheValidationChain;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.1",
+    note: "Sending a Validation Request — a cache builds preconditions from stored validators (entity tags MUST, Last-Modified SHOULD)",
+};
+const RFC_9110_13_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
+    note: "If-None-Match",
+};
+const RFC_9110_13_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
+    note: "If-Modified-Since",
+};
+
 impl Rule for CacheValidationChain {
     fn id(&self) -> &'static str {
         "cache_validation_chain"
@@ -188,26 +210,7 @@ impl Rule for CacheValidationChain {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.1",
-                note: "Sending a Validation Request — a cache builds preconditions from stored validators (entity tags MUST, Last-Modified SHOULD)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
-                note: "If-None-Match",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
-                note: "If-Modified-Since",
-            },
-        ]
+        &[RFC_9111_4_3_1, RFC_9110_13_1_2, RFC_9110_13_1_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cached_validators_reused.rs
+++ b/lint-http-rules/src/rules/cached_validators_reused.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct CachedValidatorsReused;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_13_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
+    note: "If-None-Match — a client SHOULD send it for stored responses that have entity tags when making a GET request",
+};
+const RFC_9110_13_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
+    note: "If-Modified-Since — typically used for efficient cache updates (no client obligation to send; the Last-Modified path here is a heuristic)",
+};
+
 impl Rule for CachedValidatorsReused {
     fn id(&self) -> &'static str {
         "cached_validators_reused"
@@ -95,20 +111,7 @@ impl Rule for CachedValidatorsReused {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
-                note: "If-None-Match — a client SHOULD send it for stored responses that have entity tags when making a GET request",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
-                note: "If-Modified-Since — typically used for efficient cache updates (no client obligation to send; the Last-Modified path here is a heuristic)",
-            },
-        ]
+        &[RFC_9110_13_1_2, RFC_9110_13_1_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/caching_directive_interaction.rs
+++ b/lint-http-rules/src/rules/caching_directive_interaction.rs
@@ -14,6 +14,28 @@ use crate::rules::Rule;
 /// `no-cache` with `max-age=0` is a legal, common combination and is intentionally NOT flagged.
 pub struct CachingDirectiveInteraction;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2",
+    note: "Response directives: public (§5.2.2.9), private (§5.2.2.7), no-store (§5.2.2.5), max-age/s-maxage",
+};
+const RFC_9111_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.1",
+    note: "Conflicting directives are resolved by the most restrictive; multiple values for a directive → first or stale",
+};
+const RFC_9110_5_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
+    note: "List (`#rule`) syntax: a sender MUST NOT generate empty list elements",
+};
+
 impl Rule for CachingDirectiveInteraction {
     fn id(&self) -> &'static str {
         "caching_directive_interaction"
@@ -169,26 +191,7 @@ impl Rule for CachingDirectiveInteraction {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2",
-                note: "Response directives: public (§5.2.2.9), private (§5.2.2.7), no-store (§5.2.2.5), max-age/s-maxage",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.1",
-                note: "Conflicting directives are resolved by the most restrictive; multiple values for a directive → first or stale",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
-                note: "List (`#rule`) syntax: a sender MUST NOT generate empty list elements",
-            },
-        ]
+        &[RFC_9111_5_2_2, RFC_9111_4_2_1, RFC_9110_5_6_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/charset_present.rs
+++ b/lint-http-rules/src/rules/charset_present.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct CharsetPresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "`media-type` and the case-insensitivity of its type/subtype tokens, which decides what counts as `text/*` here",
+};
+const RFC_9110_8_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
+    note: "What `charset` is for. Note it mandates nothing: no requirement to send the parameter exists, so flagging its absence is this linter's policy",
+};
+const MDN_CONTENT_TYPE: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Content-Type",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type",
+    note: "Content-Type",
+};
+
 impl Rule for CharsetPresent {
     fn id(&self) -> &'static str {
         "charset_present"
@@ -105,26 +127,7 @@ impl Rule for CharsetPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "`media-type` and the case-insensitivity of its type/subtype tokens, which decides what counts as `text/*` here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
-                note: "What `charset` is for. Note it mandates nothing: no requirement to send the parameter exists, so flagging its absence is this linter's policy",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Content-Type",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type",
-                note: "Content-Type",
-            },
-        ]
+        &[RFC_9110_8_3_1, RFC_9110_8_3_2, MDN_CONTENT_TYPE]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/charset_registered.rs
+++ b/lint-http-rules/src/rules/charset_registered.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct CharsetRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
+    note: "Charset: what the parameter means, that names are matched case-insensitively, and the \"ought to be registered\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
+};
+const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
+    note: "Parameters: case-insensitive names, and `parameter-value = ( token / quoted-string )` — the fork this rule takes on the value",
+};
+const RFC_2978_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2978",
+    section: Some("2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc2978.html#section-2.3",
+    note: "`mime-charset`, the production a charset name actually follows. It and `token` are incomparable — `{`/`}` on one side, `*`/`.`/`|` on the other — so checking `token` is stricter in one direction and looser in the other, and neither direction changes a verdict",
+};
+const IANA_CHARACTER_SETS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA Character Sets",
+    section: None,
+    url: "https://www.iana.org/assignments/character-sets/character-sets.xhtml",
+    note: "The registry this rule is named after but does not read; the configured `allowed` array stands in for it",
+};
+
 impl Rule for CharsetRegistered {
     fn id(&self) -> &'static str {
         "charset_registered"
@@ -224,30 +252,10 @@ impl Rule for CharsetRegistered {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
-                note: "Charset: what the parameter means, that names are matched case-insensitively, and the \"ought to be registered\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-                note: "Parameters: case-insensitive names, and `parameter-value = ( token / quoted-string )` — the fork this rule takes on the value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2978",
-                section: Some("2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc2978.html#section-2.3",
-                note: "`mime-charset`, the production a charset name actually follows. It and `token` are incomparable — `{`/`}` on one side, `*`/`.`/`|` on the other — so checking `token` is stricter in one direction and looser in the other, and neither direction changes a verdict",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA Character Sets",
-                section: None,
-                url: "https://www.iana.org/assignments/character-sets/character-sets.xhtml",
-                note: "The registry this rule is named after but does not read; the configured `allowed` array stands in for it",
-            },
+            RFC_9110_8_3_2,
+            RFC_9110_5_6_6,
+            RFC_2978_2_3,
+            IANA_CHARACTER_SETS,
         ]
     }
 

--- a/lint-http-rules/src/rules/clear_site_data_present.rs
+++ b/lint-http-rules/src/rules/clear_site_data_present.rs
@@ -73,6 +73,22 @@ paths = ["/logout"]"#
     Ok(ClearSiteDataConfig { paths, severity })
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const CLEAR_SITE_DATA_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Clear-Site-Data",
+    section: Some("3.1"),
+    url: "https://www.w3.org/TR/clear-site-data/#header",
+    note: "The `Clear-Site-Data` HTTP response header field (its purpose; §1.1.1 is the sign-out example this rule encodes)",
+};
+const MDN_CLEAR_SITE_DATA: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Clear-Site-Data",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
+    note: "Clear-Site-Data",
+};
+
 impl Rule for ClearSiteDataPresent {
     fn id(&self) -> &'static str {
         "clear_site_data_present"
@@ -147,20 +163,7 @@ impl Rule for ClearSiteDataPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "Clear-Site-Data",
-                section: Some("3.1"),
-                url: "https://www.w3.org/TR/clear-site-data/#header",
-                note: "The `Clear-Site-Data` HTTP response header field (its purpose; §1.1.1 is the sign-out example this rule encodes)",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Clear-Site-Data",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data",
-                note: "Clear-Site-Data",
-            },
-        ]
+        &[CLEAR_SITE_DATA_3_1, MDN_CLEAR_SITE_DATA]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
+++ b/lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
@@ -7,6 +7,46 @@ use crate::rules::Rule;
 
 pub struct CompressionAndTransferEncodingConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
+    note: "Content-Encoding — a property of the representation, and the MUST that makes it a trustworthy record of what was applied. Also contemplates a coding applied a second time, which is why this rule is advisory",
+};
+const RFC_9110_8_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
+    note: "`content-coding = token` — no parameters, which is why this field's members are split naively",
+};
+const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
+    note: "Transfer-Encoding — a property of the message, not the representation. The mirror of §8.4's sentence, and the whole basis of the distinction this rule watches",
+};
+const RFC_9112_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
+    note: "The compression transfer codings, defined by the same algorithm as the content coding of the same name",
+};
+const RFC_9112_7_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3",
+    note: "Transfer and content coding names may only overlap where the transformation is identical — so a shared name is unambiguous, and coding twice is coherent rather than malformed",
+};
+const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
+    note: "The `transfer-coding` grammar, including the quoted-string a parameter may carry — why that field's split is quote-aware",
+};
+
 impl Rule for CompressionAndTransferEncodingConsistent {
     fn id(&self) -> &'static str {
         "compression_and_transfer_encoding_consistent"
@@ -180,42 +220,12 @@ impl Rule for CompressionAndTransferEncodingConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
-                note: "Content-Encoding — a property of the representation, and the MUST that makes it a trustworthy record of what was applied. Also contemplates a coding applied a second time, which is why this rule is advisory",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
-                note: "`content-coding = token` — no parameters, which is why this field's members are split naively",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
-                note: "Transfer-Encoding — a property of the message, not the representation. The mirror of §8.4's sentence, and the whole basis of the distinction this rule watches",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
-                note: "The compression transfer codings, defined by the same algorithm as the content coding of the same name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3",
-                note: "Transfer and content coding names may only overlap where the transformation is identical — so a shared name is unambiguous, and coding twice is coherent rather than malformed",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
-                note: "The `transfer-coding` grammar, including the quoted-string a parameter may carry — why that field's split is quote-aware",
-            },
+            RFC_9110_8_4,
+            RFC_9110_8_4_1,
+            RFC_9112_6_1,
+            RFC_9112_7_2,
+            RFC_9112_7_3,
+            RFC_9110_10_1_4,
         ]
     }
 

--- a/lint-http-rules/src/rules/conditional_headers_consistent.rs
+++ b/lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -15,6 +15,34 @@ use crate::rules::Rule;
 /// - `If-Modified-Since` is only meaningful for GET/HEAD requests (flag presence on other methods)
 pub struct ConditionalHeadersConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_13_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1",
+    note: "Preconditions",
+};
+const RFC_9110_13_1_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5",
+    note: "If-Range: no If-Range without Range; no weak entity-tag in If-Range",
+};
+const RFC_9110_13_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2",
+    note: "Evaluation of Preconditions (precedence rules)",
+};
+const RFC_9110_14_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
+    note: "Range (the header If-Range depends on)",
+};
+
 impl Rule for ConditionalHeadersConsistent {
     fn id(&self) -> &'static str {
         "conditional_headers_consistent"
@@ -125,32 +153,7 @@ impl Rule for ConditionalHeadersConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1",
-                note: "Preconditions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5",
-                note: "If-Range: no If-Range without Range; no weak entity-tag in If-Range",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2",
-                note: "Evaluation of Preconditions (precedence rules)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
-                note: "Range (the header If-Range depends on)",
-            },
-        ]
+        &[RFC_9110_13_1, RFC_9110_13_1_5, RFC_9110_13_2, RFC_9110_14_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/conditional_request_handling.rs
@@ -14,6 +14,46 @@ use crate::rules::Rule;
 ///   matches the validator SHOULD be `304 Not Modified` rather than a `200`.
 pub struct ConditionalRequestHandling;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_13_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1",
+    note: "Preconditions",
+};
+const RFC_9110_13_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
+    note: "If-None-Match: GET/HEAD with a false condition MUST get 304",
+};
+const RFC_9110_13_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
+    note: "If-Modified-Since: a false condition SHOULD get 304",
+};
+const RFC_9110_13_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2",
+    note: "Evaluation of Preconditions (precedence rules)",
+};
+const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
+    note: "ETag header field",
+};
+const RFC_9110_8_8_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2",
+    note: "Last-Modified header field",
+};
+
 impl Rule for ConditionalRequestHandling {
     fn id(&self) -> &'static str {
         "conditional_request_handling"
@@ -157,42 +197,12 @@ impl Rule for ConditionalRequestHandling {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1",
-                note: "Preconditions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
-                note: "If-None-Match: GET/HEAD with a false condition MUST get 304",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
-                note: "If-Modified-Since: a false condition SHOULD get 304",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2",
-                note: "Evaluation of Preconditions (precedence rules)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-                note: "ETag header field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2",
-                note: "Last-Modified header field",
-            },
+            RFC_9110_13_1,
+            RFC_9110_13_1_2,
+            RFC_9110_13_1_3,
+            RFC_9110_13_2,
+            RFC_9110_8_8_3,
+            RFC_9110_8_8_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/connection_header_tokens_valid.rs
+++ b/lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -114,6 +114,41 @@ impl ConnectionHeaderTokensValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "The field itself: its grammar, the case-insensitivity of its options, the note that an option need not correspond to a field present in the message, and the MUST NOT this rule implements for the one field the section names",
+};
+const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement, which is why the shared list reader is not used here",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note:
+        "`token` and `tchar`: what a connection-option is made of, and the delimiters it excludes",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Several `Connection` lines in one field section are one field value, so the members are counted after the lines are joined",
+};
+
 impl Rule for ConnectionHeaderTokensValid {
     fn id(&self) -> &'static str {
         "connection_header_tokens_valid"
@@ -157,36 +192,11 @@ impl Rule for ConnectionHeaderTokensValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "The field itself: its grammar, the case-insensitivity of its options, the note that an option need not correspond to a field present in the message, and the MUST NOT this rule implements for the one field the section names",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("A"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-                note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement, which is why the shared list reader is not used here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "`token` and `tchar`: what a connection-option is made of, and the delimiters it excludes",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Several `Connection` lines in one field section are one field value, so the members are counted after the lines are joined",
-            },
+            RFC_9110_7_6_1,
+            RFC_9110_A,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/content_disposition_parameter_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_parameter_valid.rs
@@ -9,6 +9,35 @@ use crate::rules::Rule;
 
 pub struct ContentDispositionParameterValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6266_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6266",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4",
+    note:
+        "Use of `Content-Disposition` in HTTP (parameters, `filename`, `filename*`, `size` notes)",
+};
+const RFC_8187_3_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8187",
+    section: Some("3.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8187.html#section-3.2.1",
+    note: "`ext-value` syntax used for `filename*` (obsoletes RFC 5987, which this reference named; the production is unchanged)",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "`token`, which an unquoted parameter value must match (this reference named RFC 2616, long obsolete — the production is alive and well here)",
+};
+const RFC_9110_5_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
+    note: "`quoted-string`, the other permitted parameter-value form",
+};
+
 impl Rule for ContentDispositionParameterValid {
     fn id(&self) -> &'static str {
         "content_disposition_parameter_valid"
@@ -248,32 +277,7 @@ impl Rule for ContentDispositionParameterValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6266",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4",
-                note: "Use of `Content-Disposition` in HTTP (parameters, `filename`, `filename*`, `size` notes)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8187",
-                section: Some("3.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8187.html#section-3.2.1",
-                note: "`ext-value` syntax used for `filename*` (obsoletes RFC 5987, which this reference named; the production is unchanged)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "`token`, which an unquoted parameter value must match (this reference named RFC 2616, long obsolete — the production is alive and well here)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
-                note: "`quoted-string`, the other permitted parameter-value form",
-            },
-        ]
+        &[RFC_6266_4, RFC_8187_3_2_1, RFC_9110_5_6_2, RFC_9110_5_6_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_disposition_token_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_token_valid.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct ContentDispositionTokenValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6266_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6266",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4.1",
+    note: "Grammar: a mandatory `disposition-type` followed by optional `;`-separated parameters, with `disp-ext-type = token`. Whitespace around the separators is implied rather than written",
+};
+const RFC_6266_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6266",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4.2",
+    note: "Disposition Type: an unknown type is conforming and has defined handling (treat as `attachment`), which is why this rule validates the value's shape and not its membership in any list",
+};
+const RFC_6266_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6266",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4",
+    note: "Defines Content-Disposition as a *response* header field — the request half of this rule is a deliberate extension beyond the document, since upload APIs do send one",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "`token = 1*tchar` — where the production actually lives now. RFC 6266 §4.1 imports `token` from the obsolete RFC 2616; the character set is unchanged",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: a sender MUST NOT emit multiple field lines for a field whose definition has no comma-separated-list alternative",
+};
+
 impl Rule for ContentDispositionTokenValid {
     fn id(&self) -> &'static str {
         "content_disposition_token_valid"
@@ -185,36 +219,11 @@ impl Rule for ContentDispositionTokenValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6266",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4.1",
-                note: "Grammar: a mandatory `disposition-type` followed by optional `;`-separated parameters, with `disp-ext-type = token`. Whitespace around the separators is implied rather than written",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6266",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4.2",
-                note: "Disposition Type: an unknown type is conforming and has defined handling (treat as `attachment`), which is why this rule validates the value's shape and not its membership in any list",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6266",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4",
-                note: "Defines Content-Disposition as a *response* header field — the request half of this rule is a deliberate extension beyond the document, since upload APIs do send one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "`token = 1*tchar` — where the production actually lives now. RFC 6266 §4.1 imports `token` from the obsolete RFC 2616; the character set is unchanged",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: a sender MUST NOT emit multiple field lines for a field whose definition has no comma-separated-list alternative",
-            },
+            RFC_6266_4_1,
+            RFC_6266_4_2,
+            RFC_6266_4,
+            RFC_9110_5_6_2,
+            RFC_9110_5_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct ContentEncodingAndTypeConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
+    note: "`Content-Encoding = #content-coding` — the list the member checks walk. Note it does not forbid repeating a coding, so the duplicate check is this rule's judgement",
+};
+const RFC_9110_15_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
+    note: "Why a 304 should not carry Content-Encoding: a sender SHOULD NOT include representation metadata beyond the listed fields. (This reference previously pointed at §8.3, which is Content-Type, not message-body rules.) The 1xx and 204 cases have no such sentence and are inferred",
+};
+
 impl Rule for ContentEncodingAndTypeConsistent {
     fn id(&self) -> &'static str {
         "content_encoding_and_type_consistent"
@@ -144,20 +160,7 @@ impl Rule for ContentEncodingAndTypeConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
-                note: "`Content-Encoding = #content-coding` — the list the member checks walk. Note it does not forbid repeating a coding, so the duplicate check is this rule's judgement",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
-                note: "Why a 304 should not carry Content-Encoding: a sender SHOULD NOT include representation metadata beyond the listed fields. (This reference previously pointed at §8.3, which is Content-Type, not message-body rules.) The 1xx and 204 cases have no such sentence and are inferred",
-            },
-        ]
+        &[RFC_9110_8_4, RFC_9110_15_4_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_encoding_registered.rs
+++ b/lint-http-rules/src/rules/content_encoding_registered.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct ContentEncodingRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
+    note: "`Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here",
+};
+const RFC_9110_8_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
+    note: "`content-coding = token`, case-insensitive, and the \"ought to be registered\" guidance that motivates the rule without being what it checks",
+};
+const RFC_9110_12_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
+    note: "The wider Accept-Encoding grammar (`codings = content-coding / \"identity\" / \"*\"`), which is why the two headers are checked against different vocabularies",
+};
+const IANA_HTTP_PARAMETERS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Parameters",
+    section: None,
+    url: "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding",
+    note: "The registry this rule is named after but does not read; the configured `allowed` array stands in for it",
+};
+
 impl Rule for ContentEncodingRegistered {
     fn id(&self) -> &'static str {
         "content_encoding_registered"
@@ -139,30 +167,10 @@ impl Rule for ContentEncodingRegistered {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4",
-                note: "`Content-Encoding = #content-coding`, and the reservation of `identity` for Accept-Encoding — the reason it is flagged here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4.1",
-                note: "`content-coding = token`, case-insensitive, and the \"ought to be registered\" guidance that motivates the rule without being what it checks",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.3",
-                note: "The wider Accept-Encoding grammar (`codings = content-coding / \"identity\" / \"*\"`), which is why the two headers are checked against different vocabularies",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Parameters",
-                section: None,
-                url: "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding",
-                note: "The registry this rule is named after but does not read; the configured `allowed` array stands in for it",
-            },
+            RFC_9110_8_4,
+            RFC_9110_8_4_1,
+            RFC_9110_12_5_3,
+            IANA_HTTP_PARAMETERS,
         ]
     }
 

--- a/lint-http-rules/src/rules/content_length_valid.rs
+++ b/lint-http-rules/src/rules/content_length_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct ContentLengthValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Where `Content-Length = 1*DIGIT` is defined — the grammar every value here is checked against",
+};
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Why differing values are an error and why a single field line may carry a comma-separated list, provided every member is valid and identical",
+};
+
 impl Rule for ContentLengthValid {
     fn id(&self) -> &'static str {
         "content_length_valid"
@@ -88,20 +104,7 @@ impl Rule for ContentLengthValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-                note: "Where `Content-Length = 1*DIGIT` is defined — the grammar every value here is checked against",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "Why differing values are an error and why a single field line may carry a comma-separated list, provided every member is valid and identical",
-            },
-        ]
+        &[RFC_9110_8_6, RFC_9112_6_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
+++ b/lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct ContentLengthVsTransferEncoding;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
+    note: "The sender-side prohibition this rule enforces: Content-Length MUST NOT be sent in any message that contains Transfer-Encoding",
+};
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "The recipient side and the stakes: Transfer-Encoding overrides, a forwarding intermediary must strip the Content-Length, and such a message may be an attempt at request smuggling or response splitting",
+};
+
 impl Rule for ContentLengthVsTransferEncoding {
     fn id(&self) -> &'static str {
         "content_length_vs_transfer_encoding"
@@ -73,20 +89,7 @@ impl Rule for ContentLengthVsTransferEncoding {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-                note: "The sender-side prohibition this rule enforces: Content-Length MUST NOT be sent in any message that contains Transfer-Encoding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "The recipient side and the stakes: Transfer-Encoding overrides, a forwarding intermediary must strip the Content-Length, and such a message may be an attempt at request smuggling or response splitting",
-            },
-        ]
+        &[RFC_9112_6_2, RFC_9112_6_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
+++ b/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
@@ -7,6 +7,70 @@ use crate::rules::Rule;
 
 pub struct ContentLocationAndUriConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.7",
+    note: "Content-Location: the grammar, and what a value equal to or different from the target URI means. Attaches no requirement to a difference, which is why the mismatch report is an advisory",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: a sender MUST NOT emit multiple field lines for a field with no comma-separated-list alternative",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "Field Values: singleton fields, and the US-ASCII range field values are constrained to",
+};
+const RFC_9110_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1",
+    note: "URI References: a `partial-URI` is the rule for elements that carry a relative URI but no fragment, and an element's ABNF production is what says which forms it allows — the sentence behind reporting a fragment in this field",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender MUST NOT behind the fragment finding: unlike Referer's, this field's section names no component, so a fragment is a protocol element matching no ABNF rule and nothing more",
+};
+const RFC_3986_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3",
+    note: "Absolute URI: the form without a fragment identifier — the other half of the alternation, saying the same thing about its half",
+};
+const RFC_3986_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-5.2",
+    note: "Relative Resolution: the transform, merge and remove_dot_segments routines used to convert a partial-URI to absolute form before comparing it",
+};
+const RFC_3986_6_2_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1",
+    note: "Case Normalization: scheme and host fold case, the remaining components do not, and the hexadecimal of a percent-triplet that stays encoded is folded to upper case",
+};
+const RFC_3986_6_2_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.2",
+    note: "Percent-Encoding Normalization: a triplet standing for an unreserved character is decoded on both sides before comparison, so `/a~b` and `/a%7Eb` are one path. Nothing else is decoded — a delimiter would move the component boundaries (§2.4)",
+};
+const RFC_3986_6_2_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.3",
+    note: "Path Segment Normalization: dot-segments are removed from both sides before comparison, after the decoding above — §2.3 names the period among the octets a normalizer decodes, so `%2E%2E` is a dot segment. §6.2.3's scheme-based normalization is NOT applied, so a default port written out and one left off read as different authorities",
+};
+
 impl Rule for ContentLocationAndUriConsistent {
     fn id(&self) -> &'static str {
         "content_location_and_uri_consistent"
@@ -273,66 +337,16 @@ impl Rule for ContentLocationAndUriConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.7",
-                note: "Content-Location: the grammar, and what a value equal to or different from the target URI means. Attaches no requirement to a difference, which is why the mismatch report is an advisory",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: a sender MUST NOT emit multiple field lines for a field with no comma-separated-list alternative",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "Field Values: singleton fields, and the US-ASCII range field values are constrained to",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1",
-                note: "URI References: a `partial-URI` is the rule for elements that carry a relative URI but no fragment, and an element's ABNF production is what says which forms it allows — the sentence behind reporting a fragment in this field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sender MUST NOT behind the fragment finding: unlike Referer's, this field's section names no component, so a fragment is a protocol element matching no ABNF rule and nothing more",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3",
-                note: "Absolute URI: the form without a fragment identifier — the other half of the alternation, saying the same thing about its half",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-5.2",
-                note: "Relative Resolution: the transform, merge and remove_dot_segments routines used to convert a partial-URI to absolute form before comparing it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1",
-                note: "Case Normalization: scheme and host fold case, the remaining components do not, and the hexadecimal of a percent-triplet that stays encoded is folded to upper case",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.2",
-                note: "Percent-Encoding Normalization: a triplet standing for an unreserved character is decoded on both sides before comparison, so `/a~b` and `/a%7Eb` are one path. Nothing else is decoded — a delimiter would move the component boundaries (§2.4)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.3",
-                note: "Path Segment Normalization: dot-segments are removed from both sides before comparison, after the decoding above — §2.3 names the period among the octets a normalizer decodes, so `%2E%2E` is a dot segment. §6.2.3's scheme-based normalization is NOT applied, so a default port written out and one left off read as different authorities",
-            },
+            RFC_9110_8_7,
+            RFC_9110_5_3,
+            RFC_9110_5_5,
+            RFC_9110_4_1,
+            RFC_9110_2_2,
+            RFC_3986_4_3,
+            RFC_3986_5_2,
+            RFC_3986_6_2_2_1,
+            RFC_3986_6_2_2_2,
+            RFC_3986_6_2_2_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
+++ b/lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct ContentMd5VsDigestPreference;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9530_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9530",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-2",
+    note: "`Content-Digest`, the field to keep — defined for both requests and responses, which is why both are checked. Note it does not mention `Content-MD5`, so it is not what retired it",
+};
+const RFC_7231_APPENDIX_B: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7231",
+    section: Some("Appendix B"),
+    url: "https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B",
+    note: "Where `Content-MD5` was removed from HTTP, and the reason: inconsistent implementation with respect to partial responses",
+};
+const RFC_2616_14_15: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2616",
+    section: Some("14.15"),
+    url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-14.15",
+    note: "`Content-MD5`, where it was defined — and from where RFC 7231 removed it. This reference said RFC 7231 §3.3.2, a section that does not exist in RFC 7231",
+};
+
 impl Rule for ContentMd5VsDigestPreference {
     fn id(&self) -> &'static str {
         "content_md5_vs_digest_preference"
@@ -78,26 +100,7 @@ impl Rule for ContentMd5VsDigestPreference {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9530",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-2",
-                note: "`Content-Digest`, the field to keep — defined for both requests and responses, which is why both are checked. Note it does not mention `Content-MD5`, so it is not what retired it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7231",
-                section: Some("Appendix B"),
-                url: "https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B",
-                note: "Where `Content-MD5` was removed from HTTP, and the reason: inconsistent implementation with respect to partial responses",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2616",
-                section: Some("14.15"),
-                url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-14.15",
-                note: "`Content-MD5`, where it was defined — and from where RFC 7231 removed it. This reference said RFC 7231 §3.3.2, a section that does not exist in RFC 7231",
-            },
-        ]
+        &[RFC_9530_2, RFC_7231_APPENDIX_B, RFC_2616_14_15]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
+++ b/lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
@@ -7,6 +7,29 @@ use crate::rules::Rule;
 
 pub struct ContentSecurityPolicyAndFrameOptionsConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const CSP3_6_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "CSP3",
+    section: Some("6.4.2"),
+    url: "https://www.w3.org/TR/CSP3/#directive-frame-ancestors",
+    note: "`frame-ancestors` directive. Note: when present and enforceable, `frame-ancestors` overrides `X-Frame-Options` (see §6.4.2.2)",
+};
+const HTML_SPECULATIVE_LOADING: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Speculative Loading",
+    section: None,
+    url:
+        "https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header",
+    note: "HTML Living Standard — `X-Frame-Options` header and its relation to `frame-ancestors`",
+};
+const MDN_X_FRAME_OPTIONS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN X-Frame-Options",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options",
+    note: "`X-Frame-Options` — legacy header with values `DENY`, `SAMEORIGIN`, and the obsolete `ALLOW-FROM`. Note: `ALLOW-FROM` is deprecated and not supported by most modern browsers — prefer using CSP's `frame-ancestors` for origin-specific framing policies",
+};
+
 impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
     fn id(&self) -> &'static str {
         "content_security_policy_and_frame_options_consistent"
@@ -205,26 +228,7 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "CSP3",
-                section: Some("6.4.2"),
-                url: "https://www.w3.org/TR/CSP3/#directive-frame-ancestors",
-                note: "`frame-ancestors` directive. Note: when present and enforceable, `frame-ancestors` overrides `X-Frame-Options` (see §6.4.2.2)",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Speculative Loading",
-                section: None,
-                url: "https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header",
-                note: "HTML Living Standard — `X-Frame-Options` header and its relation to `frame-ancestors`",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN X-Frame-Options",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options",
-                note: "`X-Frame-Options` — legacy header with values `DENY`, `SAMEORIGIN`, and the obsolete `ALLOW-FROM`. Note: `ALLOW-FROM` is deprecated and not supported by most modern browsers — prefer using CSP's `frame-ancestors` for origin-specific framing policies",
-            },
-        ]
+        &[CSP3_6_4_2, HTML_SPECULATIVE_LOADING, MDN_X_FRAME_OPTIONS]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_security_policy_valid.rs
+++ b/lint-http-rules/src/rules/content_security_policy_valid.rs
@@ -13,6 +13,22 @@ use crate::rules::Rule;
 /// full CSP grammar; it aims to catch obvious syntactic problems and misuses.
 pub struct ContentSecurityPolicyValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const CSP3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "CSP3",
+    section: None,
+    url: "https://www.w3.org/TR/CSP3/",
+    note: "W3C Content Security Policy Level 3 — directive and source-list syntax",
+};
+const MDN_CONTENT_SECURITY_POLICY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Content-Security-Policy",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy",
+    note: "Mozilla MDN overview and directive examples",
+};
+
 impl Rule for ContentSecurityPolicyValid {
     fn id(&self) -> &'static str {
         "content_security_policy_valid"
@@ -197,20 +213,7 @@ impl Rule for ContentSecurityPolicyValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "CSP3",
-                section: None,
-                url: "https://www.w3.org/TR/CSP3/",
-                note: "W3C Content Security Policy Level 3 — directive and source-list syntax",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Content-Security-Policy",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy",
-                note: "Mozilla MDN overview and directive examples",
-            },
-        ]
+        &[CSP3, MDN_CONTENT_SECURITY_POLICY]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
+++ b/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct ContentTransferEncodingValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_B_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("B.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#appendix-B.5",
+    note: "Why the field is reported at all: HTTP does not use Content-Transfer-Encoding, and gateways from MIME-compliant protocols must remove it",
+};
+const RFC_2045_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2045",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2045.html#section-6.1",
+    note: "The MIME `mechanism` grammar the value is described against — five named encodings plus `ietf-token` / `x-token`, all case-insensitive",
+};
+const RFC_2045_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2045",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc2045.html#section-6.3",
+    note: "Private mechanisms must be spelled with an `X-` prefix, which is why an `x-` value is well-formed MIME rather than an unrecognized one",
+};
+
 impl Rule for ContentTransferEncodingValid {
     fn id(&self) -> &'static str {
         "content_transfer_encoding_valid"
@@ -113,26 +135,7 @@ impl Rule for ContentTransferEncodingValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("B.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#appendix-B.5",
-                note: "Why the field is reported at all: HTTP does not use Content-Transfer-Encoding, and gateways from MIME-compliant protocols must remove it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2045",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2045.html#section-6.1",
-                note: "The MIME `mechanism` grammar the value is described against — five named encodings plus `ietf-token` / `x-token`, all case-insensitive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2045",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc2045.html#section-6.3",
-                note: "Private mechanisms must be spelled with an `X-` prefix, which is why an `x-` value is well-formed MIME rather than an unrecognized one",
-            },
-        ]
+        &[RFC_9112_B_5, RFC_2045_6_1, RFC_2045_6_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_type_present.rs
+++ b/lint-http-rules/src/rules/content_type_present.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct ContentTypePresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "Content-Type — the SHOULD, the exception that excuses a sender who does not know the type, the recipient's two fallbacks, and what sniffing costs",
+};
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Message body length — item 1 for the statuses and HEAD responses that carry no content, item 2 for CONNECT tunnels, item 8 for why a missing Content-Length is not evidence of a body",
+};
+const RFC_9110_15_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.6",
+    note: "205 Reset Content — bodiless by its own MUST NOT, and absent from §6.3's list",
+};
+const RFC_9110_9_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
+    note: "HEAD — no content is sent, so this rule's condition is never met; the same-header-fields SHOULD is another rule's subject",
+};
+
 impl Rule for ContentTypePresent {
     fn id(&self) -> &'static str {
         "content_type_present"
@@ -130,32 +158,7 @@ impl Rule for ContentTypePresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "Content-Type — the SHOULD, the exception that excuses a sender who does not know the type, the recipient's two fallbacks, and what sniffing costs",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "Message body length — item 1 for the statuses and HEAD responses that carry no content, item 2 for CONNECT tunnels, item 8 for why a missing Content-Length is not evidence of a body",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.6",
-                note: "205 Reset Content — bodiless by its own MUST NOT, and absent from §6.3's list",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
-                note: "HEAD — no content is sent, so this rule's condition is never met; the same-header-fields SHOULD is another rule's subject",
-            },
-        ]
+        &[RFC_9110_8_3, RFC_9112_6_3, RFC_9110_15_3_6, RFC_9110_9_3_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_type_registered.rs
+++ b/lint-http-rules/src/rules/content_type_registered.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct ContentTypeRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "`media-type` syntax, the case-insensitivity of its tokens, and the \"ought to be registered with IANA\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
+};
+const RFC_6838_4_2_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6838",
+    section: Some("4.2.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8",
+    note: "Structured syntax suffixes — a suffix is appended to a base subtype after a `+`, which is what a `+json` allowlist entry matches",
+};
+const IANA_MEDIA_TYPES: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA Media Types",
+    section: None,
+    url: "https://www.iana.org/assignments/media-types/media-types.xhtml",
+    note: "The registry this rule is named after but does not read; the configured `allowed` array stands in for it",
+};
+
 impl Rule for ContentTypeRegistered {
     fn id(&self) -> &'static str {
         "content_type_registered"
@@ -141,26 +163,7 @@ impl Rule for ContentTypeRegistered {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "`media-type` syntax, the case-insensitivity of its tokens, and the \"ought to be registered with IANA\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6838",
-                section: Some("4.2.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8",
-                note: "Structured syntax suffixes — a suffix is appended to a base subtype after a `+`, which is what a `+json` allowlist entry matches",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA Media Types",
-                section: None,
-                url: "https://www.iana.org/assignments/media-types/media-types.xhtml",
-                note: "The registry this rule is named after but does not read; the configured `allowed` array stands in for it",
-            },
-        ]
+        &[RFC_9110_8_3_1, RFC_6838_4_2_8, IANA_MEDIA_TYPES]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/content_type_valid.rs
+++ b/lint-http-rules/src/rules/content_type_valid.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct ContentTypeValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "Content-Type: `Content-Type = media-type`, and the paragraph naming duplicated field lines as an error whose recipient handling differs between implementations",
+};
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "Media Type: `media-type = type \"/\" subtype parameters`, both halves `token`, both case-insensitive",
+};
+const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
+    note: "Parameters: the `name=value` grammar, and the bracketing that makes a trailing `;` conforming. Its prohibition on whitespace around `=` is NOT enforced here",
+};
+const RFC_9110_12_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
+    note: "Accept: where `*` belongs — `media-range`, which names a set of media types. Cited to explain why a wildcard is reported in Content-Type, which carries a `media-type`",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: a sender MUST NOT emit multiple field lines for a field with no comma-separated-list alternative",
+};
+
 impl Rule for ContentTypeValid {
     fn id(&self) -> &'static str {
         "content_type_valid"
@@ -115,36 +149,11 @@ impl Rule for ContentTypeValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "Content-Type: `Content-Type = media-type`, and the paragraph naming duplicated field lines as an error whose recipient handling differs between implementations",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "Media Type: `media-type = type \"/\" subtype parameters`, both halves `token`, both case-insensitive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-                note: "Parameters: the `name=value` grammar, and the bracketing that makes a trailing `;` conforming. Its prohibition on whitespace around `=` is NOT enforced here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1",
-                note: "Accept: where `*` belongs — `media-range`, which names a set of media types. Cited to explain why a wildcard is reported in Content-Type, which carries a `media-type`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: a sender MUST NOT emit multiple field lines for a field with no comma-separated-list alternative",
-            },
+            RFC_9110_8_3,
+            RFC_9110_8_3_1,
+            RFC_9110_5_6_6,
+            RFC_9110_12_5_1,
+            RFC_9110_5_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/context_fields_direction.rs
+++ b/lint-http-rules/src/rules/context_fields_direction.rs
@@ -66,6 +66,26 @@ const RESPONSE_CONTEXT_FIELDS: &[(&str, &str)] = &[
     ),
 ];
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
+    note: "Request Context Fields — the five fields whose subjects are the user, \
+           user agent and resource behind a request; the section split this rule \
+           reads the direction from",
+};
+const RFC_9110_10_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2",
+    note: "Response Context Fields — the four whose subjects are the server, the \
+           target resource and related resources. No sentence in either section \
+           forbids the misdirection, which is why the finding is advice",
+};
+
 impl Rule for ContextFieldsDirection {
     fn id(&self) -> &'static str {
         "context_fields_direction"
@@ -152,24 +172,7 @@ impl Rule for ContextFieldsDirection {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
-                note: "Request Context Fields — the five fields whose subjects are the user, \
-                       user agent and resource behind a request; the section split this rule \
-                       reads the direction from",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2",
-                note: "Response Context Fields — the four whose subjects are the server, the \
-                       target resource and related resources. No sentence in either section \
-                       forbids the misdirection, which is why the finding is advice",
-            },
-        ]
+        &[RFC_9110_10_1, RFC_9110_10_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -7,6 +7,41 @@ use crate::rules::Rule;
 
 pub struct CookieAttributeConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6265_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("4.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
+    note:
+        "Set-Cookie syntax — the cookie-name/`Secure`/`HttpOnly`/`Expires` grammar this rule checks",
+};
+const RFC_6265_5_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2",
+    note: "The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder",
+};
+const DRAFT_IETF_HTTPBIS_RFC6265BIS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "draft-ietf-httpbis-rfc6265bis",
+    section: None,
+    url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
+    note: "`SameSite` value grammar and the `SameSite=None` requires `Secure` rule. No section: a draft renumbers between revisions",
+};
+const MDN_SET_COOKIE: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Set-Cookie",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie",
+    note: "SameSite cookies (SameSite=None should be Secure) — browser compatibility guidance on `SameSite` usage",
+};
+const RFC_9110_5_6_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
+    note: "HTTP-date (IMF-fixdate) — used for the `Expires` attribute",
+};
+
 impl Rule for CookieAttributeConsistent {
     fn id(&self) -> &'static str {
         "cookie_attribute_consistent"
@@ -265,36 +300,11 @@ impl Rule for CookieAttributeConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("4.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
-                note: "Set-Cookie syntax — the cookie-name/`Secure`/`HttpOnly`/`Expires` grammar this rule checks",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2",
-                note: "The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder",
-            },
-            crate::rules::SpecRef {
-                spec: "draft-ietf-httpbis-rfc6265bis",
-                section: None,
-                url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
-                note: "`SameSite` value grammar and the `SameSite=None` requires `Secure` rule. No section: a draft renumbers between revisions",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Set-Cookie",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie",
-                note: "SameSite cookies (SameSite=None should be Secure) — browser compatibility guidance on `SameSite` usage",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
-                note: "HTTP-date (IMF-fixdate) — used for the `Expires` attribute",
-            },
+            RFC_6265_4_1_1,
+            RFC_6265_5_2_2,
+            DRAFT_IETF_HTTPBIS_RFC6265BIS,
+            MDN_SET_COOKIE,
+            RFC_9110_5_6_7,
         ]
     }
 

--- a/lint-http-rules/src/rules/cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/cookie_domain_matching.rs
@@ -20,6 +20,28 @@ use crate::rules::Rule;
 /// misses.
 pub struct CookieDomainMatching;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6265_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.4",
+    note: "The Cookie header (which cookies are sent)",
+};
+const RFC_6265_5_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3",
+    note: "Domain matching",
+};
+const RFC_6265_5_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4",
+    note: "Path matching",
+};
+
 impl Rule for CookieDomainMatching {
     fn id(&self) -> &'static str {
         "cookie_domain_matching"
@@ -135,26 +157,7 @@ impl Rule for CookieDomainMatching {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.4",
-                note: "The Cookie header (which cookies are sent)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3",
-                note: "Domain matching",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4",
-                note: "Path matching",
-            },
-        ]
+        &[RFC_6265_5_4, RFC_6265_5_1_3, RFC_6265_5_1_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct CookieDomainValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6265_5_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3",
+    note: "`Domain` attribute processing — an empty value is undefined (UA ignores it) and a leading dot is stripped; the domain-value *format* is §4.1.1 / RFC 1035",
+};
+const RFC_1035: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 1035",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc1035.html",
+    note: "Domain name label rules (length, allowed characters)",
+};
+
 impl Rule for CookieDomainValid {
     fn id(&self) -> &'static str {
         "cookie_domain_valid"
@@ -88,20 +104,7 @@ impl Rule for CookieDomainValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3",
-                note: "`Domain` attribute processing — an empty value is undefined (UA ignores it) and a leading dot is stripped; the domain-value *format* is §4.1.1 / RFC 1035",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 1035",
-                section: None,
-                url: "https://www.rfc-editor.org/rfc/rfc1035.html",
-                note: "Domain name label rules (length, allowed characters)",
-            },
-        ]
+        &[RFC_6265_5_2_3, RFC_1035]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/cookie_lifecycle.rs
@@ -14,6 +14,28 @@ use crate::rules::Rule;
 /// the `Cookie` header on outgoing requests.
 pub struct CookieLifecycle;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6265_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.3",
+    note: "Storage model",
+};
+const RFC_6265_5_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3",
+    note: "Domain matching",
+};
+const RFC_6265_5_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4",
+    note: "Path matching",
+};
+
 impl Rule for CookieLifecycle {
     fn id(&self) -> &'static str {
         "cookie_lifecycle"
@@ -211,26 +233,7 @@ impl Rule for CookieLifecycle {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.3",
-                note: "Storage model",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3",
-                note: "Domain matching",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4",
-                note: "Path matching",
-            },
-        ]
+        &[RFC_6265_5_3, RFC_6265_5_1_3, RFC_6265_5_1_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct CookiePathValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6265_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("4.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
+    note: "Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`",
+};
+const RFC_6265_5_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4",
+    note: "Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)",
+};
+const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
+    note: "Whitespace — rationale for being conservative about whitespace in header fields; this rule adopts a stricter profile by disallowing unencoded whitespace in cookie paths",
+};
+
 impl Rule for CookiePathValid {
     fn id(&self) -> &'static str {
         "cookie_path_valid"
@@ -85,26 +107,7 @@ impl Rule for CookiePathValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("4.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
-                note: "Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("5.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4",
-                note: "Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-                note: "Whitespace — rationale for being conservative about whitespace in header fields; this rule adopts a stricter profile by disallowing unencoded whitespace in cookie paths",
-            },
-        ]
+        &[RFC_6265_4_1_1, RFC_6265_5_2_4, RFC_9110_5_6_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cookie_same_site_enforced.rs
+++ b/lint-http-rules/src/rules/cookie_same_site_enforced.rs
@@ -16,6 +16,22 @@ use crate::rules::Rule;
 /// check is skipped to avoid spurious warnings.
 pub struct CookieSameSiteEnforced;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const DRAFT_IETF_HTTPBIS_RFC6265BIS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "draft-ietf-httpbis-rfc6265bis",
+    section: None,
+    url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
+    note: "`SameSite` cookie semantics. No section: a draft renumbers between revisions — this one cited §5.3.4, where `SameSite` has not lived for some time",
+};
+const FETCH: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: None,
+    url: "https://fetch.spec.whatwg.org/#sec-fetch-site",
+    note: "Fetch `Sec-Fetch-Site` (cross-site detection) and `Sec-Fetch-Mode` (the `navigate` mode gating the Lax carve-out)",
+};
+
 impl Rule for CookieSameSiteEnforced {
     fn id(&self) -> &'static str {
         "cookie_same_site_enforced"
@@ -173,20 +189,7 @@ impl Rule for CookieSameSiteEnforced {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "draft-ietf-httpbis-rfc6265bis",
-                section: None,
-                url: "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis",
-                note: "`SameSite` cookie semantics. No section: a draft renumbers between revisions — this one cited §5.3.4, where `SameSite` has not lived for some time",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: None,
-                url: "https://fetch.spec.whatwg.org/#sec-fetch-site",
-                note: "Fetch `Sec-Fetch-Site` (cross-site detection) and `Sec-Fetch-Mode` (the `navigate` mode gating the Lax carve-out)",
-            },
-        ]
+        &[DRAFT_IETF_HTTPBIS_RFC6265BIS, FETCH]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct CrossOriginEmbedderPolicyValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const MDN_CROSS_ORIGIN_EMBEDDER_POLICY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Cross-Origin-Embedder-Policy",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy",
+    note: "Cross-Origin-Embedder-Policy",
+};
+const HTML_7_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML",
+    section: Some("7.1.4"),
+    url: "https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-embedder-policy",
+    note: "The `Cross-Origin-Embedder-Policy` header — its value is one of the three embedder policy strings `unsafe-none`, `require-corp`, `credentialless`",
+};
+
 impl Rule for CrossOriginEmbedderPolicyValid {
     fn id(&self) -> &'static str {
         "cross_origin_embedder_policy_valid"
@@ -94,20 +110,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "MDN Cross-Origin-Embedder-Policy",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Embedder-Policy",
-                note: "Cross-Origin-Embedder-Policy",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML",
-                section: Some("7.1.4"),
-                url: "https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-embedder-policy",
-                note: "The `Cross-Origin-Embedder-Policy` header — its value is one of the three embedder policy strings `unsafe-none`, `require-corp`, `credentialless`",
-            },
-        ]
+        &[MDN_CROSS_ORIGIN_EMBEDDER_POLICY, HTML_7_1_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct CrossOriginOpenerPolicyValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const MDN_CROSS_ORIGIN_OPENER_POLICY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Cross-Origin-Opener-Policy",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy",
+    note: "Cross-Origin-Opener-Policy",
+};
+const HTML_7_1_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML",
+    section: Some("7.1.3.1"),
+    url: "https://html.spec.whatwg.org/multipage/browsers.html#the-coop-headers",
+    note: "The `Cross-Origin-Opener-Policy` header is parsed as a single structured-field item (token); `same-origin-plus-COEP` is derived from `same-origin` + a compatible COEP, never set directly",
+};
+const HTML: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML",
+    section: None,
+    url: "https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-opener-policies",
+    note: "“Cross-origin opener policies” — the possible opener policy values and their meanings",
+};
+
 impl Rule for CrossOriginOpenerPolicyValid {
     fn id(&self) -> &'static str {
         "cross_origin_opener_policy_valid"
@@ -98,26 +120,7 @@ impl Rule for CrossOriginOpenerPolicyValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "MDN Cross-Origin-Opener-Policy",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Opener-Policy",
-                note: "Cross-Origin-Opener-Policy",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML",
-                section: Some("7.1.3.1"),
-                url: "https://html.spec.whatwg.org/multipage/browsers.html#the-coop-headers",
-                note: "The `Cross-Origin-Opener-Policy` header is parsed as a single structured-field item (token); `same-origin-plus-COEP` is derived from `same-origin` + a compatible COEP, never set directly",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML",
-                section: None,
-                url: "https://html.spec.whatwg.org/multipage/browsers.html#cross-origin-opener-policies",
-                note: "“Cross-origin opener policies” — the possible opener policy values and their meanings",
-            },
-        ]
+        &[MDN_CROSS_ORIGIN_OPENER_POLICY, HTML_7_1_3_1, HTML]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct CrossOriginResourcePolicyValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const FETCH_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("3.7"),
+    url: "https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header",
+    note: "`Cross-Origin-Resource-Policy` — the case-sensitive `same-origin`/`same-site`/`cross-origin` grammar, and unrecognized values set to null",
+};
+const MDN_CROSS_ORIGIN_RESOURCE_POLICY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Cross-Origin-Resource-Policy",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Resource-Policy",
+    note: "Cross-Origin-Resource-Policy",
+};
+
 impl Rule for CrossOriginResourcePolicyValid {
     fn id(&self) -> &'static str {
         "cross_origin_resource_policy_valid"
@@ -96,20 +112,7 @@ impl Rule for CrossOriginResourcePolicyValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("3.7"),
-                url: "https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header",
-                note: "`Cross-Origin-Resource-Policy` — the case-sensitive `same-origin`/`same-site`/`cross-origin` grammar, and unrecognized values set to null",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Cross-Origin-Resource-Policy",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cross-Origin-Resource-Policy",
-                note: "Cross-Origin-Resource-Policy",
-            },
-        ]
+        &[FETCH_3_7, MDN_CROSS_ORIGIN_RESOURCE_POLICY]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -8,6 +8,34 @@ use crate::rules::Rule;
 /// Validate Date, Last-Modified, If-Modified-Since and Sunset header consistency and formats.
 pub struct DateAndTimeHeadersConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_6_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.1",
+    note: "`Date` header (parsed as HTTP-date for comparison)",
+};
+const RFC_9110_8_8_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2",
+    note: "`Last-Modified` header",
+};
+const RFC_9110_13_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
+    note: "`If-Modified-Since` (conditional requests)",
+};
+const RFC_8594_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8594",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8594.html#section-3",
+    note: "`Sunset` header semantics",
+};
+
 impl Rule for DateAndTimeHeadersConsistent {
     fn id(&self) -> &'static str {
         "date_and_time_headers_consistent"
@@ -205,32 +233,7 @@ impl Rule for DateAndTimeHeadersConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.1",
-                note: "`Date` header (parsed as HTTP-date for comparison)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2",
-                note: "`Last-Modified` header",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
-                note: "`If-Modified-Since` (conditional requests)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8594",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8594.html#section-3",
-                note: "`Sunset` header semantics",
-            },
-        ]
+        &[RFC_9110_6_6_1, RFC_9110_8_8_2, RFC_9110_13_1_3, RFC_8594_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/deprecation_header_syntax.rs
+++ b/lint-http-rules/src/rules/deprecation_header_syntax.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct DeprecationHeaderSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9745_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9745",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9745.html#section-2.1",
+    note: "Syntax: `Deprecation` is an Item Structured Header Field whose value MUST be a `Date`",
+};
+const RFC_9651_3_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("3.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7",
+    note: "Structured Field `Date` item syntax (leading `@`)",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: an Item field (non-list) must not appear as multiple field lines",
+};
+
 impl Rule for DeprecationHeaderSyntax {
     fn id(&self) -> &'static str {
         "deprecation_header_syntax"
@@ -89,26 +111,7 @@ impl Rule for DeprecationHeaderSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9745",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9745.html#section-2.1",
-                note: "Syntax: `Deprecation` is an Item Structured Header Field whose value MUST be a `Date`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("3.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7",
-                note: "Structured Field `Date` item syntax (leading `@`)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: an Item field (non-list) must not appear as multiple field lines",
-            },
-        ]
+        &[RFC_9745_2_1, RFC_9651_3_3_7, RFC_9110_5_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
@@ -116,6 +116,23 @@ fn highest_nc_for_nonce(
 
 pub struct DigestAuthNonceHandling;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7616_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7616",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7616.html#section-3.3",
+    note:
+        "The WWW-Authenticate Response Header Field — the server challenge (nonce, opaque, stale)",
+};
+const RFC_7616_3_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7616",
+    section: Some("3.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7616.html#section-3.4",
+    note: "The Authorization Header Field — the client response parameters (nonce, nc, opaque)",
+};
+
 impl Rule for DigestAuthNonceHandling {
     fn id(&self) -> &'static str {
         "digest_auth_nonce_handling"
@@ -268,20 +285,7 @@ impl Rule for DigestAuthNonceHandling {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 7616",
-                section: Some("3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7616.html#section-3.3",
-                note: "The WWW-Authenticate Response Header Field — the server challenge (nonce, opaque, stale)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7616",
-                section: Some("3.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7616.html#section-3.4",
-                note: "The Authorization Header Field — the client response parameters (nonce, nc, opaque)",
-            },
-        ]
+        &[RFC_7616_3_3, RFC_7616_3_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/digest_auth_valid.rs
+++ b/lint-http-rules/src/rules/digest_auth_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct DigestAuthValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7616_3_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7616",
+    section: Some("3.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7616.html#section-3.4",
+    note: "The Authorization Header Field — the Digest credentials, their parameters, the 4xx consequence for missing or improper ones, the \"MUST be used by all implementations\" on cnonce and nc, and the two historical-reasons quoting MUSTs enforced here in both directions",
+};
+const RFC_2617_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2617",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc2617.html#section-3.2.2",
+    note: "The obsolete document whose qop-less credential shape is why cnonce and nc are demanded only beside a qop: its own conditional (\"MUST be specified if a qop directive is sent\") is the observable line, and deployed servers still verify the older shape",
+};
+
 impl Rule for DigestAuthValid {
     fn id(&self) -> &'static str {
         "digest_auth_valid"
@@ -208,20 +224,7 @@ impl Rule for DigestAuthValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 7616",
-                section: Some("3.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7616.html#section-3.4",
-                note: "The Authorization Header Field — the Digest credentials, their parameters, the 4xx consequence for missing or improper ones, the \"MUST be used by all implementations\" on cnonce and nc, and the two historical-reasons quoting MUSTs enforced here in both directions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2617",
-                section: Some("3.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc2617.html#section-3.2.2",
-                note: "The obsolete document whose qop-less credential shape is why cnonce and nc are demanded only beside a qop: its own conditional (\"MUST be specified if a qop directive is sent\") is the observable line, and deployed servers still verify the older shape",
-            },
-        ]
+        &[RFC_7616_3_4, RFC_2617_3_2_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -8,6 +8,41 @@ use base64::Engine;
 
 pub struct DigestHeaderSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9530_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9530",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-2",
+    note:
+        "`Content-Digest`: a Dictionary keyed by hashing algorithm whose values are Byte Sequences",
+};
+const RFC_9530_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9530",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-3",
+    note: "`Repr-Digest`: the same syntax over representation data rather than message content",
+};
+const RFC_9530_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9530",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-4",
+    note: "`Want-Content-Digest` / `Want-Repr-Digest`: a Dictionary whose values are Integers in the range 0 to 10 inclusive",
+};
+const RFC_3230_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3230",
+    section: Some("4.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3230.html#section-4.1.1",
+    note: "Historical `Digest` / `Want-Digest`, obsoleted by RFC 9530: `digest-algorithm = token`, case-insensitive — which is why uppercase is valid there and not in the structured fields",
+};
+const RFC_7231_APPENDIX_B: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7231",
+    section: Some("Appendix B"),
+    url: "https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B",
+    note: "Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all",
+};
+
 impl Rule for DigestHeaderSyntax {
     fn id(&self) -> &'static str {
         "digest_header_syntax"
@@ -512,36 +547,11 @@ impl Rule for DigestHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9530",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-2",
-                note: "`Content-Digest`: a Dictionary keyed by hashing algorithm whose values are Byte Sequences",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9530",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-3",
-                note: "`Repr-Digest`: the same syntax over representation data rather than message content",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9530",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9530.html#section-4",
-                note: "`Want-Content-Digest` / `Want-Repr-Digest`: a Dictionary whose values are Integers in the range 0 to 10 inclusive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3230",
-                section: Some("4.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3230.html#section-4.1.1",
-                note: "Historical `Digest` / `Want-Digest`, obsoleted by RFC 9530: `digest-algorithm = token`, case-insensitive — which is why uppercase is valid there and not in the structured fields",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7231",
-                section: Some("Appendix B"),
-                url: "https://www.rfc-editor.org/rfc/rfc7231.html#appendix-B",
-                note: "Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all",
-            },
+            RFC_9530_2,
+            RFC_9530_3,
+            RFC_9530_4,
+            RFC_3230_4_1_1,
+            RFC_7231_APPENDIX_B,
         ]
     }
 

--- a/lint-http-rules/src/rules/early_data_header_safe_method.rs
+++ b/lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -109,6 +109,46 @@ impl EarlyDataHeaderSafeMethod {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_8470_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8470",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc8470.html#section-4",
+    note: "Using Early Data in HTTP Clients — the MUST NOT that licenses this rule, and it covers two sets: unsafe methods, and methods whose safety is not known. It opens \"Absent other information\", an out-of-band state no message records",
+};
+const RFC_8470_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8470",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8470.html#section-5.1",
+    note: "The Early-Data Header Field — one valid value, at most one instance, invalid or repeated instances read as a single \"1\", added by an intermediary rather than by the user agent, and forbidden in a Connection field, in a response, and in a request's trailer section",
+};
+const RFC_8470_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8470",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8470.html#section-5.2",
+    note: "The 425 (Too Early) Status Code — what a server sends instead of processing a marked request it judges too risky. Nothing here reads it: whether a given resource tolerates replay is knowledge only the origin has",
+};
+const RFC_9110_9_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.1",
+    note: "Safe Methods — the property RFC 8470 §4 names. GET, HEAD, OPTIONS and TRACE are the safe methods this document defines, which is a smaller set than the safe methods there are",
+};
+const RFC_9110_16_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.1.1",
+    note: "Method Registry — every registration MUST carry a Safe field, and entries are added by IETF Review. This is why the safe set is configured rather than compiled in",
+};
+const IANA_HTTP_METHOD_REGISTRY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Method Registry",
+    section: None,
+    url: "https://www.iana.org/assignments/http-methods/http-methods.xhtml",
+    note: "The registry itself. Its Safe column held GET, HEAD, OPTIONS, PRI, PROPFIND, QUERY, REPORT, SEARCH and TRACE when config_example.toml's array was written",
+};
+
 impl Rule for EarlyDataHeaderSafeMethod {
     fn id(&self) -> &'static str {
         "early_data_header_safe_method"
@@ -254,42 +294,12 @@ impl Rule for EarlyDataHeaderSafeMethod {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 8470",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc8470.html#section-4",
-                note: "Using Early Data in HTTP Clients — the MUST NOT that licenses this rule, and it covers two sets: unsafe methods, and methods whose safety is not known. It opens \"Absent other information\", an out-of-band state no message records",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8470",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8470.html#section-5.1",
-                note: "The Early-Data Header Field — one valid value, at most one instance, invalid or repeated instances read as a single \"1\", added by an intermediary rather than by the user agent, and forbidden in a Connection field, in a response, and in a request's trailer section",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8470",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8470.html#section-5.2",
-                note: "The 425 (Too Early) Status Code — what a server sends instead of processing a marked request it judges too risky. Nothing here reads it: whether a given resource tolerates replay is knowledge only the origin has",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.1",
-                note: "Safe Methods — the property RFC 8470 §4 names. GET, HEAD, OPTIONS and TRACE are the safe methods this document defines, which is a smaller set than the safe methods there are",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.1.1",
-                note: "Method Registry — every registration MUST carry a Safe field, and entries are added by IETF Review. This is why the safe set is configured rather than compiled in",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Method Registry",
-                section: None,
-                url: "https://www.iana.org/assignments/http-methods/http-methods.xhtml",
-                note: "The registry itself. Its Safe column held GET, HEAD, OPTIONS, PRI, PROPFIND, QUERY, REPORT, SEARCH and TRACE when config_example.toml's array was written",
-            },
+            RFC_8470_4,
+            RFC_8470_5_1,
+            RFC_8470_5_2,
+            RFC_9110_9_2_1,
+            RFC_9110_16_1_1,
+            IANA_HTTP_METHOD_REGISTRY,
         ]
     }
 

--- a/lint-http-rules/src/rules/etag_or_last_modified_present.rs
+++ b/lint-http-rules/src/rules/etag_or_last_modified_present.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct EtagOrLastModifiedPresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_8_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2.1",
+    note: "Generation: an origin server SHOULD send Last-Modified",
+};
+const RFC_9110_8_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3.1",
+    note: "Generation: an origin server SHOULD send an ETag",
+};
+
 impl Rule for EtagOrLastModifiedPresent {
     fn id(&self) -> &'static str {
         "etag_or_last_modified_present"
@@ -61,20 +77,7 @@ impl Rule for EtagOrLastModifiedPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2.1",
-                note: "Generation: an origin server SHOULD send Last-Modified",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3.1",
-                note: "Generation: an origin server SHOULD send an ETag",
-            },
-        ]
+        &[RFC_9110_8_8_2_1, RFC_9110_8_8_3_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -9,6 +9,22 @@ use crate::rules::Rule;
 /// per RFC 9110 §8.8.3. Also flags invalid UTF-8 and multiple header fields.
 pub struct EtagSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
+    note: "`ETag` header field, the `ETag = entity-tag` field production, and the `entity-tag` grammar",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: a non-list field (such as `ETag = entity-tag`) must not appear as multiple field lines",
+};
+
 impl Rule for EtagSyntax {
     fn id(&self) -> &'static str {
         "etag_syntax"
@@ -94,20 +110,7 @@ impl Rule for EtagSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-                note: "`ETag` header field, the `ETag = entity-tag` field production, and the `entity-tag` grammar",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: a non-list field (such as `ETag = entity-tag`) must not appear as multiple field lines",
-            },
-        ]
+        &[RFC_9110_8_8_3, RFC_9110_5_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -19,6 +19,53 @@ pub struct ExpectHeaderValid;
 /// cite(RFC 9110 § 10.1.1): "The Expect field value is case-insensitive."
 const HUNDRED_CONTINUE: &str = "100-continue";
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1",
+    note: "Expect: the field's grammar, the one expectation this specification defines, and the four client requirements — of which the MUST NOT on a request without content and the SHOULD after a 417 are the two a captured message can measure",
+};
+const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "Collected ABNF for senders: `Expect` with its list construct expanded, which is where the whole value being optional is written out",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "List sender requirements — the MUST NOT behind the empty-element finding",
+};
+const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
+    note:
+        "`parameters`, the production this rule's transcribed grammar used to end one term short of",
+};
+const RFC_9110_15_5_18: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.18"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.18",
+    note: "417 Expectation Failed — what the status the repeat check reads means",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "Requirements Notation — where the sentence that makes an element the ABNF does not generate a violation lives, rather than §2.4 Error Handling",
+};
+const RFC_9110_B_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("B.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.3",
+    note: "Changes from RFC 7231: the list-based grammar for `Expect` was restored, and an expectation's parameters may be empty — two sentences that decide how this rule reads the field",
+};
+
 impl Rule for ExpectHeaderValid {
     fn id(&self) -> &'static str {
         "expect_header_valid"
@@ -188,48 +235,13 @@ impl Rule for ExpectHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1",
-                note: "Expect: the field's grammar, the one expectation this specification defines, and the four client requirements — of which the MUST NOT on a request without content and the SHOULD after a 417 are the two a captured message can measure",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("A"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-                note: "Collected ABNF for senders: `Expect` with its list construct expanded, which is where the whole value being optional is written out",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "List sender requirements — the MUST NOT behind the empty-element finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-                note: "`parameters`, the production this rule's transcribed grammar used to end one term short of",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.18"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.18",
-                note: "417 Expectation Failed — what the status the repeat check reads means",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "Requirements Notation — where the sentence that makes an element the ABNF does not generate a violation lives, rather than §2.4 Error Handling",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("B.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.3",
-                note: "Changes from RFC 7231: the list-based grammar for `Expect` was restored, and an expectation's parameters may be empty — two sentences that decide how this rule reads the field",
-            },
+            RFC_9110_10_1_1,
+            RFC_9110_A,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_6,
+            RFC_9110_15_5_18,
+            RFC_9110_2_2,
+            RFC_9110_B_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
+++ b/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
@@ -12,6 +12,22 @@ use chrono::{DateTime, Utc};
 /// while `Expires` is in the past relative to Date).
 pub struct ExpiresAndCacheControlConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.3",
+    note: "Cache-Control overrides Expires: a recipient MUST ignore Expires when max-age is present, and a shared cache MUST ignore it when s-maxage is present",
+};
+const RFC_9111_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
+    note: "Freshness and age calculations using `max-age`, `s-maxage`, and `Expires`",
+};
+
 impl Rule for ExpiresAndCacheControlConsistent {
     fn id(&self) -> &'static str {
         "expires_and_cache_control_consistent"
@@ -194,20 +210,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.3",
-                note: "Cache-Control overrides Expires: a recipient MUST ignore Expires when max-age is present, and a shared cache MUST ignore it when s-maxage is present",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
-                note: "Freshness and age calculations using `max-age`, `s-maxage`, and `Expires`",
-            },
-        ]
+        &[RFC_9111_5_3, RFC_9111_4_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/extension_headers_registered.rs
+++ b/lint-http-rules/src/rules/extension_headers_registered.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct ExtensionHeadersRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
+    note: "Field Names (case-insensitive, and registration is an \"ought to\"; the same paragraph makes a proxy forward what it does not recognize)",
+};
+const RFC_9110_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5",
+    note: "Trailer Fields (a trailer field name is a field name, so the array reaches it)",
+};
+const RFC_9110_16_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.1",
+    note: "Field Name Registry (what registration is; this rule does not consult it)",
+};
+const RFC_9110_16_3_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.3.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.2.1",
+    note: "Considerations for New Field Names (no \"X-\" prefix)",
+};
+const IANA_HTTP_FIELD_NAME_REGISTRY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Field Name Registry",
+    section: None,
+    url: "https://www.iana.org/assignments/http-fields/http-fields.xhtml",
+    note: "The registry § 5.1 points at, for deciding what belongs in the array",
+};
+
 impl Rule for ExtensionHeadersRegistered {
     fn id(&self) -> &'static str {
         "extension_headers_registered"
@@ -74,36 +108,11 @@ impl Rule for ExtensionHeadersRegistered {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
-                note: "Field Names (case-insensitive, and registration is an \"ought to\"; the same paragraph makes a proxy forward what it does not recognize)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5",
-                note: "Trailer Fields (a trailer field name is a field name, so the array reaches it)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.1",
-                note: "Field Name Registry (what registration is; this rule does not consult it)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.3.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.2.1",
-                note: "Considerations for New Field Names (no \"X-\" prefix)",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Field Name Registry",
-                section: None,
-                url: "https://www.iana.org/assignments/http-fields/http-fields.xhtml",
-                note: "The registry § 5.1 points at, for deciding what belongs in the array",
-            },
+            RFC_9110_5_1,
+            RFC_9110_6_5,
+            RFC_9110_16_3_1,
+            RFC_9110_16_3_2_1,
+            IANA_HTTP_FIELD_NAME_REGISTRY,
         ]
     }
 

--- a/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
+++ b/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct FormDataContentDispositionValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7578_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7578",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7578.html#section-4.2",
+    note: "Each multipart/form-data *part* MUST contain a `Content-Disposition` header with disposition-type `form-data` and MUST also contain a `name` parameter — a requirement on parts, which this rule approximates at the message level",
+};
+const RFC_6266_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6266",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4.1",
+    note: "The disposition types HTTP messages actually use (`inline`, `attachment`); a message-level `form-data` is outside this grammar, which is why the type gate skips everything else",
+};
+
 impl Rule for FormDataContentDispositionValid {
     fn id(&self) -> &'static str {
         "form_data_content_disposition_valid"
@@ -184,20 +200,7 @@ impl Rule for FormDataContentDispositionValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 7578",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7578.html#section-4.2",
-                note: "Each multipart/form-data *part* MUST contain a `Content-Disposition` header with disposition-type `form-data` and MUST also contain a `name` parameter — a requirement on parts, which this rule approximates at the message level",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6266",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6266.html#section-4.1",
-                note: "The disposition types HTTP messages actually use (`inline`, `attachment`); a message-level `form-data` is outside this grammar, which is why the type gate skips everything else",
-            },
-        ]
+        &[RFC_7578_4_2, RFC_6266_4_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/forwarded_header_valid.rs
+++ b/lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -263,6 +263,46 @@ impl ForwardedHeaderValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7239_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-4",
+    note: "The field's grammar, the case-insensitivity of parameter names, the MUST NOT on naming a parameter twice in one element, and the sentence restricting the field to requests",
+};
+const RFC_7239_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6",
+    note: "`node`, `nodename`, `node-port`: the obfuscated forms MUST begin with an underscore, a numeric port is one to five digits, and an address with a port MUST be quoted. §6.1's SHOULD asks for the RFC 5952 textual form",
+};
+const RFC_7239_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("5"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-5",
+    note: "The four registered parameters. `host` MUST conform to the Host ABNF and `proto` to a URI scheme name; extension parameters SHOULD be registered, in a registry this rule does not hold",
+};
+const RFC_7239_8_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("8.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-8.2",
+    note: "Why a response must not carry the field: it reveals the whole proxy chain to the client",
+};
+const RFC_9110_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
+    note: "`Host = uri-host [ \":\" port ]`, which §5.3 makes the syntax of a `host` parameter",
+};
+const RFC_3986_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1",
+    note: "`scheme = ALPHA *( ALPHA / DIGIT / \"+\" / \"-\" / \".\" )`, which §5.4 makes the syntax of a `proto` parameter",
+};
+
 impl Rule for ForwardedHeaderValid {
     fn id(&self) -> &'static str {
         "forwarded_header_valid"
@@ -344,42 +384,12 @@ impl Rule for ForwardedHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-4",
-                note: "The field's grammar, the case-insensitivity of parameter names, the MUST NOT on naming a parameter twice in one element, and the sentence restricting the field to requests",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("6"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6",
-                note: "`node`, `nodename`, `node-port`: the obfuscated forms MUST begin with an underscore, a numeric port is one to five digits, and an address with a port MUST be quoted. §6.1's SHOULD asks for the RFC 5952 textual form",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("5"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-5",
-                note: "The four registered parameters. `host` MUST conform to the Host ABNF and `proto` to a URI scheme name; extension parameters SHOULD be registered, in a registry this rule does not hold",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("8.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-8.2",
-                note: "Why a response must not carry the field: it reveals the whole proxy chain to the client",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
-                note: "`Host = uri-host [ \":\" port ]`, which §5.3 makes the syntax of a `host` parameter",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1",
-                note: "`scheme = ALPHA *( ALPHA / DIGIT / \"+\" / \"-\" / \".\" )`, which §5.4 makes the syntax of a `proto` parameter",
-            },
+            RFC_7239_4,
+            RFC_7239_6,
+            RFC_7239_5,
+            RFC_7239_8_2,
+            RFC_9110_7_2,
+            RFC_3986_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/from_header_email_syntax.rs
+++ b/lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -10,6 +10,89 @@ use crate::rules::Rule;
 
 pub struct FromHeaderEmailSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.2",
+    note: "`From = mailbox` — one address, imported by reference from RFC 5322 §3.4; the section's three other requirements are about parties and intents a capture does not state",
+};
+const RFC_9110_10_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
+    note: "Request context fields — the sentence behind the scope, since there is no response half of this field",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "A sender MUST NOT write a second field line for a field whose value is not a comma-separated list",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "Singleton fields, and the `OWS` a parser must exclude before evaluating a field value",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The MUST NOT that makes a value outside the field's ABNF a finding",
+};
+const RFC_5322_3_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4",
+    note: "`mailbox = name-addr / addr-spec`, and `mailbox-list` beside it — the production this field does *not* import",
+};
+const RFC_5322_3_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1",
+    note: "`addr-spec = local-part \"@\" domain`, `domain-literal`, and the sentence handing a `dot-atom` domain to the host-name documents",
+};
+const RFC_5322_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.2",
+    note: "`CFWS` — folding whitespace and nested parenthesised comments, admitted around nearly every token of a mailbox",
+};
+const RFC_5322_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3",
+    note: "`atext`, `atom` and `dot-atom-text` — the `1*atext` floors either side of every dot",
+};
+const RFC_5322_3_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.4",
+    note:
+        "`quoted-string` and `qtext`, the alternative a local-part or a display-name word may take",
+};
+const RFC_5322_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5322",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-4",
+    note: "Obsolete syntax: MUST NOT be generated, MUST be accepted by a receiver — this rule reports on the generator",
+};
+const RFC_1035_2_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 1035",
+    section: Some("2.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1",
+    note: "Preferred name syntax for the `dot-atom` form of a domain — advisory, and the one finding here that is reported as advice",
+};
+const RFC_1123_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 1123",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc1123.html",
+    note: "Relaxes RFC 1035's first-character rule to a letter or a digit",
+};
+
 impl Rule for FromHeaderEmailSyntax {
     fn id(&self) -> &'static str {
         "from_header_email_syntax"
@@ -186,89 +269,19 @@ impl Rule for FromHeaderEmailSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.2",
-                note: "`From = mailbox` — one address, imported by reference from RFC 5322 §3.4; the section's three other requirements are about parties and intents a capture does not state",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
-                note: "Request context fields — the sentence behind the scope, since there is no response half of this field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "A sender MUST NOT write a second field line for a field whose value is not a comma-separated list",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "Singleton fields, and the `OWS` a parser must exclude before evaluating a field value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The MUST NOT that makes a value outside the field's ABNF a finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5322",
-                section: Some("3.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4",
-                note: "`mailbox = name-addr / addr-spec`, and `mailbox-list` beside it — the production this field does *not* import",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5322",
-                section: Some("3.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1",
-                note: "`addr-spec = local-part \"@\" domain`, `domain-literal`, and the sentence handing a `dot-atom` domain to the host-name documents",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5322",
-                section: Some("3.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.2",
-                note: "`CFWS` — folding whitespace and nested parenthesised comments, admitted around nearly every token of a mailbox",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5322",
-                section: Some("3.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3",
-                note: "`atext`, `atom` and `dot-atom-text` — the `1*atext` floors either side of every dot",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5322",
-                section: Some("3.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.4",
-                note: "`quoted-string` and `qtext`, the alternative a local-part or a display-name word may take",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5322",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-4",
-                note: "Obsolete syntax: MUST NOT be generated, MUST be accepted by a receiver — this rule reports on the generator",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 1035",
-                section: Some("2.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1",
-                note: "Preferred name syntax for the `dot-atom` form of a domain — advisory, and the one finding here that is reported as advice",
-            },
-            // The URL carries no `#section-2.1`, and that is not an omission:
-            // RFC 1123's HTML rendering anchors its top-level sections only, so
-            // the fragment the other twelve rows spell would resolve to nothing.
-            // The section number is still stated in `section`, which is what a
-            // reader needs; a link that scrolls nowhere is worse than none.
-            crate::rules::SpecRef {
-                spec: "RFC 1123",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc1123.html",
-                note: "Relaxes RFC 1035's first-character rule to a letter or a digit",
-            },
+            RFC_9110_10_1_2,
+            RFC_9110_10_1,
+            RFC_9110_5_3,
+            RFC_9110_5_5,
+            RFC_9110_2_2,
+            RFC_5322_3_4,
+            RFC_5322_3_4_1,
+            RFC_5322_3_2_2,
+            RFC_5322_3_2_3,
+            RFC_5322_3_2_4,
+            RFC_5322_4,
+            RFC_1035_2_3_1,
+            RFC_1123_2_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/head_response_headers_match_get.rs
@@ -116,6 +116,34 @@ fn content_length_finding(
 
 pub struct HeadResponseHeadersMatchGet;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_9_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
+    note: "The rule's sentence, quoted whole: \"The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET. However, a server MAY omit header fields for which a value is determined only while generating the content.\" The MAY names a class, and the section prints Content-Length and Vary as examples of it rather than as its membership",
+};
+const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Content-Length is the one requirement here that is not a SHOULD: \"a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a response if the same request had used the GET method\". The same sentence opens with the MAY that lets a HEAD response omit it",
+};
+const RFC_9110_8_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8",
+    note: "Why a difference between the two responses is not automatically a finding: validator fields \"describe the selected representation chosen by the origin server while handling the response\", so an ETag or Last-Modified that moved between the observed GET and this HEAD says the resource changed, and the rule declines",
+};
+const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
+    note: "Transfer-Encoding is excluded outright: it \"MAY be sent in a response to a HEAD request\", the indication \"is not required\", and any recipient on the response chain \"can remove transfer codings when they are not needed\" — so neither its presence nor its value is comparable across the two messages",
+};
+
 impl Rule for HeadResponseHeadersMatchGet {
     fn id(&self) -> &'static str {
         "head_response_headers_match_get"
@@ -326,32 +354,7 @@ impl Rule for HeadResponseHeadersMatchGet {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
-                note: "The rule's sentence, quoted whole: \"The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET. However, a server MAY omit header fields for which a value is determined only while generating the content.\" The MAY names a class, and the section prints Content-Length and Vary as examples of it rather than as its membership",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-                note: "Content-Length is the one requirement here that is not a SHOULD: \"a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a response if the same request had used the GET method\". The same sentence opens with the MAY that lets a HEAD response omit it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8",
-                note: "Why a difference between the two responses is not automatically a finding: validator fields \"describe the selected representation chosen by the origin server while handling the response\", so an ETag or Last-Modified that moved between the observed GET and this HEAD says the resource changed, and the rule declines",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
-                note: "Transfer-Encoding is excluded outright: it \"MAY be sent in a response to a HEAD request\", the indication \"is not required\", and any recipient on the response chain \"can remove transfer codings when they are not needed\" — so neither its presence nor its value is comparable across the two messages",
-            },
-        ]
+        &[RFC_9110_9_3_2, RFC_9110_8_6, RFC_9110_8_8, RFC_9112_6_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/header_field_names_token_valid.rs
+++ b/lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct HeaderFieldNamesTokenValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
+    note: "Field Names (field-name = token)",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "Tokens (the tchar set the production expands to)",
+};
+const RFC_9110_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5",
+    note: "Trailer Fields",
+};
+const RFC_9113_8_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.1",
+    note: "Field Validity (HTTP/2 recipients validate names against §5.1)",
+};
+const RFC_9114_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
+    note: "HTTP Fields (HTTP/3 defers field-name properties to §5.1)",
+};
+
 impl Rule for HeaderFieldNamesTokenValid {
     fn id(&self) -> &'static str {
         "header_field_names_token_valid"
@@ -50,36 +84,11 @@ impl Rule for HeaderFieldNamesTokenValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1",
-                note: "Field Names (field-name = token)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "Tokens (the tchar set the production expands to)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5",
-                note: "Trailer Fields",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.1",
-                note: "Field Validity (HTTP/2 recipients validate names against §5.1)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
-                note: "HTTP Fields (HTTP/3 defers field-name properties to §5.1)",
-            },
+            RFC_9110_5_1,
+            RFC_9110_5_6_2,
+            RFC_9110_6_5,
+            RFC_9113_8_2_1,
+            RFC_9114_4_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/host_and_authority_consistent.rs
+++ b/lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -130,6 +130,71 @@ impl HostAndAuthorityConsistent {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9113_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
+    note: "HTTP/2's half: the client's MUST NOT, the server's SHOULD-treat-as-malformed, and the two sentences that define the comparison over *normalized* values — which is why a default or empty port is not a difference on this version",
+};
+const RFC_9114_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
+    note: "HTTP/3's half: both fields present MUST contain the same value and MUST NOT be empty, with no normalization named anywhere in the document — the sentence that makes one pair of values conforming over HTTP/2 and malformed here",
+};
+const RFC_9110_4_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.3",
+    note: "What scheme-based normalization involves for an \"http\" or \"https\" URI — the default port, the case of the host, the percent-encoded unreserved character, and the sentence that keeps every other component case-sensitive",
+};
+const RFC_3986_6_2_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1",
+    note: "Case normalization — including the hexadecimal digits of a percent-encoding triplet, which is why a triplet that stays encoded is still put in one form",
+};
+const RFC_3986_6_2_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.2",
+    note:
+        "Percent-encoding normalization — decode any triplet standing for an unreserved character",
+};
+const RFC_3986_6_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.3",
+    note: "Scheme-based normalization, and the sentence that keeps an empty delimiter where no scheme licenses removing it — which is why nothing is elided from an authority-form target",
+};
+const RFC_9110_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1",
+    note: "The default port for an \"http\" URI is 80 — one of the two numbers scheme-based normalization needs, and the reason the scheme is read from the recorded target rather than assumed",
+};
+const RFC_9110_4_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.2",
+    note: "The default port for an \"https\" URI is 443",
+};
+const RFC_9110_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
+    note: "Which versions carry the two fields at once: in HTTP/2 and HTTP/3 the `Host` field is supplanted by `:authority`, which is why the rule is gated to those two",
+};
+const RFC_9112_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2",
+    note: "Why HTTP/1.1 is not measured: an absolute-form target beside a `Host` is answered by having the recipient ignore the field, not by calling the sender wrong",
+};
+
 impl Rule for HostAndAuthorityConsistent {
     fn id(&self) -> &'static str {
         "host_and_authority_consistent"
@@ -347,66 +412,16 @@ impl Rule for HostAndAuthorityConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
-                note: "HTTP/2's half: the client's MUST NOT, the server's SHOULD-treat-as-malformed, and the two sentences that define the comparison over *normalized* values — which is why a default or empty port is not a difference on this version",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
-                note: "HTTP/3's half: both fields present MUST contain the same value and MUST NOT be empty, with no normalization named anywhere in the document — the sentence that makes one pair of values conforming over HTTP/2 and malformed here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.3",
-                note: "What scheme-based normalization involves for an \"http\" or \"https\" URI — the default port, the case of the host, the percent-encoded unreserved character, and the sentence that keeps every other component case-sensitive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1",
-                note: "Case normalization — including the hexadecimal digits of a percent-encoding triplet, which is why a triplet that stays encoded is still put in one form",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.2",
-                note: "Percent-encoding normalization — decode any triplet standing for an unreserved character",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.3",
-                note: "Scheme-based normalization, and the sentence that keeps an empty delimiter where no scheme licenses removing it — which is why nothing is elided from an authority-form target",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1",
-                note: "The default port for an \"http\" URI is 80 — one of the two numbers scheme-based normalization needs, and the reason the scheme is read from the recorded target rather than assumed",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.2",
-                note: "The default port for an \"https\" URI is 443",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
-                note: "Which versions carry the two fields at once: in HTTP/2 and HTTP/3 the `Host` field is supplanted by `:authority`, which is why the rule is gated to those two",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.2",
-                note: "Why HTTP/1.1 is not measured: an absolute-form target beside a `Host` is answered by having the recipient ignore the field, not by calling the sender wrong",
-            },
+            RFC_9113_8_3_1,
+            RFC_9114_4_3_1,
+            RFC_9110_4_2_3,
+            RFC_3986_6_2_2_1,
+            RFC_3986_6_2_2_2,
+            RFC_3986_6_2_3,
+            RFC_9110_4_2_1,
+            RFC_9110_4_2_2,
+            RFC_9110_7_2,
+            RFC_9112_3_2_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/host_header.rs
+++ b/lint-http-rules/src/rules/host_header.rs
@@ -31,6 +31,40 @@ fn sends_authority_as_control_data(tx: &crate::http_transaction::HttpTransaction
     crate::helpers::uri::extract_authority_from_request_target(&tx.request.uri).is_some()
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
+    note: "Host and :authority — the grammar, the MUST, and the pseudo-header the MUST excepts. The SHOULD to send Host first is not checked: the capture does not preserve field order.",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order — a sender MUST NOT repeat a field name unless the field is a comma-separated list, and Host is not one",
+};
+const RFC_9112_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
+    note: "Request Target — Host is required in all HTTP/1.1 requests, its value excludes userinfo, and it is empty when the target URI has no authority",
+};
+const RFC_3986_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2",
+    note: "Host — an IP literal is distinguished by its square brackets; every other host is a registered name",
+};
+const RFC_3986_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
+    note: "Port — `port = *DIGIT` bounds nothing, so a port outside the TCP range is not a syntax finding",
+};
+
 impl Rule for HostHeader {
     fn id(&self) -> &'static str {
         "host_header"
@@ -165,36 +199,11 @@ impl Rule for HostHeader {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
-                note: "Host and :authority — the grammar, the MUST, and the pseudo-header the MUST excepts. The SHOULD to send Host first is not checked: the capture does not preserve field order.",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order — a sender MUST NOT repeat a field name unless the field is a comma-separated list, and Host is not one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
-                note: "Request Target — Host is required in all HTTP/1.1 requests, its value excludes userinfo, and it is empty when the target URI has no authority",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2",
-                note: "Host — an IP literal is distinguished by its square brackets; every other host is a registered name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
-                note: "Port — `port = *DIGIT` bounds nothing, so a port outside the TCP range is not a syntax finding",
-            },
+            RFC_9110_7_2,
+            RFC_9110_5_3,
+            RFC_9112_3_2,
+            RFC_3986_3_2_2,
+            RFC_3986_3_2_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -112,6 +112,70 @@ fn connect_port_range_finding(port: &str) -> Option<String> {
     })
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9113_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3",
+    note: "HTTP Control Data — what a pseudo-header field is, and that a request carrying an invalid one is malformed. Its two requirements about the field block itself (ordering before regular field lines, one occurrence per name) are not checked: a capture holds no pseudo-header fields and no field order.",
+};
+const RFC_9113_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
+    note: "Request Pseudo-Header Fields — what each of `:method`, `:scheme`, `:authority` and `:path` conveys, the `'*'` value for asterisk-form OPTIONS, the `:path`-must-not-be-empty MUST, and the userinfo MUST NOT written for `http` and `https` targets",
+};
+const RFC_9113_8_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.2",
+    note: "Response Pseudo-Header Fields — `:status` is always present in this model and its range is RFC 9110 §15's, so nothing here reads it",
+};
+const RFC_9113_8_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.5",
+    note: "The CONNECT Method — `:method` is set to CONNECT, `:scheme` and `:path` are omitted, `:authority` carries the host and port, and the proxy opens a TCP connection to them",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "Overview of methods — `method = token`, and the token is case-sensitive, which is why CONNECT and OPTIONS are matched exactly",
+};
+const RFC_9110_9_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
+    note: "CONNECT — the host and port number of the tunnel destination, the absence of a default port, and the server's MUST to reject an empty or invalid one. This is where the port requirements come from; the grammar states none.",
+};
+const RFC_9110_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
+    note: "Determining the Target Resource — the asterisk is OPTIONS's target and the method-specific forms must not be used with other methods",
+};
+const RFC_9112_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3",
+    note: "authority-form — the production RFC 9113 §8.5 points at for what `:authority` carries on a CONNECT, and where both halves turn out to be `*`-quantified",
+};
+const RFC_8441_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8441",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc8441.html#section-4",
+    note: "The Extended CONNECT Method — `:protocol` is what distinguishes it, and on such a request `:scheme` and `:path` MUST be included. A capture records no `:protocol`, which is why an absolute-form CONNECT target is accepted.",
+};
+const RFC_6335_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6335",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc6335.html#section-6",
+    note: "Port Number Ranges — the 16-bit namespace that bounds a CONNECT port above, and the reserved edge values that are why `0` is not reported",
+};
+
 impl Rule for Http2PseudoHeadersValid {
     fn id(&self) -> &'static str {
         "http2_pseudo_headers_valid"
@@ -361,66 +425,16 @@ impl Rule for Http2PseudoHeadersValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3",
-                note: "HTTP Control Data — what a pseudo-header field is, and that a request carrying an invalid one is malformed. Its two requirements about the field block itself (ordering before regular field lines, one occurrence per name) are not checked: a capture holds no pseudo-header fields and no field order.",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
-                note: "Request Pseudo-Header Fields — what each of `:method`, `:scheme`, `:authority` and `:path` conveys, the `'*'` value for asterisk-form OPTIONS, the `:path`-must-not-be-empty MUST, and the userinfo MUST NOT written for `http` and `https` targets",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.2",
-                note: "Response Pseudo-Header Fields — `:status` is always present in this model and its range is RFC 9110 §15's, so nothing here reads it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.5",
-                note: "The CONNECT Method — `:method` is set to CONNECT, `:scheme` and `:path` are omitted, `:authority` carries the host and port, and the proxy opens a TCP connection to them",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "Overview of methods — `method = token`, and the token is case-sensitive, which is why CONNECT and OPTIONS are matched exactly",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
-                note: "CONNECT — the host and port number of the tunnel destination, the absence of a default port, and the server's MUST to reject an empty or invalid one. This is where the port requirements come from; the grammar states none.",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
-                note: "Determining the Target Resource — the asterisk is OPTIONS's target and the method-specific forms must not be used with other methods",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3",
-                note: "authority-form — the production RFC 9113 §8.5 points at for what `:authority` carries on a CONNECT, and where both halves turn out to be `*`-quantified",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8441",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc8441.html#section-4",
-                note: "The Extended CONNECT Method — `:protocol` is what distinguishes it, and on such a request `:scheme` and `:path` MUST be included. A capture records no `:protocol`, which is why an absolute-form CONNECT target is accepted.",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6335",
-                section: Some("6"),
-                url: "https://www.rfc-editor.org/rfc/rfc6335.html#section-6",
-                note: "Port Number Ranges — the 16-bit namespace that bounds a CONNECT port above, and the reserved edge values that are why `0` is not reported",
-            },
+            RFC_9113_8_3,
+            RFC_9113_8_3_1,
+            RFC_9113_8_3_2,
+            RFC_9113_8_5,
+            RFC_9110_9_1,
+            RFC_9110_9_3_6,
+            RFC_9110_7_1,
+            RFC_9112_3_2_3,
+            RFC_8441_4,
+            RFC_6335_6,
         ]
     }
 

--- a/lint-http-rules/src/rules/http3_goaway_semantics.rs
+++ b/lint-http-rules/src/rules/http3_goaway_semantics.rs
@@ -18,6 +18,16 @@ use crate::rules::ProtocolRule;
 
 pub struct Http3GoawaySemantics;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9114_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-5.2",
+    note: "Connection Shutdown (GOAWAY)",
+};
+
 impl ProtocolRule for Http3GoawaySemantics {
     fn id(&self) -> &'static str {
         "http3_goaway_semantics"
@@ -129,12 +139,7 @@ impl ProtocolRule for Http3GoawaySemantics {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9114",
-            section: Some("5.2"),
-            url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-5.2",
-            note: "Connection Shutdown (GOAWAY)",
-        }]
+        &[RFC_9114_5_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/http3_max_push_id.rs
@@ -18,6 +18,22 @@ use crate::rules::ProtocolRule;
 
 pub struct Http3MaxPushId;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9114_7_2_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("7.2.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.7",
+    note: "`MAX_PUSH_ID` frame",
+};
+const RFC_9114_8_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("8.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-8.1",
+    note: "HTTP/3 error codes (`H3_ID_ERROR`)",
+};
+
 impl ProtocolRule for Http3MaxPushId {
     fn id(&self) -> &'static str {
         "http3_max_push_id"
@@ -104,20 +120,7 @@ impl ProtocolRule for Http3MaxPushId {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("7.2.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.7",
-                note: "`MAX_PUSH_ID` frame",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("8.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-8.1",
-                note: "HTTP/3 error codes (`H3_ID_ERROR`)",
-            },
-        ]
+        &[RFC_9114_7_2_7, RFC_9114_8_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -7,6 +7,51 @@ use crate::rules::Rule;
 
 pub struct Http3PseudoHeadersValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9114_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3",
+    note: "HTTP Control Data",
+};
+const RFC_9114_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
+    note: "Request Pseudo-Header Fields — the exactly-one MUST for `:method`, \
+           `:scheme` and `:path`, the `:authority`-or-Host requirement for schemes \
+           with a mandatory authority component, and the MUST NOT on the deprecated \
+           userinfo subcomponent for http and https URIs",
+};
+const RFC_3986_3_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.1",
+    note: "User Information — the sentence asking an application not to render what \
+           follows the first colon of a userinfo, which is why both findings here \
+           withhold the password half",
+};
+const RFC_9114_4_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.2",
+    note: "Response Pseudo-Header Fields",
+};
+const RFC_9114_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.4",
+    note: "The CONNECT Method",
+};
+const RFC_9110_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
+    note: "Determining the Target Resource (asterisk-form request target)",
+};
+
 impl Rule for Http3PseudoHeadersValid {
     fn id(&self) -> &'static str {
         "http3_pseudo_headers_valid"
@@ -203,47 +248,12 @@ impl Rule for Http3PseudoHeadersValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3",
-                note: "HTTP Control Data",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
-                note: "Request Pseudo-Header Fields — the exactly-one MUST for `:method`, \
-                       `:scheme` and `:path`, the `:authority`-or-Host requirement for schemes \
-                       with a mandatory authority component, and the MUST NOT on the deprecated \
-                       userinfo subcomponent for http and https URIs",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.1",
-                note: "User Information — the sentence asking an application not to render what \
-                       follows the first colon of a userinfo, which is why both findings here \
-                       withhold the password half",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.2",
-                note: "Response Pseudo-Header Fields",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.4",
-                note: "The CONNECT Method",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
-                note: "Determining the Target Resource (asterisk-form request target)",
-            },
+            RFC_9114_4_3,
+            RFC_9114_4_3_1,
+            RFC_3986_3_2_1,
+            RFC_9114_4_3_2,
+            RFC_9114_4_4,
+            RFC_9110_7_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/http3_settings_frame.rs
@@ -33,6 +33,28 @@ const RESERVED_SETTING_IDS: &[u64] = &[
     0x05, // Reserved (SETTINGS_MAX_FRAME_SIZE in HTTP/2)
 ];
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9114_7_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("7.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4",
+    note: "SETTINGS",
+};
+const RFC_9114_7_2_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("7.2.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4.1",
+    note: "Defined SETTINGS Parameters",
+};
+const RFC_9114_11_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("11.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-11.2.2",
+    note: "Settings Parameters (Table 3: the Reserved rows)",
+};
+
 impl ProtocolRule for Http3SettingsFrame {
     fn id(&self) -> &'static str {
         "http3_settings_frame"
@@ -138,26 +160,7 @@ impl ProtocolRule for Http3SettingsFrame {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("7.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4",
-                note: "SETTINGS",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("7.2.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4.1",
-                note: "Defined SETTINGS Parameters",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("11.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-11.2.2",
-                note: "Settings Parameters (Table 3: the Reserved rows)",
-            },
-        ]
+        &[RFC_9114_7_2_4, RFC_9114_7_2_4_1, RFC_9114_11_2_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/http3_status_code_valid.rs
+++ b/lint-http-rules/src/rules/http3_status_code_valid.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct Http3StatusCodeValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9114_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
+    note: "HTTP Upgrade",
+};
+const RFC_9114_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.1",
+    note: "HTTP Message Framing, where interim and final responses are described. This note said HTTP Message Exchanges, which is not a section RFC 9114 has",
+};
+const RFC_9110_15_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2",
+    note: "Informational 1xx — where 101 is defined, and where the rule 101 breaks is written. Its sentence forbidding content and trailers on a 1xx is version-independent and is enforced by no_body_for_1xx_204_304, not here",
+};
+const RFC_9220: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9220",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc9220.html",
+    note: "Bootstrapping WebSockets with HTTP/3",
+};
+
 impl Rule for Http3StatusCodeValid {
     fn id(&self) -> &'static str {
         "http3_status_code_valid"
@@ -87,32 +115,7 @@ impl Rule for Http3StatusCodeValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
-                note: "HTTP Upgrade",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.1",
-                note: "HTTP Message Framing, where interim and final responses are described. This note said HTTP Message Exchanges, which is not a section RFC 9114 has",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2",
-                note: "Informational 1xx — where 101 is defined, and where the rule 101 breaks is written. Its sentence forbidding content and trailers on a 1xx is version-independent and is enforced by no_body_for_1xx_204_304, not here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9220",
-                section: None,
-                url: "https://www.rfc-editor.org/rfc/rfc9220.html",
-                note: "Bootstrapping WebSockets with HTTP/3",
-            },
-        ]
+        &[RFC_9114_4_5, RFC_9114_4_1, RFC_9110_15_2, RFC_9220]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/http_version_syntax.rs
+++ b/lint-http-rules/src/rules/http_version_syntax.rs
@@ -7,6 +7,58 @@ use crate::rules::Rule;
 
 pub struct HttpVersionSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-2.3",
+    note: "The production, the sentence saying it is case-sensitive, and the sentence saying only an HTTP/1.x message carries it in a start-line",
+};
+const RFC_9110_2_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.5",
+    note: "What the two digits mean, and the `0` used for a major version that defines no minor versions",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The MUST NOT that makes a value matching no production a finding; RFC 9112 §1.1 is the bridge to it",
+};
+const RFC_9112_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3",
+    note: "The request-line, which ends with the protocol version",
+};
+const RFC_9112_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-4",
+    note: "The status-line, which begins with it",
+};
+const RFC_9113_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
+    note: "HTTP/2 carries no version indicator; its implicit protocol version is `2.0`",
+};
+const RFC_9114_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
+    note: "HTTP/3 has nowhere to carry the identifier the request line holds; its implicit protocol version is `3.0`",
+};
+const RFC_5234_B_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5234",
+    section: Some("B.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5234.html#appendix-B.1",
+    note: "`DIGIT = %x30-39` — the alphabet the two positions admit",
+};
+
 impl Rule for HttpVersionSyntax {
     fn id(&self) -> &'static str {
         "http_version_syntax"
@@ -54,54 +106,14 @@ impl Rule for HttpVersionSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-2.3",
-                note: "The production, the sentence saying it is case-sensitive, and the sentence saying only an HTTP/1.x message carries it in a start-line",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.5",
-                note: "What the two digits mean, and the `0` used for a major version that defines no minor versions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The MUST NOT that makes a value matching no production a finding; RFC 9112 §1.1 is the bridge to it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3",
-                note: "The request-line, which ends with the protocol version",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-4",
-                note: "The status-line, which begins with it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
-                note: "HTTP/2 carries no version indicator; its implicit protocol version is `2.0`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
-                note: "HTTP/3 has nowhere to carry the identifier the request line holds; its implicit protocol version is `3.0`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5234",
-                section: Some("B.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5234.html#appendix-B.1",
-                note: "`DIGIT = %x30-39` — the alphabet the two positions admit",
-            },
+            RFC_9112_2_3,
+            RFC_9110_2_5,
+            RFC_9110_2_2,
+            RFC_9112_3,
+            RFC_9112_4,
+            RFC_9113_8_3_1,
+            RFC_9114_4_3_1,
+            RFC_5234_B_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/if_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -10,6 +10,22 @@ use crate::rules::Rule;
 /// entity-tag grammar itself is RFC 9110 §8.8.3, owned by `validate_entity_tag`.
 pub struct IfMatchEtagSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
+    note: "ETag header field",
+};
+const RFC_9110_13_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1",
+    note: "If-Match",
+};
+
 impl Rule for IfMatchEtagSyntax {
     fn id(&self) -> &'static str {
         "if_match_etag_syntax"
@@ -113,20 +129,7 @@ impl Rule for IfMatchEtagSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-                note: "ETag header field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.1",
-                note: "If-Match",
-            },
-        ]
+        &[RFC_9110_8_8_3, RFC_9110_13_1_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
@@ -9,6 +9,16 @@ use crate::rules::Rule;
 /// generate it as an IMF-fixdate (§5.6.7). This checks the sender's obligation.
 pub struct IfModifiedSinceDateSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_13_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
+    note: "If-Modified-Since header",
+};
+
 impl Rule for IfModifiedSinceDateSyntax {
     fn id(&self) -> &'static str {
         "if_modified_since_date_syntax"
@@ -90,12 +100,7 @@ impl Rule for IfModifiedSinceDateSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9110",
-            section: Some("13.1.3"),
-            url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3",
-            note: "If-Modified-Since header",
-        }]
+        &[RFC_9110_13_1_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -10,6 +10,22 @@ use crate::rules::Rule;
 /// entity-tag grammar itself is RFC 9110 §8.8.3, owned by `validate_entity_tag`.
 pub struct IfNoneMatchEtagSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
+    note: "ETag header field",
+};
+const RFC_9110_13_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
+    note: "If-None-Match",
+};
+
 impl Rule for IfNoneMatchEtagSyntax {
     fn id(&self) -> &'static str {
         "if_none_match_etag_syntax"
@@ -114,20 +130,7 @@ impl Rule for IfNoneMatchEtagSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3",
-                note: "ETag header field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2",
-                note: "If-None-Match",
-            },
-        ]
+        &[RFC_9110_8_8_3, RFC_9110_13_1_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
@@ -9,6 +9,16 @@ use crate::rules::Rule;
 /// generate it as an IMF-fixdate (§5.6.7). This checks the sender's obligation.
 pub struct IfUnmodifiedSinceDateSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_13_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.4",
+    note: "If-Unmodified-Since header",
+};
+
 impl Rule for IfUnmodifiedSinceDateSyntax {
     fn id(&self) -> &'static str {
         "if_unmodified_since_date_syntax"
@@ -84,12 +94,7 @@ impl Rule for IfUnmodifiedSinceDateSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9110",
-            section: Some("13.1.4"),
-            url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.4",
-            note: "If-Unmodified-Since header",
-        }]
+        &[RFC_9110_13_1_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/immutable_cache_never_stale.rs
+++ b/lint-http-rules/src/rules/immutable_cache_never_stale.rs
@@ -29,6 +29,22 @@ use crate::rules::Rule;
 /// regardless of whether the request is conditional or unconditional.
 pub struct ImmutableCacheNeverStale;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_8246_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8246",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8246.html#section-2",
+    note: "The Immutable Cache-Control Extension — the directive definition and its SHOULD NOT-revalidate-while-fresh behavior",
+};
+const RFC_9111_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
+    note: "Freshness — Calculating Freshness Lifetime (§4.2.1) and Calculating Age (§4.2.3)",
+};
+
 impl Rule for ImmutableCacheNeverStale {
     fn id(&self) -> &'static str {
         "immutable_cache_never_stale"
@@ -129,20 +145,7 @@ impl Rule for ImmutableCacheNeverStale {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 8246",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8246.html#section-2",
-                note: "The Immutable Cache-Control Extension — the directive definition and its SHOULD NOT-revalidate-while-fresh behavior",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
-                note: "Freshness — Calculating Freshness Lifetime (§4.2.1) and Calculating Age (§4.2.3)",
-            },
-        ]
+        &[RFC_8246_2, RFC_9111_4_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/immutable_requires_freshness.rs
+++ b/lint-http-rules/src/rules/immutable_requires_freshness.rs
@@ -26,6 +26,22 @@ pub struct ImmutableRequiresFreshness;
 /// with a positive `max-age` is still *fresh*, it just cannot be reused without revalidation.)
 const NEVER_FRESH: &[&str] = &["no-store", "no-cache", "max-age=0", "s-maxage=0"];
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_8246_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8246",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8246.html#section-2",
+    note: "The `immutable` Cache-Control extension — applies only during the freshness lifetime",
+};
+const RFC_9111_5_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2",
+    note: "Response directives: `no-store`, `no-cache`, `max-age`, `s-maxage`",
+};
+
 impl Rule for ImmutableRequiresFreshness {
     fn id(&self) -> &'static str {
         "immutable_requires_freshness"
@@ -125,20 +141,7 @@ impl Rule for ImmutableRequiresFreshness {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 8246",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8246.html#section-2",
-                note: "The `immutable` Cache-Control extension — applies only during the freshness lifetime",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2",
-                note: "Response directives: `no-store`, `no-cache`, `max-age`, `s-maxage`",
-            },
-        ]
+        &[RFC_8246_2, RFC_9111_5_2_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/keep_alive_header_valid.rs
+++ b/lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -65,6 +65,104 @@ fn parse_keep_alive_config(
 
 pub struct KeepAliveHeaderValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_2068_19_7_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2068",
+    section: Some("19.7.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-19.7.1.1",
+    note: "The `Keep-Alive` grammar, the sentence saying HTTP/1.1 defines no \
+           parameters for it, and the field's one requirement on a sender — the \
+           matching connection token. Obsoleted, and still the document RFC 9110 \
+           §7.6.1 names for this field, so this is where the productions are read \
+           from. The reference here used to be RFC 7230 §6.7, which is `Upgrade`",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "The current specification's own pointer: `Keep-Alive` appears in the list \
+           of fields an intermediary should remove before forwarding, annotated \
+           *Section 19.7.1 of [RFC2068]*. It is also what makes the field \
+           connection-specific, and therefore hop-by-hop",
+};
+const RFC_2068_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2068",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-2.1",
+    note: "The two notation rules that make this field's list read differently from a \
+           field RFC 9110 defines: `#rule` permits null elements, and `implied *LWS` \
+           permits whitespace between a token and a delimiter — which is what makes \
+           `timeout = 30` conforming rather than a `BWS` defect",
+};
+const RFC_2068_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2068",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-2.2",
+    note: "`token`, `tspecials`, `LWS` and `quoted-string`. This document's `token` \
+           admits exactly the characters RFC 9110 §5.6.2's `tchar` does — the \
+           seventeen `tspecials` are RFC 9110's delimiters and both alphabets stop at \
+           US-ASCII — so the shared helper is the same production under another name",
+};
+const RFC_2068_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2068",
+    section: Some("3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-3.7",
+    note: "`value = token | quoted-string`, the right-hand half of `keepalive-param`. \
+           The rule name is defined once for the document and `keepalive-param` uses \
+           it, which is why a parameter value may be quoted at all",
+};
+const RFC_2068_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2068",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-4.2",
+    note: "This document's statement of the rule that makes repeated field lines one \
+           list — the same requirement RFC 9110 §5.2 states, which is what the shared \
+           line-joining helper cites",
+};
+const DRAFT_THOMSON_HYBI_HTTP_TIMEOUT_03_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "draft-thomson-hybi-http-timeout-03",
+    section: Some("2"),
+    url: "https://www.ietf.org/archive/id/draft-thomson-hybi-http-timeout-03.txt",
+    note: "The only document that ever gave `timeout` a grammar or a meaning. An \
+           individual Internet-Draft, never adopted, expired 2013-01-18 — quoted as \
+           the only published reading of the parameter and never as a requirement. \
+           Its §2.2.1 deprecates `max`; its §7.2 asks IANA for a registry that was \
+           never created, which is why this rule carries no list of parameter names",
+};
+const RFC_9111_1_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("1.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2",
+    note: "`delta-seconds = 1*DIGIT`, the production the draft's `timeout` value is. \
+           `1*DIGIT` is what a leading `+` fails, and a standard-library integer \
+           parser accepts",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender MUST NOT behind every grammar finding here: a value that derives \
+           from none of the productions is a protocol element matching no ABNF rule",
+};
+const RFC_2616_19_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2616",
+    section: Some("19.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-19.6.2",
+    note: "Where the grammar stopped being restated: RFC 2616 kept the compatibility \
+           discussion and sent the reader back to RFC 2068 for the field itself. The \
+           same shape as RFC 9111 §5.5 and `Warning`",
+};
+const IANA_HTTP_FIELD_NAME_REGISTRY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Field Name Registry",
+    section: None,
+    url: "https://www.iana.org/assignments/http-fields/http-fields.xhtml",
+    note: "`Keep-Alive` is registered `permanent`, with RFC 2068 as its only \
+           reference — not `obsoleted`, unlike `Warning`. Corroboration for reading \
+           an obsoleted document, not an authority this rule enforces",
+};
+
 impl Rule for KeepAliveHeaderValid {
     fn id(&self) -> &'static str {
         "keep_alive_header_valid"
@@ -210,101 +308,17 @@ impl Rule for KeepAliveHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 2068",
-                section: Some("19.7.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-19.7.1.1",
-                note: "The `Keep-Alive` grammar, the sentence saying HTTP/1.1 defines no \
-                       parameters for it, and the field's one requirement on a sender — the \
-                       matching connection token. Obsoleted, and still the document RFC 9110 \
-                       §7.6.1 names for this field, so this is where the productions are read \
-                       from. The reference here used to be RFC 7230 §6.7, which is `Upgrade`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "The current specification's own pointer: `Keep-Alive` appears in the list \
-                       of fields an intermediary should remove before forwarding, annotated \
-                       *Section 19.7.1 of [RFC2068]*. It is also what makes the field \
-                       connection-specific, and therefore hop-by-hop",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2068",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-2.1",
-                note: "The two notation rules that make this field's list read differently from a \
-                       field RFC 9110 defines: `#rule` permits null elements, and `implied *LWS` \
-                       permits whitespace between a token and a delimiter — which is what makes \
-                       `timeout = 30` conforming rather than a `BWS` defect",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2068",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-2.2",
-                note: "`token`, `tspecials`, `LWS` and `quoted-string`. This document's `token` \
-                       admits exactly the characters RFC 9110 §5.6.2's `tchar` does — the \
-                       seventeen `tspecials` are RFC 9110's delimiters and both alphabets stop at \
-                       US-ASCII — so the shared helper is the same production under another name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2068",
-                section: Some("3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-3.7",
-                note: "`value = token | quoted-string`, the right-hand half of `keepalive-param`. \
-                       The rule name is defined once for the document and `keepalive-param` uses \
-                       it, which is why a parameter value may be quoted at all",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2068",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc2068.html#section-4.2",
-                note: "This document's statement of the rule that makes repeated field lines one \
-                       list — the same requirement RFC 9110 §5.2 states, which is what the shared \
-                       line-joining helper cites",
-            },
-            crate::rules::SpecRef {
-                spec: "draft-thomson-hybi-http-timeout-03",
-                section: Some("2"),
-                url: "https://www.ietf.org/archive/id/draft-thomson-hybi-http-timeout-03.txt",
-                note: "The only document that ever gave `timeout` a grammar or a meaning. An \
-                       individual Internet-Draft, never adopted, expired 2013-01-18 — quoted as \
-                       the only published reading of the parameter and never as a requirement. \
-                       Its §2.2.1 deprecates `max`; its §7.2 asks IANA for a registry that was \
-                       never created, which is why this rule carries no list of parameter names",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("1.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2",
-                note: "`delta-seconds = 1*DIGIT`, the production the draft's `timeout` value is. \
-                       `1*DIGIT` is what a leading `+` fails, and a standard-library integer \
-                       parser accepts",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note:
-                    "The sender MUST NOT behind every grammar finding here: a value that derives \
-                       from none of the productions is a protocol element matching no ABNF rule",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2616",
-                section: Some("19.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-19.6.2",
-                note: "Where the grammar stopped being restated: RFC 2616 kept the compatibility \
-                       discussion and sent the reader back to RFC 2068 for the field itself. The \
-                       same shape as RFC 9111 §5.5 and `Warning`",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Field Name Registry",
-                section: None,
-                url: "https://www.iana.org/assignments/http-fields/http-fields.xhtml",
-                note: "`Keep-Alive` is registered `permanent`, with RFC 2068 as its only \
-                       reference — not `obsoleted`, unlike `Warning`. Corroboration for reading \
-                       an obsoleted document, not an authority this rule enforces",
-            },
+            RFC_2068_19_7_1_1,
+            RFC_9110_7_6_1,
+            RFC_2068_2_1,
+            RFC_2068_2_2,
+            RFC_2068_3_7,
+            RFC_2068_4_2,
+            DRAFT_THOMSON_HYBI_HTTP_TIMEOUT_03_2,
+            RFC_9111_1_2_2,
+            RFC_9110_2_2,
+            RFC_2616_19_6_2,
+            IANA_HTTP_FIELD_NAME_REGISTRY,
         ]
     }
 

--- a/lint-http-rules/src/rules/language_tag_syntax.rs
+++ b/lint-http-rules/src/rules/language_tag_syntax.rs
@@ -7,6 +7,41 @@ use crate::rules::Rule;
 
 pub struct LanguageTagSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_8_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.5.1",
+    note: "Language Tags: the sentence that assigns a different production to each of the two fields — `language-range` for Accept-Language, `language-tag` for Content-Language",
+};
+const RFC_5646_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5646",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1",
+    note: "Syntax: the `Language-Tag` production Content-Language carries. Its prose properties are enforced; its subtag ordering and length classes are not",
+};
+const RFC_4647_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 4647",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc4647.html#section-2.1",
+    note: "Basic Language Range: the production Accept-Language carries, including the `*` alternative and the statement that a range needs no well-formedness at all",
+};
+const RFC_9110_8_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.5",
+    note:
+        "Content-Language: `#language-tag` — a list of tags, with no wildcard and no weight in it",
+};
+const RFC_9110_12_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.4",
+    note: "Accept-Language: where the `language-range` production is pulled in by reference. The weight beside it is `accept_language_weight_valid`'s subject",
+};
+
 impl Rule for LanguageTagSyntax {
     fn id(&self) -> &'static str {
         "language_tag_syntax"
@@ -173,36 +208,11 @@ impl Rule for LanguageTagSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.5.1",
-                note: "Language Tags: the sentence that assigns a different production to each of the two fields — `language-range` for Accept-Language, `language-tag` for Content-Language",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5646",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1",
-                note: "Syntax: the `Language-Tag` production Content-Language carries. Its prose properties are enforced; its subtag ordering and length classes are not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 4647",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc4647.html#section-2.1",
-                note: "Basic Language Range: the production Accept-Language carries, including the `*` alternative and the statement that a range needs no well-formedness at all",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.5",
-                note: "Content-Language: `#language-tag` — a list of tags, with no wildcard and no weight in it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.4",
-                note: "Accept-Language: where the `language-range` production is pulled in by reference. The weight beside it is `accept_language_weight_valid`'s subject",
-            },
+            RFC_9110_8_5_1,
+            RFC_5646_2_1,
+            RFC_4647_2_1,
+            RFC_9110_8_5,
+            RFC_9110_12_5_4,
         ]
     }
 

--- a/lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
+++ b/lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
@@ -7,6 +7,16 @@ use crate::rules::Rule;
 
 pub struct LastModifiedRfc1123Syntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_5_6_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
+    note: "Date/Time Formats",
+};
+
 impl Rule for LastModifiedRfc1123Syntax {
     fn id(&self) -> &'static str {
         "last_modified_rfc1123_syntax"
@@ -75,12 +85,7 @@ impl Rule for LastModifiedRfc1123Syntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9110",
-            section: Some("5.6.7"),
-            url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
-            note: "Date/Time Formats",
-        }]
+        &[RFC_9110_5_6_7]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/link_header_valid.rs
+++ b/lint-http-rules/src/rules/link_header_valid.rs
@@ -12,6 +12,190 @@ use crate::rules::Rule;
 
 pub struct LinkHeaderValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_8288_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3",
+    note: "The serialisation: `Link = #link-value`, the angle-bracketed \
+           `URI-Reference`, and `link-param = token BWS [ \"=\" BWS ( token / \
+           quoted-string ) ]` — whose optional group is what makes a valueless \
+           parameter conforming. Also the sentence equating the token and \
+           quoted-string forms, which is why a value is judged after unquoting",
+};
+const RFC_8288_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.1",
+    note: "The link target: one IRI converted to a `URI-Reference` and written inside \
+           angle brackets. The conversion is why an octet no URI admits is a finding \
+           rather than an encoding question",
+};
+const RFC_8288_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.3",
+    note: "`rel` MUST be present and MUST NOT appear more than once; its value is \
+           `relation-type *( 1*SP relation-type )`; `relation-type = reg-rel-type / \
+           ext-rel-type` with `ext-rel-type = URI`, required to be absolute. The \
+           section that makes a URI-shaped relation type conforming and a capital \
+           letter in a registered one not",
+};
+const RFC_8288_3_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("3.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.4.1",
+    note: "The four serialisation-defined attributes this document bounds to one \
+           occurrence — `media`, `title`, `title*`, `type` — each in its own MUST \
+           NOT. `hreflang` is the one it deliberately leaves unbounded, saying that \
+           repeating it means several languages are available. Also the per-attribute \
+           value ABNFs: `Language-Tag` for `hreflang`, `type-name \"/\" \
+           subtype-name` for `type`, and `media-query-list` for `media` — the first \
+           two measured here, the third declined for the reasons the description \
+           gives",
+};
+const RFC_8288_2_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("2.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-2.1.1",
+    note: "Registered relation type names conform to `reg-rel-type` and are compared \
+           case-insensitively — the sentence behind folding case when asking whether \
+           a relation type is `preload`",
+};
+const RFC_8288_2_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("2.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-2.1.2",
+    note: "Extension relation types are URIs that uniquely identify the relation, \
+           compared as strings. Why a value matching no registered spelling is \
+           measured as a URI rather than reported",
+};
+const RFC_8288_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-2.2",
+    note: "Target attribute names are compared case-insensitively — the MUST behind \
+           recognising `rel`, `as` and the bounded four whatever case they were \
+           written in. Its `SHOULD NOT include \"%\", \"'\", or \"*\"` is advice \
+           about portability across serialisations and is not enforced here: §3.4.1 \
+           of this same document defines `title*`",
+};
+const RFC_8288_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-1.1",
+    note: "Which document's notation governs: the `#rule`, `token`, `quoted-string`, \
+           `BWS`, `OWS` and `LOALPHA` are imported rather than redefined, so the \
+           shared helpers that transcribe them are the right readers here. Its \
+           second list imports the value productions by name — `URI` and \
+           `URI-Reference` from RFC 3986, `type-name` and `subtype-name` from \
+           RFC 6838, `Language-Tag` from RFC 5646, and `media-query-list` from the \
+           2012 CSS3 Media Queries Recommendation, which is why a `media` value is \
+           the one this rule does not measure",
+};
+const RFC_8288_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8288",
+    section: Some("1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-1.2",
+    note: "The bridge to a modal: this document states no requirement of its own that \
+           a value match its ABNF, it adopts the core specification's conformance \
+           section — which is RFC 9110 §2.2 in the document now in force",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender MUST NOT behind every grammar finding here: a member deriving \
+           from none of §3's productions is a protocol element matching no ABNF rule",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The list construct: `#` sets no minimum, so an empty `Link:` declares no \
+           link rather than declaring one badly — and a sender MUST NOT write an \
+           empty element between two real ones",
+};
+const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
+    note: "`BWS` is admitted beside the `=` for historical reasons and a sender MUST \
+           NOT generate it — the half of the production that makes the recipient's \
+           trim required and the sender's whitespace a finding",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Repeated `Link` field lines are one list. RFC 8288 §3.5 shows the same \
+           thing from the other side, printing a two-member field value and the two \
+           field lines it is equivalent to",
+};
+const RFC_3986_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3",
+    note: "`URI` — the production `ext-rel-type` is, and the reason a relation type \
+           with a scheme is read as one instead of being measured against `tchar`. \
+           `URI-Reference` (§4.1) is the target's",
+};
+const RFC_5646_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5646",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1",
+    note: "Syntax: `Language-Tag`, the whole of §3.4.1's ABNF for an `hreflang` \
+           value. What is enforced is the catalogue's shared conservative floor — \
+           subtag shape, from this section's prose — not the full grammar and not \
+           the registry",
+};
+const RFC_6838_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6838",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2",
+    note: "Naming Requirements: `restricted-name`, the production behind both \
+           halves of a `type` value. It opens on a letter or digit and closes at \
+           127 characters, and §3.4.1's ABNF for the value ends at the \
+           subtype-name, so there is no parameters group and no wildcard here",
+};
+const HTML_SEMANTICS_4_2_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Semantics",
+    section: Some("4.2.4.4"),
+    url: "https://html.spec.whatwg.org/multipage/semantics.html#processing-link-headers",
+    note: "*Processing `Link` headers* — the algorithm that reads this field out of a \
+           **response** and, for `rel=preload`, returns early when `as` does not \
+           exist. The only published sentence pairing the two, and the reason that \
+           finding is worded as a member being discarded rather than as a MUST",
+};
+const HTML_LINKS_4_6_8_20: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Links",
+    section: Some("4.6.8.20"),
+    url: "https://html.spec.whatwg.org/multipage/links.html#link-type-preload",
+    note: "Where the `preload` keyword itself is defined, and where it says the \
+           resource is fetched *according to the preload destination given by the \
+           `as` attribute*. The old reference here named a retired W3C Preload \
+           specification in its note while pointing at this page",
+};
+const HTML_LINKS_4_6_8_20_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Links",
+    section: Some("4.6.8.20"),
+    url: "https://html.spec.whatwg.org/multipage/links.html#preload-destination",
+    note: "*Preload destination* — the six strings the header path admits — and \
+           *translate a preload destination*, which returns null for anything else \
+           before Fetch's own translation is consulted. The reason the table here \
+           holds six values and not Fetch's twenty",
+};
+const RFC_8297_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8297",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-2",
+    note: "Early Hints. Named because a check here used to be gated on the 103 status \
+           and rest on this document: it states nothing about a `Link` member's \
+           content, and its modals are addressed to the client",
+};
+
 impl Rule for LinkHeaderValid {
     fn id(&self) -> &'static str {
         "link_header_valid"
@@ -170,187 +354,26 @@ impl Rule for LinkHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3",
-                note: "The serialisation: `Link = #link-value`, the angle-bracketed \
-                       `URI-Reference`, and `link-param = token BWS [ \"=\" BWS ( token / \
-                       quoted-string ) ]` — whose optional group is what makes a valueless \
-                       parameter conforming. Also the sentence equating the token and \
-                       quoted-string forms, which is why a value is judged after unquoting",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.1",
-                note: "The link target: one IRI converted to a `URI-Reference` and written inside \
-                       angle brackets. The conversion is why an octet no URI admits is a finding \
-                       rather than an encoding question",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.3",
-                note: "`rel` MUST be present and MUST NOT appear more than once; its value is \
-                       `relation-type *( 1*SP relation-type )`; `relation-type = reg-rel-type / \
-                       ext-rel-type` with `ext-rel-type = URI`, required to be absolute. The \
-                       section that makes a URI-shaped relation type conforming and a capital \
-                       letter in a registered one not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("3.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-3.4.1",
-                note: "The four serialisation-defined attributes this document bounds to one \
-                       occurrence — `media`, `title`, `title*`, `type` — each in its own MUST \
-                       NOT. `hreflang` is the one it deliberately leaves unbounded, saying that \
-                       repeating it means several languages are available. Also the per-attribute \
-                       value ABNFs: `Language-Tag` for `hreflang`, `type-name \"/\" \
-                       subtype-name` for `type`, and `media-query-list` for `media` — the first \
-                       two measured here, the third declined for the reasons the description \
-                       gives",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("2.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-2.1.1",
-                note: "Registered relation type names conform to `reg-rel-type` and are compared \
-                       case-insensitively — the sentence behind folding case when asking whether \
-                       a relation type is `preload`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("2.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-2.1.2",
-                note: "Extension relation types are URIs that uniquely identify the relation, \
-                       compared as strings. Why a value matching no registered spelling is \
-                       measured as a URI rather than reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-2.2",
-                note: "Target attribute names are compared case-insensitively — the MUST behind \
-                       recognising `rel`, `as` and the bounded four whatever case they were \
-                       written in. Its `SHOULD NOT include \"%\", \"'\", or \"*\"` is advice \
-                       about portability across serialisations and is not enforced here: §3.4.1 \
-                       of this same document defines `title*`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-1.1",
-                note: "Which document's notation governs: the `#rule`, `token`, `quoted-string`, \
-                       `BWS`, `OWS` and `LOALPHA` are imported rather than redefined, so the \
-                       shared helpers that transcribe them are the right readers here. Its \
-                       second list imports the value productions by name — `URI` and \
-                       `URI-Reference` from RFC 3986, `type-name` and `subtype-name` from \
-                       RFC 6838, `Language-Tag` from RFC 5646, and `media-query-list` from the \
-                       2012 CSS3 Media Queries Recommendation, which is why a `media` value is \
-                       the one this rule does not measure",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8288",
-                section: Some("1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8288.html#section-1.2",
-                note: "The bridge to a modal: this document states no requirement of its own that \
-                       a value match its ABNF, it adopts the core specification's conformance \
-                       section — which is RFC 9110 §2.2 in the document now in force",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sender MUST NOT behind every grammar finding here: a member deriving \
-                       from none of §3's productions is a protocol element matching no ABNF rule",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The list construct: `#` sets no minimum, so an empty `Link:` declares no \
-                       link rather than declaring one badly — and a sender MUST NOT write an \
-                       empty element between two real ones",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-                note: "`BWS` is admitted beside the `=` for historical reasons and a sender MUST \
-                       NOT generate it — the half of the production that makes the recipient's \
-                       trim required and the sender's whitespace a finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Repeated `Link` field lines are one list. RFC 8288 §3.5 shows the same \
-                       thing from the other side, printing a two-member field value and the two \
-                       field lines it is equivalent to",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3",
-                note: "`URI` — the production `ext-rel-type` is, and the reason a relation type \
-                       with a scheme is read as one instead of being measured against `tchar`. \
-                       `URI-Reference` (§4.1) is the target's",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5646",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1",
-                note: "Syntax: `Language-Tag`, the whole of §3.4.1's ABNF for an `hreflang` \
-                       value. What is enforced is the catalogue's shared conservative floor — \
-                       subtag shape, from this section's prose — not the full grammar and not \
-                       the registry",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6838",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2",
-                note: "Naming Requirements: `restricted-name`, the production behind both \
-                       halves of a `type` value. It opens on a letter or digit and closes at \
-                       127 characters, and §3.4.1's ABNF for the value ends at the \
-                       subtype-name, so there is no parameters group and no wildcard here",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Semantics",
-                section: Some("4.2.4.4"),
-                url:
-                    "https://html.spec.whatwg.org/multipage/semantics.html#processing-link-headers",
-                note: "*Processing `Link` headers* — the algorithm that reads this field out of a \
-                       **response** and, for `rel=preload`, returns early when `as` does not \
-                       exist. The only published sentence pairing the two, and the reason that \
-                       finding is worded as a member being discarded rather than as a MUST",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Links",
-                section: Some("4.6.8.20"),
-                url: "https://html.spec.whatwg.org/multipage/links.html#link-type-preload",
-                note: "Where the `preload` keyword itself is defined, and where it says the \
-                       resource is fetched *according to the preload destination given by the \
-                       `as` attribute*. The old reference here named a retired W3C Preload \
-                       specification in its note while pointing at this page",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Links",
-                section: Some("4.6.8.20"),
-                url: "https://html.spec.whatwg.org/multipage/links.html#preload-destination",
-                note: "*Preload destination* — the six strings the header path admits — and \
-                       *translate a preload destination*, which returns null for anything else \
-                       before Fetch's own translation is consulted. The reason the table here \
-                       holds six values and not Fetch's twenty",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8297",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-2",
-                note: "Early Hints. Named because a check here used to be gated on the 103 status \
-                       and rest on this document: it states nothing about a `Link` member's \
-                       content, and its modals are addressed to the client",
-            },
+            RFC_8288_3,
+            RFC_8288_3_1,
+            RFC_8288_3_3,
+            RFC_8288_3_4_1,
+            RFC_8288_2_1_1,
+            RFC_8288_2_1_2,
+            RFC_8288_2_2,
+            RFC_8288_1_1,
+            RFC_8288_1_2,
+            RFC_9110_2_2,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_3,
+            RFC_9110_5_2,
+            RFC_3986_3,
+            RFC_5646_2_1,
+            RFC_6838_4_2,
+            HTML_SEMANTICS_4_2_4_4,
+            HTML_LINKS_4_6_8_20,
+            HTML_LINKS_4_6_8_20_2,
+            RFC_8297_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/location_header_uri_valid.rs
+++ b/lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -8,6 +8,46 @@ use crate::rules::Rule;
 
 pub struct LocationHeaderUriValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
+    note: "Location: the field definition, `Location = URI-reference`, and the Note explaining why the field cannot be a list — the comma list separator is valid data inside a URI-reference",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "Conformance: a sender MUST NOT generate a protocol element that does not match its ABNF. This is what makes a malformed `Location` value a violation, since §10.2.2 itself forbids nothing",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: a sender MUST NOT generate multiple field lines for a field with no comma-separated-list alternative. `Location` has none, so two lines are reported",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "Field Values: singleton fields, the care a comma needs in a field carrying a URI-reference, and the MUST to exclude leading and trailing whitespace before evaluating a field value",
+};
+const RFC_3986_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2",
+    note: "Characters: the limited set a URI is composed from — `unreserved`, `gen-delims`, `sub-delims` — and the `pct-encoded` triplet every other octet must be written as",
+};
+const RFC_3986_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1",
+    note: "`URI-reference = URI / relative-ref`. §4.4 is why an empty value is one of them, and so why the empty-value finding here is advisory",
+};
+
 impl Rule for LocationHeaderUriValid {
     fn id(&self) -> &'static str {
         "location_header_uri_valid"
@@ -167,42 +207,12 @@ impl Rule for LocationHeaderUriValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
-                note: "Location: the field definition, `Location = URI-reference`, and the Note explaining why the field cannot be a list — the comma list separator is valid data inside a URI-reference",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "Conformance: a sender MUST NOT generate a protocol element that does not match its ABNF. This is what makes a malformed `Location` value a violation, since §10.2.2 itself forbids nothing",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: a sender MUST NOT generate multiple field lines for a field with no comma-separated-list alternative. `Location` has none, so two lines are reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "Field Values: singleton fields, the care a comma needs in a field carrying a URI-reference, and the MUST to exclude leading and trailing whitespace before evaluating a field value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2",
-                note: "Characters: the limited set a URI is composed from — `unreserved`, `gen-delims`, `sub-delims` — and the `pct-encoded` triplet every other octet must be written as",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.1",
-                note: "`URI-reference = URI / relative-ref`. §4.4 is why an empty value is one of them, and so why the empty-value finding here is advisory",
-            },
+            RFC_9110_10_2_2,
+            RFC_9110_2_2,
+            RFC_9110_5_3,
+            RFC_9110_5_5,
+            RFC_3986_2,
+            RFC_3986_4_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/location_on_redirect_present.rs
+++ b/lint-http-rules/src/rules/location_on_redirect_present.rs
@@ -84,6 +84,64 @@ fn location_asked_for(status: u16) -> Option<&'static str> {
     None
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
+    note: "Defines `Location = URI-reference` and what the value refers to on a 201 and on a 3xx; it asks no one to send the field",
+};
+const RFC_9110_15_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
+    note: "What a provided Location buys: a user agent MAY redirect to it automatically, even where it does not understand the status code",
+};
+const RFC_9110_15_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.1",
+    note: "300 Multiple Choices: the SHOULD applies only if the server has a preferred choice, so this rule does not report a 300",
+};
+const RFC_9110_15_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.2",
+    note: "301 Moved Permanently: the server SHOULD generate a Location header field containing a preferred URI reference for the new permanent URI",
+};
+const RFC_9110_15_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.3",
+    note: "302 Found: the server SHOULD generate a Location header field containing a URI reference for the different URI",
+};
+const RFC_9110_15_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.4",
+    note: "303 See Other: the status is defined as a redirection to the resource indicated by a URI in the Location header field",
+};
+const RFC_9110_15_4_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.8",
+    note: "307 Temporary Redirect: the server SHOULD generate a Location header field containing a URI reference for the different URI",
+};
+const RFC_9110_15_4_9: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.9"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.9",
+    note: "308 Permanent Redirect: the server SHOULD generate a Location header field containing a preferred URI reference for the new permanent URI",
+};
+const RFC_9110_15_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
+    note: "201 Created: with no Location field, the resource created is identified by the target URI — which is why this rule does not report a 201",
+};
+
 impl Rule for LocationOnRedirectPresent {
     fn id(&self) -> &'static str {
         "location_on_redirect_present"
@@ -150,60 +208,15 @@ impl Rule for LocationOnRedirectPresent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
-                note: "Defines `Location = URI-reference` and what the value refers to on a 201 and on a 3xx; it asks no one to send the field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
-                note: "What a provided Location buys: a user agent MAY redirect to it automatically, even where it does not understand the status code",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.1",
-                note: "300 Multiple Choices: the SHOULD applies only if the server has a preferred choice, so this rule does not report a 300",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.2",
-                note: "301 Moved Permanently: the server SHOULD generate a Location header field containing a preferred URI reference for the new permanent URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.3",
-                note: "302 Found: the server SHOULD generate a Location header field containing a URI reference for the different URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.4",
-                note: "303 See Other: the status is defined as a redirection to the resource indicated by a URI in the Location header field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.8",
-                note: "307 Temporary Redirect: the server SHOULD generate a Location header field containing a URI reference for the different URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.9"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.9",
-                note: "308 Permanent Redirect: the server SHOULD generate a Location header field containing a preferred URI reference for the new permanent URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
-                note: "201 Created: with no Location field, the resource created is identified by the target URI — which is why this rule does not report a 201",
-            },
+            RFC_9110_10_2_2,
+            RFC_9110_15_4,
+            RFC_9110_15_4_1,
+            RFC_9110_15_4_2,
+            RFC_9110_15_4_3,
+            RFC_9110_15_4_4,
+            RFC_9110_15_4_8,
+            RFC_9110_15_4_9,
+            RFC_9110_15_3_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/max_age_directive_valid.rs
+++ b/lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -30,6 +30,22 @@ use crate::rules::Rule;
 /// lifetime of a cached response.
 pub struct MaxAgeDirectiveValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
+    note: "Freshness — fresh/stale definitions, and reuse without contacting the origin as an efficiency opportunity (age itself is calculated per §4.2.3)",
+};
+const RFC_9111_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
+    note: "Validation — a cache that cannot serve a stored response can use a conditional request to revalidate it",
+};
+
 impl Rule for MaxAgeDirectiveValid {
     fn id(&self) -> &'static str {
         "max_age_directive_valid"
@@ -153,20 +169,7 @@ impl Rule for MaxAgeDirectiveValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
-                note: "Freshness — fresh/stale definitions, and reuse without contacting the origin as an efficiency opportunity (age itself is calculated per §4.2.3)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
-                note: "Validation — a cache that cannot serve a stored response can use a conditional request to revalidate it",
-            },
-        ]
+        &[RFC_9111_4_2, RFC_9111_4_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/max_forwards_numeric.rs
+++ b/lint-http-rules/src/rules/max_forwards_numeric.rs
@@ -8,6 +8,40 @@ use crate::rules::Rule;
 
 pub struct MaxForwardsNumeric;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_7_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.2",
+    note: "The field: its grammar (`1*DIGIT`), the methods it works with, and the recipient's permission to ignore it on the others. The section's requirements on intermediaries — check and update the value, do not forward at zero — are stated here and are not measurable from one captured leg; this rule reads the syntax only",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "A sender MUST NOT generate multiple field lines with the same name unless the field's definition allows them to be recombined as a comma-separated list. `Max-Forwards` has no such alternative, so two lines are reported",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Repeated field lines in one section are one field value, joined with a comma — so the value measured against `1*DIGIT` is the one a recipient reads",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "Singleton fields, why detecting a singleton sent with several members is worth doing, and the MUST to exclude leading and trailing whitespace before evaluating a field value",
+};
+const RFC_9110_9_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7",
+    note: "A client MAY send the field in an OPTIONS request to target a specific recipient, and a proxy MUST NOT generate it while forwarding a request that arrived without it — the second is undecidable from a captured message, since nothing on the wire records who wrote a field",
+};
+
 impl Rule for MaxForwardsNumeric {
     fn id(&self) -> &'static str {
         "max_forwards_numeric"
@@ -136,36 +170,11 @@ impl Rule for MaxForwardsNumeric {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.2",
-                note: "The field: its grammar (`1*DIGIT`), the methods it works with, and the recipient's permission to ignore it on the others. The section's requirements on intermediaries — check and update the value, do not forward at zero — are stated here and are not measurable from one captured leg; this rule reads the syntax only",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "A sender MUST NOT generate multiple field lines with the same name unless the field's definition allows them to be recombined as a comma-separated list. `Max-Forwards` has no such alternative, so two lines are reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Repeated field lines in one section are one field value, joined with a comma — so the value measured against `1*DIGIT` is the one a recipient reads",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "Singleton fields, why detecting a singleton sent with several members is worth doing, and the MUST to exclude leading and trailing whitespace before evaluating a field value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7",
-                note: "A client MAY send the field in an OPTIONS request to target a specific recipient, and a proxy MUST NOT generate it while forwarding a request that arrived without it — the second is undecidable from a captured message, since nothing on the wire records who wrote a field",
-            },
+            RFC_9110_7_6_2,
+            RFC_9110_5_3,
+            RFC_9110_5_2,
+            RFC_9110_5_5,
+            RFC_9110_9_3_7,
         ]
     }
 

--- a/lint-http-rules/src/rules/media_type_suffix_valid.rs
+++ b/lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct MediaTypeSuffixValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6838_4_2_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6838",
+    section: Some("4.2.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8",
+    note: "Structured Syntax Name Suffixes: that an unregistered `+suffix` SHOULD NOT be used, and — the sharper half — that a suffix MUST NOT name a syntax the type does not employ",
+};
+const RFC_6838_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6838",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2",
+    note: "Naming Requirements: `restricted-name`, which decides where a suffix starts (\"characters after last plus\") and that a name must begin with ALPHA or DIGIT — so a subtype that is only a suffix has no base name",
+};
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "Media Type: the subtype a suffix lives in is case-insensitive, which is why suffixes are compared folded",
+};
+const IANA_MEDIA_TYPE_STRUCTURED_SUFFIXES: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA Media Type Structured Suffixes",
+    section: None,
+    url: "https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xhtml",
+    note: "The registry this rule stands in for but does not read; the configured `allowed` array is what it actually checks against",
+};
+
 impl Rule for MediaTypeSuffixValid {
     fn id(&self) -> &'static str {
         "media_type_suffix_valid"
@@ -219,30 +247,10 @@ impl Rule for MediaTypeSuffixValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6838",
-                section: Some("4.2.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2.8",
-                note: "Structured Syntax Name Suffixes: that an unregistered `+suffix` SHOULD NOT be used, and — the sharper half — that a suffix MUST NOT name a syntax the type does not employ",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6838",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6838.html#section-4.2",
-                note: "Naming Requirements: `restricted-name`, which decides where a suffix starts (\"characters after last plus\") and that a name must begin with ALPHA or DIGIT — so a subtype that is only a suffix has no base name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "Media Type: the subtype a suffix lives in is case-insensitive, which is why suffixes are compared folded",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA Media Type Structured Suffixes",
-                section: None,
-                url: "https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xhtml",
-                note: "The registry this rule stands in for but does not read; the configured `allowed` array is what it actually checks against",
-            },
+            RFC_6838_4_2_8,
+            RFC_6838_4_2,
+            RFC_9110_8_3_1,
+            IANA_MEDIA_TYPE_STRUCTURED_SUFFIXES,
         ]
     }
 

--- a/lint-http-rules/src/rules/multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct MultipartBoundarySyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_2046_5_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2046",
+    section: Some("5.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
+    note: "Multipart common syntax: the required `boundary` parameter, the `boundary`/`bchars`/`bcharsnospace` grammar, the 1-to-70-character limit and the ban on a trailing space, and the warning that a boundary often has to be quoted",
+};
+const RFC_9110_8_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.3",
+    note: "Multipart Types: where HTTP adopts RFC 2046 §5.1.1 and makes the boundary part of the media type value. It also says HTTP framing does not use the boundary as a length indicator, so nothing here is a framing check",
+};
+const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
+    note: "Parameters: the `parameters`/`parameter`/`parameter-value` grammar this walks, case-insensitive parameter names, and the equivalence of the quoted and unquoted forms",
+};
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "Media Type: the case-insensitivity of `type`, which is what scopes this rule to `multipart`",
+};
+
 impl Rule for MultipartBoundarySyntax {
     fn id(&self) -> &'static str {
         "multipart_boundary_syntax"
@@ -82,30 +110,10 @@ impl Rule for MultipartBoundarySyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 2046",
-                section: Some("5.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
-                note: "Multipart common syntax: the required `boundary` parameter, the `boundary`/`bchars`/`bcharsnospace` grammar, the 1-to-70-character limit and the ban on a trailing space, and the warning that a boundary often has to be quoted",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.3",
-                note: "Multipart Types: where HTTP adopts RFC 2046 §5.1.1 and makes the boundary part of the media type value. It also says HTTP framing does not use the boundary as a length indicator, so nothing here is a framing check",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-                note: "Parameters: the `parameters`/`parameter`/`parameter-value` grammar this walks, case-insensitive parameter names, and the equivalence of the quoted and unquoted forms",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "Media Type: the case-insensitivity of `type`, which is what scopes this rule to `multipart`",
-            },
+            RFC_2046_5_1_1,
+            RFC_9110_8_3_3,
+            RFC_9110_5_6_6,
+            RFC_9110_8_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
+++ b/lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct MultipartContentTypeAndBodyConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_2046_5_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2046",
+    section: Some("5.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
+    note: "Multipart common syntax: `dash-boundary`, `delimiter` and `close-delimiter`, the requirement that a delimiter begin a line, the instruction to compare against the beginning of a candidate line rather than the whole of it, and the ignoring of preamble and epilogue",
+};
+const RFC_9110_8_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.3",
+    note: "Multipart Types: where HTTP adopts RFC 2046 §5.1.1, and the CRLF-between-parts requirement this rule tolerates rather than enforces. It also says HTTP framing does not use the boundary as a length indicator, so nothing here is a framing check",
+};
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "Content-Type: the field describes a representation in either direction, which is what puts request and response bodies both in scope",
+};
+
 impl Rule for MultipartContentTypeAndBodyConsistent {
     fn id(&self) -> &'static str {
         "multipart_content_type_and_body_consistent"
@@ -120,26 +142,7 @@ impl Rule for MultipartContentTypeAndBodyConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 2046",
-                section: Some("5.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1",
-                note: "Multipart common syntax: `dash-boundary`, `delimiter` and `close-delimiter`, the requirement that a delimiter begin a line, the instruction to compare against the beginning of a candidate line rather than the whole of it, and the ignoring of preamble and epilogue",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.3",
-                note: "Multipart Types: where HTTP adopts RFC 2046 §5.1.1, and the CRLF-between-parts requirement this rule tolerates rather than enforces. It also says HTTP framing does not use the boundary as a length indicator, so nothing here is a framing check",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "Content-Type: the field describes a representation in either direction, which is what puts request and response bodies both in scope",
-            },
-        ]
+        &[RFC_2046_5_1_1, RFC_9110_8_3_3, RFC_9110_8_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/must_revalidate_enforced.rs
+++ b/lint-http-rules/src/rules/must_revalidate_enforced.rs
@@ -33,6 +33,34 @@ use crate::rules::Rule;
 /// to revalidate.
 pub struct MustRevalidateEnforced;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.2",
+    note: "`must-revalidate`",
+};
+const RFC_9111_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
+    note: "Freshness (a response is stale once its age reaches its freshness lifetime)",
+};
+const RFC_9111_4_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.3",
+    note: "Calculating Age (the response age this rule estimates)",
+};
+const RFC_9111_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
+    note: "Validation (revalidating a stale entry before reuse)",
+};
+
 impl Rule for MustRevalidateEnforced {
     fn id(&self) -> &'static str {
         "must_revalidate_enforced"
@@ -135,32 +163,7 @@ impl Rule for MustRevalidateEnforced {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.2",
-                note: "`must-revalidate`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2",
-                note: "Freshness (a response is stale once its age reaches its freshness lifetime)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.2.3",
-                note: "Calculating Age (the response age this rule estimates)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
-                note: "Validation (revalidating a stale entry before reuse)",
-            },
-        ]
+        &[RFC_9111_5_2_2_2, RFC_9111_4_2, RFC_9111_4_2_3, RFC_9111_4_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
+++ b/lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
@@ -18,6 +18,70 @@ impl NoBodyFor1xx204304 {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2",
+    note: "Informational 1xx — \"A 1xx response is terminated by the end of the header section; it cannot contain content or trailers\"",
+};
+const RFC_9110_15_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5",
+    note: "204 (No Content) — the same sentence, written again for this status",
+};
+const RFC_9110_15_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
+    note: "304 (Not Modified) — the same sentence a third time. It forbids content and trailers, and says nothing against the two header fields that describe the 200 that was not sent",
+};
+const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Content-Length — a MUST NOT on 1xx and 204 at any value, and a MAY on a 304 to a conditional GET. That MAY's own MUST NOT (the value must equal the unsent 200's content length) is undecidable from one exchange and is left unenforced",
+};
+const RFC_9110_6_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1",
+    note: "Content Semantics — the summary this rule is named after. It is about content, not about header fields; taking it for a rule about fields is what put the 304 in front of two prohibitions that exempt it",
+};
+const RFC_9110_15_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.6",
+    note: "205 (Reset Content) — bodiless by a MUST NOT of its own, but with ordinary framing, so it is not reported by this rule and has none of its own",
+};
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Message body length, item 1 — these responses end at the first empty line \"regardless of the header fields present\", which is why a field's presence is its own defect rather than evidence of a body",
+};
+const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
+    note: "Transfer-Encoding — a MUST NOT on 1xx and 204, and a MAY on a 304 to a GET. HTTP/1.1's document, so the check does not run on later versions",
+};
+const RFC_9113_8_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
+    note: "HTTP/2 — Transfer-Encoding is connection-specific and must not appear at all, whatever the status. No rule reports it yet",
+};
+const RFC_9114_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.1",
+    note: "HTTP/3 — transfer codings are not defined and the field must not be used; no_connection_specific_fields reports it. The same section repeats the trailers half for interim responses",
+};
+
 impl Rule for NoBodyFor1xx204304 {
     fn id(&self) -> &'static str {
         "no_body_for_1xx_204_304"
@@ -214,66 +278,16 @@ impl Rule for NoBodyFor1xx204304 {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2",
-                note: "Informational 1xx — \"A 1xx response is terminated by the end of the header section; it cannot contain content or trailers\"",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5",
-                note: "204 (No Content) — the same sentence, written again for this status",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5",
-                note: "304 (Not Modified) — the same sentence a third time. It forbids content and trailers, and says nothing against the two header fields that describe the 200 that was not sent",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-                note: "Content-Length — a MUST NOT on 1xx and 204 at any value, and a MAY on a 304 to a conditional GET. That MAY's own MUST NOT (the value must equal the unsent 200's content length) is undecidable from one exchange and is left unenforced",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1",
-                note: "Content Semantics — the summary this rule is named after. It is about content, not about header fields; taking it for a rule about fields is what put the 304 in front of two prohibitions that exempt it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.6",
-                note: "205 (Reset Content) — bodiless by a MUST NOT of its own, but with ordinary framing, so it is not reported by this rule and has none of its own",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "Message body length, item 1 — these responses end at the first empty line \"regardless of the header fields present\", which is why a field's presence is its own defect rather than evidence of a body",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
-                note: "Transfer-Encoding — a MUST NOT on 1xx and 204, and a MAY on a 304 to a GET. HTTP/1.1's document, so the check does not run on later versions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
-                note: "HTTP/2 — Transfer-Encoding is connection-specific and must not appear at all, whatever the status. No rule reports it yet",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.1",
-                note: "HTTP/3 — transfer codings are not defined and the field must not be used; no_connection_specific_fields reports it. The same section repeats the trailers half for interim responses",
-            },
+            RFC_9110_15_2,
+            RFC_9110_15_3_5,
+            RFC_9110_15_4_5,
+            RFC_9110_8_6,
+            RFC_9110_6_4_1,
+            RFC_9110_15_3_6,
+            RFC_9112_6_3,
+            RFC_9112_6_1,
+            RFC_9113_8_2_2,
+            RFC_9114_4_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/no_cache_revalidation.rs
+++ b/lint-http-rules/src/rules/no_cache_revalidation.rs
@@ -35,6 +35,22 @@ use crate::rules::Rule;
 /// could not possibly be revalidated.
 pub struct NoCacheRevalidation;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4",
+    note: "`no-cache`",
+};
+const RFC_9111_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
+    note: "Validation (the conditional request that satisfies no-cache)",
+};
+
 impl Rule for NoCacheRevalidation {
     fn id(&self) -> &'static str {
         "no_cache_revalidation"
@@ -103,20 +119,7 @@ impl Rule for NoCacheRevalidation {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.4",
-                note: "`no-cache`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
-                note: "Validation (the conditional request that satisfies no-cache)",
-            },
-        ]
+        &[RFC_9111_5_2_2_4, RFC_9111_4_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -257,6 +257,45 @@ impl NoConnectionSpecificFields {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9113_8_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
+    note: "Connection-Specific Header Fields — HTTP/2's prohibition, and the one \
+           sentence of the two that closes the list of names",
+};
+const RFC_9114_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
+    note: "HTTP Fields — HTTP/3's prohibition, which enumerates nothing and defers \
+           to RFC 9110 §7.6.1",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "Connection — the field itself, and the open list of those that carry \
+           connection-specific semantics",
+};
+const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
+    note: "TE — the capabilities of the client, which is why a response carrying \
+           the field gets no part of the exception",
+};
+const RFC_5234_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5234",
+    section: Some("2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3",
+    note: "Terminal Values — an ABNF string is case-insensitive, which is what \
+           licenses matching `trailers` without regard to case",
+};
+
 impl Rule for NoConnectionSpecificFields {
     fn id(&self) -> &'static str {
         "no_connection_specific_fields"
@@ -324,41 +363,11 @@ impl Rule for NoConnectionSpecificFields {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
-                note: "Connection-Specific Header Fields — HTTP/2's prohibition, and the one \
-                       sentence of the two that closes the list of names",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
-                note: "HTTP Fields — HTTP/3's prohibition, which enumerates nothing and defers \
-                       to RFC 9110 §7.6.1",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "Connection — the field itself, and the open list of those that carry \
-                       connection-specific semantics",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
-                note: "TE — the capabilities of the client, which is why a response carrying \
-                       the field gets no part of the exception",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5234",
-                section: Some("2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3",
-                note: "Terminal Values — an ABNF string is case-insensitive, which is what \
-                       licenses matching `trailers` without regard to case",
-            },
+            RFC_9113_8_2_2,
+            RFC_9114_4_2,
+            RFC_9110_7_6_1,
+            RFC_9110_10_1_4,
+            RFC_5234_2_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -31,6 +31,22 @@ use crate::rules::Rule;
 /// filtered out.
 pub struct NoStoreEnforced;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2_2_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.5",
+    note: "`no-store`",
+};
+const RFC_9111_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
+    note: "Validation (conditional requests carry the validators this rule tracks)",
+};
+
 impl Rule for NoStoreEnforced {
     fn id(&self) -> &'static str {
         "no_store_enforced"
@@ -207,20 +223,7 @@ impl Rule for NoStoreEnforced {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2.2.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.5",
-                note: "`no-store`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3",
-                note: "Validation (conditional requests carry the validators this rule tracks)",
-            },
-        ]
+        &[RFC_9111_5_2_2_5, RFC_9111_4_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/oauth2_code_flow.rs
+++ b/lint-http-rules/src/rules/oauth2_code_flow.rs
@@ -27,6 +27,29 @@ use crate::rules::Rule;
 /// available for correlation, depending on query configuration.
 pub struct Oauth2CodeFlow;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6749_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6749",
+    section: Some("4.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.1",
+    note:
+        "Authorization Request — response_type MUST be \"code\"; the state parameter is RECOMMENDED",
+};
+const RFC_6749_4_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6749",
+    section: Some("4.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2",
+    note: "Authorization Response — the callback carries the code, and echoes the exact state if the request had one",
+};
+const RFC_6749_10_12: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6749",
+    section: Some("10.12"),
+    url: "https://www.rfc-editor.org/rfc/rfc6749.html#section-10.12",
+    note: "Cross-Site Request Forgery — the client MUST implement CSRF protection for its redirection URI and SHOULD use the state parameter for it (the rule's real basis)",
+};
+
 impl Rule for Oauth2CodeFlow {
     fn id(&self) -> &'static str {
         "oauth2_code_flow"
@@ -142,26 +165,7 @@ impl Rule for Oauth2CodeFlow {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6749",
-                section: Some("4.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.1",
-                note: "Authorization Request — response_type MUST be \"code\"; the state parameter is RECOMMENDED",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6749",
-                section: Some("4.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6749.html#section-4.1.2",
-                note: "Authorization Response — the callback carries the code, and echoes the exact state if the request had one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6749",
-                section: Some("10.12"),
-                url: "https://www.rfc-editor.org/rfc/rfc6749.html#section-10.12",
-                note: "Cross-Site Request Forgery — the client MUST implement CSRF protection for its redirection URI and SHOULD use the state parameter for it (the rule's real basis)",
-            },
-        ]
+        &[RFC_6749_4_1_1, RFC_6749_4_1_2, RFC_6749_10_12]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/options_method_capabilities.rs
+++ b/lint-http-rules/src/rules/options_method_capabilities.rs
@@ -52,6 +52,52 @@ const ADVERTISED_CAPABILITIES: [(&str, &str, bool); 3] = [
     ("accept-patch", "Accept-Patch", false),
 ];
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_9_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7",
+    note: "OPTIONS — the client `MUST` about `Content-Type`, the `SHOULD` to advertise, which names a class ending \"including potential extensions not defined by this specification\" rather than a field, the asterisk target that names no resource, and the `Max-Forwards` `MUST NOT` no capture can attribute",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, which is why `OPTIONS` is matched exactly and a lowercase `options` is not an OPTIONS",
+};
+const RFC_9110_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4",
+    note: "Content — the octet stream left after framing is removed, which is what the `Content-Type` check measures instead of the presence of a framing field",
+};
+const RFC_9110_15_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3",
+    note: "2xx is the class named Successful, which is the range \"a successful response to OPTIONS\" means",
+};
+const RFC_9110_10_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
+    note: "`Allow` advertises the target resource's methods, is a `MAY` on any response other than a 405 — so it is not asked for by name — and an empty value of it means the resource allows no methods",
+};
+const RFC_9110_14_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
+    note: "`Accept-Ranges` advertises range-request support for the target resource — a second member of the class §9.3.7 asks for",
+};
+const RFC_5789_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
+    note: "`Accept-Patch` advertises the patch formats a resource accepts, and this section asks for it in an OPTIONS response by name",
+};
+
 impl Rule for OptionsMethodCapabilities {
     fn id(&self) -> &'static str {
         "options_method_capabilities"
@@ -180,48 +226,13 @@ impl Rule for OptionsMethodCapabilities {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7",
-                note: "OPTIONS — the client `MUST` about `Content-Type`, the `SHOULD` to advertise, which names a class ending \"including potential extensions not defined by this specification\" rather than a field, the asterisk target that names no resource, and the `Max-Forwards` `MUST NOT` no capture can attribute",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, which is why `OPTIONS` is matched exactly and a lowercase `options` is not an OPTIONS",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4",
-                note: "Content — the octet stream left after framing is removed, which is what the `Content-Type` check measures instead of the presence of a framing field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3",
-                note: "2xx is the class named Successful, which is the range \"a successful response to OPTIONS\" means",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
-                note: "`Allow` advertises the target resource's methods, is a `MAY` on any response other than a 405 — so it is not asked for by name — and an empty value of it means the resource allows no methods",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.3",
-                note: "`Accept-Ranges` advertises range-request support for the target resource — a second member of the class §9.3.7 asks for",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
-                note: "`Accept-Patch` advertises the patch formats a resource accepts, and this section asks for it in an OPTIONS response by name",
-            },
+            RFC_9110_9_3_7,
+            RFC_9110_9_1,
+            RFC_9110_6_4,
+            RFC_9110_15_3,
+            RFC_9110_10_2_1,
+            RFC_9110_14_3,
+            RFC_5789_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct OriginIsolatedHeaderValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const HTML_7_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML",
+    section: Some("7.1.2"),
+    url: "https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters",
+    note: "`Origin-Agent-Cluster` — a structured-header boolean; only the `?1` true value requests an origin-keyed agent cluster",
+};
+const RFC_9651_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3",
+    note: "Structured Headers boolean values (§3–§4)",
+};
+
 impl Rule for OriginIsolatedHeaderValid {
     fn id(&self) -> &'static str {
         "origin_isolated_header_valid"
@@ -87,20 +103,7 @@ impl Rule for OriginIsolatedHeaderValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "HTML",
-                section: Some("7.1.2"),
-                url: "https://html.spec.whatwg.org/multipage/browsers.html#origin-keyed-agent-clusters",
-                note: "`Origin-Agent-Cluster` — a structured-header boolean; only the `?1` true value requests an origin-keyed agent cluster",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3",
-                note: "Structured Headers boolean values (§3–§4)",
-            },
-        ]
+        &[HTML_7_1_2, RFC_9651_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct OriginMatchingForCors;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6454: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6454",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc6454.html",
+    note: "The Web Origin Concept",
+};
+const FETCH_4_10: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("4.10"),
+    url: "https://fetch.spec.whatwg.org/#concept-cors-check",
+    note: "Fetch CORS check — the response origin must byte-match the request `Origin` (or be `*` for a non-credentialed request); this rule's matching logic lives here (two of its three cites)",
+};
+const MDN_ACCESS_CONTROL_ALLOW_ORIGIN: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Access-Control-Allow-Origin",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin",
+    note: "Access-Control-Allow-Origin",
+};
+
 impl Rule for OriginMatchingForCors {
     fn id(&self) -> &'static str {
         "origin_matching_for_cors"
@@ -121,26 +143,7 @@ impl Rule for OriginMatchingForCors {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6454",
-                section: None,
-                url: "https://www.rfc-editor.org/rfc/rfc6454.html",
-                note: "The Web Origin Concept",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("4.10"),
-                url: "https://fetch.spec.whatwg.org/#concept-cors-check",
-                note: "Fetch CORS check — the response origin must byte-match the request `Origin` (or be `*` for a non-credentialed request); this rule's matching logic lives here (two of its three cites)",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Access-Control-Allow-Origin",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin",
-                note: "Access-Control-Allow-Origin",
-            },
-        ]
+        &[RFC_6454, FETCH_4_10, MDN_ACCESS_CONTROL_ALLOW_ORIGIN]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/patch_method_content_type_match.rs
+++ b/lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -97,6 +97,46 @@ fn advertised_formats(headers: &hyper::HeaderMap) -> Option<Vec<String>> {
     )
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_5789_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
+    note: "The `Accept-Patch` header — the patch document formats a server accepts, advertised per resource and readable from a response to any method. This reference said §2.2, which is Error Handling",
+};
+const RFC_5789_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2.2",
+    note: "Error handling — `415 (Unsupported Media Type)` is what a server may answer a format it does not support with, which is the consequence this rule anticipates rather than a requirement it enforces",
+};
+const RFC_9110_12_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.3",
+    note: "Request content negotiation — enrols `Accept-Patch` among the preferences a server sends to influence the content of subsequent requests, which is what lets §12.4.3 reach it",
+};
+const RFC_9110_12_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.3",
+    note: "Wildcard values — a field has one only where its own definition indicates one, and where none is present the values not mentioned are considered unacceptable. Both halves of this rule",
+};
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "`Content-Type` is a singleton, and recipients differ over which member wins when it is sent more than once — so a duplicated field states no media type to compare",
+};
+const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
+    note: "The `media-type` grammar: type and subtype are case-insensitive, and whether a parameter is significant depends on the media type's registration",
+};
+
 impl Rule for PatchMethodContentTypeMatch {
     fn id(&self) -> &'static str {
         "patch_method_content_type_match"
@@ -229,42 +269,12 @@ impl Rule for PatchMethodContentTypeMatch {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
-                note: "The `Accept-Patch` header — the patch document formats a server accepts, advertised per resource and readable from a response to any method. This reference said §2.2, which is Error Handling",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2.2",
-                note: "Error handling — `415 (Unsupported Media Type)` is what a server may answer a format it does not support with, which is the consequence this rule anticipates rather than a requirement it enforces",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.3",
-                note: "Request content negotiation — enrols `Accept-Patch` among the preferences a server sends to influence the content of subsequent requests, which is what lets §12.4.3 reach it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.3",
-                note: "Wildcard values — a field has one only where its own definition indicates one, and where none is present the values not mentioned are considered unacceptable. Both halves of this rule",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "`Content-Type` is a singleton, and recipients differ over which member wins when it is sent more than once — so a duplicated field states no media type to compare",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
-                note: "The `media-type` grammar: type and subtype are case-insensitive, and whether a parameter is significant depends on the media type's registration",
-            },
+            RFC_5789_3_1,
+            RFC_5789_2_2,
+            RFC_9110_12_3,
+            RFC_9110_12_4_3,
+            RFC_9110_8_3,
+            RFC_9110_8_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/patch_partial_update.rs
+++ b/lint-http-rules/src/rules/patch_partial_update.rs
@@ -16,6 +16,52 @@ use crate::rules::Rule;
 /// (`patch_method_content_type_match`).
 pub struct PatchPartialUpdate;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_5789_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2",
+    note: "The PATCH method — a patch document is identified by a media type, the request's fields describe that document rather than the resource, and no patch format is one implementations must support, which is why this rule reports the field's absence and does not judge its value",
+};
+const RFC_5789_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2.2",
+    note: "Error Handling — `415 (Unsupported Media Type)` is offered, not required, for a patch format the server does not support; it is the recipient's side of the media type this rule asks for",
+};
+const RFC_5789_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5789",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
+    note: "The `Accept-Patch` header — how a server says which patch formats it takes. It is a response field, so a lone request cannot be measured against it; `patch_method_content_type_match` is the rule that has one",
+};
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "Content-Type — the SHOULD this rule enforces, the exception excusing a sender that does not know its own media type, and the two guesses a recipient is left with when the field is absent",
+};
+const RFC_9110_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4",
+    note: "Content — the octet stream left once framing has been taken off, which is why a `Transfer-Encoding` is not evidence of any and the captured count decides",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "Methods overview — the method token is case-sensitive, which is why `PATCH` is matched exactly and a lowercase `patch` is not a PATCH request",
+};
+const RFC_9110_12_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.3",
+    note: "Request content negotiation — names `Accept-Patch` as the way the acceptable PATCH content types are discovered, rather than inferred from a media type's spelling",
+};
+
 impl Rule for PatchPartialUpdate {
     fn id(&self) -> &'static str {
         "patch_partial_update"
@@ -113,48 +159,13 @@ impl Rule for PatchPartialUpdate {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2",
-                note: "The PATCH method — a patch document is identified by a media type, the request's fields describe that document rather than the resource, and no patch format is one implementations must support, which is why this rule reports the field's absence and does not judge its value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-2.2",
-                note: "Error Handling — `415 (Unsupported Media Type)` is offered, not required, for a patch format the server does not support; it is the recipient's side of the media type this rule asks for",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5789",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1",
-                note: "The `Accept-Patch` header — how a server says which patch formats it takes. It is a response field, so a lone request cannot be measured against it; `patch_method_content_type_match` is the rule that has one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "Content-Type — the SHOULD this rule enforces, the exception excusing a sender that does not know its own media type, and the two guesses a recipient is left with when the field is absent",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4",
-                note: "Content — the octet stream left once framing has been taken off, which is why a `Transfer-Encoding` is not evidence of any and the captured count decides",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "Methods overview — the method token is case-sensitive, which is why `PATCH` is matched exactly and a lowercase `patch` is not a PATCH request",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.3",
-                note: "Request content negotiation — names `Accept-Patch` as the way the acceptable PATCH content types are discovered, rather than inferred from a media type's spelling",
-            },
+            RFC_5789_2,
+            RFC_5789_2_2,
+            RFC_5789_3_1,
+            RFC_9110_8_3,
+            RFC_9110_6_4,
+            RFC_9110_9_1,
+            RFC_9110_12_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
@@ -8,6 +8,28 @@ use crate::rules::Rule;
 
 pub struct PermissionsPolicyDirectivesValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const PERMISSIONS_POLICY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Permissions Policy",
+    section: None,
+    url: "https://w3c.github.io/webappsec-permissions-policy/#structured-header-serialization",
+    note: "§5.2 Structured header serialization — the production this rule enforces. Not §5.1, which is the HTML attribute and has a different feature-identifier grammar. No section number: an editor's draft renumbers",
+};
+const RFC_9651_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.2",
+    note: "Dictionaries — member keys cannot contain uppercase, unknown members MUST be ignored, and members may be split across field lines",
+};
+const RFC_9651_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2",
+    note: "Parsing — a failure discards the entire field value, which is why a malformed member name is not a local problem",
+};
+
 impl Rule for PermissionsPolicyDirectivesValid {
     fn id(&self) -> &'static str {
         "permissions_policy_directives_valid"
@@ -120,26 +142,7 @@ impl Rule for PermissionsPolicyDirectivesValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "Permissions Policy",
-                section: None,
-                url: "https://w3c.github.io/webappsec-permissions-policy/#structured-header-serialization",
-                note: "§5.2 Structured header serialization — the production this rule enforces. Not §5.1, which is the HTML attribute and has a different feature-identifier grammar. No section number: an editor's draft renumbers",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.2",
-                note: "Dictionaries — member keys cannot contain uppercase, unknown members MUST be ignored, and members may be split across field lines",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2",
-                note: "Parsing — a failure discards the entire field value, which is why a malformed member name is not a local problem",
-            },
-        ]
+        &[PERMISSIONS_POLICY, RFC_9651_3_2, RFC_9651_4_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/post_creates_resource.rs
+++ b/lint-http-rules/src/rules/post_creates_resource.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct PostCreatesResource;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_9_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.3",
+    note: "POST: the SHOULD this rule enforces — an origin server that created one or more resources sends a 201 containing a Location field that provides an identifier for the primary resource created",
+};
+const RFC_9110_15_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
+    note: "201 Created: the status indicates one or more new resources were created, which is what makes §9.3.3's condition observable, and the primary resource is identified by the Location field or, if none is received, by the target URI",
+};
+const RFC_9110_10_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
+    note: "Location: on a 201 (Created) response the value refers to the primary resource created by the request. The field's relationship to any other status is left to \"the combination of request method and status code semantics\", which is why a Location on a non-201 is not reported here",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, which is why `POST` is matched exactly and a lowercase `post` is not a POST",
+};
+
 impl Rule for PostCreatesResource {
     fn id(&self) -> &'static str {
         "post_creates_resource"
@@ -113,30 +141,10 @@ impl Rule for PostCreatesResource {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.3",
-                note: "POST: the SHOULD this rule enforces — an origin server that created one or more resources sends a 201 containing a Location field that provides an identifier for the primary resource created",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
-                note: "201 Created: the status indicates one or more new resources were created, which is what makes §9.3.3's condition observable, and the primary resource is identified by the Location field or, if none is received, by the target URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
-                note: "Location: on a 201 (Created) response the value refers to the primary resource created by the request. The field's relationship to any other status is left to \"the combination of request method and status code semantics\", which is why a Location on a non-201 is not reported here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, which is why `POST` is matched exactly and a lowercase `post` is not a POST",
-            },
+            RFC_9110_9_3_3,
+            RFC_9110_15_3_2,
+            RFC_9110_10_2_2,
+            RFC_9110_9_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/pragma_token_valid.rs
@@ -16,6 +16,16 @@ use crate::rules::Rule;
 /// RFC 9110 §5.6 machinery, applied here as a well-formedness check for a deprecated field.
 pub struct PragmaTokenValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.4",
+    note: "Pragma",
+};
+
 impl Rule for PragmaTokenValid {
     fn id(&self) -> &'static str {
         "pragma_token_valid"
@@ -95,12 +105,7 @@ impl Rule for PragmaTokenValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("5.4"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.4",
-            note: "Pragma",
-        }]
+        &[RFC_9111_5_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
+++ b/lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
@@ -88,6 +88,58 @@ fn vary_nominates_prefer(response_headers: &hyper::HeaderMap) -> bool {
     crate::helpers::headers::vary_nomination(response_headers).nominates("prefer")
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7240_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-2",
+    note: "The `Vary` MUST this rule enforces, its `Vary: *` alternative, the case rule for comparing preference token names, and the statement that servers are allowed to ignore stated preferences — which is why a missing `Preference-Applied` is not a finding",
+};
+const RFC_7240_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-3",
+    note: "`Preference-Applied` — a MAY, with its grammar, and the sentence narrowing its use to the case where a client could not otherwise tell that a preference was applied. The field's presence is this rule's evidence, not its requirement",
+};
+const RFC_7240_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-4",
+    note: "What each of the four defined preferences does to the response, which is what makes it one that \"might result in a variance to a cache's handling of a response entity\": §4.1 and §4.3 (a 202 in place of the result), §4.2 (a representation or a minimal answer), §4.4 (a 4xx in place of processing)",
+};
+const RFC_7240_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-5.1",
+    note: "The \"HTTP Preferences\" registry keeps a preference's effect in its own registration, which is why a name RFC 7240 does not define is left unjudged rather than assumed to vary the entity",
+};
+const RFC_9110_12_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.5",
+    note: "`Vary = #( \"*\" / field-name )` — a list field, read across its lines, whose members are field names and so compared case-insensitively",
+};
+const RFC_9110_9_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.3",
+    note: "Which methods have caching semantics. With §9.3.3's condition on POST responses, this is why the gate is GET and HEAD — the methods where one exchange shows a cache would hold the response under the target URI alone",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, so the gate compares the octets as written rather than folding an unrecognized method into GET",
+};
+const RFC_9111_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1",
+    note: "What the `Vary` this rule asks for buys: without it a stored response is matched on the target URI alone, and the request field that selected it is not part of the key",
+};
+
 impl Rule for PreferHeaderAndPreferenceApplied {
     fn id(&self) -> &'static str {
         "prefer_header_and_preference_applied"
@@ -208,54 +260,14 @@ impl Rule for PreferHeaderAndPreferenceApplied {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-2",
-                note: "The `Vary` MUST this rule enforces, its `Vary: *` alternative, the case rule for comparing preference token names, and the statement that servers are allowed to ignore stated preferences — which is why a missing `Preference-Applied` is not a finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-3",
-                note: "`Preference-Applied` — a MAY, with its grammar, and the sentence narrowing its use to the case where a client could not otherwise tell that a preference was applied. The field's presence is this rule's evidence, not its requirement",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-4",
-                note: "What each of the four defined preferences does to the response, which is what makes it one that \"might result in a variance to a cache's handling of a response entity\": §4.1 and §4.3 (a 202 in place of the result), §4.2 (a representation or a minimal answer), §4.4 (a 4xx in place of processing)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-5.1",
-                note: "The \"HTTP Preferences\" registry keeps a preference's effect in its own registration, which is why a name RFC 7240 does not define is left unjudged rather than assumed to vary the entity",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.5",
-                note: "`Vary = #( \"*\" / field-name )` — a list field, read across its lines, whose members are field names and so compared case-insensitively",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.3",
-                note: "Which methods have caching semantics. With §9.3.3's condition on POST responses, this is why the gate is GET and HEAD — the methods where one exchange shows a cache would hold the response under the target URI alone",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, so the gate compares the octets as written rather than folding an unrecognized method into GET",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1",
-                note: "What the `Vary` this rule asks for buys: without it a stored response is matched on the target URI alone, and the request field that selected it is not part of the key",
-            },
+            RFC_7240_2,
+            RFC_7240_3,
+            RFC_7240_4,
+            RFC_7240_5_1,
+            RFC_9110_12_5_5,
+            RFC_9110_9_2_3,
+            RFC_9110_9_1,
+            RFC_9111_4_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/prefer_header_valid.rs
+++ b/lint-http-rules/src/rules/prefer_header_valid.rs
@@ -86,6 +86,64 @@ fn one_of(value: Option<&str>, admitted: &'static [&'static str]) -> Option<Stri
     ))
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7240_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-2",
+    note: "`Prefer` — the grammar, the equivalence of several field lines with one, the equivalence of an empty value with no value, the case rules for names and values, the SHOULD NOT against repeating a token, and the server's MUST to ignore a preference it does not recognize",
+};
+const RFC_7240_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-4",
+    note: "The four preferences this document defines, each with its own production: `respond-async` (§4.1), `return` (§4.2), `wait` (§4.3) and `handling` (§4.4). §4.2 and §4.4 add that the two values of `return` and of `handling` are mutually exclusive",
+};
+const RFC_7240_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-5.1",
+    note: "The \"HTTP Preferences\" registry is open under Specification Required, and a registration carries its own enumeration of admitted values — which is why a preference RFC 7240 does not define has its value left unjudged here",
+};
+const RFC_7240_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-1.1",
+    note: "Where `token`, `word`, `OWS`, `BWS`, the `#rule` extension and `delta-seconds` come from. The named sources are RFC 7230 and RFC 7231, which RFC 9110 obsoletes; `word` is the one name RFC 9110 did not keep, and the `delta-seconds` pointer is wrong twice over — RFC 7231 §8.1.3 is a registration procedure, and RFC 7231 does not define `delta-seconds` anywhere. It was RFC 7234 §1.2.1's, and the live definition is RFC 9111 §1.2.2",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The MUST NOT on generating a protocol element that does not match its ABNF — what makes a value outside a §4 production a finding, since RFC 7240 writes those productions and states no requirement about them",
+};
+const RFC_9110_5_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
+    note: "The `#rule` extension: §5.6.1.1 forbids the sender an empty list element, §5.6.1.2 prints the values a `1#` production rejects for having no non-empty member",
+};
+const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
+    note: "`BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `preference` and in `parameter`",
+};
+const RFC_9111_1_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("1.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2",
+    note: "`delta-seconds = 1*DIGIT` — what the `wait` preference's value has to be",
+};
+const RFC_5234_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5234",
+    section: Some("2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3",
+    note: "An ABNF string literal matches any case, which is why `return=Minimal` is not reported against §4.2's `\"minimal\"`",
+};
+
 impl Rule for PreferHeaderValid {
     fn id(&self) -> &'static str {
         "prefer_header_valid"
@@ -306,60 +364,15 @@ impl Rule for PreferHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-2",
-                note: "`Prefer` — the grammar, the equivalence of several field lines with one, the equivalence of an empty value with no value, the case rules for names and values, the SHOULD NOT against repeating a token, and the server's MUST to ignore a preference it does not recognize",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-4",
-                note: "The four preferences this document defines, each with its own production: `respond-async` (§4.1), `return` (§4.2), `wait` (§4.3) and `handling` (§4.4). §4.2 and §4.4 add that the two values of `return` and of `handling` are mutually exclusive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-5.1",
-                note: "The \"HTTP Preferences\" registry is open under Specification Required, and a registration carries its own enumeration of admitted values — which is why a preference RFC 7240 does not define has its value left unjudged here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-1.1",
-                note: "Where `token`, `word`, `OWS`, `BWS`, the `#rule` extension and `delta-seconds` come from. The named sources are RFC 7230 and RFC 7231, which RFC 9110 obsoletes; `word` is the one name RFC 9110 did not keep, and the `delta-seconds` pointer is wrong twice over — RFC 7231 §8.1.3 is a registration procedure, and RFC 7231 does not define `delta-seconds` anywhere. It was RFC 7234 §1.2.1's, and the live definition is RFC 9111 §1.2.2",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The MUST NOT on generating a protocol element that does not match its ABNF — what makes a value outside a §4 production a finding, since RFC 7240 writes those productions and states no requirement about them",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
-                note: "The `#rule` extension: §5.6.1.1 forbids the sender an empty list element, §5.6.1.2 prints the values a `1#` production rejects for having no non-empty member",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-                note: "`BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `preference` and in `parameter`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("1.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-1.2.2",
-                note: "`delta-seconds = 1*DIGIT` — what the `wait` preference's value has to be",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5234",
-                section: Some("2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3",
-                note: "An ABNF string literal matches any case, which is why `return=Minimal` is not reported against §4.2's `\"minimal\"`",
-            },
+            RFC_7240_2,
+            RFC_7240_4,
+            RFC_7240_5_1,
+            RFC_7240_1_1,
+            RFC_9110_2_2,
+            RFC_9110_5_6_1,
+            RFC_9110_5_6_3,
+            RFC_9111_1_2_2,
+            RFC_5234_2_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/preference_applied_header_valid.rs
+++ b/lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -99,6 +99,40 @@ fn read_prefer(headers: &hyper::HeaderMap) -> PreferSection {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7240_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-3",
+    note: "`Preference-Applied` — the field's definition, its grammar, and the sentence saying it is the `Prefer` grammar without parameters",
+};
+const RFC_7240_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-2",
+    note: "`Prefer` — the multi-line equivalence, the first-instance rule, the case rules for names and values, and the equivalence of an empty value with no value",
+};
+const RFC_7240_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7240",
+    section: Some("1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-1.1",
+    note: "Where `token`, `word`, `OWS`, `BWS` and the `#rule` extension come from. The named source is RFC 7230, which RFC 9110 obsoletes; `word` is the one name RFC 9110 did not keep, though both halves of it survive as `token` and `quoted-string`",
+};
+const RFC_9110_5_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
+    note: "The `#rule` extension: §5.6.1.1 forbids the sender an empty list element, §5.6.1.2 prints the values a `1#` production rejects for having no non-empty member",
+};
+const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
+    note: "`BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `applied-pref`",
+};
+
 impl Rule for PreferenceAppliedHeaderValid {
     fn id(&self) -> &'static str {
         "preference_applied_header_valid"
@@ -277,36 +311,11 @@ impl Rule for PreferenceAppliedHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-3",
-                note: "`Preference-Applied` — the field's definition, its grammar, and the sentence saying it is the `Prefer` grammar without parameters",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-2",
-                note: "`Prefer` — the multi-line equivalence, the first-instance rule, the case rules for names and values, and the equivalence of an empty value with no value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7240",
-                section: Some("1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7240.html#section-1.1",
-                note: "Where `token`, `word`, `OWS`, `BWS` and the `#rule` extension come from. The named source is RFC 7230, which RFC 9110 obsoletes; `word` is the one name RFC 9110 did not keep, though both halves of it survive as `token` and `quoted-string`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
-                note: "The `#rule` extension: §5.6.1.1 forbids the sender an empty list element, §5.6.1.2 prints the values a `1#` production rejects for having no non-empty member",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-                note: "`BWS`: a recipient must remove it before interpreting the element, and a sender must not have written it — both directions are read at the `=` in `applied-pref`",
-            },
+            RFC_7240_3,
+            RFC_7240_2,
+            RFC_7240_1_1,
+            RFC_9110_5_6_1,
+            RFC_9110_5_6_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
+++ b/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct PriorityAndCacheabilityConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9218_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9218",
+    section: Some("5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-5",
+    note: "`Priority` response header guidance: \"When an origin server generates the Priority response header ... the server is expected to control the cacheability ... by using header fields that control the caching behavior (e.g., Cache-Control, Vary)\"",
+};
+const RFC_9111: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: None,
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html",
+    note: "HTTP caching and `Cache-Control`/`Vary` semantics (informative)",
+};
+
 impl Rule for PriorityAndCacheabilityConsistent {
     fn id(&self) -> &'static str {
         "priority_and_cacheability_consistent"
@@ -91,20 +107,7 @@ impl Rule for PriorityAndCacheabilityConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9218",
-                section: Some("5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-5",
-                note: "`Priority` response header guidance: \"When an origin server generates the Priority response header ... the server is expected to control the cacheability ... by using header fields that control the caching behavior (e.g., Cache-Control, Vary)\"",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: None,
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html",
-                note: "HTTP caching and `Cache-Control`/`Vary` semantics (informative)",
-            },
-        ]
+        &[RFC_9218_5, RFC_9111]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/priority_header_syntax.rs
+++ b/lint-http-rules/src/rules/priority_header_syntax.rs
@@ -92,6 +92,46 @@ impl PriorityHeaderSyntax {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9218_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9218",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4",
+    note: "Priority Parameters — the Dictionary encoding, and the MUST to ignore an unknown parameter, an out-of-range value or a value of unexpected type rather than treat it as an error",
+};
+const RFC_9218_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9218",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4.1",
+    note: "Urgency — an Integer between 0 and 7 inclusive, defaulting to 3",
+};
+const RFC_9218_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9218",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4.2",
+    note: "Incremental — a Boolean, defaulting to false",
+};
+const RFC_9218_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9218",
+    section: Some("8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-8",
+    note: "Why an ignored parameter costs different things in a request and in a response: only in a request does omission imply the default",
+};
+const RFC_9218_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9218",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4.3.1",
+    note: "The \"HTTP Priority\" registry — open, and holding only u and i, which is why an unrecognised key is not a finding",
+};
+const RFC_9651_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2",
+    note: "Structured Fields parsing — the MUST to join field lines, and the discard rule that makes one malformed parameter cost the whole field",
+};
+
 impl Rule for PriorityHeaderSyntax {
     fn id(&self) -> &'static str {
         "priority_header_syntax"
@@ -133,42 +173,12 @@ impl Rule for PriorityHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9218",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4",
-                note: "Priority Parameters — the Dictionary encoding, and the MUST to ignore an unknown parameter, an out-of-range value or a value of unexpected type rather than treat it as an error",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9218",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4.1",
-                note: "Urgency — an Integer between 0 and 7 inclusive, defaulting to 3",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9218",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4.2",
-                note: "Incremental — a Boolean, defaulting to false",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9218",
-                section: Some("8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-8",
-                note: "Why an ignored parameter costs different things in a request and in a response: only in a request does omission imply the default",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9218",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9218.html#section-4.3.1",
-                note: "The \"HTTP Priority\" registry — open, and holding only u and i, which is why an unrecognised key is not a finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2",
-                note: "Structured Fields parsing — the MUST to join field lines, and the discard rule that makes one malformed parameter cost the whole field",
-            },
+            RFC_9218_4,
+            RFC_9218_4_1,
+            RFC_9218_4_2,
+            RFC_9218_8,
+            RFC_9218_4_3_1,
+            RFC_9651_4_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -17,6 +17,16 @@ use crate::rules::Rule;
 /// a shared cache has handed off a private response to another client.
 pub struct PrivateCacheVisibility;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2_2_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.7",
+    note: "`private` — a shared cache MUST NOT store an unqualified-private response",
+};
+
 impl Rule for PrivateCacheVisibility {
     fn id(&self) -> &'static str {
         "private_cache_visibility"
@@ -152,12 +162,7 @@ impl Rule for PrivateCacheVisibility {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("5.2.2.7"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.7",
-            note: "`private` — a shared cache MUST NOT store an unqualified-private response",
-        }]
+        &[RFC_9111_5_2_2_7]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/problem_details_content_type.rs
+++ b/lint-http-rules/src/rules/problem_details_content_type.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct ProblemDetailsContentType;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9457_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9457",
+    section: Some("1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-1",
+    note: "Which status codes problem details suit, and the two sentences saying an application-specific format is often the better answer — between them the reason this rule's finding is advice and not a defect",
+};
+const RFC_9457_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9457",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-3",
+    note: "The problem details JSON object, and the media type that identifies it: `application/problem+json`",
+};
+const RFC_9457_B: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9457",
+    section: Some("B"),
+    url: "https://www.rfc-editor.org/rfc/rfc9457.html#appendix-B",
+    note: "The equivalent XML format and its media type, `application/problem+xml` — the second value this rule accepts is defined in an appendix, not in the body of the document",
+};
+const RFC_9110_8_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
+    note: "The field this rule reads: that it is a singleton and what recipients do when it is sent twice (the reason a duplicated field line is declined), and, in §8.3.1, that its type and subtype tokens are case-insensitive",
+};
+
 impl Rule for ProblemDetailsContentType {
     fn id(&self) -> &'static str {
         "problem_details_content_type"
@@ -111,32 +139,7 @@ impl Rule for ProblemDetailsContentType {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9457",
-                section: Some("1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-1",
-                note: "Which status codes problem details suit, and the two sentences saying an application-specific format is often the better answer — between them the reason this rule's finding is advice and not a defect",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9457",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-3",
-                note: "The problem details JSON object, and the media type that identifies it: `application/problem+json`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9457",
-                section: Some("B"),
-                url: "https://www.rfc-editor.org/rfc/rfc9457.html#appendix-B",
-                note: "The equivalent XML format and its media type, `application/problem+xml` — the second value this rule accepts is defined in an appendix, not in the body of the document",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3",
-                note: "The field this rule reads: that it is a singleton and what recipients do when it is sent twice (the reason a duplicated field line is declined), and, in §8.3.1, that its type and subtype tokens are case-insensitive",
-            },
-        ]
+        &[RFC_9457_1, RFC_9457_3, RFC_9457_B, RFC_9110_8_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/problem_details_structure_valid.rs
+++ b/lint-http-rules/src/rules/problem_details_structure_valid.rs
@@ -46,6 +46,34 @@ impl ProblemDetailsStructureValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9457_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9457",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-3",
+    note: "The problem details JSON object and the media type that identifies it; §3.1 and §3.1.1 are where every member is made optional and `type` is given a value for its own absence",
+};
+const RFC_9457_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9457",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-4.2.1",
+    note: "`about:blank`, the registered problem type for a problem with no semantics beyond the status code — and the sentence saying an object carrying no explicit `type` implicitly uses it, which is why an empty object is conforming",
+};
+const RFC_9110_8_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.1",
+    note: "Representation data is in the format its metadata names — the sentence that makes a mismatch between the content and the `Content-Type` a contradiction rather than a preference; §8.3 adds what the recipient does with the indicated media type, and §8.4 that a content coding has to be undone first",
+};
+const RFC_8259_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8259",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8259.html#section-2",
+    note: "What a JSON text is — the measure for content that is empty or does not parse; §8.1 adds the UTF-8 requirement the parser also enforces",
+};
+
 impl Rule for ProblemDetailsStructureValid {
     fn id(&self) -> &'static str {
         "problem_details_structure_valid"
@@ -205,32 +233,7 @@ impl Rule for ProblemDetailsStructureValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9457",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-3",
-                note: "The problem details JSON object and the media type that identifies it; §3.1 and §3.1.1 are where every member is made optional and `type` is given a value for its own absence",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9457",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9457.html#section-4.2.1",
-                note: "`about:blank`, the registered problem type for a problem with no semantics beyond the status code — and the sentence saying an object carrying no explicit `type` implicitly uses it, which is why an empty object is conforming",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.1",
-                note: "Representation data is in the format its metadata names — the sentence that makes a mismatch between the content and the `Content-Type` a contradiction rather than a preference; §8.3 adds what the recipient does with the indicated media type, and §8.4 that a content coding has to be undone first",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8259",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8259.html#section-2",
-                note: "What a JSON text is — the measure for content that is empty or does not parse; §8.1 adds the UTF-8 requirement the parser also enforces",
-            },
-        ]
+        &[RFC_9457_3, RFC_9457_4_2_1, RFC_9110_8_1, RFC_8259_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/proxy_connection_discouraged.rs
+++ b/lint-http-rules/src/rules/proxy_connection_discouraged.rs
@@ -8,6 +8,28 @@ use crate::rules::Rule;
 
 pub struct ProxyConnectionDiscouraged;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_C_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("C.2.2"),
+    // An appendix anchors as `appendix-C.2.2`, not `section-c.2.2`,
+    // and the letter is case-sensitive -- the `section-` prefix
+    // every other `SpecRef` in the tree uses scrolls nowhere here.
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#appendix-C.2.2",
+    note: "Keep-Alive Connections — the only description of the field in either core \
+           document, and it states no requirement: the section carries no BCP 14 \
+           keyword",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "Connection — lists the field among those intermediaries are asked to \
+           remove before forwarding, and names Appendix C.2.2 as its definition",
+};
+
 impl Rule for ProxyConnectionDiscouraged {
     fn id(&self) -> &'static str {
         "proxy_connection_discouraged"
@@ -100,26 +122,7 @@ impl Rule for ProxyConnectionDiscouraged {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("C.2.2"),
-                // An appendix anchors as `appendix-C.2.2`, not `section-c.2.2`,
-                // and the letter is case-sensitive -- the `section-` prefix
-                // every other `SpecRef` in the tree uses scrolls nowhere here.
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#appendix-C.2.2",
-                note: "Keep-Alive Connections — the only description of the field in either core \
-                       document, and it states no requirement: the section carries no BCP 14 \
-                       keyword",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "Connection — lists the field among those intermediaries are asked to \
-                       remove before forwarding, and names Appendix C.2.2 as its definition",
-            },
-        ]
+        &[RFC_9112_C_2_2, RFC_9110_7_6_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/quic_transport_parameters_valid.rs
+++ b/lint-http-rules/src/rules/quic_transport_parameters_valid.rs
@@ -41,6 +41,28 @@ pub struct QuicTransportParametersValid;
 /// large timeouts waste server resources for idle connections.
 const MAX_REASONABLE_IDLE_TIMEOUT_MS: u64 = 600_000;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9000_18_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9000",
+    section: Some("18.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9000.html#section-18.2",
+    note: "Transport Parameter Definitions",
+};
+const RFC_9114_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-6.1",
+    note: "Bidirectional Streams — servers SHOULD grant non-zero stream and flow-control limits",
+};
+const RFC_9114_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-6.2",
+    note: "Unidirectional Streams — restricting their flow-control window blocks control/QPACK",
+};
+
 impl ProtocolRule for QuicTransportParametersValid {
     fn id(&self) -> &'static str {
         "quic_transport_parameters_valid"
@@ -184,26 +206,7 @@ impl ProtocolRule for QuicTransportParametersValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9000",
-                section: Some("18.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9000.html#section-18.2",
-                note: "Transport Parameter Definitions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-6.1",
-                note: "Bidirectional Streams — servers SHOULD grant non-zero stream and flow-control limits",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-6.2",
-                note: "Unidirectional Streams — restricting their flow-control window blocks control/QPACK",
-            },
-        ]
+        &[RFC_9000_18_2, RFC_9114_6_1, RFC_9114_6_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -84,6 +84,34 @@ fn response_is_multipart_byteranges(headers: &hyper::HeaderMap) -> bool {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
+    note: "206 Partial Content: single-part 206 responses MUST include a `Content-Range` header describing the enclosed range",
+};
+const RFC_9110_15_3_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2",
+    note: "206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response",
+};
+const RFC_9110_14_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4",
+    note: "Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges",
+};
+const RFC_9110_15_5_17: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.17"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.17",
+    note: "416 Range Not Satisfiable: the status code is the rejection of the ranges in the request's `Range` field; a server answering a *byte*-range request SHOULD include `Content-Range: bytes */<complete-length>`",
+};
+
 impl Rule for RangeAndContentRangeConsistent {
     fn id(&self) -> &'static str {
         "range_and_content_range_consistent"
@@ -348,30 +376,10 @@ impl Rule for RangeAndContentRangeConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7",
-                note: "206 Partial Content: single-part 206 responses MUST include a `Content-Range` header describing the enclosed range",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2",
-                note: "206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4",
-                note: "Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.17"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.17",
-                note: "416 Range Not Satisfiable: the status code is the rejection of the ranges in the request's `Range` field; a server answering a *byte*-range request SHOULD include `Content-Range: bytes */<complete-length>`",
-            },
+            RFC_9110_15_3_7,
+            RFC_9110_15_3_7_2,
+            RFC_9110_14_4,
+            RFC_9110_15_5_17,
         ]
     }
 

--- a/lint-http-rules/src/rules/range_header_syntax.rs
+++ b/lint-http-rules/src/rules/range_header_syntax.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct RangeHeaderSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_14_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.1",
+    note: "Range Specifiers: `ranges-specifier = range-unit \"=\" range-set`, and the grammar under it is generic — each range unit says which of `int-range`, `suffix-range` and `other-range` its specifiers may use. A ranges-specifier is invalid when it holds a range-spec \"that is invalid or undefined for the indicated range-unit\", which is the sentence every check here rests on and the one that bounds them to the unit the rule knows",
+};
+const RFC_9110_14_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2",
+    note: "Byte Ranges: the two forms the `bytes` unit defines, both `1*DIGIT`, with `other-range` withdrawn for this unit. It also requires recipients to anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows — so positions are compared as digits and no ceiling is imposed — and it defines satisfiability, which is a question about the representation and not about the field",
+};
+const RFC_9110_14_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
+    note: "`Range`: the field is a `ranges-specifier` on a GET request. A server MUST ignore one received with a method for which range handling is not defined, an origin server MUST ignore one whose range unit it does not understand, and a server that supports range requests MAY ignore or reject an invalid one — which is what a finding here costs. The ascending-order requirement is a SHOULD carrying an exception about the client's own needs, which a request does not record",
+};
+const RFC_9110_14_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
+    note: "Range Units: `range-unit = token`, case-insensitive, an open registry, \"intended to be extensible\" — which is why a unit other than `bytes` is not a finding",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "Sender Requirements for the list construct: OWS on either side of each comma, and a sender MUST NOT generate empty list elements. Recipients are told the opposite in §5.6.1.2 — parse and ignore them — so the shared list reader, which drops them, cannot answer this rule's question",
+};
+
 impl Rule for RangeHeaderSyntax {
     fn id(&self) -> &'static str {
         "range_header_syntax"
@@ -141,36 +175,11 @@ impl Rule for RangeHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.1",
-                note: "Range Specifiers: `ranges-specifier = range-unit \"=\" range-set`, and the grammar under it is generic — each range unit says which of `int-range`, `suffix-range` and `other-range` its specifiers may use. A ranges-specifier is invalid when it holds a range-spec \"that is invalid or undefined for the indicated range-unit\", which is the sentence every check here rests on and the one that bounds them to the unit the rule knows",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2",
-                note: "Byte Ranges: the two forms the `bytes` unit defines, both `1*DIGIT`, with `other-range` withdrawn for this unit. It also requires recipients to anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows — so positions are compared as digits and no ceiling is imposed — and it defines satisfiability, which is a question about the representation and not about the field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
-                note: "`Range`: the field is a `ranges-specifier` on a GET request. A server MUST ignore one received with a method for which range handling is not defined, an origin server MUST ignore one whose range unit it does not understand, and a server that supports range requests MAY ignore or reject an invalid one — which is what a finding here costs. The ascending-order requirement is a SHOULD carrying an exception about the client's own needs, which a request does not record",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
-                note: "Range Units: `range-unit = token`, case-insensitive, an open registry, \"intended to be extensible\" — which is why a unit other than `bytes` is not a finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "Sender Requirements for the list construct: OWS on either side of each comma, and a sender MUST NOT generate empty list elements. Recipients are told the opposite in §5.6.1.2 — parse and ignore them — so the shared list reader, which drops them, cannot answer this rule's question",
-            },
+            RFC_9110_14_1_1,
+            RFC_9110_14_1_2,
+            RFC_9110_14_2,
+            RFC_9110_14_1,
+            RFC_9110_5_6_1_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -46,6 +46,40 @@ use crate::rules::Rule;
 /// combined however the request is phrased (§15.3.7.3).
 pub struct RangeRequestAndCaching;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.1",
+    note: "The requirement, and it is a MUST: send the stored response's entity tags, using `If-Match`, `If-None-Match` **or** `If-Range`. The `Last-Modified` bullets are a SHOULD that excludes subranges and a MAY that covers them",
+};
+const RFC_9110_13_1_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("13.1.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5",
+    note: "`If-Range` precondition to `Range` requests, its exact-match comparison, and the MUST NOT against putting a date there while holding an entity tag. RFC 7233 §3.2 defined the field; RFC 9110 obsoleted RFC 7233, and this reference had not moved",
+};
+const RFC_9110_15_3_7_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.7.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.3",
+    note: "Partial responses combine only when they share the same strong validator — the client-side premise, and the reason a weak tag is skipped",
+};
+const RFC_9111_3_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("3.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-3.4",
+    note: "Combining partial content requires a shared strong validator",
+};
+const RFC_9110_14_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
+    note: "GET is the only method for which range handling is defined, which is what bounds this rule to GET",
+};
+
 impl Rule for RangeRequestAndCaching {
     fn id(&self) -> &'static str {
         "range_request_and_caching"
@@ -216,36 +250,11 @@ impl Rule for RangeRequestAndCaching {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.3.1",
-                note: "The requirement, and it is a MUST: send the stored response's entity tags, using `If-Match`, `If-None-Match` **or** `If-Range`. The `Last-Modified` bullets are a SHOULD that excludes subranges and a MAY that covers them",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("13.1.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.5",
-                note: "`If-Range` precondition to `Range` requests, its exact-match comparison, and the MUST NOT against putting a date there while holding an entity tag. RFC 7233 §3.2 defined the field; RFC 9110 obsoleted RFC 7233, and this reference had not moved",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.7.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.3",
-                note: "Partial responses combine only when they share the same strong validator — the client-side premise, and the reason a weak tag is skipped",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("3.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-3.4",
-                note: "Combining partial content requires a shared strong validator",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("14.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.2",
-                note: "GET is the only method for which range handling is defined, which is what bounds this rule to GET",
-            },
+            RFC_9111_4_3_1,
+            RFC_9110_13_1_5,
+            RFC_9110_15_3_7_3,
+            RFC_9111_3_4,
+            RFC_9110_14_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/redirect_chain_valid.rs
+++ b/lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -91,6 +91,46 @@ fn location_names_another_resource(status: u16) -> Option<&'static str> {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
+    note: "Redirection 3xx: a client SHOULD detect and intervene in cyclical redirections, and MAY follow a Location even where the specific status code is not understood",
+};
+const RFC_9110_10_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
+    note: "Location: a relative reference is resolved against the target URI, and a fragmentless value inherits the target's fragment",
+};
+const RFC_9110_15_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
+    note: "201 Created: with no Location field the resource created is the target URI, which is why a 201 naming its own target is not reported",
+};
+const RFC_9112_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.3",
+    note: "Reconstructing the target URI: the authority comes from Host when the request-target has none, and the scheme from the connection — which the capture does not record",
+};
+const RFC_3986_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("5"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-5",
+    note: "Reference resolution: the transform that makes a Location value and a request-target comparable",
+};
+const RFC_3986_6_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2",
+    note: "Syntax-Based Normalization: all three of its normalizations are applied to both sides after resolution — the percent-encoding decoded where the octet is unreserved, the dot segments removed, and the case of the path and query left alone. §6.2.3's scheme-based normalization is not applied",
+};
+
 impl Rule for RedirectChainValid {
     fn id(&self) -> &'static str {
         "redirect_chain_valid"
@@ -257,42 +297,12 @@ impl Rule for RedirectChainValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
-                note: "Redirection 3xx: a client SHOULD detect and intervene in cyclical redirections, and MAY follow a Location even where the specific status code is not understood",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
-                note: "Location: a relative reference is resolved against the target URI, and a fragmentless value inherits the target's fragment",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
-                note: "201 Created: with no Location field the resource created is the target URI, which is why a 201 naming its own target is not reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.3",
-                note: "Reconstructing the target URI: the authority comes from Host when the request-target has none, and the scheme from the connection — which the capture does not record",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("5"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-5",
-                note: "Reference resolution: the transform that makes a Location value and a request-target comparable",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2",
-                note: "Syntax-Based Normalization: all three of its normalizations are applied to both sides after resolution — the percent-encoding decoded where the octet is unreserved, the dot segments removed, and the case of the path and query left alone. §6.2.3's scheme-based normalization is not applied",
-            },
+            RFC_9110_15_4,
+            RFC_9110_10_2_2,
+            RFC_9110_15_3_2,
+            RFC_9112_3_3,
+            RFC_3986_5,
+            RFC_3986_6_2_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
+++ b/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -54,6 +54,34 @@ fn location_has_a_referent(status: u16) -> bool {
     (300..=399).contains(&status)
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
+    note: "`Location = URI-reference`; the value's referent is defined for 201 (Created) and for 3xx (Redirection) responses, and for no other status",
+};
+const RFC_9110_15_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
+    note: "201 Created: the primary resource created is identified by a Location field or, if none is received, by the target URI — a description, not a request for the field",
+};
+const RFC_9110_15_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
+    note: "Redirection 3xx: a provided Location may be followed automatically even where the user agent does not understand the specific status code",
+};
+const RFC_9110_15: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
+    note: "An unrecognized status code is equivalent to the x00 of its class, which is what makes 3xx a class here rather than a list of six codes",
+};
+
 impl Rule for RedirectStatusAndLocationValid {
     fn id(&self) -> &'static str {
         "redirect_status_and_location_valid"
@@ -120,32 +148,7 @@ impl Rule for RedirectStatusAndLocationValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2",
-                note: "`Location = URI-reference`; the value's referent is defined for 201 (Created) and for 3xx (Redirection) responses, and for no other status",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2",
-                note: "201 Created: the primary resource created is identified by a Location field or, if none is received, by the target URI — a description, not a request for the field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
-                note: "Redirection 3xx: a provided Location may be followed automatically even where the user agent does not understand the specific status code",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
-                note: "An unrecognized status code is equivalent to the x00 of its class, which is what makes 3xx a class here rather than a list of six codes",
-            },
-        ]
+        &[RFC_9110_10_2_2, RFC_9110_15_3_2, RFC_9110_15_4, RFC_9110_15]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/referer_uri_valid.rs
@@ -41,6 +41,76 @@ fn redacted_userinfo(value: &str) -> Option<String> {
     Some(value.replacen(authority, &redacted, 1))
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.3",
+    note: "Referer — the field's grammar, the fragment and userinfo MUST NOT, the unsecured-request MUST NOT, and the two declined conditionals",
+};
+const RFC_9110_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1",
+    note: "URI References — `partial-URI` is the rule for elements that carry a relative URI but no fragment, and an element's ABNF is what says which forms it allows",
+};
+const RFC_9110_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1",
+    note: "http URI Scheme — a TCP connection and no more, and the MUST NOT against an empty host identifier",
+};
+const RFC_9110_4_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.2",
+    note: "https URI Scheme — what \"secured\" means for a resource named by one, and the MUST NOT against an empty host identifier",
+};
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order — the MUST NOT against a second field line for a field with no list alternative",
+};
+const RFC_9110_17_9: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("17.9"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-17.9",
+    note: "Disclosure of Sensitive Information in URIs — why §10.1.3 limits the field",
+};
+const RFC_3986_3_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.1",
+    note: "User Information — the production, its `@` delimiter, the deprecated `user:password` form, and the request not to render what follows the first colon",
+};
+const RFC_3986_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.2",
+    note: "Relative Reference — `relative-part`, and why a first path segment holding a colon is not one",
+};
+const RFC_3986_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3",
+    note: "Absolute URI — the form without a fragment identifier",
+};
+const RFC_3986_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("4.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.4",
+    note: "Same-Document Reference — what an empty value is",
+};
+const RFC_3986_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
+    note: "Percent-Encoding — the triplet the `%` obliges",
+};
+
 impl Rule for RefererUriValid {
     fn id(&self) -> &'static str {
         "referer_uri_valid"
@@ -351,72 +421,17 @@ impl Rule for RefererUriValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.3",
-                note: "Referer — the field's grammar, the fragment and userinfo MUST NOT, the unsecured-request MUST NOT, and the two declined conditionals",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1",
-                note: "URI References — `partial-URI` is the rule for elements that carry a relative URI but no fragment, and an element's ABNF is what says which forms it allows",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1",
-                note: "http URI Scheme — a TCP connection and no more, and the MUST NOT against an empty host identifier",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.2",
-                note: "https URI Scheme — what \"secured\" means for a resource named by one, and the MUST NOT against an empty host identifier",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order — the MUST NOT against a second field line for a field with no list alternative",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("17.9"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-17.9",
-                note: "Disclosure of Sensitive Information in URIs — why §10.1.3 limits the field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.1",
-                note: "User Information — the production, its `@` delimiter, the deprecated `user:password` form, and the request not to render what follows the first colon",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.2",
-                note: "Relative Reference — `relative-part`, and why a first path segment holding a colon is not one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3",
-                note: "Absolute URI — the form without a fragment identifier",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("4.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.4",
-                note: "Same-Document Reference — what an empty value is",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
-                note: "Percent-Encoding — the triplet the `%` obliges",
-            },
+            RFC_9110_10_1_3,
+            RFC_9110_4_1,
+            RFC_9110_4_2_1,
+            RFC_9110_4_2_2,
+            RFC_9110_5_3,
+            RFC_9110_17_9,
+            RFC_3986_3_2_1,
+            RFC_3986_4_2,
+            RFC_3986_4_3,
+            RFC_3986_4_4,
+            RFC_3986_2_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/refresh_header_syntax.rs
+++ b/lint-http-rules/src/rules/refresh_header_syntax.rs
@@ -191,6 +191,40 @@ fn refresh_value_error(s: &str) -> Option<String> {
     find_invalid_url_unit(&url).map(|why| format!("the URL {url:?} {why}"))
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const HTML_SPECULATIVE_LOADING_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Speculative Loading",
+    section: Some("7.8"),
+    url: "https://html.spec.whatwg.org/multipage/speculative-loading.html#the-refresh-header",
+    note: "The `Refresh` header. Three sentences: it is the `meta` pragma's HTTP equivalent, it takes the same value, and its processing model is elsewhere. It states no requirement of its own",
+};
+const HTML_SEMANTICS_4_2_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Semantics",
+    section: Some("4.2.5.3"),
+    url: "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh",
+    note: "Refresh state: the shared declarative refresh steps, and the authoring conformance requirement this rule enforces — the only sentence in HTML that says what a conforming value looks like",
+};
+const HTML_DOCUMENT_LIFECYCLE_7_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Document Lifecycle",
+    section: Some("7.5.1"),
+    url: "https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object",
+    note: "Create and initialize a Document object: the field is isomorphic-decoded before parsing, and a note records that multiple field lines are unspecified",
+};
+const URL_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "URL",
+    section: Some("4.3"),
+    url: "https://url.spec.whatwg.org/#url-writing",
+    note: "URL writing: valid URL string, URL code points and URL units — the alphabet the `URL=` value is judged against, which is not RFC 3986's",
+};
+const MDN_REFRESH: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Refresh",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Refresh",
+    note: "`Refresh` header, with browser support notes",
+};
+
 impl Rule for RefreshHeaderSyntax {
     fn id(&self) -> &'static str {
         "refresh_header_syntax"
@@ -275,36 +309,11 @@ impl Rule for RefreshHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "HTML Speculative Loading",
-                section: Some("7.8"),
-                url: "https://html.spec.whatwg.org/multipage/speculative-loading.html#the-refresh-header",
-                note: "The `Refresh` header. Three sentences: it is the `meta` pragma's HTTP equivalent, it takes the same value, and its processing model is elsewhere. It states no requirement of its own",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Semantics",
-                section: Some("4.2.5.3"),
-                url: "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh",
-                note: "Refresh state: the shared declarative refresh steps, and the authoring conformance requirement this rule enforces — the only sentence in HTML that says what a conforming value looks like",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Document Lifecycle",
-                section: Some("7.5.1"),
-                url: "https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object",
-                note: "Create and initialize a Document object: the field is isomorphic-decoded before parsing, and a note records that multiple field lines are unspecified",
-            },
-            crate::rules::SpecRef {
-                spec: "URL",
-                section: Some("4.3"),
-                url: "https://url.spec.whatwg.org/#url-writing",
-                note: "URL writing: valid URL string, URL code points and URL units — the alphabet the `URL=` value is judged against, which is not RFC 3986's",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Refresh",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Refresh",
-                note: "`Refresh` header, with browser support notes",
-            },
+            HTML_SPECULATIVE_LOADING_7_8,
+            HTML_SEMANTICS_4_2_5_3,
+            HTML_DOCUMENT_LIFECYCLE_7_5_1,
+            URL_4_3,
+            MDN_REFRESH,
         ]
     }
 

--- a/lint-http-rules/src/rules/request_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/request_body_length_accuracy.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct RequestBodyLengthAccuracy;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Message body length — item 6 is what licenses this rule at all, and its condition is 'without Transfer-Encoding'; item 3 is why a message carrying both is measured by neither",
+};
+const RFC_9112_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
+    note: "Content-Length as framing — why a mismatch matters rather than merely differing. Also the MUST NOT against sending it beside Transfer-Encoding, which is another rule's finding",
+};
+const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Where the field and its `1*DIGIT` grammar are actually defined — the syntax itself is `content_length_valid`'s subject, not this rule's",
+};
+
 impl Rule for RequestBodyLengthAccuracy {
     fn id(&self) -> &'static str {
         "request_body_length_accuracy"
@@ -126,26 +148,7 @@ impl Rule for RequestBodyLengthAccuracy {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "Message body length — item 6 is what licenses this rule at all, and its condition is 'without Transfer-Encoding'; item 3 is why a message carrying both is measured by neither",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-                note: "Content-Length as framing — why a mismatch matters rather than merely differing. Also the MUST NOT against sending it beside Transfer-Encoding, which is another rule's finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-                note: "Where the field and its `1*DIGIT` grammar are actually defined — the syntax itself is `content_length_valid`'s subject, not this rule's",
-            },
-        ]
+        &[RFC_9112_6_3, RFC_9112_6_2, RFC_9110_8_6]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/request_method_token_valid.rs
+++ b/lint-http-rules/src/rules/request_method_token_valid.rs
@@ -89,6 +89,53 @@ fn parse_method_token_config(
 
 pub struct RequestMethodTokenValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "`method = token`, the token's case-sensitivity, the convention that standardized methods are defined in all-uppercase US-ASCII letters, and the 501 an origin server gives an unrecognized method",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sentence that makes a value outside its ABNF a violation rather than an observation",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "`token = 1*tchar`. The character set is transcribed once, in `helpers::token::is_tchar`; the `1*` floor is what the empty-method branch here reads",
+};
+const RFC_9110_16_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.1.1",
+    note: "The IANA method registry, which holds the names `registered_methods` is a deployment's copy of, and grows by IETF Review",
+};
+const RFC_9112_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.1",
+    note: "Where an HTTP/1.1 message carries the method. This reference said §5.1, which is Field Line Parsing",
+};
+const RFC_9113_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
+    note:
+        "The `:method` pseudo-header field, which is where an HTTP/2 request carries the same value",
+};
+const RFC_9114_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
+    note: "The `:method` pseudo-header field over HTTP/3",
+};
+
 impl Rule for RequestMethodTokenValid {
     fn id(&self) -> &'static str {
         "request_method_token_valid"
@@ -221,48 +268,13 @@ impl Rule for RequestMethodTokenValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "`method = token`, the token's case-sensitivity, the convention that standardized methods are defined in all-uppercase US-ASCII letters, and the 501 an origin server gives an unrecognized method",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sentence that makes a value outside its ABNF a violation rather than an observation",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "`token = 1*tchar`. The character set is transcribed once, in `helpers::token::is_tchar`; the `1*` floor is what the empty-method branch here reads",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.1.1",
-                note: "The IANA method registry, which holds the names `registered_methods` is a deployment's copy of, and grows by IETF Review",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.1",
-                note: "Where an HTTP/1.1 message carries the method. This reference said §5.1, which is Field Line Parsing",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
-                note: "The `:method` pseudo-header field, which is where an HTTP/2 request carries the same value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
-                note: "The `:method` pseudo-header field over HTTP/3",
-            },
+            RFC_9110_9_1,
+            RFC_9110_2_2,
+            RFC_9110_5_6_2,
+            RFC_9110_16_1_1,
+            RFC_9112_3_1,
+            RFC_9113_8_3_1,
+            RFC_9114_4_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
@@ -7,6 +7,29 @@ use crate::rules::Rule;
 
 pub struct RequestOriginHeaderPresentForCors;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6454_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6454",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1",
+    note:
+        "Origin header field syntax the value is validated against (`serialized-origin` / `null`)",
+};
+const FETCH_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("3.2"),
+    url: "https://fetch.spec.whatwg.org/#origin-header",
+    note: "Origin header — used for CORS fetches and any request whose method is neither GET nor HEAD (where both inline cites resolve)",
+};
+const MDN_ORIGIN: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN Origin",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin",
+    note: "Origin",
+};
+
 impl Rule for RequestOriginHeaderPresentForCors {
     fn id(&self) -> &'static str {
         "request_origin_header_present_for_cors"
@@ -96,26 +119,7 @@ impl Rule for RequestOriginHeaderPresentForCors {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6454",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1",
-                note: "Origin header field syntax the value is validated against (`serialized-origin` / `null`)",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("3.2"),
-                url: "https://fetch.spec.whatwg.org/#origin-header",
-                note: "Origin header — used for CORS fetches and any request whose method is neither GET nor HEAD (where both inline cites resolve)",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN Origin",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Origin",
-                note: "Origin",
-            },
-        ]
+        &[RFC_6454_7_1, FETCH_3_2, MDN_ORIGIN]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/request_target_form_valid.rs
+++ b/lint-http-rules/src/rules/request_target_form_valid.rs
@@ -114,6 +114,40 @@ fn classify(target: &str) -> Option<TargetForm<'_>> {
 
 pub struct RequestTargetFormValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
+    note: "Request Target: the four forms, and the exclusion of whitespace from all of them",
+};
+const RFC_9112_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3",
+    note: "authority-form: CONNECT's target, and where the port number is asked for in prose rather than in the grammar",
+};
+const RFC_9112_3_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.4",
+    note: "asterisk-form: the server-wide OPTIONS request's target",
+};
+const RFC_9110_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
+    note: "Determining the Target Resource: the two method-specific forms, the MUST NOT that keeps each to its method, and the reconstruction being specific to each major protocol version",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender's MUST NOT against generating protocol elements outside the ABNF, which is what makes a target in none of the four forms a violation",
+};
+
 impl Rule for RequestTargetFormValid {
     fn id(&self) -> &'static str {
         "request_target_form_valid"
@@ -319,38 +353,12 @@ impl Rule for RequestTargetFormValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        use crate::rules::SpecRef;
         &[
-            SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
-                note: "Request Target: the four forms, and the exclusion of whitespace from all of them",
-            },
-            SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.3",
-                note: "authority-form: CONNECT's target, and where the port number is asked for in prose rather than in the grammar",
-            },
-            SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.4",
-                note: "asterisk-form: the server-wide OPTIONS request's target",
-            },
-            SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
-                note: "Determining the Target Resource: the two method-specific forms, the MUST NOT that keeps each to its method, and the reconstruction being specific to each major protocol version",
-            },
-            SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sender's MUST NOT against generating protocol elements outside the ABNF, which is what makes a target in none of the four forms a violation",
-            },
+            RFC_9112_3_2,
+            RFC_9112_3_2_3,
+            RFC_9112_3_2_4,
+            RFC_9110_7_1,
+            RFC_9110_2_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/request_target_no_fragment.rs
+++ b/lint-http-rules/src/rules/request_target_no_fragment.rs
@@ -7,6 +7,65 @@ use crate::rules::Rule;
 
 pub struct RequestTargetNoFragment;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_3986_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.5",
+    note: "Fragment: indicated by a number sign and terminated by the end of the URI; separated from the rest of the URI before a dereference and resolved solely by the user agent",
+};
+const RFC_3986_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.2",
+    note: "Reserved characters: data that would conflict with a delimiter's purpose is percent-encoded before the URI is formed, which is why %23 is not this rule's finding",
+};
+const RFC_3986_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3",
+    note: "absolute-URI: the URI production with the fragment component dropped",
+};
+const RFC_9110_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
+    note: "Determining the Target Resource: the target URI excludes the reference's fragment, and the components sent are collectively the request target on every major version",
+};
+const RFC_9110_4_2_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.2.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.5",
+    note: "http(s) references with fragment identifiers: whether an element admits a fragment is decided by the ABNF rule it uses",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender MUST NOT that a value matching no production breaks; RFC 9112 §1.1 carries it to the HTTP/1.1 productions",
+};
+const RFC_9112_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
+    note: "Request Target: the four forms an HTTP/1.1 request-line may carry, none of which derives a fragment",
+};
+const RFC_9113_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
+    note:
+        "HTTP/2 request pseudo-header fields: :path is the path and query parts of the target URI",
+};
+const RFC_9114_4_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
+    note: "HTTP/3 request pseudo-header fields: the same two parts of the target URI",
+};
+
 impl Rule for RequestTargetNoFragment {
     fn id(&self) -> &'static str {
         "request_target_no_fragment"
@@ -133,60 +192,15 @@ impl Rule for RequestTargetNoFragment {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.5",
-                note: "Fragment: indicated by a number sign and terminated by the end of the URI; separated from the rest of the URI before a dereference and resolved solely by the user agent",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.2",
-                note: "Reserved characters: data that would conflict with a delimiter's purpose is percent-encoded before the URI is formed, which is why %23 is not this rule's finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3",
-                note: "absolute-URI: the URI production with the fragment component dropped",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
-                note: "Determining the Target Resource: the target URI excludes the reference's fragment, and the components sent are collectively the request target on every major version",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.2.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.5",
-                note: "http(s) references with fragment identifiers: whether an element admits a fragment is decided by the ABNF rule it uses",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sender MUST NOT that a value matching no production breaks; RFC 9112 §1.1 carries it to the HTTP/1.1 productions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
-                note: "Request Target: the four forms an HTTP/1.1 request-line may carry, none of which derives a fragment",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1",
-                note: "HTTP/2 request pseudo-header fields: :path is the path and query parts of the target URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.3.1",
-                note: "HTTP/3 request pseudo-header fields: the same two parts of the target URI",
-            },
+            RFC_3986_3_5,
+            RFC_3986_2_2,
+            RFC_3986_4_3,
+            RFC_9110_7_1,
+            RFC_9110_4_2_5,
+            RFC_9110_2_2,
+            RFC_9112_3_2,
+            RFC_9113_8_3_1,
+            RFC_9114_4_3_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
+++ b/lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
@@ -7,6 +7,52 @@ use crate::rules::Rule;
 
 pub struct RequestUriPercentEncodingValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_3986_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
+    note: "Percent-Encoding: the triplet production, and percent-encoding as the mechanism for an octet whose character is outside the allowed set",
+};
+const RFC_3986_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2",
+    note: "Characters: the limited set a URI is composed from, whose terminals the notation maps back through US-ASCII",
+};
+const RFC_3986_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.4",
+    note: "When to Encode or Decode: a URI on the wire is already in its percent-encoded form, a '%' meant as data is written %25, and octets decoded before their components are separated can be taken for delimiters",
+};
+const RFC_9110_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1",
+    note: "URI References: the generic syntax's productions are adopted by name for the HTTP elements that carry a URI",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender MUST NOT that a value matching no production breaks",
+};
+const RFC_9110_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
+    note: "Determining the Target Resource: the components sent are collectively the request target on every major protocol version",
+};
+const RFC_5234_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 5234",
+    section: Some("2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3",
+    note: "ABNF strings are case insensitive, which is why a lowercase hexadecimal digit derives from HEXDIG",
+};
+
 impl Rule for RequestUriPercentEncodingValid {
     fn id(&self) -> &'static str {
         "request_uri_percent_encoding_valid"
@@ -143,48 +189,13 @@ impl Rule for RequestUriPercentEncodingValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
-                note: "Percent-Encoding: the triplet production, and percent-encoding as the mechanism for an octet whose character is outside the allowed set",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2",
-                note: "Characters: the limited set a URI is composed from, whose terminals the notation maps back through US-ASCII",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.4",
-                note: "When to Encode or Decode: a URI on the wire is already in its percent-encoded form, a '%' meant as data is written %25, and octets decoded before their components are separated can be taken for delimiters",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-4.1",
-                note: "URI References: the generic syntax's productions are adopted by name for the HTTP elements that carry a URI",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sender MUST NOT that a value matching no production breaks",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.1",
-                note: "Determining the Target Resource: the components sent are collectively the request target on every major protocol version",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 5234",
-                section: Some("2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc5234.html#section-2.3",
-                note: "ABNF strings are case insensitive, which is why a lowercase hexadecimal digit derives from HEXDIG",
-            },
+            RFC_3986_2_1,
+            RFC_3986_2,
+            RFC_3986_2_4,
+            RFC_9110_4_1,
+            RFC_9110_2_2,
+            RFC_9110_7_1,
+            RFC_5234_2_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/request_version_method_valid.rs
+++ b/lint-http-rules/src/rules/request_version_method_valid.rs
@@ -49,6 +49,46 @@ fn request_declares_content(req: &crate::http_transaction::RequestInfo) -> bool 
         || crate::helpers::headers::declared_content_length(&req.headers).is_some_and(|n| n > 0)
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "Methods overview — the method token is case-sensitive, which is why the four names below are matched exactly and a lowercase `get` is not a GET",
+};
+const RFC_9110_9_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1",
+    note: "GET — the SHOULD NOT, its `unless` clause, and the sentence that declines to rely on the private agreement the clause describes. Also the statement that framing is independent of the method, which is why a Transfer-Encoding alone is not content",
+};
+const RFC_9110_9_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
+    note: "HEAD — the same paragraph, word for word",
+};
+const RFC_9110_9_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.5",
+    note: "DELETE — the same paragraph again",
+};
+const RFC_9110_9_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
+    note: "CONNECT — a definition rather than a modal, and the sentence that makes the octets after the header section tunnel payload instead of content",
+};
+const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Content-Length as the amount of data enclosed — the fallback evidence when no body was captured",
+};
+
 impl Rule for RequestVersionMethodValid {
     fn id(&self) -> &'static str {
         "request_version_method_valid"
@@ -123,42 +163,12 @@ impl Rule for RequestVersionMethodValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "Methods overview — the method token is case-sensitive, which is why the four names below are matched exactly and a lowercase `get` is not a GET",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1",
-                note: "GET — the SHOULD NOT, its `unless` clause, and the sentence that declines to rely on the private agreement the clause describes. Also the statement that framing is independent of the method, which is why a Transfer-Encoding alone is not content",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
-                note: "HEAD — the same paragraph, word for word",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.5",
-                note: "DELETE — the same paragraph again",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
-                note: "CONNECT — a definition rather than a modal, and the sentence that makes the octets after the header section tunnel payload instead of content",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-                note: "Content-Length as the amount of data enclosed — the fallback evidence when no body was captured",
-            },
+            RFC_9110_9_1,
+            RFC_9110_9_3_1,
+            RFC_9110_9_3_2,
+            RFC_9110_9_3_5,
+            RFC_9110_9_3_6,
+            RFC_9110_8_6,
         ]
     }
 

--- a/lint-http-rules/src/rules/response_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/response_body_length_accuracy.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct ResponseBodyLengthAccuracy;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Message body length, in precedence order — this rule is item 6, and items 1, 2 and 3 are why most responses are exempt rather than checked",
+};
+const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
+    note: "Content-Length: the field, its grammar, the MUSTs that make a HEAD or 304 response's value describe a body it did not send, and the MUST NOT against forwarding a value known to be incorrect — this rule's reason to exist",
+};
+const RFC_9112_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
+    note: "Content-Length as framing, and the MUST NOT against sending it beside Transfer-Encoding — another rule's finding",
+};
+const RFC_9110_9_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
+    note: "HEAD — servers SHOULD answer it with the fields they would have sent for GET, which is what made the exemption the common case rather than a corner",
+};
+
 impl Rule for ResponseBodyLengthAccuracy {
     fn id(&self) -> &'static str {
         "response_body_length_accuracy"
@@ -169,32 +197,7 @@ impl Rule for ResponseBodyLengthAccuracy {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "Message body length, in precedence order — this rule is item 6, and items 1, 2 and 3 are why most responses are exempt rather than checked",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
-                note: "Content-Length: the field, its grammar, the MUSTs that make a HEAD or 304 response's value describe a body it did not send, and the MUST NOT against forwarding a value known to be incorrect — this rule's reason to exist",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-                note: "Content-Length as framing, and the MUST NOT against sending it beside Transfer-Encoding — another rule's finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
-                note: "HEAD — servers SHOULD answer it with the fields they would have sent for GET, which is what made the exemption the common case rather than a corner",
-            },
-        ]
+        &[RFC_9112_6_3, RFC_9110_8_6, RFC_9112_6_2, RFC_9110_9_3_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/retry_after_date_or_delay.rs
+++ b/lint-http-rules/src/rules/retry_after_date_or_delay.rs
@@ -7,6 +7,16 @@ use crate::rules::Rule;
 
 pub struct RetryAfterDateOrDelay;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3",
+    note: "Retry-After header",
+};
+
 impl Rule for RetryAfterDateOrDelay {
     fn id(&self) -> &'static str {
         "retry_after_date_or_delay"
@@ -87,12 +97,7 @@ impl Rule for RetryAfterDateOrDelay {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9110",
-            section: Some("10.2.3"),
-            url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3",
-            note: "Retry-After header",
-        }]
+        &[RFC_9110_10_2_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/retry_after_status_valid.rs
+++ b/lint-http-rules/src/rules/retry_after_status_valid.rs
@@ -41,6 +41,34 @@ fn status_defines_retry_after(status: u16) -> bool {
     status == 429
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3",
+    note: "Defines Retry-After generally, with no condition on the status code, then says what it indicates on a 503 and on any 3xx",
+};
+const RFC_9110_15_5_14: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.14"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.14",
+    note: "413 Content Too Large: when the condition is temporary the server SHOULD generate a Retry-After header field",
+};
+const RFC_9110_15_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.6.4",
+    note: "503 Service Unavailable: the server MAY send a Retry-After header field",
+};
+const RFC_6585_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6585",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6585.html#section-4",
+    note: "429 Too Many Requests: the response MAY include a Retry-After header",
+};
+
 impl Rule for RetryAfterStatusValid {
     fn id(&self) -> &'static str {
         "retry_after_status_valid"
@@ -111,30 +139,10 @@ impl Rule for RetryAfterStatusValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3",
-                note: "Defines Retry-After generally, with no condition on the status code, then says what it indicates on a 503 and on any 3xx",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.14"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.14",
-                note: "413 Content Too Large: when the condition is temporary the server SHOULD generate a Retry-After header field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.6.4",
-                note: "503 Service Unavailable: the server MAY send a Retry-After header field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6585",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6585.html#section-4",
-                note: "429 Too Many Requests: the response MAY include a Retry-After header",
-            },
+            RFC_9110_10_2_3,
+            RFC_9110_15_5_14,
+            RFC_9110_15_6_4,
+            RFC_6585_4,
         ]
     }
 

--- a/lint-http-rules/src/rules/s_max_age_enforced.rs
+++ b/lint-http-rules/src/rules/s_max_age_enforced.rs
@@ -24,6 +24,16 @@ use crate::rules::Rule;
 /// the entry as fresh until `max-age` expired.
 pub struct SMaxAgeEnforced;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_5_2_2_10: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.2.2.10"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.10",
+    note: "`s-maxage` — applies only to shared caches and overrides `max-age`/`Expires` for those caches",
+};
+
 impl Rule for SMaxAgeEnforced {
     fn id(&self) -> &'static str {
         "s_max_age_enforced"
@@ -120,14 +130,7 @@ impl Rule for SMaxAgeEnforced {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.2.2.10"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.2.10",
-                note: "`s-maxage` — applies only to shared caches and overrides `max-age`/`Expires` for those caches",
-            },
-        ]
+        &[RFC_9111_5_2_2_10]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
@@ -14,6 +14,16 @@ use crate::rules::Rule;
 /// carries no case folding; token syntax is validated.
 pub struct SecFetchDestValueValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const FETCH_METADATA_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+spec: "Fetch Metadata",
+section: Some("2.1"),
+url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-dest-header",
+note: "Fetch Metadata (W3C) — `Sec-Fetch-Dest`: an sf-token whose valid values are Fetch's request destinations",
+        };
+
 impl Rule for SecFetchDestValueValid {
     fn id(&self) -> &'static str {
         "sec_fetch_dest_value_valid"
@@ -113,12 +123,7 @@ impl Rule for SecFetchDestValueValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "Fetch Metadata",
-            section: Some("2.1"),
-            url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-dest-header",
-            note: "Fetch Metadata (W3C) — `Sec-Fetch-Dest`: an sf-token whose valid values are Fetch's request destinations",
-        }]
+        &[FETCH_METADATA_2_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
@@ -11,6 +11,16 @@ use crate::rules::Rule;
 /// token carries no case folding; token syntax is validated.
 pub struct SecFetchModeValueValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const FETCH_METADATA_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+spec: "Fetch Metadata",
+section: Some("2.2"),
+url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-mode-header",
+note: "Fetch Metadata (W3C) — `Sec-Fetch-Mode`: an sf-token whose valid values are the five request modes",
+        };
+
 impl Rule for SecFetchModeValueValid {
     fn id(&self) -> &'static str {
         "sec_fetch_mode_value_valid"
@@ -100,12 +110,7 @@ impl Rule for SecFetchModeValueValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "Fetch Metadata",
-            section: Some("2.2"),
-            url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-mode-header",
-            note: "Fetch Metadata (W3C) — `Sec-Fetch-Mode`: an sf-token whose valid values are the five request modes",
-        }]
+        &[FETCH_METADATA_2_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
@@ -11,6 +11,16 @@ use crate::rules::Rule;
 /// structured-field token carries no case folding; token syntax is validated.
 pub struct SecFetchSiteValueValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const FETCH_METADATA_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+spec: "Fetch Metadata",
+section: Some("2.3"),
+url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-site-header",
+note: "Fetch Metadata (W3C) — `Sec-Fetch-Site`: an sf-token whose valid values are the four initiator/target relationships",
+        };
+
 impl Rule for SecFetchSiteValueValid {
     fn id(&self) -> &'static str {
         "sec_fetch_site_value_valid"
@@ -101,12 +111,7 @@ impl Rule for SecFetchSiteValueValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "Fetch Metadata",
-            section: Some("2.3"),
-            url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-site-header",
-            note: "Fetch Metadata (W3C) — `Sec-Fetch-Site`: an sf-token whose valid values are the four initiator/target relationships",
-        }]
+        &[FETCH_METADATA_2_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
@@ -10,6 +10,16 @@ use crate::rules::Rule;
 /// fields or non-ASCII values are flagged as violations.
 pub struct SecFetchUserValueValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const FETCH_METADATA_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch Metadata",
+    section: Some("2.4"),
+    url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-user-header",
+    note: "Fetch Metadata (W3C) — `Sec-Fetch-User` header (boolean, serialized as `?1`)",
+};
+
 impl Rule for SecFetchUserValueValid {
     fn id(&self) -> &'static str {
         "sec_fetch_user_value_valid"
@@ -88,12 +98,7 @@ impl Rule for SecFetchUserValueValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "Fetch Metadata",
-            section: Some("2.4"),
-            url: "https://www.w3.org/TR/fetch-metadata/#sec-fetch-user-header",
-            note: "Fetch Metadata (W3C) — `Sec-Fetch-User` header (boolean, serialized as `?1`)",
-        }]
+        &[FETCH_METADATA_2_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
+++ b/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
@@ -233,6 +233,34 @@ impl SecWebsocketExtensionsSyntax {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
+    note: "Negotiating Extensions — the grammar, the MUST that makes a non-conforming \
+           value a failure of the connection, the note that the notation is RFC \
+           2616's, and the requirement on a quoted-string value after unescaping",
+};
+const RFC_2616_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2616",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-2.1",
+    note: "Augmented BNF — the notation §9.1 imports by name: the `#rule` whose null \
+           elements are allowed (RFC 9110 §5.6.1.1 forbids them) and the implied \
+           *LWS rule that permits whitespace beside the separators. Obsolete and \
+           correct: the current document is what sends the reader here",
+};
+const RFC_6455_11_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("11.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-11.4",
+    note: "WebSocket Extension Name Registry — First Come First Served, which is why \
+           no extension-token is compared against a list here",
+};
+
 impl Rule for SecWebsocketExtensionsSyntax {
     fn id(&self) -> &'static str {
         "sec_websocket_extensions_syntax"
@@ -272,32 +300,7 @@ impl Rule for SecWebsocketExtensionsSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
-                note: "Negotiating Extensions — the grammar, the MUST that makes a non-conforming \
-                       value a failure of the connection, the note that the notation is RFC \
-                       2616's, and the requirement on a quoted-string value after unescaping",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2616",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-2.1",
-                note: "Augmented BNF — the notation §9.1 imports by name: the `#rule` whose null \
-                       elements are allowed (RFC 9110 §5.6.1.1 forbids them) and the implied \
-                       *LWS rule that permits whitespace beside the separators. Obsolete and \
-                       correct: the current document is what sends the reader here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("11.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-11.4",
-                note: "WebSocket Extension Name Registry — First Come First Served, which is why \
-                       no extension-token is compared against a list here",
-            },
-        ]
+        &[RFC_6455_9_1, RFC_2616_2_1, RFC_6455_11_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
+++ b/lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
@@ -161,6 +161,52 @@ impl SecWebsocketHeadersConsistent {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
+    note: "Client Requirements — the numbered list this rule measures: GET, HTTP version at least 1.1, `Upgrade: websocket`, the `Upgrade` connection-option, the `Sec-WebSocket-Key` nonce, `Sec-WebSocket-Version: 13`, and `Sec-WebSocket-Protocol`'s non-empty unique `token` members",
+};
+const RFC_6455_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
+    note: "Reading the Client's Opening Handshake — the same list from the server's side, which is where the two case-insensitive comparisons and the `Origin` decline are stated",
+};
+const RFC_6455_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.3",
+    note: "Collected ABNF — `Sec-WebSocket-Key = base64-value-non-empty`, `Sec-WebSocket-Version-Client = version`, `Sec-WebSocket-Protocol-Client = 1#token`; the client's version field is one `version` and only the server's is a list",
+};
+const RFC_6455_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.4",
+    note: "Supporting Multiple Versions — why a `Sec-WebSocket-Version` other than 13 is a version advertisement rather than a malformed value, and what a server owes it",
+};
+const RFC_8441_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8441",
+    section: Some("5"),
+    url: "https://www.rfc-editor.org/rfc/rfc8441.html#section-5",
+    note: "Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Key` is not processed — the sentences behind this rule's version gate",
+};
+const RFC_9220_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9220",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9220.html#section-3",
+    note: "Carries RFC 8441's mechanism to HTTP/3 with identical semantics",
+};
+const RFC_4648_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 4648",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3",
+    note: "The instruction to reject encoded data holding a character outside the base alphabet, which is what makes a malformed `Sec-WebSocket-Key` reportable rather than merely unusual",
+};
+
 impl Rule for SecWebsocketHeadersConsistent {
     fn id(&self) -> &'static str {
         "sec_websocket_headers_consistent"
@@ -238,48 +284,13 @@ impl Rule for SecWebsocketHeadersConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
-                note: "Client Requirements — the numbered list this rule measures: GET, HTTP version at least 1.1, `Upgrade: websocket`, the `Upgrade` connection-option, the `Sec-WebSocket-Key` nonce, `Sec-WebSocket-Version: 13`, and `Sec-WebSocket-Protocol`'s non-empty unique `token` members",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
-                note: "Reading the Client's Opening Handshake — the same list from the server's side, which is where the two case-insensitive comparisons and the `Origin` decline are stated",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.3",
-                note: "Collected ABNF — `Sec-WebSocket-Key = base64-value-non-empty`, `Sec-WebSocket-Version-Client = version`, `Sec-WebSocket-Protocol-Client = 1#token`; the client's version field is one `version` and only the server's is a list",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.4",
-                note: "Supporting Multiple Versions — why a `Sec-WebSocket-Version` other than 13 is a version advertisement rather than a malformed value, and what a server owes it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8441",
-                section: Some("5"),
-                url: "https://www.rfc-editor.org/rfc/rfc8441.html#section-5",
-                note: "Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Key` is not processed — the sentences behind this rule's version gate",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9220",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9220.html#section-3",
-                note: "Carries RFC 8441's mechanism to HTTP/3 with identical semantics",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 4648",
-                section: Some("3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3",
-                note: "The instruction to reject encoded data holding a character outside the base alphabet, which is what makes a malformed `Sec-WebSocket-Key` reportable rather than merely unusual",
-            },
+            RFC_6455_4_1,
+            RFC_6455_4_2_1,
+            RFC_6455_4_3,
+            RFC_6455_4_4,
+            RFC_8441_5,
+            RFC_9220_3,
+            RFC_4648_3_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/sec_websocket_version_advertised.rs
+++ b/lint-http-rules/src/rules/sec_websocket_version_advertised.rs
@@ -90,6 +90,42 @@ impl SecWebsocketVersionAdvertised {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.3",
+    note: "Collected ABNF — `Sec-WebSocket-Version-Server = 1#version`, the `version` \
+           production under it, the suffix convention that makes this field the \
+           response's, and the note that the notation is RFC 2616's",
+};
+const RFC_2616_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 2616",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-2.1",
+    note: "Augmented BNF — the `#rule` §4.3 imports: null elements are allowed (RFC \
+           9110 §5.6.1.1 forbids them) and `1#` requires one that is not. Obsolete \
+           and correct: the current document is what sends the reader here",
+};
+const RFC_6455_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.4",
+    note: "Supporting Multiple Versions — the conditional MUST whose antecedent is the \
+           server's own state, and the worked example printing one advertisement as \
+           one field line and as two",
+};
+const RFC_6455_11_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("11.3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-11.3.5",
+    note: "The field's registration — when a server sends it, and that it holds the \
+           versions the server supports, which is what a list holding the requested \
+           one contradicts",
+};
+
 impl Rule for SecWebsocketVersionAdvertised {
     fn id(&self) -> &'static str {
         "sec_websocket_version_advertised"
@@ -149,41 +185,7 @@ impl Rule for SecWebsocketVersionAdvertised {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.3",
-                note: "Collected ABNF — `Sec-WebSocket-Version-Server = 1#version`, the `version` \
-                       production under it, the suffix convention that makes this field the \
-                       response's, and the note that the notation is RFC 2616's",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 2616",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc2616.html#section-2.1",
-                note: "Augmented BNF — the `#rule` §4.3 imports: null elements are allowed (RFC \
-                       9110 §5.6.1.1 forbids them) and `1#` requires one that is not. Obsolete \
-                       and correct: the current document is what sends the reader here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.4",
-                note:
-                    "Supporting Multiple Versions — the conditional MUST whose antecedent is the \
-                       server's own state, and the worked example printing one advertisement as \
-                       one field line and as two",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("11.3.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-11.3.5",
-                note: "The field's registration — when a server sends it, and that it holds the \
-                       versions the server supports, which is what a list holding the requested \
-                       one contradicts",
-            },
-        ]
+        &[RFC_6455_4_3, RFC_2616_2_1, RFC_6455_4_4, RFC_6455_11_3_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/server_header_product_valid.rs
+++ b/lint-http-rules/src/rules/server_header_product_valid.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct ServerHeaderProductValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.4",
+    note: "`Server = product *( RWS ( product / comment ) )`; the section defines the field and defers the product syntax itself to Section 10.1.5",
+};
+const RFC_9110_10_1_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5",
+    note: "`product = token [\"/\" product-version]` and `product-version = token`, defined once under `User-Agent` and shared by `Server`",
+};
+const RFC_9110_5_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5",
+    note: "`comment = \"(\" *( ctext / quoted-pair / comment ) \")\"` — comments nest, and `ctext` admits `obs-text` but not the parentheses or the backslash",
+};
+
 impl Rule for ServerHeaderProductValid {
     fn id(&self) -> &'static str {
         "server_header_product_valid"
@@ -67,26 +89,7 @@ impl Rule for ServerHeaderProductValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.4",
-                note: "`Server = product *( RWS ( product / comment ) )`; the section defines the field and defers the product syntax itself to Section 10.1.5",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5",
-                note: "`product = token [\"/\" product-version]` and `product-version = token`, defined once under `User-Agent` and shared by `Server`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5",
-                note: "`comment = \"(\" *( ctext / quoted-pair / comment ) \")\"` — comments nest, and `ctext` admits `obs-text` but not the parentheses or the backslash",
-            },
-        ]
+        &[RFC_9110_10_2_4, RFC_9110_10_1_5, RFC_9110_5_6_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -127,6 +127,70 @@ fn is_valid_floating_point_number(s: &str) -> bool {
 /// § 2 prints.
 pub struct ServerTimingHeaderSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const SERVER_TIMING_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Server Timing",
+    section: Some("2"),
+    url: "https://www.w3.org/TR/server-timing/#the-server-timing-header-field",
+    note: "The `Server-Timing` Header Field: the ABNF this rule enforces, the two parameter names the specification establishes, and the user-agent parsing algorithm. Eight BCP 14 keywords: six addressed to the user agent, a MAY permitting a response to repeat a metric name, and a SHOULD NOT on a parameter name appearing twice in one metric — that last one is the only sentence in the whole document that measures what a server wrote. The section takes `#`, `*`, `OWS`, `token` and `quoted-string` from `[RFC7230]`, which is obsolete; the current productions are RFC 9110 § 5.6.1, § 5.6.3, § 5.6.2 and § 5.6.4 and are carried forward unchanged, so nothing this rule decides turns on which document is read. The document is a W3C Working Draft (7 April 2026) whose own Status section says \"It is inappropriate to cite this document as other than a work in progress\" — and it is nonetheless the field's only specification: the IANA HTTP Field Name Registry lists `Server-Timing` as **permanent** with this document as its sole reference, the same way it lists `Keep-Alive` against an obsoleted RFC. A work in progress is what there is to read",
+};
+const SERVER_TIMING_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Server Timing",
+    section: Some("3.2"),
+    url: "https://www.w3.org/TR/server-timing/#dom-performanceservertiming-duration",
+    note: "The `duration` attribute: `params[\"dur\"]` parsed with HTML's rules for parsing floating-point number values, returning 0 on error. This is what a non-numeric `dur` costs, and it is a consequence rather than a requirement — the lookup is by the exact string, which is why a differently-cased name surfaces nothing",
+};
+const SERVER_TIMING_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Server Timing",
+    section: Some("3.3"),
+    url: "https://www.w3.org/TR/server-timing/#dom-performanceservertiming-description",
+    note: "The `description` attribute: `params[\"desc\"]` if it exists, otherwise the empty string. The same exact-string lookup as § 3.2's",
+};
+const IANA_HTTP_FIELD_NAME_REGISTRY: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Field Name Registry",
+    section: None,
+    url: "https://www.iana.org/assignments/http-fields/http-fields.xhtml",
+    note: "Where the claim above is checkable: `Server-Timing` is listed `permanent`, with the W3C Working Draft as its only reference. No branch of this rule consults the registry — the field's grammar comes from the document, not from an entry — but the footing does, and an operator asked to trust a work in progress should be able to see that IANA does",
+};
+const HTML_COMMON_MICROSYNTAXES_2_3_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Common Microsyntaxes",
+    section: Some("2.3.4.3"),
+    url: "https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#floating-point-numbers",
+    note: "Floating-point numbers: the *valid floating-point number* production a conforming author writes, kept deliberately apart from the *rules for parsing floating-point number values* a user agent runs. `dur` is measured against the first. Neither is `f64::from_str`, which admits Infinity, NaN and a leading `+`",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "Conformance and Error Handling: \"A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules.\" The Server Timing specification states no requirement on a server, so every grammar finding here rests on this sentence",
+};
+const RFC_9110_5_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
+    note: "Lists (#rule ABNF Extension): `#element => [ 1#element ]` is why an empty `Server-Timing` field value is zero metrics and not a defect, and § 5.6.1.1's \"a sender MUST NOT generate empty list elements\" is why a comma with nothing between it and the next one is",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "Tokens: `metric-name` and both halves of a parameter's name are `token`, whose characters are all visible US-ASCII — so an `obs-text` octet in one of those positions is the defect, not the reader's inability to decode it",
+};
+const RFC_9110_5_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
+    note: "Quoted Strings: the other alternative a `server-timing-param-value` may be. `qdtext` admits `obs-text`, which is why a `desc` carrying a high octet is conforming, and `quoted-pair` is why a DQUOTE inside one is not a terminator",
+};
+const RFC_9110_6_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
+    note: "Limitations on Use of Trailers: the sentence that decides whether this field may sit in a trailer section at all. Not asked here — `trailer_fields_valid` owns it — but it is why the second section this rule reads is worth naming: the Server Timing specification puts the field there only in a section marked non-normative",
+};
+
 impl Rule for ServerTimingHeaderSyntax {
     fn id(&self) -> &'static str {
         "server_timing_header_syntax"
@@ -210,66 +274,16 @@ impl Rule for ServerTimingHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "Server Timing",
-                section: Some("2"),
-                url: "https://www.w3.org/TR/server-timing/#the-server-timing-header-field",
-                note: "The `Server-Timing` Header Field: the ABNF this rule enforces, the two parameter names the specification establishes, and the user-agent parsing algorithm. Eight BCP 14 keywords: six addressed to the user agent, a MAY permitting a response to repeat a metric name, and a SHOULD NOT on a parameter name appearing twice in one metric — that last one is the only sentence in the whole document that measures what a server wrote. The section takes `#`, `*`, `OWS`, `token` and `quoted-string` from `[RFC7230]`, which is obsolete; the current productions are RFC 9110 § 5.6.1, § 5.6.3, § 5.6.2 and § 5.6.4 and are carried forward unchanged, so nothing this rule decides turns on which document is read. The document is a W3C Working Draft (7 April 2026) whose own Status section says \"It is inappropriate to cite this document as other than a work in progress\" — and it is nonetheless the field's only specification: the IANA HTTP Field Name Registry lists `Server-Timing` as **permanent** with this document as its sole reference, the same way it lists `Keep-Alive` against an obsoleted RFC. A work in progress is what there is to read",
-            },
-            crate::rules::SpecRef {
-                spec: "Server Timing",
-                section: Some("3.2"),
-                url: "https://www.w3.org/TR/server-timing/#dom-performanceservertiming-duration",
-                note: "The `duration` attribute: `params[\"dur\"]` parsed with HTML's rules for parsing floating-point number values, returning 0 on error. This is what a non-numeric `dur` costs, and it is a consequence rather than a requirement — the lookup is by the exact string, which is why a differently-cased name surfaces nothing",
-            },
-            crate::rules::SpecRef {
-                spec: "Server Timing",
-                section: Some("3.3"),
-                url: "https://www.w3.org/TR/server-timing/#dom-performanceservertiming-description",
-                note: "The `description` attribute: `params[\"desc\"]` if it exists, otherwise the empty string. The same exact-string lookup as § 3.2's",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Field Name Registry",
-                section: None,
-                url: "https://www.iana.org/assignments/http-fields/http-fields.xhtml",
-                note: "Where the claim above is checkable: `Server-Timing` is listed `permanent`, with the W3C Working Draft as its only reference. No branch of this rule consults the registry — the field's grammar comes from the document, not from an entry — but the footing does, and an operator asked to trust a work in progress should be able to see that IANA does",
-            },
-            crate::rules::SpecRef {
-                spec: "HTML Common Microsyntaxes",
-                section: Some("2.3.4.3"),
-                url: "https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#floating-point-numbers",
-                note: "Floating-point numbers: the *valid floating-point number* production a conforming author writes, kept deliberately apart from the *rules for parsing floating-point number values* a user agent runs. `dur` is measured against the first. Neither is `f64::from_str`, which admits Infinity, NaN and a leading `+`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "Conformance and Error Handling: \"A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules.\" The Server Timing specification states no requirement on a server, so every grammar finding here rests on this sentence",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
-                note: "Lists (#rule ABNF Extension): `#element => [ 1#element ]` is why an empty `Server-Timing` field value is zero metrics and not a defect, and § 5.6.1.1's \"a sender MUST NOT generate empty list elements\" is why a comma with nothing between it and the next one is",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "Tokens: `metric-name` and both halves of a parameter's name are `token`, whose characters are all visible US-ASCII — so an `obs-text` octet in one of those positions is the defect, not the reader's inability to decode it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
-                note: "Quoted Strings: the other alternative a `server-timing-param-value` may be. `qdtext` admits `obs-text`, which is why a `desc` carrying a high octet is conforming, and `quoted-pair` is why a DQUOTE inside one is not a terminator",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
-                note: "Limitations on Use of Trailers: the sentence that decides whether this field may sit in a trailer section at all. Not asked here — `trailer_fields_valid` owns it — but it is why the second section this rule reads is worth naming: the Server Timing specification puts the field there only in a section marked non-normative",
-            },
+            SERVER_TIMING_2,
+            SERVER_TIMING_3_2,
+            SERVER_TIMING_3_3,
+            IANA_HTTP_FIELD_NAME_REGISTRY,
+            HTML_COMMON_MICROSYNTAXES_2_3_4_3,
+            RFC_9110_2_2,
+            RFC_9110_5_6_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
+            RFC_9110_6_5_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
+++ b/lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -96,6 +96,41 @@ const SINGLETON_FIELDS: &[(&str, &str)] = &[
     ("expires", "`Expires = HTTP-date` (RFC 9111 §5.3)"),
 ];
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
+    note: "Field Order: the MUST NOT this rule enforces — multiple field lines with \
+           one name in a message, headers or trailers, unless the field's \
+           definition has a comma-separated-list alternative",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "Field Values: what a singleton field is, and the sentence saying that \
+           detecting an erroneously repeated one improves interoperability",
+};
+const RFC_9110_5_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
+    note: "Lists: the `#rule` extension — the shape a field's definition has when \
+           §5.3's exception applies to it, and the shape none of the sixteen \
+           grammars in this rule's table has",
+};
+const RFC_9111_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.1",
+    note: "Age — defined as a singleton header field in as many words, with the \
+           recipient's first-member recovery beside it, which is a recipient's \
+           SHOULD and not a sender's licence",
+};
+
 impl Rule for SingletonFieldsNotRepeated {
     fn id(&self) -> &'static str {
         "singleton_fields_not_repeated"
@@ -167,39 +202,7 @@ impl Rule for SingletonFieldsNotRepeated {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3",
-                note: "Field Order: the MUST NOT this rule enforces — multiple field lines with \
-                       one name in a message, headers or trailers, unless the field's \
-                       definition has a comma-separated-list alternative",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "Field Values: what a singleton field is, and the sentence saying that \
-                       detecting an erroneously repeated one improves interoperability",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1",
-                note: "Lists: the `#rule` extension — the shape a field's definition has when \
-                       §5.3's exception applies to it, and the shape none of the sixteen \
-                       grammars in this rule's table has",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.1",
-                note: "Age — defined as a singleton header field in as many words, with the \
-                       recipient's first-member recovery beside it, which is a recipient's \
-                       SHOULD and not a sender's licence",
-            },
-        ]
+        &[RFC_9110_5_3, RFC_9110_5_5, RFC_9110_5_6_1, RFC_9111_5_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -20,6 +20,34 @@ use crate::rules::Rule;
 ///   should appear (the connection has been handed off to the upgraded protocol).
 pub struct Status101SwitchingProtocols;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2",
+    note: "101 Switching Protocols",
+};
+const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "Upgrade",
+};
+const RFC_9113_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6",
+    note: "The Upgrade Header Field (HTTP/2 forbids 101)",
+};
+const RFC_9114_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
+    note: "HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism",
+};
+
 impl Rule for Status101SwitchingProtocols {
     fn id(&self) -> &'static str {
         "status_101_switching_protocols"
@@ -217,32 +245,7 @@ impl Rule for Status101SwitchingProtocols {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2.2",
-                note: "101 Switching Protocols",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-                note: "Upgrade",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.6",
-                note: "The Upgrade Header Field (HTTP/2 forbids 101)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
-                note: "HTTP Upgrade — the only place RFC 9114 mentions 101; forbids it alongside the Upgrade mechanism",
-            },
-        ]
+        &[RFC_9110_15_2_2, RFC_9110_7_8, RFC_9113_8_6, RFC_9114_4_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
+++ b/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
@@ -58,6 +58,34 @@ use crate::rules::Rule;
 /// Report a `103 (Early Hints)` recorded as a request's response.
 pub struct Status103EarlyHintsBeforeFinal;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
+    note: "The requirement this rule rests on: a single request's interim responses are followed by exactly one final response — the sentence RFC 8297 never states, and the reason the finding is about one request rather than two transactions",
+};
+const RFC_9110_15_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2",
+    note: "What makes a 103 interim, and the only MUST NOT in reach that is addressed to the sender: HTTP/1.0 defined no 1xx status codes, so a server must not send one to an HTTP/1.0 client",
+};
+const RFC_8297_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8297",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-2",
+    note: "The status code's definition, which is the scope gate — and every one of the document's BCP 14 keywords: three requirements addressed to the client and two MAYs addressed to the server, so nothing here is a requirement this rule could enforce",
+};
+const RFC_8297_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8297",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-3",
+    note: "Why an interim response recorded as the answer is worth reporting rather than shrugging at: the document's Security Considerations are about a recipient mishandling an informational response as a final one",
+};
+
 impl Rule for Status103EarlyHintsBeforeFinal {
     fn id(&self) -> &'static str {
         "status_103_early_hints_before_final"
@@ -140,32 +168,7 @@ impl Rule for Status103EarlyHintsBeforeFinal {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
-                note: "The requirement this rule rests on: a single request's interim responses are followed by exactly one final response — the sentence RFC 8297 never states, and the reason the finding is about one request rather than two transactions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.2",
-                note: "What makes a 103 interim, and the only MUST NOT in reach that is addressed to the sender: HTTP/1.0 defined no 1xx status codes, so a server must not send one to an HTTP/1.0 client",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8297",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-2",
-                note: "The status code's definition, which is the scope gate — and every one of the document's BCP 14 keywords: three requirements addressed to the client and two MAYs addressed to the server, so nothing here is a requirement this rule could enforce",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8297",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8297.html#section-3",
-                note: "Why an interim response recorded as the answer is worth reporting rather than shrugging at: the document's Security Considerations are about a recipient mishandling an informational response as a final one",
-            },
-        ]
+        &[RFC_9110_15, RFC_9110_15_2, RFC_8297_2, RFC_8297_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
+++ b/lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
@@ -34,6 +34,52 @@ impl Status200Vs204BodyConsistent {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.1",
+    note: "200 (OK) — the whole basis of this rule, and both of its sentences matter: a 200 is expected to contain content \"unless the message framing explicitly indicates that the content has zero length\" (the reported state is that exception, not a breach), and the 204 advice is an \"ought to\" conditioned on the request preferring no content, which is not observable. The same paragraph excludes CONNECT",
+};
+const RFC_9110_15_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5",
+    note: "204 (No Content) — the alternative the advice names: success, no content, and terminated by the end of the header section",
+};
+const RFC_9110_6_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1",
+    note: "Content Semantics — which responses have no content (HEAD, 2xx to CONNECT, 1xx, 204, 304) and, for every other response, that its content \"might be of zero length\": a zero-length 200 is contemplated by the specification",
+};
+const RFC_9110_9_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
+    note: "HEAD — \"the server MUST NOT send content in the response\", so an empty response to HEAD says nothing about what the server intended",
+};
+const RFC_9110_9_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
+    note: "CONNECT — a 2xx switches the connection to tunnel mode immediately after the header section; 204 is not an alternative there",
+};
+const RFC_9110_9_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7",
+    note: "OPTIONS — \"The response content, if any\", so a successful OPTIONS carrying none is anticipated by the method's definition. It is reported like any other 200: the sentence describing the method is not the sentence this rule enforces",
+};
+const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
+    note: "Message body length — a Transfer-Encoding overrides a Content-Length, so the declared length is read only in its absence; the captured content length is still consulted",
+};
+
 impl Rule for Status200Vs204BodyConsistent {
     fn id(&self) -> &'static str {
         "status_200_vs_204_body_consistent"
@@ -147,48 +193,13 @@ impl Rule for Status200Vs204BodyConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.1",
-                note: "200 (OK) — the whole basis of this rule, and both of its sentences matter: a 200 is expected to contain content \"unless the message framing explicitly indicates that the content has zero length\" (the reported state is that exception, not a breach), and the 204 advice is an \"ought to\" conditioned on the request preferring no content, which is not observable. The same paragraph excludes CONNECT",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.3.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.5",
-                note: "204 (No Content) — the alternative the advice names: success, no content, and terminated by the end of the header section",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1",
-                note: "Content Semantics — which responses have no content (HEAD, 2xx to CONNECT, 1xx, 204, 304) and, for every other response, that its content \"might be of zero length\": a zero-length 200 is contemplated by the specification",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2",
-                note: "HEAD — \"the server MUST NOT send content in the response\", so an empty response to HEAD says nothing about what the server intended",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6",
-                note: "CONNECT — a 2xx switches the connection to tunnel mode immediately after the header section; 204 is not an alternative there",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7",
-                note: "OPTIONS — \"The response content, if any\", so a successful OPTIONS carrying none is anticipated by the method's definition. It is reported like any other 200: the sentence describing the method is not the sentence this rule enforces",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
-                note: "Message body length — a Transfer-Encoding overrides a Content-Length, so the declared length is read only in its absence; the captured content length is still consulted",
-            },
+            RFC_9110_15_3_1,
+            RFC_9110_15_3_5,
+            RFC_9110_6_4_1,
+            RFC_9110_9_3_2,
+            RFC_9110_9_3_6,
+            RFC_9110_9_3_7,
+            RFC_9112_6_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
+++ b/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
@@ -47,6 +47,52 @@ fn unambiguous_alternative(status: u16) -> Option<(&'static str, &'static str)> 
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.2",
+    note: "301 Moved Permanently: a user agent MAY change the method from POST to GET, and 308 is the status named for a server that does not want that",
+};
+const RFC_9110_15_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.3",
+    note: "302 Found: the same permission, answered by 307 rather than by 308 — the alternative is per status",
+};
+const RFC_9110_15_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
+    note: "Why only these two: 307 and 308 were added to indicate method-preserving redirects, and 301 and 302 were adjusted to allow a POST to be redirected as GET. This is also the only sentence that says 308 preserves the method — §15.4.9 does not repeat it. Also what a provided Location buys: a user agent MAY follow it automatically",
+};
+const RFC_9110_15_4_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.8",
+    note: "307 Temporary Redirect: the user agent MUST NOT change the request method when it redirects automatically — the unambiguous half of the 302 pair, and never reported by this rule",
+};
+const RFC_9110_15_4_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.4.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.4",
+    note: "303 See Other: defined as a redirection to a resource the user agent retrieves, so the change of method is what the status means rather than something left open",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, so the rule compares it exactly rather than folding case",
+};
+const RFC_9110_9_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.3",
+    note: "The 303 alternative: an origin server MAY redirect a POST with a 303, if the result of processing it is equivalent to a representation of an existing resource",
+};
+
 impl Rule for Status3xxVsRequestMethod {
     fn id(&self) -> &'static str {
         "status_3xx_vs_request_method"
@@ -123,48 +169,13 @@ impl Rule for Status3xxVsRequestMethod {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.2",
-                note: "301 Moved Permanently: a user agent MAY change the method from POST to GET, and 308 is the status named for a server that does not want that",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.3",
-                note: "302 Found: the same permission, answered by 307 rather than by 308 — the alternative is per status",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4",
-                note: "Why only these two: 307 and 308 were added to indicate method-preserving redirects, and 301 and 302 were adjusted to allow a POST to be redirected as GET. This is also the only sentence that says 308 preserves the method — §15.4.9 does not repeat it. Also what a provided Location buys: a user agent MAY follow it automatically",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.8",
-                note: "307 Temporary Redirect: the user agent MUST NOT change the request method when it redirects automatically — the unambiguous half of the 302 pair, and never reported by this rule",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.4.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.4",
-                note: "303 See Other: defined as a redirection to a resource the user agent retrieves, so the change of method is what the status means rather than something left open",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, so the rule compares it exactly rather than folding case",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.3",
-                note: "The 303 alternative: an origin server MAY redirect a POST with a 303, if the result of processing it is equivalent to a representation of an existing resource",
-            },
+            RFC_9110_15_4_2,
+            RFC_9110_15_4_3,
+            RFC_9110_15_4,
+            RFC_9110_15_4_8,
+            RFC_9110_15_4_4,
+            RFC_9110_9_1,
+            RFC_9110_9_3_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/status_405_allow_valid.rs
+++ b/lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -50,6 +50,52 @@ impl Status405AllowValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_5_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.6",
+    note: "The status code and its MUST — including the clause after \"containing\", which asks the field to hold the methods the target resource supports and so contradicts a list naming the method this response refuses",
+};
+const RFC_9110_10_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
+    note: "The field: the same MUST worded with the MAY that licenses silence on every other response, the sentence giving an empty value a meaning in this exact response, and the set of allowed methods being the origin server's at the time of each request",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, which is why the request's method is matched against the members exactly; also the 405-versus-501 division and the sentence leaving each resource to decide which methods it allows",
+};
+const RFC_9110_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-3.7",
+    note: "Why a requirement addressed to an origin server is measured against whatever answered: every one of them applies to a gateway's outbound communication",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "A field value excludes the whitespace around it, which is why a value that is only whitespace is the empty value and answers the requirement — and why the value is read as octets rather than through a UTF-8 decode, since `obs-text` is an octet field content admits",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "The delimiter set that makes splitting this field on every comma exact: a `method` is a `token`, which admits no comma, and the field embeds no `quoted-string` for one to hide inside",
+};
+const RFC_9110_6_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
+    note: "Why an `Allow` in the trailer section does not answer this requirement — a trailer field needs its own definition's permission, and the field's definition gives none",
+};
+
 impl Rule for Status405AllowValid {
     fn id(&self) -> &'static str {
         "status_405_allow_valid"
@@ -177,48 +223,13 @@ impl Rule for Status405AllowValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.6",
-                note: "The status code and its MUST — including the clause after \"containing\", which asks the field to hold the methods the target resource supports and so contradicts a list naming the method this response refuses",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1",
-                note: "The field: the same MUST worded with the MAY that licenses silence on every other response, the sentence giving an empty value a meaning in this exact response, and the set of allowed methods being the origin server's at the time of each request",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, which is why the request's method is matched against the members exactly; also the 405-versus-501 division and the sentence leaving each resource to decide which methods it allows",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-3.7",
-                note: "Why a requirement addressed to an origin server is measured against whatever answered: every one of them applies to a gateway's outbound communication",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "A field value excludes the whitespace around it, which is why a value that is only whitespace is the empty value and answers the requirement — and why the value is read as octets rather than through a UTF-8 decode, since `obs-text` is an octet field content admits",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "The delimiter set that makes splitting this field on every comma exact: a `method` is a `token`, which admits no comma, and the field embeds no `quoted-string` for one to hide inside",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
-                note: "Why an `Allow` in the trailer section does not answer this requirement — a trailer field needs its own definition's permission, and the field's definition gives none",
-            },
+            RFC_9110_15_5_6,
+            RFC_9110_10_2_1,
+            RFC_9110_9_1,
+            RFC_9110_3_7,
+            RFC_9110_5_5,
+            RFC_9110_5_6_2,
+            RFC_9110_6_5_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/status_426_upgrade_valid.rs
+++ b/lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -8,6 +8,61 @@ use crate::rules::Rule;
 
 pub struct Status426UpgradeValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_5_22: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.22"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.22",
+    note: "426 Upgrade Required — the MUST, its object clause (to indicate the \
+           required protocol(s)), and what the status itself says the server is \
+           asking the client to do",
+};
+const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "Upgrade — the same MUST from the field's side, worded with the ordering \
+           clause; also the MAY that licenses the field's absence on every other \
+           response",
+};
+const RFC_9113_8_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
+    note: "Connection-Specific Header Fields — why an HTTP/2 response is not asked \
+           for a field it must not generate",
+};
+const RFC_9114_4_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
+    note: "HTTP Upgrade — HTTP/3 does not have the mechanism this field belongs to, \
+           which is a stronger reason than the field being forbidden",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "A field value excludes the whitespace around it, so a value that is only \
+           whitespace is the empty value",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Several `Upgrade` lines in one field section are one field value, so the \
+           field is there if any line carries it",
+};
+const RFC_9110_6_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
+    note: "Why an `Upgrade` in the trailer section does not answer this requirement — \
+           a trailer field needs its own definition's permission, and §7.8 gives none",
+};
+
 impl Rule for Status426UpgradeValid {
     fn id(&self) -> &'static str {
         "status_426_upgrade_valid"
@@ -148,57 +203,13 @@ impl Rule for Status426UpgradeValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.22"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.22",
-                note: "426 Upgrade Required — the MUST, its object clause (to indicate the \
-                       required protocol(s)), and what the status itself says the server is \
-                       asking the client to do",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-                note: "Upgrade — the same MUST from the field's side, worded with the ordering \
-                       clause; also the MAY that licenses the field's absence on every other \
-                       response",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
-                note: "Connection-Specific Header Fields — why an HTTP/2 response is not asked \
-                       for a field it must not generate",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.5",
-                note: "HTTP Upgrade — HTTP/3 does not have the mechanism this field belongs to, \
-                       which is a stronger reason than the field being forbidden",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "A field value excludes the whitespace around it, so a value that is only \
-                       whitespace is the empty value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Several `Upgrade` lines in one field section are one field value, so the \
-                       field is there if any line carries it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
-                note: "Why an `Upgrade` in the trailer section does not answer this requirement — \
-                       a trailer field needs its own definition's permission, and §7.8 gives none",
-            },
+            RFC_9110_15_5_22,
+            RFC_9110_7_8,
+            RFC_9113_8_2_2,
+            RFC_9114_4_5,
+            RFC_9110_5_5,
+            RFC_9110_5_2,
+            RFC_9110_6_5_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/status_and_caching_semantics.rs
+++ b/lint-http-rules/src/rules/status_and_caching_semantics.rs
@@ -10,6 +10,22 @@ use crate::rules::Rule;
 /// Default-cacheable status codes are: 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, 501.
 pub struct StatusAndCachingSemantics;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-3",
+    note: "Storing Responses in Caches (the freshness signals a cache requires: Expires, max-age, s-maxage, or a heuristically cacheable status)",
+};
+const RFC_9110_15_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1",
+    note: "Overview of Status Codes (which status codes are defined as heuristically cacheable)",
+};
+
 impl Rule for StatusAndCachingSemantics {
     fn id(&self) -> &'static str {
         "status_and_caching_semantics"
@@ -103,20 +119,7 @@ impl Rule for StatusAndCachingSemantics {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-3",
-                note: "Storing Responses in Caches (the freshness signals a cache requires: Expires, max-age, s-maxage, or a heuristically cacheable status)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1",
-                note: "Overview of Status Codes (which status codes are defined as heuristically cacheable)",
-            },
-        ]
+        &[RFC_9111_3, RFC_9110_15_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/status_code_semantics.rs
+++ b/lint-http-rules/src/rules/status_code_semantics.rs
@@ -41,6 +41,46 @@ fn carries_a_challenge(headers: &hyper::HeaderMap, name: &str) -> bool {
     })
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.2",
+    note: "401 (Unauthorized) — the MUST for a `WWW-Authenticate` header field containing at least one challenge",
+};
+const RFC_9110_11_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
+    note: "`WWW-Authenticate` — the field definition, the same MUST for a 401, and the MAY that permits the field on any other response (which is why this rule reports no such response)",
+};
+const RFC_9110_15_5_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.5.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.8",
+    note: "407 (Proxy Authentication Required) — the MUST for a `Proxy-Authenticate` header field containing a challenge applicable to that proxy",
+};
+const RFC_9110_11_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.7.1",
+    note: "`Proxy-Authenticate` — at least one field in each 407 the proxy generates, and the sentence limiting the field to the next outbound client, which is all that stands behind the advisory finding on other statuses",
+};
+const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
+    note: "Empty list elements do not contribute to the count of elements present — why `WWW-Authenticate: ,` carries no challenge",
+};
+const RFC_9110_15: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
+    note: "Status Codes — the part of the document both status definitions live in",
+};
+
 impl Rule for StatusCodeSemantics {
     fn id(&self) -> &'static str {
         "status_code_semantics"
@@ -186,42 +226,12 @@ impl Rule for StatusCodeSemantics {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.2",
-                note: "401 (Unauthorized) — the MUST for a `WWW-Authenticate` header field containing at least one challenge",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
-                note: "`WWW-Authenticate` — the field definition, the same MUST for a 401, and the MAY that permits the field on any other response (which is why this rule reports no such response)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.5.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.8",
-                note: "407 (Proxy Authentication Required) — the MUST for a `Proxy-Authenticate` header field containing a challenge applicable to that proxy",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.7.1",
-                note: "`Proxy-Authenticate` — at least one field in each 407 the proxy generates, and the sentence limiting the field to the next outbound client, which is all that stands behind the advisory finding on other statuses",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2",
-                note: "Empty list elements do not contribute to the count of elements present — why `WWW-Authenticate: ,` carries no challenge",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
-                note: "Status Codes — the part of the document both status definitions live in",
-            },
+            RFC_9110_15_5_2,
+            RFC_9110_11_6_1,
+            RFC_9110_15_5_8,
+            RFC_9110_11_7_1,
+            RFC_9110_5_6_1_2,
+            RFC_9110_15,
         ]
     }
 

--- a/lint-http-rules/src/rules/status_code_valid_range.rs
+++ b/lint-http-rules/src/rules/status_code_valid_range.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct StatusCodeValidRange;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_15: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
+    note: "Status Codes: the three-digit code, the 100..599 range, the statement that values outside it are invalid, what 600..999 is used for, and what a client does with an invalid code",
+};
+const RFC_9110_15_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("15.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1",
+    note: "Overview of Status Codes: additional codes `ought to be` registered — the modal that keeps this rule from checking registration",
+};
+const RFC_9110_16_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.2.2",
+    note: "Considerations for New Status Codes: a new code must fall under one of the five classes §15 defines, so the range cannot widen",
+};
+const RFC_9112_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-4",
+    note: "Status Line: `status-code = 3DIGIT`, the written form an HTTP/1.1 response can carry, and the optional reason phrase this rule does not read",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "Conformance: a sender must not generate an element that does not match its ABNF — reached from RFC 9112 §1.1, and the modal behind the one value no `status-code` can express",
+};
+
 impl Rule for StatusCodeValidRange {
     fn id(&self) -> &'static str {
         "status_code_valid_range"
@@ -116,36 +150,11 @@ impl Rule for StatusCodeValidRange {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15",
-                note: "Status Codes: the three-digit code, the 100..599 range, the statement that values outside it are invalid, what 600..999 is used for, and what a client does with an invalid code",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("15.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1",
-                note: "Overview of Status Codes: additional codes `ought to be` registered — the modal that keeps this rule from checking registration",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.2.2",
-                note: "Considerations for New Status Codes: a new code must fall under one of the five classes §15 defines, so the range cannot widen",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-4",
-                note: "Status Line: `status-code = 3DIGIT`, the written form an HTTP/1.1 response can carry, and the optional reason phrase this rule does not read",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "Conformance: a sender must not generate an element that does not match its ABNF — reached from RFC 9112 §1.1, and the modal behind the one value no `status-code` can express",
-            },
+            RFC_9110_15,
+            RFC_9110_15_1,
+            RFC_9110_16_2_2,
+            RFC_9112_4,
+            RFC_9110_2_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/strict_transport_security_valid.rs
+++ b/lint-http-rules/src/rules/strict_transport_security_valid.rs
@@ -7,6 +7,40 @@ use crate::rules::Rule;
 
 pub struct StrictTransportSecurityValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6797_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6797",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1",
+    note: "Strict-Transport-Security header",
+};
+const RFC_6797_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6797",
+    section: Some("6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.1",
+    note: "The max-age Directive",
+};
+const RFC_6797_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6797",
+    section: Some("6.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.2",
+    note: "The includeSubDomains Directive",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "Tokens — `token` syntax for directive names",
+};
+const RFC_9110_5_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
+    note: "Quoted Strings — `quoted-string` syntax for directive values",
+};
+
 impl Rule for StrictTransportSecurityValid {
     fn id(&self) -> &'static str {
         "strict_transport_security_valid"
@@ -175,36 +209,11 @@ impl Rule for StrictTransportSecurityValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6797",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1",
-                note: "Strict-Transport-Security header",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6797",
-                section: Some("6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.1",
-                note: "The max-age Directive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6797",
-                section: Some("6.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6797.html#section-6.1.2",
-                note: "The includeSubDomains Directive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "Tokens — `token` syntax for directive names",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
-                note: "Quoted Strings — `quoted-string` syntax for directive values",
-            },
+            RFC_6797_6_1,
+            RFC_6797_6_1_1,
+            RFC_6797_6_1_2,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
         ]
     }
 

--- a/lint-http-rules/src/rules/structured_headers_valid.rs
+++ b/lint-http-rules/src/rules/structured_headers_valid.rs
@@ -81,6 +81,34 @@ impl StructuredHeadersValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9651_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2",
+    note: "Parsing — the algorithm this rule runs, the field_type it needs and does not have, the MUST to join field lines, and the discard rule that makes a failure cost the whole field",
+};
+const RFC_9651_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3",
+    note: "The bare item types, including the Date and Display String added over RFC 8941",
+};
+const RFC_9651_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-2.4",
+    note: "Why a 9651 parser must accept the two new types: it parses everything an 8941 parser does, and more",
+};
+const RFC_9651_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-5",
+    note: "The registry's \"Structured Type\" column — where the field_type this rule lacks is published, for the fields that have one",
+};
+
 impl Rule for StructuredHeadersValid {
     fn id(&self) -> &'static str {
         "structured_headers_valid"
@@ -143,32 +171,7 @@ impl Rule for StructuredHeadersValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-4.2",
-                note: "Parsing — the algorithm this rule runs, the field_type it needs and does not have, the MUST to join field lines, and the discard rule that makes a failure cost the whole field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3",
-                note: "The bare item types, including the Date and Display String added over RFC 8941",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("2.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-2.4",
-                note: "Why a 9651 parser must accept the two new types: it parses everything an 8941 parser does, and more",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-5",
-                note: "The registry's \"Structured Type\" column — where the field_type this rule lacks is published, for the fields that have one",
-            },
-        ]
+        &[RFC_9651_4_2, RFC_9651_3_3, RFC_9651_2_4, RFC_9651_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
+++ b/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
@@ -8,6 +8,34 @@ use chrono::TimeZone;
 
 pub struct SunsetAndDeprecationConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_8594_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8594",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8594.html#section-3",
+    note: "`Sunset` header semantics (HTTP-date)",
+};
+const RFC_9745_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9745",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9745.html#section-2.1",
+    note: "`Deprecation` is a Structured Field Date (`@<seconds>`)",
+};
+const RFC_9745_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9745",
+    section: Some("4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9745.html#section-4",
+    note: "Sunset MUST NOT be earlier than Deprecation",
+};
+const RFC_9651_3_3_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9651",
+    section: Some("3.3.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7",
+    note: "Structured Field `Date` item syntax",
+};
+
 impl Rule for SunsetAndDeprecationConsistent {
     fn id(&self) -> &'static str {
         "sunset_and_deprecation_consistent"
@@ -126,32 +154,7 @@ impl Rule for SunsetAndDeprecationConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 8594",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8594.html#section-3",
-                note: "`Sunset` header semantics (HTTP-date)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9745",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9745.html#section-2.1",
-                note: "`Deprecation` is a Structured Field Date (`@<seconds>`)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9745",
-                section: Some("4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9745.html#section-4",
-                note: "Sunset MUST NOT be earlier than Deprecation",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9651",
-                section: Some("3.3.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7",
-                note: "Structured Field `Date` item syntax",
-            },
-        ]
+        &[RFC_8594_3, RFC_9745_2_1, RFC_9745_4, RFC_9651_3_3_7]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/te_header_valid.rs
+++ b/lint-http-rules/src/rules/te_header_valid.rs
@@ -337,6 +337,82 @@ impl TeHeaderValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
+    note: "The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it",
+};
+const RFC_9110_10_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
+    note: "The section the field is defined in — request context fields. It is the whole of the ground for reporting a TE in a response, and it carries no modal",
+};
+const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
+};
+const RFC_9110_12_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("12.4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
+    note: "`weight` and `qvalue`, and the MUST NOT on generating more than three digits after the point",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The sender's half of the list construct: no empty elements. The recipient's half (§5.6.1.2, ignore them) is a different party's requirement",
+};
+const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
+    note: "`BWS`: the whitespace around a transfer-parameter's `=`, which a recipient MUST remove and a sender MUST NOT write",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "The `Connection` field the option is listed in, and the note that some versions of HTTP do not allow the field at all",
+};
+const RFC_9112_7_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
+    note: "HTTP/1.1's own account of the field: what an empty value means, the `q` rank, the `chunked` MUST NOT, and why the connection option is required",
+};
+const RFC_9112_7_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3",
+    note: "`q` is a pseudo-parameter rather than a transfer-parameter, and its name is case-insensitive",
+};
+const RFC_9113_8_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
+    note: "HTTP/2 forbids the `Connection` field, and excepts `TE` in a request when it holds nothing but `trailers`",
+};
+const RFC_9114_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
+    note: "The same for HTTP/3. `no_connection_specific_fields` is the rule that enforces the value restriction, on both versions",
+};
+const RFC_9110_6_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
+    note: "What the `trailers` keyword says on the wire: the client will not discard a trailer section",
+};
+
 impl Rule for TeHeaderValid {
     fn id(&self) -> &'static str {
         "te_header_valid"
@@ -414,78 +490,18 @@ impl Rule for TeHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
-                note: "The field: what a member is, the grammar of its parameters, and the connection option a sender of TE must send beside it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1",
-                note: "The section the field is defined in — request context fields. It is the whole of the ground for reporting a TE in a response, and it carries no modal",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("A"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-                note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("12.4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2",
-                note: "`weight` and `qvalue`, and the MUST NOT on generating more than three digits after the point",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The sender's half of the list construct: no empty elements. The recipient's half (§5.6.1.2, ignore them) is a different party's requirement",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3",
-                note: "`BWS`: the whitespace around a transfer-parameter's `=`, which a recipient MUST remove and a sender MUST NOT write",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "The `Connection` field the option is listed in, and the note that some versions of HTTP do not allow the field at all",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
-                note: "HTTP/1.1's own account of the field: what an empty value means, the `q` rank, the `chunked` MUST NOT, and why the connection option is required",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.3",
-                note: "`q` is a pseudo-parameter rather than a transfer-parameter, and its name is case-insensitive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
-                note: "HTTP/2 forbids the `Connection` field, and excepts `TE` in a request when it holds nothing but `trailers`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
-                note: "The same for HTTP/3. `no_connection_specific_fields` is the rule that enforces the value restriction, on both versions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
-                note: "What the `trailers` keyword says on the wire: the client will not discard a trailer section",
-            },
+            RFC_9110_10_1_4,
+            RFC_9110_10_1,
+            RFC_9110_A,
+            RFC_9110_12_4_2,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_3,
+            RFC_9110_7_6_1,
+            RFC_9112_7_4,
+            RFC_9112_7_3,
+            RFC_9113_8_2_2,
+            RFC_9114_4_2,
+            RFC_9110_6_5_1,
         ]
     }
 

--- a/lint-http-rules/src/rules/timing_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/timing_allow_origin_valid.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct TimingAllowOriginValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RESOURCE_TIMING_3_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Resource Timing",
+    section: Some("3.5.2"),
+    url: "https://www.w3.org/TR/resource-timing/#sec-timing-allow-origin",
+    note: "`Timing-Allow-Origin` response header and its ABNF",
+};
+const FETCH_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("3.2"),
+    url: "https://fetch.spec.whatwg.org/#origin-header",
+    note: "`origin-or-null` and `serialized-origin`, the productions the grammar's members resolve to (`null` is case-sensitive)",
+};
+const RFC_6454_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6454",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1",
+    note: "Historical serialized-origin shape (`scheme \"://\" host [ \":\" port ]`) the conservative validator implements; Fetch supplants the serialization",
+};
+
 impl Rule for TimingAllowOriginValid {
     fn id(&self) -> &'static str {
         "timing_allow_origin_valid"
@@ -120,26 +142,7 @@ impl Rule for TimingAllowOriginValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "Resource Timing",
-                section: Some("3.5.2"),
-                url: "https://www.w3.org/TR/resource-timing/#sec-timing-allow-origin",
-                note: "`Timing-Allow-Origin` response header and its ABNF",
-            },
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("3.2"),
-                url: "https://fetch.spec.whatwg.org/#origin-header",
-                note: "`origin-or-null` and `serialized-origin`, the productions the grammar's members resolve to (`null` is case-sensitive)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6454",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6454.html#section-7.1",
-                note: "Historical serialized-origin shape (`scheme \"://\" host [ \":\" port ]`) the conservative validator implements; Fetch supplants the serialization",
-            },
-        ]
+        &[RESOURCE_TIMING_3_5_2, FETCH_3_2, RFC_6454_7_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/trace_method_echo.rs
+++ b/lint-http-rules/src/rules/trace_method_echo.rs
@@ -51,6 +51,48 @@ fn carries_a_value(headers: &hyper::HeaderMap, name: &str) -> bool {
         .any(|v| v.as_bytes().iter().any(|b| !matches!(b, b' ' | b'\t')))
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_9_3_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.3.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.8",
+    note: "TRACE — the two client `MUST NOT`s this rule reports, the example naming credentials and cookies, and the `SHOULD` to reflect the message, which is addressed to a recipient no message identifies",
+};
+const RFC_9110_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
+    note: "The method token is case-sensitive, which is why `TRACE` is matched exactly and a lowercase `trace` is not a TRACE",
+};
+const RFC_9110_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4",
+    note: "Content — the octet stream left after framing is removed, which is what the content check measures instead of the presence of a framing field",
+};
+const RFC_9110_11_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2",
+    note: "`Authorization` carries the user agent's credentials; §11.7.2 says the same of `Proxy-Authorization` for a proxy",
+};
+const RFC_6265_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6265",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.2.1",
+    note: "`Cookie` is the field a user agent returns stored cookies in — the second kind of data §9.3.8's example names",
+};
+const RFC_9110_B_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("B.3"),
+    // `appendix-B.3`, not `section-B.3`: an appendix anchors under
+    // its own prefix, and the `section-` form scrolls nowhere.
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.3",
+    note: "Changes from RFC 7231 — the normative requirement to use `message/http` in TRACE responses was removed, which is why this rule no longer asks for it",
+};
+
 impl Rule for TraceMethodEcho {
     fn id(&self) -> &'static str {
         "trace_method_echo"
@@ -133,44 +175,12 @@ impl Rule for TraceMethodEcho {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.3.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.8",
-                note: "TRACE — the two client `MUST NOT`s this rule reports, the example naming credentials and cookies, and the `SHOULD` to reflect the message, which is addressed to a recipient no message identifies",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1",
-                note: "The method token is case-sensitive, which is why `TRACE` is matched exactly and a lowercase `trace` is not a TRACE",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4",
-                note: "Content — the octet stream left after framing is removed, which is what the content check measures instead of the presence of a framing field",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2",
-                note: "`Authorization` carries the user agent's credentials; §11.7.2 says the same of `Proxy-Authorization` for a proxy",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6265",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.2.1",
-                note: "`Cookie` is the field a user agent returns stored cookies in — the second kind of data §9.3.8's example names",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("B.3"),
-                // `appendix-B.3`, not `section-B.3`: an appendix anchors under
-                // its own prefix, and the `section-` form scrolls nowhere.
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.3",
-                note: "Changes from RFC 7231 — the normative requirement to use `message/http` in TRACE responses was removed, which is why this rule no longer asks for it",
-            },
+            RFC_9110_9_3_8,
+            RFC_9110_9_1,
+            RFC_9110_6_4,
+            RFC_9110_11_6_2,
+            RFC_6265_4_2_1,
+            RFC_9110_B_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/trailer_fields_valid.rs
+++ b/lint-http-rules/src/rules/trailer_fields_valid.rs
@@ -22,6 +22,52 @@ use crate::rules::Rule;
 /// cite(RFC 9110 § 6.5.1): "A trailer section is only possible when supported by the version of HTTP in use and enabled by an explicit framing mechanism."
 pub struct TrailerFieldsValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5",
+    note: "Trailer fields: what a trailer section is, and why what it carries cannot unmake a routing or processing choice already made from the header section",
+};
+const RFC_9110_6_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
+    note: "The MUST NOT behind the first finding, and it is deny-by-default: a trailer field is permitted only where the field's own definition says so. This rule reports the subset it can name; a field it does not recognise is not thereby approved",
+};
+const RFC_9110_6_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.2",
+    note: "The `Trailer` field, whose SHOULD asks a sender to indicate which fields might appear — the sentence behind the undeclared-field finding, which said §6.5 in the finding text",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "`Connection`: naming a field as a connection-option makes its value control information for this connection, and every intermediary removes it from the trailer section before forwarding",
+};
+const RFC_9110_11_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.3",
+    note: "`Authentication-Info` may be sent as a trailer field when the authentication scheme allows it — a field §6.5.1's authentication category would forbid, permitted by name in its own definition. §11.7.3 says the same of `Proxy-Authentication-Info`. Neither is reported",
+};
+const RFC_9110_16_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.2",
+    note: "The registry's advice to authors of new fields, and the sentence that makes §6.5.1 deny-by-default: a field is not allowable in trailers unless its definition says it is",
+};
+const RFC_9112_7_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1.2",
+    note: "The chunked transfer coding's trailer section — HTTP/1.1's framing mechanism for the section this rule reads, and the reason the framing precondition in §6.5.1 needs no check here",
+};
+
 impl Rule for TrailerFieldsValid {
     fn id(&self) -> &'static str {
         "trailer_fields_valid"
@@ -78,48 +124,13 @@ impl Rule for TrailerFieldsValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5",
-                note: "Trailer fields: what a trailer section is, and why what it carries cannot unmake a routing or processing choice already made from the header section",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
-                note: "The MUST NOT behind the first finding, and it is deny-by-default: a trailer field is permitted only where the field's own definition says so. This rule reports the subset it can name; a field it does not recognise is not thereby approved",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.2",
-                note: "The `Trailer` field, whose SHOULD asks a sender to indicate which fields might appear — the sentence behind the undeclared-field finding, which said §6.5 in the finding text",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "`Connection`: naming a field as a connection-option makes its value control information for this connection, and every intermediary removes it from the trailer section before forwarding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.3",
-                note: "`Authentication-Info` may be sent as a trailer field when the authentication scheme allows it — a field §6.5.1's authentication category would forbid, permitted by name in its own definition. §11.7.3 says the same of `Proxy-Authentication-Info`. Neither is reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.3.2",
-                note: "The registry's advice to authors of new fields, and the sentence that makes §6.5.1 deny-by-default: a field is not allowable in trailers unless its definition says it is",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1.2",
-                note: "The chunked transfer coding's trailer section — HTTP/1.1's framing mechanism for the section this rule reads, and the reason the framing precondition in §6.5.1 needs no check here",
-            },
+            RFC_9110_6_5,
+            RFC_9110_6_5_1,
+            RFC_9110_6_6_2,
+            RFC_9110_7_6_1,
+            RFC_9110_11_6_3,
+            RFC_9110_16_3_2,
+            RFC_9112_7_1_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/trailer_header_valid.rs
+++ b/lint-http-rules/src/rules/trailer_header_valid.rs
@@ -125,6 +125,52 @@ impl TrailerHeaderValid {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_6_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.2",
+    note: "The `Trailer` field itself: what its value means, and the SHOULD that asks a sender to write one",
+};
+const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement and is why the shared list reader is not used here",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Several `Trailer` lines in one field section are one field value, so the members are counted after the lines are joined",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "`Connection` and hop-by-hop semantics; the sentence that removes connection-options from a trailer section is the MUST behind the nomination finding. This said RFC 7230 §6.1 — the right section of an obsoleted document, with the two notes swapped between them",
+};
+const RFC_9110_6_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("6.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
+    note: "Limitations on use of trailers. Applied here only to `Trailer` naming itself; the general question is `trailer_fields_valid`'s",
+};
+const RFC_9112_7_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1.2",
+    note: "The chunked transfer coding's trailer section — HTTP/1.1's framing mechanism for the section this field announces. This said RFC 7230 §4.1.2",
+};
+
 impl Rule for TrailerHeaderValid {
     fn id(&self) -> &'static str {
         "trailer_header_valid"
@@ -168,48 +214,13 @@ impl Rule for TrailerHeaderValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.2",
-                note: "The `Trailer` field itself: what its value means, and the SHOULD that asks a sender to write one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("A"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-                note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement and is why the shared list reader is not used here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Several `Trailer` lines in one field section are one field value, so the members are counted after the lines are joined",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "`Connection` and hop-by-hop semantics; the sentence that removes connection-options from a trailer section is the MUST behind the nomination finding. This said RFC 7230 §6.1 — the right section of an obsoleted document, with the two notes swapped between them",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("6.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1",
-                note: "Limitations on use of trailers. Applied here only to `Trailer` naming itself; the general question is `trailer_fields_valid`'s",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.1.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1.2",
-                note: "The chunked transfer coding's trailer section — HTTP/1.1's framing mechanism for the section this field announces. This said RFC 7230 §4.1.2",
-            },
+            RFC_9110_6_6_2,
+            RFC_9110_A,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_2,
+            RFC_9110_7_6_1,
+            RFC_9110_6_5_1,
+            RFC_9112_7_1_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/transfer_coding_registered.rs
+++ b/lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -21,6 +21,53 @@ const PARAMETERLESS_CODINGS: [&str; 6] = [
 
 pub struct TransferCodingRegistered;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
+    note: "Transfer-Encoding = #transfer-coding, and the 501 a recipient owes a coding it does not understand",
+};
+const RFC_9112_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7",
+    note: "Transfer codings: the names are case-insensitive and 'ought to be' registered — the whole of this rule's strength",
+};
+const RFC_9112_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1",
+    note: "Chunked, which likewise defines no parameters",
+};
+const RFC_9112_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
+    note:
+        "The five compression codings, which define no parameters — §7.1 says the same of chunked",
+};
+const RFC_9112_7_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
+    note: "Negotiating transfer codings: chunked is forbidden in TE, an empty TE is conforming, and the q is a rank",
+};
+const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
+    note: "TE, and the grammar both fields share — including the quoted-string a transfer-parameter may carry",
+};
+const IANA_HTTP_PARAMETERS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "IANA HTTP Parameters",
+    section: None,
+    url: "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding",
+    note: "The registry this rule is named after and does not read: names are checked against the configured 'allowed' list instead",
+};
+
 impl Rule for TransferCodingRegistered {
     fn id(&self) -> &'static str {
         "transfer_coding_registered"
@@ -356,48 +403,13 @@ impl Rule for TransferCodingRegistered {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
-                note: "Transfer-Encoding = #transfer-coding, and the 501 a recipient owes a coding it does not understand",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7",
-                note: "Transfer codings: the names are case-insensitive and 'ought to be' registered — the whole of this rule's strength",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1",
-                note: "Chunked, which likewise defines no parameters",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.2",
-                note: "The five compression codings, which define no parameters — §7.1 says the same of chunked",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.4",
-                note: "Negotiating transfer codings: chunked is forbidden in TE, an empty TE is conforming, and the q is a rank",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
-                note: "TE, and the grammar both fields share — including the quoted-string a transfer-parameter may carry",
-            },
-            crate::rules::SpecRef {
-                spec: "IANA HTTP Parameters",
-                section: None,
-                url: "https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#transfer-coding",
-                note: "The registry this rule is named after and does not read: names are checked against the configured 'allowed' list instead",
-            },
+            RFC_9112_6_1,
+            RFC_9112_7,
+            RFC_9112_7_1,
+            RFC_9112_7_2,
+            RFC_9112_7_4,
+            RFC_9110_10_1_4,
+            IANA_HTTP_PARAMETERS,
         ]
     }
 

--- a/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -7,6 +7,34 @@ use crate::rules::Rule;
 
 pub struct TransferEncodingChunkedFinal;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
+    note: "Transfer-Encoding — every requirement this rule enforces is here: chunked at most once, and chunked last (unconditionally for requests, or the connection closes for responses)",
+};
+const RFC_9112_9_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("9.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-9.6",
+    note: "The 'close' connection option — how a response announces the alternative §6.1 gives it. §9.6 makes announcing a SHOULD, which bounds what this rule can conclude",
+};
+const RFC_9112_7_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("7.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1",
+    note: "Chunked Transfer Coding — what chunked is, and why nothing may follow it. It does NOT contain the ordering requirement this rule's SpecRef used to attribute to it",
+};
+const RFC_9110_10_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
+    note: "The transfer-coding grammar the members are parsed with, including the quoted-string a parameter may carry",
+};
+
 impl Rule for TransferEncodingChunkedFinal {
     fn id(&self) -> &'static str {
         "transfer_encoding_chunked_final"
@@ -229,32 +257,7 @@ impl Rule for TransferEncodingChunkedFinal {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1",
-                note: "Transfer-Encoding — every requirement this rule enforces is here: chunked at most once, and chunked last (unconditionally for requests, or the connection closes for responses)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("9.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-9.6",
-                note: "The 'close' connection option — how a response announces the alternative §6.1 gives it. §9.6 makes announcing a SHOULD, which bounds what this rule can conclude",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("7.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1",
-                note: "Chunked Transfer Coding — what chunked is, and why nothing may follow it. It does NOT contain the ordering requirement this rule's SpecRef used to attribute to it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4",
-                note: "The transfer-coding grammar the members are parsed with, including the quoted-string a parameter may carry",
-            },
-        ]
+        &[RFC_9112_6_1, RFC_9112_9_6, RFC_9112_7_1, RFC_9110_10_1_4]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
+++ b/lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -105,6 +105,40 @@ impl UpgradeAndConnectionConsistent {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "Upgrade — the sender's obligation to name the field as a connection-option \
+           beside it, and the `#protocol` grammar that makes the field's presence the \
+           thing the obligation turns on",
+};
+const RFC_9110_7_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
+    note: "Connection — the same obligation stated generally, what a recipient does \
+           with a connection-specific field that arrives without its option, the \
+           sentence permitting an option that names no present field, and the note \
+           that some versions do not allow the field at all",
+};
+const RFC_9113_8_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9113",
+    section: Some("8.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
+    note: "Connection-specific header fields — why an HTTP/2 message is not asked \
+           for an option it must not send",
+};
+const RFC_9114_4_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9114",
+    section: Some("4.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
+    note: "HTTP fields — the same prohibition for HTTP/3",
+};
+
 impl Rule for UpgradeAndConnectionConsistent {
     fn id(&self) -> &'static str {
         "upgrade_and_connection_consistent"
@@ -145,38 +179,7 @@ impl Rule for UpgradeAndConnectionConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-                note: "Upgrade — the sender's obligation to name the field as a connection-option \
-                       beside it, and the `#protocol` grammar that makes the field's presence the \
-                       thing the obligation turns on",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1",
-                note: "Connection — the same obligation stated generally, what a recipient does \
-                       with a connection-specific field that arrives without its option, the \
-                       sentence permitting an option that names no present field, and the note \
-                       that some versions do not allow the field at all",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9113",
-                section: Some("8.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.2",
-                note: "Connection-specific header fields — why an HTTP/2 message is not asked \
-                       for an option it must not send",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9114",
-                section: Some("4.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9114.html#section-4.2",
-                note: "HTTP fields — the same prohibition for HTTP/3",
-            },
-        ]
+        &[RFC_9110_7_8, RFC_9110_7_6_1, RFC_9113_8_2_2, RFC_9114_4_2]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/upgrade_header_syntax.rs
+++ b/lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -169,6 +169,62 @@ impl UpgradeHeaderSyntax {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "Upgrade — the field's own section, where `protocol`, `protocol-name` and \
+           `protocol-version` are printed, both directions are licensed to carry the \
+           field, and the registry is named as advice",
+};
+const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("A"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
+    note: "The collected grammar, where the list construct is expanded for a sender — \
+           the form that shows both that the whole value may be empty and that a \
+           member may not",
+};
+const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
+    note: "Field Values — that a value is in the format its field's grammar defines, \
+           which is what makes a malformed member a finding at all, and that the \
+           value's own ends carry no whitespace",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The sender's half of the list construct: the empty member is its MUST NOT, \
+           and the `#element` expansion is why an empty value is not",
+};
+const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "`token` and `tchar`: what both halves of a protocol are made of, and the \
+           delimiters they exclude",
+};
+const RFC_9110_16_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("16.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.7",
+    note: "The Upgrade Token Registry — First Come First Served, which is why no \
+           protocol name is compared against a list here",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Several `Upgrade` lines in one field section are one field value, so the \
+           members are counted after the lines are joined",
+};
+
 impl Rule for UpgradeHeaderSyntax {
     fn id(&self) -> &'static str {
         "upgrade_header_syntax"
@@ -221,58 +277,13 @@ impl Rule for UpgradeHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-                note: "Upgrade — the field's own section, where `protocol`, `protocol-name` and \
-                       `protocol-version` are printed, both directions are licensed to carry the \
-                       field, and the registry is named as advice",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("A"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
-                note: "The collected grammar, where the list construct is expanded for a sender — \
-                       the form that shows both that the whole value may be empty and that a \
-                       member may not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5",
-                note: "Field Values — that a value is in the format its field's grammar defines, \
-                       which is what makes a malformed member a finding at all, and that the \
-                       value's own ends carry no whitespace",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The sender's half of the list construct: the empty member is its MUST NOT, \
-                       and the `#element` expansion is why an empty value is not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-                note: "`token` and `tchar`: what both halves of a protocol are made of, and the \
-                       delimiters they exclude",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("16.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-16.7",
-                note: "The Upgrade Token Registry — First Come First Served, which is why no \
-                       protocol name is compared against a list here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Several `Upgrade` lines in one field section are one field value, so the \
-                       members are counted after the lines are joined",
-            },
+            RFC_9110_7_8,
+            RFC_9110_A,
+            RFC_9110_5_5,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_16_7,
+            RFC_9110_5_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/user_agent_present.rs
+++ b/lint-http-rules/src/rules/user_agent_present.rs
@@ -7,6 +7,28 @@ use crate::rules::Rule;
 
 pub struct UserAgentPresent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5",
+    note: "`A user agent SHOULD send a User-Agent header field in each request unless specifically configured not to do so.` The exception is a fact about the sender's configuration rather than about the request, so a conforming suppression and a plain omission are the same absence here and both are reported",
+};
+const RFC_9110_3_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("3.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-3.5",
+    note: "a user agent is any client program that initiates a request — browsers, spiders, command-line tools, appliances, firmware update scripts — so the requirement is not a browser requirement",
+};
+const RFC_9110_17_13: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("17.13"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-17.13",
+    note: "why a client is configured not to send the field: a `User-Agent` might carry enough information to identify a specific device, usually combined with other characteristics, and reducing that fingerprint is a deliberate choice this rule cannot see",
+};
+
 impl Rule for UserAgentPresent {
     fn id(&self) -> &'static str {
         "user_agent_present"
@@ -71,26 +93,7 @@ impl Rule for UserAgentPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5",
-                note: "`A user agent SHOULD send a User-Agent header field in each request unless specifically configured not to do so.` The exception is a fact about the sender's configuration rather than about the request, so a conforming suppression and a plain omission are the same absence here and both are reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("3.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-3.5",
-                note: "a user agent is any client program that initiates a request — browsers, spiders, command-line tools, appliances, firmware update scripts — so the requirement is not a browser requirement",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("17.13"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-17.13",
-                note: "why a client is configured not to send the field: a `User-Agent` might carry enough information to identify a specific device, usually combined with other characteristics, and reducing that fingerprint is a deliberate choice this rule cannot see",
-            },
-        ]
+        &[RFC_9110_10_1_5, RFC_9110_3_5, RFC_9110_17_13]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/user_agent_token_valid.rs
+++ b/lint-http-rules/src/rules/user_agent_token_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct UserAgentTokenValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_10_1_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("10.1.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5",
+    note: "`User-Agent = product *( RWS ( product / comment ) )`, a request context field; `product = token [\"/\" product-version]` is defined here once and `Server` shares it. The section's further requirements — no advertising or nonessential information in a product identifier, no needlessly fine-grained detail — are about intent and are not decidable from a field value",
+};
+const RFC_9110_5_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5",
+    note: "`comment = \"(\" *( ctext / quoted-pair / comment ) \")\"` — comments nest, and `ctext` admits `obs-text` but not the parentheses or the backslash",
+};
+
 impl Rule for UserAgentTokenValid {
     fn id(&self) -> &'static str {
         "user_agent_token_valid"
@@ -87,20 +103,7 @@ impl Rule for UserAgentTokenValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("10.1.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5",
-                note: "`User-Agent = product *( RWS ( product / comment ) )`, a request context field; `product = token [\"/\" product-version]` is defined here once and `Server` shares it. The section's further requirements — no advertising or nonessential information in a product identifier, no needlessly fine-grained detail — are about intent and are not decidable from a field value",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5",
-                note: "`comment = \"(\" *( ctext / quoted-pair / comment ) \")\"` — comments nest, and `ctext` admits `obs-text` but not the parentheses or the backslash",
-            },
-        ]
+        &[RFC_9110_10_1_5, RFC_9110_5_6_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/vary_and_cache_consistent.rs
+++ b/lint-http-rules/src/rules/vary_and_cache_consistent.rs
@@ -13,6 +13,22 @@ use crate::rules::Rule;
 /// `Vary: *` is present. This rule flags those cases as likely misconfiguration.
 pub struct VaryAndCacheConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1",
+    note: "Calculating Cache Keys with the Vary Header Field (a `Vary: *` never matches)",
+};
+const RFC_9111_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-3",
+    note: "Storing Responses in Caches (cacheability requirements)",
+};
+
 impl Rule for VaryAndCacheConsistent {
     fn id(&self) -> &'static str {
         "vary_and_cache_consistent"
@@ -99,21 +115,7 @@ impl Rule for VaryAndCacheConsistent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1",
-                note:
-                    "Calculating Cache Keys with the Vary Header Field (a `Vary: *` never matches)",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-3",
-                note: "Storing Responses in Caches (cacheability requirements)",
-            },
-        ]
+        &[RFC_9111_4_1, RFC_9111_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/vary_header_cache_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -34,6 +34,16 @@ use crate::rules::Rule;
 ///   semantics.
 pub struct VaryHeaderCacheValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9111_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+spec: "RFC 9111",
+section: Some("4.1"),
+url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1",
+note: "Calculating Cache Keys with the Vary Header Field (all Vary-nominated request fields must match for reuse)",
+        };
+
 impl Rule for VaryHeaderCacheValid {
     fn id(&self) -> &'static str {
         "vary_header_cache_valid"
@@ -214,12 +224,7 @@ impl Rule for VaryHeaderCacheValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9111",
-            section: Some("4.1"),
-            url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-4.1",
-            note: "Calculating Cache Keys with the Vary Header Field (all Vary-nominated request fields must match for reuse)",
-        }]
+        &[RFC_9111_4_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/vary_header_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_valid.rs
@@ -12,6 +12,16 @@ use crate::rules::Rule;
 /// field-names (RFC 7231's `"*" / 1#field-name` exclusivity was dropped).
 pub struct VaryHeaderValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_12_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+spec: "RFC 9110",
+section: Some("12.5.5"),
+url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.5",
+note: "Vary = #( \"*\" / field-name ) — a comma-separated list; \"*\" is an ordinary member (RFC 7231's \"*\"-or-a-list form is obsolete). Not checked: the same section's \"A proxy MUST NOT generate \\\"*\\\"\", since a forwarded \"*\" is indistinguishable from a generated one in an observed response",
+        };
+
 impl Rule for VaryHeaderValid {
     fn id(&self) -> &'static str {
         "vary_header_valid"
@@ -106,12 +116,7 @@ impl Rule for VaryHeaderValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[crate::rules::SpecRef {
-            spec: "RFC 9110",
-            section: Some("12.5.5"),
-            url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.5",
-            note: "Vary = #( \"*\" / field-name ) — a comma-separated list; \"*\" is an ordinary member (RFC 7231's \"*\"-or-a-list form is obsolete). Not checked: the same section's \"A proxy MUST NOT generate \\\"*\\\"\", since a forwarded \"*\" is indistinguishable from a generated one in an observed response",
-        }]
+        &[RFC_9110_12_5_5]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -10,6 +10,61 @@ use crate::rules::Rule;
 
 pub struct ViaHeaderSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_7_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3",
+    note: "The `Via` grammar this rule parses, the sentence that puts the field in both \
+           directions, and the requirements about forwarding and combining that a single \
+           captured message cannot answer",
+};
+const RFC_9110_7_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
+    note: "`received-protocol` points here for its two halves: `protocol-name = token` \
+           and `protocol-version = token`",
+};
+const RFC_9110_B_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("B.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2",
+    note: "Why a `received-by` is a token: RFC 9110 removed `uri-host` from the \
+           production, which is what makes a bracketed IPv6 literal a finding here and \
+           not under RFC 7230",
+};
+const RFC_9110_5_6_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5",
+    note: "The `comment` a member may end with, and the `ctext` that admits `obs-text` \
+           inside it",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "`Via` is a `#` list, so an empty member is the sender's defect and an empty \
+           value is not",
+};
+const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
+    note: "Several `Via` lines in one section are one field value, which is why the \
+           members are counted after they are joined",
+};
+const RFC_3986_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
+    note: "`port = *DIGIT` — the production `received-by` reaches through RFC 9110 §4.1, \
+           with no range and no minimum digit count",
+};
+
 impl Rule for ViaHeaderSyntax {
     fn id(&self) -> &'static str {
         "via_header_syntax"
@@ -81,57 +136,13 @@ impl Rule for ViaHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3",
-                note: "The `Via` grammar this rule parses, the sentence that puts the field in both \
-                       directions, and the requirements about forwarding and combining that a single \
-                       captured message cannot answer",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.8",
-                note: "`received-protocol` points here for its two halves: `protocol-name = token` \
-                       and `protocol-version = token`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("B.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2",
-                note: "Why a `received-by` is a token: RFC 9110 removed `uri-host` from the \
-                       production, which is what makes a bracketed IPv6 literal a finding here and \
-                       not under RFC 7230",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.5",
-                note: "The `comment` a member may end with, and the `ctext` that admits `obs-text` \
-                       inside it",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "`Via` is a `#` list, so an empty member is the sender's defect and an empty \
-                       value is not",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2",
-                note: "Several `Via` lines in one section are one field value, which is why the \
-                       members are counted after they are joined",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
-                note: "`port = *DIGIT` — the production `received-by` reaches through RFC 9110 §4.1, \
-                       with no range and no minimum digit count",
-            },
+            RFC_9110_7_6_3,
+            RFC_9110_7_8,
+            RFC_9110_B_2,
+            RFC_9110_5_6_5,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_2,
+            RFC_3986_3_2_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/warning_header_syntax.rs
+++ b/lint-http-rules/src/rules/warning_header_syntax.rs
@@ -13,6 +13,81 @@ use crate::rules::Rule;
 
 pub struct WarningHeaderSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7234_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7234",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc7234.html#section-5.5",
+    note: "The last statement of the `Warning` grammar, and the requirements about \
+           warn-codes and warn-dates that go with it. Obsoleted by RFC 9111, which \
+           removed the field rather than restating it — so this is where the \
+           productions are read from, and RFC 9111 §5.5 is where the field's status \
+           is read from",
+};
+const RFC_9111_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9111",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.5",
+    note: "Where `Warning` is obsoleted. The section carries no BCP 14 keyword, so it \
+           states no requirement on a sender and the field's presence is not reported",
+};
+const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
+    note: "The sender MUST NOT behind every finding here: a value that derives from \
+           none of §5.5's productions is a protocol element matching no ABNF rule",
+};
+const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The list construct's sender requirement — an empty member is the finding, \
+           and §5.6.1.2's worked example is what makes an empty *value* one too, \
+           because `Warning` is `1#`",
+};
+const RFC_9110_5_6_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
+    note: "`quoted-string`, the `qdtext` that admits `obs-text` inside a warn-text, \
+           and the recipient's handling of a `quoted-pair` — which is why a warn-date \
+           is unescaped before it is read as a date",
+};
+const RFC_9110_5_6_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.7"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
+    note: "`HTTP-date`, and the MUST that a sender generate it in the IMF-fixdate \
+           format — the two obsolete formats parse and are still findings. This \
+           reference said §7.1.1.1, which is RFC 7231's number for it and does not \
+           exist in RFC 9110",
+};
+const RFC_9110_7_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.6.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3",
+    note: "`pseudonym = token`, the second alternative of `warn-agent`. RFC 7234 \
+           imported the name from RFC 7230 §5.7.1; this is where it lives now",
+};
+const RFC_9110_B_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("B.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2",
+    note: "Why `Via` and `Warning` no longer agree: RFC 9110 removed `uri-host` from \
+           `received-by`, and RFC 7234's `warn-agent` — the same production — was \
+           never touched, so a bracketed IPv6 literal is a finding there and not here",
+};
+const RFC_3986_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2",
+    note: "`host`, which `warn-agent`'s first alternative reaches through RFC 9110 \
+           §4.1 — including the `reg-name` that derives the empty string",
+};
+
 impl Rule for WarningHeaderSyntax {
     fn id(&self) -> &'static str {
         "warning_header_syntax"
@@ -131,77 +206,15 @@ impl Rule for WarningHeaderSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7234",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc7234.html#section-5.5",
-                note: "The last statement of the `Warning` grammar, and the requirements about \
-                       warn-codes and warn-dates that go with it. Obsoleted by RFC 9111, which \
-                       removed the field rather than restating it — so this is where the \
-                       productions are read from, and RFC 9111 §5.5 is where the field's status \
-                       is read from",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9111",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc9111.html#section-5.5",
-                note: "Where `Warning` is obsoleted. The section carries no BCP 14 keyword, so it \
-                       states no requirement on a sender and the field's presence is not reported",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
-                note: "The sender MUST NOT behind every finding here: a value that derives from \
-                       none of §5.5's productions is a protocol element matching no ABNF rule",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.1.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-                note: "The list construct's sender requirement — an empty member is the finding, \
-                       and §5.6.1.2's worked example is what makes an empty *value* one too, \
-                       because `Warning` is `1#`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
-                note: "`quoted-string`, the `qdtext` that admits `obs-text` inside a warn-text, \
-                       and the recipient's handling of a `quoted-pair` — which is why a warn-date \
-                       is unescaped before it is read as a date",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("5.6.7"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
-                note: "`HTTP-date`, and the MUST that a sender generate it in the IMF-fixdate \
-                       format — the two obsolete formats parse and are still findings. This \
-                       reference said §7.1.1.1, which is RFC 7231's number for it and does not \
-                       exist in RFC 9110",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.6.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.3",
-                note: "`pseudonym = token`, the second alternative of `warn-agent`. RFC 7234 \
-                       imported the name from RFC 7230 §5.7.1; this is where it lives now",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("B.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2",
-                note: "Why `Via` and `Warning` no longer agree: RFC 9110 removed `uri-host` from \
-                       `received-by`, and RFC 7234's `warn-agent` — the same production — was \
-                       never touched, so a bracketed IPv6 literal is a finding there and not here",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2",
-                note: "`host`, which `warn-agent`'s first alternative reaches through RFC 9110 \
-                       §4.1 — including the `reg-name` that derives the empty string",
-            },
+            RFC_7234_5_5,
+            RFC_9111_5_5,
+            RFC_9110_2_2,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_4,
+            RFC_9110_5_6_7,
+            RFC_9110_7_6_3,
+            RFC_9110_B_2,
+            RFC_3986_3_2_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/websocket_frame_masking.rs
+++ b/lint-http-rules/src/rules/websocket_frame_masking.rs
@@ -19,6 +19,38 @@ use crate::rules::ProtocolRule;
 
 pub struct WebsocketFrameMasking;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.1",
+    note: "Overview — both masking MUSTs, the reason the client's exists, and the two \
+           recipient MUSTs that say what a conforming peer does about a breach",
+};
+const RFC_6455_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.2",
+    note: "Base Framing Protocol — the MASK bit itself: what it means, and that a \
+           masking key is present exactly when it is set",
+};
+const RFC_6455_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.3",
+    note: "Client-to-Server Masking — the key's own requirements, which a capture \
+           holding no key cannot measure",
+};
+const RFC_6455_10_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("10.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-10.3",
+    note: "Attacks On Infrastructure (Masking) — why the client's MUST is there, and \
+           why an intercepting proxy is the party it protects",
+};
+
 impl ProtocolRule for WebsocketFrameMasking {
     fn id(&self) -> &'static str {
         "websocket_frame_masking"
@@ -96,36 +128,7 @@ impl ProtocolRule for WebsocketFrameMasking {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.1",
-                note: "Overview — both masking MUSTs, the reason the client's exists, and the two \
-                       recipient MUSTs that say what a conforming peer does about a breach",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.2",
-                note: "Base Framing Protocol — the MASK bit itself: what it means, and that a \
-                       masking key is present exactly when it is set",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.3",
-                note: "Client-to-Server Masking — the key's own requirements, which a capture \
-                       holding no key cannot measure",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("10.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-10.3",
-                note: "Attacks On Infrastructure (Masking) — why the client's MUST is there, and \
-                       why an intercepting proxy is the party it protects",
-            },
-        ]
+        &[RFC_6455_5_1, RFC_6455_5_2, RFC_6455_5_3, RFC_6455_10_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
+++ b/lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
@@ -320,6 +320,58 @@ impl WebsocketFrameOpcodeSequence {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.1",
+    note: "Overview: when an endpoint may transmit a data frame",
+};
+const RFC_6455_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.2",
+    note: "Base Framing Protocol, opcode definitions and reserved ranges",
+};
+const RFC_6455_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.4",
+    note: "Fragmentation: what a fragmented message is made of",
+};
+const RFC_6455_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5",
+    note: "Control Frames: the class test and its two constraints",
+};
+const RFC_6455_5_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.1",
+    note: "Close: the body's first two bytes, and the end of what a sender may send",
+};
+const RFC_6455_5_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.6"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.6",
+    note: "Data Frames: the class test for the sequence questions",
+};
+const RFC_6455_5_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.8",
+    note: "Extensibility: what the reserved opcodes are reserved for",
+};
+const RFC_6455_11_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("11.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-11.8",
+    note: "WebSocket Opcode Registry: the field's range and its registration policy",
+};
+
 impl ProtocolRule for WebsocketFrameOpcodeSequence {
     fn id(&self) -> &'static str {
         "websocket_frame_opcode_sequence"
@@ -386,54 +438,14 @@ impl ProtocolRule for WebsocketFrameOpcodeSequence {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.1",
-                note: "Overview: when an endpoint may transmit a data frame",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.2",
-                note: "Base Framing Protocol, opcode definitions and reserved ranges",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.4",
-                note: "Fragmentation: what a fragmented message is made of",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.5"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5",
-                note: "Control Frames: the class test and its two constraints",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.1",
-                note: "Close: the body's first two bytes, and the end of what a sender may send",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.6"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.6",
-                note: "Data Frames: the class test for the sequence questions",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.8",
-                note: "Extensibility: what the reserved opcodes are reserved for",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("11.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-11.8",
-                note: "WebSocket Opcode Registry: the field's range and its registration policy",
-            },
+            RFC_6455_5_1,
+            RFC_6455_5_2,
+            RFC_6455_5_4,
+            RFC_6455_5_5,
+            RFC_6455_5_5_1,
+            RFC_6455_5_6,
+            RFC_6455_5_8,
+            RFC_6455_11_8,
         ]
     }
 

--- a/lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
+++ b/lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
@@ -38,6 +38,31 @@ impl WebsocketFrameRsvBits {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.2",
+    note: "Base Framing Protocol — the three reserved bits, their width, the \
+           conditional MUST on the sender and the MUST-fail on the recipient",
+};
+const RFC_6455_5_8: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("5.8"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.8",
+    note: "Extensibility — what the reserved bits are reserved for, and that the \
+           negotiation happens in the opening handshake",
+};
+const RFC_6455_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
+    note: "Negotiating Extensions — why the server's response field is the whole of \
+           the agreement, and the client's own field only an offer",
+};
+
 impl ProtocolRule for WebsocketFrameRsvBits {
     fn id(&self) -> &'static str {
         "websocket_frame_rsv_bits"
@@ -141,29 +166,7 @@ impl ProtocolRule for WebsocketFrameRsvBits {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.2",
-                note: "Base Framing Protocol — the three reserved bits, their width, the \
-                       conditional MUST on the sender and the MUST-fail on the recipient",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("5.8"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-5.8",
-                note: "Extensibility — what the reserved bits are reserved for, and that the \
-                       negotiation happens in the opening handshake",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
-                note: "Negotiating Extensions — why the server's response field is the whole of \
-                       the agreement, and the client's own field only an offer",
-            },
-        ]
+        &[RFC_6455_5_2, RFC_6455_5_8, RFC_6455_9_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/websocket_handshake_valid.rs
+++ b/lint-http-rules/src/rules/websocket_handshake_valid.rs
@@ -358,6 +358,52 @@ fn extension_token(member: &str) -> &str {
     }
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_6455_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
+    note: "Client Requirements — the numbered list a client validates the server's response against, and the sentence handing every non-101 back to plain HTTP",
+};
+const RFC_6455_4_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
+    note: "Reading the Client's Opening Handshake — the description a handshake has to match, and the requirement to refuse one that does not, which is what makes a 101 over a malformed key the server's defect",
+};
+const RFC_6455_4_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.2",
+    note: "Sending the Server's Opening Handshake — what a server sends if it accepts, the five things it sends instead if it does not, and how `Sec-WebSocket-Accept`, `/subprotocol/` and `/extensions/` are derived from the request",
+};
+const RFC_6455_4_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("4.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.3",
+    note: "Collected ABNF — `Sec-WebSocket-Protocol-Server = token` against the client's `1#token`, and the `extension` production whose first half is the name",
+};
+const RFC_6455_9_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 6455",
+    section: Some("9.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
+    note: "Negotiating Extensions — the server's list is the extensions in use, each extension's own document defines what a valid answer to its parameters is, and an `extension-token` is a registered name",
+};
+const RFC_8441_5: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8441",
+    section: Some("5"),
+    url: "https://www.rfc-editor.org/rfc/rfc8441.html#section-5",
+    note: "Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Accept` is not processed — the sentences behind this rule's version gate",
+};
+const RFC_9220_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9220",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9220.html#section-3",
+    note: "Carries RFC 8441's mechanism to HTTP/3 with identical semantics",
+};
+
 impl Rule for WebsocketHandshakeValid {
     fn id(&self) -> &'static str {
         "websocket_handshake_valid"
@@ -448,48 +494,13 @@ impl Rule for WebsocketHandshakeValid {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1",
-                note: "Client Requirements — the numbered list a client validates the server's response against, and the sentence handing every non-101 back to plain HTTP",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.1",
-                note: "Reading the Client's Opening Handshake — the description a handshake has to match, and the requirement to refuse one that does not, which is what makes a 101 over a malformed key the server's defect",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.2.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.2.2",
-                note: "Sending the Server's Opening Handshake — what a server sends if it accepts, the five things it sends instead if it does not, and how `Sec-WebSocket-Accept`, `/subprotocol/` and `/extensions/` are derived from the request",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("4.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-4.3",
-                note: "Collected ABNF — `Sec-WebSocket-Protocol-Server = token` against the client's `1#token`, and the `extension` production whose first half is the name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 6455",
-                section: Some("9.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc6455.html#section-9.1",
-                note: "Negotiating Extensions — the server's list is the extensions in use, each extension's own document defines what a valid answer to its parameters is, and an `extension-token` is a registered name",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8441",
-                section: Some("5"),
-                url: "https://www.rfc-editor.org/rfc/rfc8441.html#section-5",
-                note: "Updates RFC 6455: over HTTP/2 the handshake is an extended CONNECT, `Connection` and `Upgrade` MUST NOT be included, and `Sec-WebSocket-Accept` is not processed — the sentences behind this rule's version gate",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9220",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9220.html#section-3",
-                note: "Carries RFC 8441's mechanism to HTTP/3 with identical semantics",
-            },
+            RFC_6455_4_1,
+            RFC_6455_4_2_1,
+            RFC_6455_4_2_2,
+            RFC_6455_4_3,
+            RFC_6455_9_1,
+            RFC_8441_5,
+            RFC_9220_3,
         ]
     }
 

--- a/lint-http-rules/src/rules/well_known_uri_syntax.rs
+++ b/lint-http-rules/src/rules/well_known_uri_syntax.rs
@@ -76,6 +76,76 @@ fn is_well_known_segment(segment: &str) -> bool {
             && crate::helpers::uri::decode_unreserved(segment) == WELL_KNOWN_SEGMENT)
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_8615_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8615",
+    section: Some("1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-1",
+    note: "Introduction — the prefix this memo reserves, trailing slash included; that other schemes carry well-known URIs only where their definitions allow it; and the origin's control over its own URI space",
+};
+const RFC_8615_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8615",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-2",
+    note: "Notational Conventions — the BCP 14 keywords apply when, and only when, they appear in all capitals, which is why §3's lowercase \"should not expect a resource\" is declined",
+};
+const RFC_8615_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8615",
+    section: Some("3"),
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-3",
+    note: "Well-Known URIs — the definition and its scheme proviso, the `segment-nz` MUST on a registered name, the MAY for additional path components, and the sentence saying a `.well-known` elsewhere in the path is not one",
+};
+const RFC_8615_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8615",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-3.1",
+    note: "Registering Well-Known URIs — the registry, and that a widely deployed name may be registered by a third party, which is why an unregistered name is not a finding",
+};
+const RFC_8615_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8615",
+    section: Some("5.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-5.1",
+    note: "The Well-Known URI Registry — Specification Required, on the advice of experts",
+};
+const RFC_8615_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 8615",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-5.2",
+    note: "The URI Schemes Registry — the \"Well-Known URI Support\" column that tracks which schemes carry well-known URIs",
+};
+const RFC_3986_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3",
+    note: "Path — `segment-nz = 1*pchar`, what a `pchar` is, and where the path component ends",
+};
+const RFC_3986_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.3",
+    note: "Unreserved Characters — the production, and the equivalence that makes `%2Ewell-known` and `.well-known` the same segment",
+};
+const RFC_3986_6_2_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1",
+    note: "Case Normalization — the components other than scheme and host are case-sensitive, so the prefix is matched as written",
+};
+const RFC_3986_6_2_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 3986",
+    section: Some("6.2.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.3",
+    note: "Path Segment Normalization — dot segments are removed before the path's hierarchy is read, and *after* the `unreserved` octets are decoded, so an encoded `%2E%2E` is the dot segment it stands for",
+};
+const RFC_9112_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9112",
+    section: Some("3.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
+    note: "Request Target — the four forms, two of which carry no path component",
+};
+
 impl Rule for WellKnownUriSyntax {
     fn id(&self) -> &'static str {
         "well_known_uri_syntax"
@@ -287,72 +357,17 @@ impl Rule for WellKnownUriSyntax {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 8615",
-                section: Some("1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-1",
-                note: "Introduction — the prefix this memo reserves, trailing slash included; that other schemes carry well-known URIs only where their definitions allow it; and the origin's control over its own URI space",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8615",
-                section: Some("2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-2",
-                note: "Notational Conventions — the BCP 14 keywords apply when, and only when, they appear in all capitals, which is why §3's lowercase \"should not expect a resource\" is declined",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8615",
-                section: Some("3"),
-                url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-3",
-                note: "Well-Known URIs — the definition and its scheme proviso, the `segment-nz` MUST on a registered name, the MAY for additional path components, and the sentence saying a `.well-known` elsewhere in the path is not one",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8615",
-                section: Some("3.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-3.1",
-                note: "Registering Well-Known URIs — the registry, and that a widely deployed name may be registered by a third party, which is why an unregistered name is not a finding",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8615",
-                section: Some("5.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-5.1",
-                note: "The Well-Known URI Registry — Specification Required, on the advice of experts",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 8615",
-                section: Some("5.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc8615.html#section-5.2",
-                note: "The URI Schemes Registry — the \"Well-Known URI Support\" column that tracks which schemes carry well-known URIs",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("3.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.3",
-                note: "Path — `segment-nz = 1*pchar`, what a `pchar` is, and where the path component ends",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.3",
-                note: "Unreserved Characters — the production, and the equivalence that makes `%2Ewell-known` and `.well-known` the same segment",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.1",
-                note: "Case Normalization — the components other than scheme and host are case-sensitive, so the prefix is matched as written",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 3986",
-                section: Some("6.2.2.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-6.2.2.3",
-                note: "Path Segment Normalization — dot segments are removed before the path's hierarchy is read, and *after* the `unreserved` octets are decoded, so an encoded `%2E%2E` is the dot segment it stands for",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9112",
-                section: Some("3.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2",
-                note: "Request Target — the four forms, two of which carry no path component",
-            },
+            RFC_8615_1,
+            RFC_8615_2,
+            RFC_8615_3,
+            RFC_8615_3_1,
+            RFC_8615_5_1,
+            RFC_8615_5_2,
+            RFC_3986_3_3,
+            RFC_3986_2_3,
+            RFC_3986_6_2_2_1,
+            RFC_3986_6_2_2_3,
+            RFC_9112_3_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct WwwAuthenticateChallengeSyntax;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_9110_11_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
+    note: "WWW-Authenticate",
+};
+const RFC_9110_11_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3",
+    note: "Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]` (RFC 7235, which defined this, is obsoleted by RFC 9110; `token68` itself is defined in §11.2)",
+};
+
 impl Rule for WwwAuthenticateChallengeSyntax {
     fn id(&self) -> &'static str {
         "www_authenticate_challenge_syntax"
@@ -62,20 +78,7 @@ impl Rule for WwwAuthenticateChallengeSyntax {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.6.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
-                note: "WWW-Authenticate",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("11.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3",
-                note: "Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]` (RFC 7235, which defined this, is obsoleted by RFC 9110; `token68` itself is defined in §11.2)",
-            },
-        ]
+        &[RFC_9110_11_6_1, RFC_9110_11_3]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/x_content_type_options_present.rs
+++ b/lint-http-rules/src/rules/x_content_type_options_present.rs
@@ -56,6 +56,23 @@ fn parse_x_content_type_options_config(
     })
 }
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const FETCH_3_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "Fetch",
+    section: Some("3.6"),
+    url: "https://fetch.spec.whatwg.org/#x-content-type-options-header",
+    note: "`X-Content-Type-Options`: the conformance value ABNF (`\"nosniff\" ; case-insensitive`) and the determine-nosniff algorithm",
+};
+const MDN_X_CONTENT_TYPE_OPTIONS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN X-Content-Type-Options",
+    section: None,
+    url:
+        "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options",
+    note: "Web Docs: X-Content-Type-Options",
+};
+
 impl Rule for XContentTypeOptionsPresent {
     fn id(&self) -> &'static str {
         "x_content_type_options_present"
@@ -150,20 +167,7 @@ impl Rule for XContentTypeOptionsPresent {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "Fetch",
-                section: Some("3.6"),
-                url: "https://fetch.spec.whatwg.org/#x-content-type-options-header",
-                note: "`X-Content-Type-Options`: the conformance value ABNF (`\"nosniff\" ; case-insensitive`) and the determine-nosniff algorithm",
-            },
-            crate::rules::SpecRef {
-                spec: "MDN X-Content-Type-Options",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options",
-                note: "Web Docs: X-Content-Type-Options",
-            },
-        ]
+        &[FETCH_3_6, MDN_X_CONTENT_TYPE_OPTIONS]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/x_forwarded_consistent.rs
+++ b/lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -118,6 +118,46 @@ fn check_member(field: &str, kind: Members, member: &str) -> Option<String> {
 
 pub struct XForwardedConsistent;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const RFC_7239_7_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("7.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-7.4",
+    note: "Transition: what each `X-Forwarded-*` field converts into, and the one difference in how an IPv6 address is written there. The only sentences in any specification that reach these fields.",
+};
+const RFC_7239_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-1",
+    note: "Names `X-Forwarded-For`, `X-Forwarded-By` and `X-Forwarded-Proto` as non-standard header fields",
+};
+const RFC_7239_6: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6",
+    note: "`node` — the identifier an `X-Forwarded-For` / `X-Forwarded-By` member becomes once §7.4's conversion prepends `for=` / `by=`",
+};
+const RFC_7239_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("5.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-5.4",
+    note: "`proto` is a URI scheme name; `http` and `https` are called typical, not exhaustive",
+};
+const RFC_7239_5_3: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7239",
+    section: Some("5.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-5.3",
+    note: "`host` conforms to the `Host` field ABNF. That `X-Forwarded-Host` is the field this parameter carries is a reading of §7.4's `X-Forwarded-*` wildcard, not a sentence.",
+};
+const RFC_9110_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 9110",
+    section: Some("7.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
+    note: "`Host = uri-host [ \":\" port ]`, the production an `X-Forwarded-Host` member is measured against",
+};
+
 impl Rule for XForwardedConsistent {
     fn id(&self) -> &'static str {
         "x_forwarded_consistent"
@@ -176,42 +216,12 @@ impl Rule for XForwardedConsistent {
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("7.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-7.4",
-                note: "Transition: what each `X-Forwarded-*` field converts into, and the one difference in how an IPv6 address is written there. The only sentences in any specification that reach these fields.",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-1",
-                note: "Names `X-Forwarded-For`, `X-Forwarded-By` and `X-Forwarded-Proto` as non-standard header fields",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("6"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6",
-                note: "`node` — the identifier an `X-Forwarded-For` / `X-Forwarded-By` member becomes once §7.4's conversion prepends `for=` / `by=`",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("5.4"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-5.4",
-                note: "`proto` is a URI scheme name; `http` and `https` are called typical, not exhaustive",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7239",
-                section: Some("5.3"),
-                url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-5.3",
-                note: "`host` conforms to the `Host` field ABNF. That `X-Forwarded-Host` is the field this parameter carries is a reading of §7.4's `X-Forwarded-*` wildcard, not a sentence.",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 9110",
-                section: Some("7.2"),
-                url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2",
-                note: "`Host = uri-host [ \":\" port ]`, the production an `X-Forwarded-Host` member is measured against",
-            },
+            RFC_7239_7_4,
+            RFC_7239_1,
+            RFC_7239_6,
+            RFC_7239_5_4,
+            RFC_7239_5_3,
+            RFC_9110_7_2,
         ]
     }
 

--- a/lint-http-rules/src/rules/x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/x_frame_options_value_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct XFrameOptionsValueValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const HTML_SPECULATIVE_LOADING_7_7: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "HTML Speculative Loading",
+    section: Some("7.7"),
+    url: "https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header",
+    note: "Governing definition: conformance ABNF `\"DENY\" / \"SAMEORIGIN\"`, case-insensitive processing, `ALLOW-FROM` not to be implemented",
+};
+const RFC_7034_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "RFC 7034",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7034.html#section-2.1",
+    note: "Historical definition (including the dropped `ALLOW-FROM` variant); superseded by the HTML Standard",
+};
+
 impl Rule for XFrameOptionsValueValid {
     fn id(&self) -> &'static str {
         "x_frame_options_value_valid"
@@ -97,20 +113,7 @@ impl Rule for XFrameOptionsValueValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "HTML Speculative Loading",
-                section: Some("7.7"),
-                url: "https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header",
-                note: "Governing definition: conformance ABNF `\"DENY\" / \"SAMEORIGIN\"`, case-insensitive processing, `ALLOW-FROM` not to be implemented",
-            },
-            crate::rules::SpecRef {
-                spec: "RFC 7034",
-                section: Some("2.1"),
-                url: "https://www.rfc-editor.org/rfc/rfc7034.html#section-2.1",
-                note: "Historical definition (including the dropped `ALLOW-FROM` variant); superseded by the HTML Standard",
-            },
-        ]
+        &[HTML_SPECULATIVE_LOADING_7_7, RFC_7034_2_1]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -7,6 +7,22 @@ use crate::rules::Rule;
 
 pub struct XXssProtectionValueValid;
 
+/// The specification references this rule declares, each named so a finding
+/// site can cite the one it enforces. `specifications()` below is built from
+/// exactly these, so the docs and the citations cannot name different text.
+const MDN_X_XSS_PROTECTION: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "MDN X-XSS-Protection",
+    section: None,
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection",
+    note: "X-XSS-Protection",
+};
+const OWASP_SECURE_HEADERS: crate::rules::SpecRef = crate::rules::SpecRef {
+    spec: "OWASP Secure Headers",
+    section: None,
+    url: "https://owasp.org/www-project-secure-headers/",
+    note: "OWASP guidance",
+};
+
 impl Rule for XXssProtectionValueValid {
     fn id(&self) -> &'static str {
         "x_xss_protection_value_valid"
@@ -95,20 +111,7 @@ impl Rule for XXssProtectionValueValid {
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[
-            crate::rules::SpecRef {
-                spec: "MDN X-XSS-Protection",
-                section: None,
-                url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection",
-                note: "X-XSS-Protection",
-            },
-            crate::rules::SpecRef {
-                spec: "OWASP Secure Headers",
-                section: None,
-                url: "https://owasp.org/www-project-secure-headers/",
-                note: "OWASP guidance",
-            },
-        ]
+        &[MDN_X_XSS_PROTECTION, OWASP_SECURE_HEADERS]
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -8,35 +8,35 @@ sources:
     snippet: If credentials is `true`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
-      line: 82
+      line: 104
   - label: access_control_allow_credentials_when_origin (2)
     section: § 4.10
     snippet: If request’s credentials mode is not "include" and origin is `*`, then return success.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
-      line: 81
+      line: 103
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 83
+      line: 105
   - label: access_control_allow_origin_valid
     section: § 3.3.3
     snippet: Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response.
     cited_by:
     - file: lint-http-rules/src/rules/access_control_allow_origin_valid.rs
-      line: 42
+      line: 70
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 59
+      line: 81
   - label: cross_origin_resource_policy_valid
     section: § 3.7
     snippet: Cross-Origin-Resource-Policy = %s"same-origin" / %s"same-site" / %s"cross-origin" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 73
+      line: 89
   - label: cross_origin_resource_policy_valid (2)
     section: § 3.7
     snippet: If policy is neither `same-origin`, `same-site`, nor `cross-origin`, then set policy to null.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
-      line: 74
+      line: 90
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 3.2
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
@@ -60,61 +60,61 @@ sources:
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
     cited_by:
     - file: lint-http-rules/src/rules/origin_matching_for_cors.rs
-      line: 99
+      line: 121
   - label: refresh_header_syntax
     section: § 2.2.2
     snippet: Return the values of all headers in list whose name is a byte-case-insensitive match for name, separated from each other by 0x2C 0x20
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 222
+      line: 256
   - label: request_origin_header_present_for_cors
     section: § 3.2
     snippet: It is used for all HTTP fetches whose request’s response tainting is "cors", as well as those where request’s method is neither `GET` nor `HEAD`.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 34
+      line: 57
   - label: request_origin_header_present_for_cors (2)
     section: § 3.2
     snippet: The `Origin` request header indicates where a fetch originates from.
     cited_by:
     - file: lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
-      line: 69
+      line: 92
   - label: sec_fetch_dest_value_valid
     section: § 2.2.5
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 93
+      line: 103
   - label: timing_allow_origin_valid
     section: § 3.2
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 93
+      line: 115
   - label: x_content_type_options_present
     section: § 3.6
     snippet: If values[0] is an ASCII case-insensitive match for "nosniff", then return true.
     cited_by:
     - file: lint-http-rules/src/rules/x_content_type_options_present.rs
-      line: 98
+      line: 115
   - label: x_content_type_options_present (2)
     section: § 3.6
     snippet: The `X-Content-Type-Options` response header can be used to require checking of a response’s `Content-Type` header against the destination of a request.
     cited_by:
     - file: lint-http-rules/src/rules/x_content_type_options_present.rs
-      line: 122
+      line: 139
   - label: x_content_type_options_present (3)
     section: § 3.6
     snippet: X-Content-Type-Options = "nosniff" ; case-insensitive
     cited_by:
     - file: lint-http-rules/src/rules/x_content_type_options_present.rs
-      line: 97
+      line: 114
   - label: x_content_type_options_present (4)
     section: § 3.6.1
     snippet: Only request destinations that are script-like or "style" are considered as any exploits pertain to them.
     cited_by:
     - file: lint-http-rules/src/rules/x_content_type_options_present.rs
-      line: 128
+      line: 145
 - label: HTML
   url: https://html.spec.whatwg.org/multipage/browsers.html
   type: text/html
@@ -124,25 +124,25 @@ sources:
     snippet: An embedder policy value is one of three strings that controls the fetching of cross-origin resources without explicit permission from resource owners.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
-      line: 73
+      line: 89
   - label: cross_origin_opener_policy_valid
     section: § 7.1.3.1
     snippet: Let parsedItem be the result of getting a structured field value given `Cross-Origin-Opener-Policy` and "item" from response's header list.
     cited_by:
     - file: lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
-      line: 72
+      line: 94
   - label: origin_isolated_header_valid
     section: § 7.1.2
     snippet: This header is a structured header whose value must be a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 63
+      line: 79
   - label: origin_isolated_header_valid (2)
     section: § 7.1.2
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 75
+      line: 91
 - label: HTML Links
   url: https://html.spec.whatwg.org/multipage/links.html
   type: text/html
@@ -152,13 +152,13 @@ sources:
     snippet: A preload destination is "fetch", "font", "image", "script", "style", or "track".
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 853
+      line: 876
   - label: link_header_valid (2)
     section: § 4.6.8.20
     snippet: If destination is not a preload destination, then return null.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 854
+      line: 877
 - label: HTML Speculative Loading
   url: https://html.spec.whatwg.org/multipage/speculative-loading.html
   type: text/html
@@ -168,49 +168,49 @@ sources:
     snippet: The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 102
+      line: 125
   - label: refresh_header_syntax
     section: § 7.8
     snippet: It takes the same value and works largely the same.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 254
+      line: 288
   - label: refresh_header_syntax (2)
     section: § 7.8
     snippet: The `Refresh` HTTP response header is the HTTP-equivalent to a meta element with an http-equiv attribute in the Refresh state.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 200
+      line: 234
   - label: x_frame_options_value_valid
     section: § 7.7
     snippet: For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 65
+      line: 81
   - label: x_frame_options_value_valid (2)
     section: § 7.7
     snippet: HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 31
+      line: 47
   - label: x_frame_options_value_valid (3)
     section: § 7.7
     snippet: In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 75
+      line: 91
   - label: x_frame_options_value_valid (4)
     section: § 7.7
     snippet: It was originally defined in HTTP Header Field X-Frame-Options, but the definition and processing model here supersedes that document.
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 30
+      line: 46
   - label: x_frame_options_value_valid (5)
     section: § 7.7
     snippet: X-Frame-Options = "DENY" / "SAMEORIGIN"
     cited_by:
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 64
+      line: 80
 - label: HTML Semantics
   url: https://html.spec.whatwg.org/multipage/semantics.html
   type: text/html
@@ -220,37 +220,37 @@ sources:
     snippet: Apply link options from parsed header attributes to options given attribs
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 809
+      line: 832
   - label: link_header_valid (2)
     section: § 4.2.4.4
     snippet: If attribs["as"] does not exist, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 810
+      line: 833
   - label: link_header_valid (3)
     section: § 4.2.4.4
     snippet: If attribs["crossorigin"] exists and is an ASCII case-insensitive match for one of the CORS settings attribute keywords
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 830
+      line: 853
   - label: link_header_valid (4)
     section: § 4.2.4.4
     snippet: If destination is null, then return false.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 829
+      line: 852
   - label: link_header_valid (5)
     section: § 4.2.4.4
     snippet: Let destination be the result of translating attribs["as"].
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 828
+      line: 851
   - label: link_header_valid (6)
     section: § 4.2.4.4
     snippet: To process link headers given a Document doc, a response response, and a "pre-media" or "media" phase
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 808
+      line: 831
   - label: refresh_header_syntax
     section: § 4.2.5.3
     snippet: 'For meta elements with an http-equiv attribute in the Refresh state, the content attribute must have a value consisting either of:'
@@ -324,13 +324,13 @@ sources:
     snippet: Let value be the isomorphic decoding of the value of the header.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 240
+      line: 274
   - label: refresh_header_syntax (2)
     section: § 7.5.1
     snippet: We do not currently have a spec for how to handle multiple `Refresh` headers.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 221
+      line: 255
 - label: URL
   url: https://url.spec.whatwg.org/
   type: text/html
@@ -386,7 +386,7 @@ sources:
     snippet: To isomorphic decode a byte sequence input, return a string whose code point length is equal to input’s length and whose code points have the same values as the values of input’s bytes, in the same order.
     cited_by:
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 241
+      line: 275
   - label: refresh_header_syntax (2)
     section: § 4.6
     snippet: ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
@@ -402,19 +402,19 @@ sources:
     snippet: The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 101
+      line: 124
   - label: content_security_policy_and_frame_options_consistent (2)
     section: § 6.4.2.2
     snippet: the frame-ancestors directive overrides the ``X-Frame-Options`` header.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 100
+      line: 123
   - label: content_security_policy_valid
     section: § 2.3
     snippet: directive-name = 1*( ALPHA / DIGIT / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_valid.rs
-      line: 80
+      line: 96
 - label: Clear-Site-Data
   url: https://www.w3.org/TR/clear-site-data/
   type: text/html
@@ -423,13 +423,13 @@ sources:
     snippet: A user signs out of Super Secret Social Network via a CSRF-protected POST to https://supersecretsocialnetwork.example.com/logout, and the site author wishes to ensure that locally stored data is removed as a result
     cited_by:
     - file: lint-http-rules/src/rules/clear_site_data_present.rs
-      line: 129
+      line: 145
   - label: clear_site_data_present (2)
     section: § 3.1
     snippet: The Clear-Site-Data HTTP response header field sends a signal to the user agent that it ought to remove all data of a certain set of types.
     cited_by:
     - file: lint-http-rules/src/rules/clear_site_data_present.rs
-      line: 132
+      line: 148
 - label: Fetch Metadata
   url: https://www.w3.org/TR/fetch-metadata/
   type: text/html
@@ -439,90 +439,90 @@ sources:
     snippet: HTTP request header exposes a request’s destination to a server
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 36
+      line: 46
   - label: sec_fetch_dest_value_valid (2)
     section: § 2.1
     snippet: If r’s destination is the empty string, set header’s value to the string "empty"
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 96
+      line: 106
   - label: sec_fetch_dest_value_valid (3)
     section: § 2.1
     snippet: In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 91
+      line: 101
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 85
+      line: 95
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 86
+      line: 96
   - label: sec_fetch_dest_value_valid (4)
     section: § 2.1
     snippet: It is a Structured Field whose value MUST be a token.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 65
+      line: 75
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 74
+      line: 84
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 62
+      line: 72
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 71
+      line: 81
   - label: sec_fetch_dest_value_valid (5)
     section: § 2.1
     snippet: Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch].
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 92
+      line: 102
   - label: sec_fetch_mode_value_valid
     section: § 2.2
     snippet: HTTP request header exposes a request’s mode to a server
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 33
+      line: 43
   - label: sec_fetch_mode_value_valid (2)
     section: § 2.2
     snippet: Valid Sec-Fetch-Mode values include "cors", "navigate", "no-cors", "same-origin", and "websocket".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 86
+      line: 96
   - label: sec_fetch_site_value_valid
     section: § 2.3
     snippet: HTTP request header exposes the relationship between a request initiator’s origin and its target’s origin
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 33
+      line: 43
   - label: sec_fetch_site_value_valid (2)
     section: § 2.3
     snippet: It is a Structured Field whose value is a token.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 63
+      line: 73
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 72
+      line: 82
   - label: sec_fetch_site_value_valid (3)
     section: § 2.3
     snippet: Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 87
+      line: 97
   - label: sec_fetch_user_value_valid
     snippet: 'Sec-Fetch-User = sf-boolean Note: The header is delivered only for navigation requests, and only when its value is true.'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 70
+      line: 80
   - label: sec_fetch_user_value_valid (2)
     section: § 2.4
     snippet: HTTP request header exposes whether or not a navigation request was triggered by user activation.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 33
+      line: 43
   - label: sec_fetch_user_value_valid (3)
     section: § 2.4
     snippet: It is a Structured Field whose value is a boolean.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 62
+      line: 72
 - label: Resource Timing
   url: https://www.w3.org/TR/resource-timing/
   type: text/html
@@ -531,31 +531,31 @@ sources:
     snippet: Timing-Allow-Origin = 1#( origin-or-null / wildcard )
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 60
+      line: 82
   - label: timing_allow_origin_valid (2)
     section: § 3.5.2
     snippet: Server-side applications may return the Timing-Allow-Origin HTTP response header to allow the User Agent to fully expose, to the document origin(s) specified, the values of attributes that would have been zero due to those cross-origin restrictions.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 30
+      line: 52
   - label: timing_allow_origin_valid (3)
     section: § 3.5.2
     snippet: 'The header’s value is represented by the following ABNF [RFC5234] (using List Extension, [RFC9110]):'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 71
+      line: 93
   - label: timing_allow_origin_valid (4)
     section: § 3.5.2
     snippet: The recipient MAY combine multiple Timing-Allow-Origin header fields by appending each subsequent field value to the combined field value in order, separated by a comma.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 44
+      line: 66
   - label: timing_allow_origin_valid (5)
     section: § 3.5.2
     snippet: The sender MAY generate multiple Timing-Allow-Origin header fields.
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 43
+      line: 65
 - label: Server Timing
   url: https://www.w3.org/TR/server-timing/
   type: text/html
@@ -565,7 +565,7 @@ sources:
     snippet: '*( OWS ";" OWS server-timing-param ) metric-name = token'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 369
+      line: 383
   - label: server_timing_header_syntax
     section: § 2
     snippet: A user agent that does not recognize particular server-timing-param-name in the Server-Timing header field of a response MUST ignore those tokens and continue processing instead of signaling an error.
@@ -577,31 +577,31 @@ sources:
     snippet: All subsequent occurrences MUST be ignored without signaling an error or otherwise altering the processing of the server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 497
+      line: 511
   - label: server_timing_header_syntax (3)
     section: § 2
     snippet: If any server-timing-param-name is specified more than once, only the first instance is to be considered, even if the server-timing-param is incomplete or invalid.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 496
+      line: 510
   - label: server_timing_header_syntax (4)
     section: § 2
     snippet: 'See [RFC7230] for definitions of #, *, OWS, token, and quoted-string.'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 340
+      line: 354
   - label: Server-Timing grammar
     section: § 2
     snippet: 'Server-Timing = #server-timing-metric'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 339
+      line: 353
   - label: server_timing_header_syntax (5)
     section: § 2
     snippet: The Server-Timing header field is used to communicate one or more metrics and descriptions for the given request-response cycle.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 138
+      line: 202
   - label: server_timing_header_syntax (6)
     section: § 2
     snippet: This specification establishes the server-timing-params for server-timing-param-names "dur" for duration and "desc" for description, both optional.
@@ -613,55 +613,55 @@ sources:
     snippet: To avoid any possible ambiguity, individual server-timing-param-names SHOULD NOT appear multiple times within a server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 495
+      line: 509
   - label: server_timing_header_syntax (8)
     section: § 2
     snippet: User agents MUST ignore extraneous characters found after a server-timing-param-value but before the next server-timing-param and before the end of the current server-timing-metric.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 516
+      line: 530
   - label: server-timing-metric grammar
     section: § 2
     snippet: server-timing-metric = metric-name *( OWS ";" OWS server-timing-param )
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 368
+      line: 382
   - label: server-timing-param grammar
     section: § 2
     snippet: server-timing-param = server-timing-param-name OWS "=" OWS server-timing-param-value
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 441
+      line: 455
   - label: server-timing-param-name grammar
     section: § 2
     snippet: server-timing-param-name = token
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 442
+      line: 456
   - label: server-timing-param-value grammar
     section: § 2
     snippet: server-timing-param-value = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 546
+      line: 560
   - label: server_timing_header_syntax (9)
     section: § 3.2
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 614
+      line: 628
   - label: server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 613
+      line: 627
   - label: server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 597
+      line: 611
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -671,33 +671,33 @@ sources:
     snippet: Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 362
+      line: 365
   - label: permissions_policy_directives_valid (2)
     section: § 5.2
     snippet: Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 94
+      line: 116
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 346
+      line: 349
   - label: permissions_policy_directives_valid (3)
     section: § 5.2
     snippet: The Member Names must be Tokens.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 459
+      line: 462
   - label: permissions_policy_directives_valid (4)
     section: § 5.2
     snippet: 'The Member Values represent allowlists, and must be one of:'
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 345
+      line: 348
   - label: permissions_policy_directives_valid (5)
     section: § 6.1
     snippet: The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 98
+      line: 120
 - label: draft-ietf-httpbis-rfc6265bis
   url: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis
   type: text/html
@@ -707,31 +707,31 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 120
+      line: 155
   - label: cookie_attribute_consistent (2)
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 246
+      line: 281
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_same_site_enforced.rs
-      line: 139
+      line: 155
   - label: cookie_same_site_enforced (2)
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is something other than these three known keywords, the attribute's value will be subject to a default enforcement mode that is equivalent to "Lax".
     cited_by:
     - file: lint-http-rules/src/rules/cookie_same_site_enforced.rs
-      line: 131
+      line: 147
   - label: cookie_same_site_enforced (3)
     section: § 4.1.2.7
     snippet: If the value is "Lax", the cookie will be sent with same-site requests, and with "cross-site" top-level navigations, as described in Section 5.6.7.1.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_same_site_enforced.rs
-      line: 149
+      line: 165
 - label: draft-thomson-hybi-http-timeout-03
   url: https://www.ietf.org/archive/id/draft-thomson-hybi-http-timeout-03.txt
   type: text/plain
@@ -741,19 +741,19 @@ sources:
     snippet: keep-alive-extension = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 484
+      line: 498
   - label: keep_alive_header_valid (2)
     section: § 2
     snippet: keep-alive-info      =   "timeout" "=" delta-seconds
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 525
+      line: 539
   - label: keep_alive_header_valid (3)
     section: § 2.1
     snippet: The value of the "timeout" parameter is a single integer in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 596
+      line: 610
 - label: MDN Content-Type
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
   fragments:
@@ -761,7 +761,7 @@ sources:
     snippet: Indicates the character encoding standard used. The value is case insensitive but lowercase is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/charset_present.rs
-      line: 88
+      line: 110
 - label: MDN X-XSS-Protection
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection
   fragments:
@@ -769,22 +769,22 @@ sources:
     snippet: Disables XSS filtering.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 66
+      line: 82
   - label: x_xss_protection_value_valid (2)
     snippet: Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 72
+      line: 88
   - label: x_xss_protection_value_valid (3)
     snippet: Even though this feature can protect users of older web browsers that don't support CSP, in some cases, X-XSS-Protection can create XSS vulnerabilities in otherwise safe websites.
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 65
+      line: 81
   - label: x_xss_protection_value_valid (4)
     snippet: response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when they detected reflected cross-site scripting
     cited_by:
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 31
+      line: 47
 - label: RFC 1035
   url: https://www.rfc-editor.org/rfc/rfc1035.txt
   type: text/plain
@@ -826,19 +826,19 @@ sources:
     snippet: These values are not case sensitive
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 72
+      line: 94
   - label: content_transfer_encoding_valid (2)
     section: § 6.1
     snippet: mechanism := "7bit" / "8bit" / "binary" / "quoted-printable" / "base64" / ietf-token / x-token
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 44
+      line: 66
   - label: content_transfer_encoding_valid (3)
     section: § 6.3
     snippet: Implementors may, if necessary, define private Content-Transfer-Encoding values, but must use an x-token, which is a name prefixed by "X-", to indicate its non-standard status
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 71
+      line: 93
 - label: RFC 2046
   url: https://www.rfc-editor.org/rfc/rfc2046.txt
   type: text/plain
@@ -848,111 +848,111 @@ sources:
     snippet: All subtypes of "multipart" must use this syntax.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 183
+      line: 191
   - label: multipart_boundary_syntax (2)
     section: § 5.1.1
     snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 373
+      line: 381
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 43
+      line: 65
   - label: multipart_boundary_syntax (3)
     section: § 5.1.1
     snippet: The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 374
+      line: 382
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 210
+      line: 213
   - label: multipart_boundary_syntax (4)
     section: § 5.1.1
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 247
+      line: 255
   - label: multipart_boundary_syntax (5)
     section: § 5.1.1
     snippet: The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 335
+      line: 343
   - label: multipart_boundary_syntax (6)
     section: § 5.1.1
     snippet: bchars := bcharsnospace / " "
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 297
+      line: 305
   - label: multipart_boundary_syntax (7)
     section: § 5.1.1
     snippet: bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 298
+      line: 306
   - label: multipart_boundary_syntax (8)
     section: § 5.1.1
     snippet: boundary := 0*69<bchars> bcharsnospace
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 334
+      line: 342
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 355
+      line: 363
   - label: multipart_content_type_and_body_consistent
     section: § 5.1.1
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 256
+      line: 259
   - label: multipart_content_type_and_body_consistent (2)
     section: § 5.1.1
     snippet: Boundary string comparisons must compare the boundary value with the beginning of each candidate line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 255
+      line: 258
   - label: multipart_content_type_and_body_consistent (3)
     section: § 5.1.1
     snippet: Such a delimiter line is identical to the previous delimiter lines, with the addition of two more hyphens after the boundary parameter value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 268
+      line: 271
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 336
+      line: 339
   - label: multipart_content_type_and_body_consistent (4)
     section: § 5.1.1
     snippet: The boundary delimiter MUST occur at the beginning of a line, i.e., following a CRLF, and the initial CRLF is considered to be attached to the boundary delimiter line rather than part of the preceding part.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 230
+      line: 233
   - label: multipart_content_type_and_body_consistent (5)
     section: § 5.1.1
     snippet: The boundary delimiter line following the last body part is a distinguished delimiter that indicates that no further body parts will follow.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 322
+      line: 325
   - label: multipart_content_type_and_body_consistent (6)
     section: § 5.1.1
     snippet: The use of the "multipart" media type with only a single body part may be useful in certain contexts, and is explicitly permitted.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 323
+      line: 326
   - label: multipart_content_type_and_body_consistent (7)
     section: § 5.1.1
     snippet: close-delimiter := delimiter "--"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 267
+      line: 270
   - label: multipart_content_type_and_body_consistent (8)
     section: § 5.1.1
     snippet: dash-boundary := "--" boundary
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 209
+      line: 212
   - label: multipart_content_type_and_body_consistent (9)
     section: § 5.1.1
     snippet: implementations must ignore anything that appears before the first boundary delimiter line or after the last one.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 303
+      line: 306
 - label: RFC 2068
   url: https://www.rfc-editor.org/rfc/rfc2068.txt
   type: text/plain
@@ -962,85 +962,85 @@ sources:
     snippet: HTTP/1.1 does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 526
+      line: 540
   - label: keep_alive_header_valid (2)
     section: § 19.7.1.1
     snippet: If the Keep-Alive header is sent, the corresponding connection token MUST be transmitted.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 419
+      line: 433
   - label: keep_alive_header_valid (3)
     section: § 19.7.1.1
     snippet: Keep-Alive-header = "Keep-Alive" ":" 0# keepalive-param
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 432
+      line: 446
   - label: keep_alive_header_valid (4)
     section: § 19.7.1.1
     snippet: The Keep-Alive header itself is optional, and is used only if a parameter is being sent.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 450
+      line: 464
   - label: keep_alive_header_valid (5)
     section: § 19.7.1.1
     snippet: When the Keep-Alive connection-token has been transmitted with a request or a response, a Keep-Alive header field MAY also be included.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 75
+      line: 173
   - label: keep_alive_header_valid (6)
     section: § 19.7.1.1
     snippet: keepalive-param = param-name "=" value
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 483
+      line: 497
   - label: keep_alive_header_valid (7)
     section: § 2.1
     snippet: At least one delimiter (tspecials) must exist between any two tokens, since they would otherwise be interpreted as a single token.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 493
+      line: 507
   - label: keep_alive_header_valid (8)
     section: § 2.1
     snippet: Wherever this construct is used, null elements are allowed, but do not contribute
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 449
+      line: 463
   - label: keep_alive_header_valid (9)
     section: § 2.1
     snippet: linear whitespace (LWS) can be included between any two adjacent words (token or quoted-string), and between adjacent tokens and delimiters (tspecials), without changing the interpretation of a field.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 506
+      line: 520
   - label: LWS grammar
     section: § 2.2
     snippet: LWS            = [CRLF] 1*( SP | HT )
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 507
+      line: 521
   - label: keep_alive_header_valid (10)
     section: § 2.2
     snippet: The backslash character ("\") may be used as a single-character quoting mechanism only within quoted-string and comment constructs.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 562
+      line: 576
   - label: keep_alive_header_valid (11)
     section: § 2.2
     snippet: quoted-string  = ( <"> *(qdtext) <"> )
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 561
+      line: 575
   - label: keep_alive_header_valid (12)
     section: § 2.2
     snippet: token          = 1*<any CHAR except CTLs or tspecials>
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 560
+      line: 574
   - label: keep_alive_header_valid (13)
     section: § 3.7
     snippet: value          = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 559
+      line: 573
 - label: RFC 2616
   url: https://www.rfc-editor.org/rfc/rfc2616.txt
   type: text/plain
@@ -1076,7 +1076,7 @@ sources:
     snippet: This MUST be specified if a qop directive is sent (see above), and MUST NOT be specified if the server did not send a qop directive in the WWW-Authenticate header field.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 105
+      line: 121
 - label: RFC 3230
   url: https://www.rfc-editor.org/rfc/rfc3230.txt
   type: text/plain
@@ -1086,13 +1086,13 @@ sources:
     snippet: All digest-algorithm values are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 104
+      line: 139
   - label: digest_header_syntax (2)
     section: § 4.1.1
     snippet: digest-algorithm = token
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 103
+      line: 138
 - label: RFC 3986
   url: https://www.rfc-editor.org/rfc/rfc3986.txt
   type: text/plain
@@ -1102,9 +1102,9 @@ sources:
     snippet: Some protocol elements allow only the absolute form of a URI without a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 154
+      line: 218
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 196
+      line: 266
   - label: host_and_authority_consistent
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1140,7 +1140,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1045
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 134
+      line: 168
   - label: lint-http-rules/src/helpers/ipv6.rs (2)
     section: § 3.2.2
     snippet: This is the only place where square bracket characters are allowed in the URI syntax.
@@ -1158,9 +1158,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 339
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 115
+      line: 179
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 109
+      line: 155
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 2.1
     snippet: A percent-encoded octet is encoded as a character triplet, consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value.
@@ -1174,7 +1174,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 72
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 108
+      line: 154
   - label: lint-http-rules/src/helpers/uri.rs (4)
     section: § 2.1
     snippet: If two URIs differ only in the case of hexadecimal digits used in percent-encoded octets, they are equivalent.
@@ -1222,13 +1222,13 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 102
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 57
+      line: 121
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 208
+      line: 273
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 543
+      line: 566
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 102
+      line: 172
   - label: lint-http-rules/src/helpers/uri.rs (9)
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
@@ -1264,7 +1264,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 680
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 63
+      line: 109
   - label: lint-http-rules/src/helpers/uri.rs (14)
     section: § 3
     snippet: hier-part   = "//" authority path-abempty / path-absolute / path-rootless / path-empty
@@ -1286,9 +1286,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 942
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 927
+      line: 950
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 214
+      line: 284
   - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
@@ -1346,11 +1346,11 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 139
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 207
+      line: 272
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 107
+      line: 153
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 476
+      line: 489
   - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
@@ -1366,7 +1366,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 51
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 388
+      line: 399
   - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
@@ -1380,7 +1380,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 138
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 105
+      line: 151
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 48
   - label: lint-http-rules/src/helpers/uri.rs (25)
@@ -1390,7 +1390,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 139
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 215
+      line: 285
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 91
   - label: lint-http-rules/src/helpers/uri.rs (26)
@@ -1414,7 +1414,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 65
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 95
+      line: 154
   - label: lint-http-rules/src/helpers/uri.rs (27)
     section: § 5.2.3
     snippet: If the base URI has a defined authority component and an empty path, then return a string consisting of "/" concatenated with the reference's path
@@ -1466,9 +1466,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 767
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 225
+      line: 289
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 157
+      line: 227
   - label: lint-http-rules/src/helpers/uri.rs (35)
     section: § 6.2.2.1
     snippet: the scheme and host are case-insensitive and therefore should be normalized to lowercase
@@ -1476,9 +1476,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 466
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 224
+      line: 288
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 200
+      line: 240
   - label: lint-http-rules/src/helpers/uri.rs (36)
     section: § 6.2.2.2
     snippet: These URIs should be normalized by decoding any percent-encoded octet that corresponds to an unreserved character, as described in Section 2.3.
@@ -1496,99 +1496,99 @@ sources:
     snippet: URI-reference = URI / relative-ref
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 68
+      line: 108
   - label: location_header_uri_valid (2)
     section: § 4.4
     snippet: The most frequent examples of same-document references are relative references that are empty or include only the number sign ("#") separator followed by a fragment identifier.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 124
+      line: 164
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 141
+      line: 211
   - label: referer_uri_valid
     section: § 3.2.1
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 246
+      line: 316
   - label: referer_uri_valid (2)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 197
+      line: 267
   - label: request_target_no_fragment
     section: § 2.2
     snippet: If data for a URI component would conflict with a reserved character's purpose as a delimiter, then the conflicting data must be percent-encoded before the URI is formed.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 50
+      line: 109
   - label: URI
     section: § 3
     snippet: URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 94
+      line: 153
   - label: request_target_no_fragment (2)
     section: § 3.5
     snippet: A fragment identifier component is indicated by the presence of a number sign ("#") character and terminated by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 49
+      line: 108
   - label: request_target_no_fragment (3)
     section: § 3.5
     snippet: the fragment identifier is separated from the rest of the URI prior to a dereference, and thus the identifying information within the fragment itself is dereferenced solely by the user agent, regardless of the URI scheme
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 114
+      line: 173
   - label: request_uri_percent_encoding_valid
     section: § 2
     snippet: The ABNF notation defines its terminal values to be non-negative integers (codepoints) based on the US-ASCII coded character set [ASCII].
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 110
+      line: 156
   - label: request_uri_percent_encoding_valid (2)
     section: § 2
     snippet: the integer values used by the ABNF must be mapped back to their corresponding characters via US-ASCII in order to complete the syntax rules.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 111
+      line: 157
   - label: request_uri_percent_encoding_valid (3)
     section: § 2.4
     snippet: Because the percent ("%") character serves as the indicator for percent-encoded octets, it must be percent-encoded as "%25" for that octet to be used as data within a URI.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 61
+      line: 107
   - label: request_uri_percent_encoding_valid (4)
     section: § 2.4
     snippet: Once produced, a URI is always in its percent-encoded form.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 62
+      line: 108
   - label: query
     section: § 3.4
     snippet: query       = *( pchar / "/" / "?" )
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 106
+      line: 152
   - label: well_known_uri_syntax
     section: § 3.3
     snippet: The path is terminated by the first question mark ("?") or number sign ("#") character, or by the end of the URI.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 140
+      line: 210
   - label: path-absolute
     section: § 3.3
     snippet: path-absolute = "/" [ segment-nz *( "/" segment ) ]
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 156
+      line: 226
   - label: segment-nz
     section: § 3.3
     snippet: segment-nz    = 1*pchar
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 251
+      line: 321
 - label: RFC 4647
   url: https://www.rfc-editor.org/rfc/rfc4647.txt
   type: text/plain
@@ -1598,7 +1598,7 @@ sources:
     snippet: A basic language range differs from the language tags defined in [RFC4646] only in that there is no requirement that it be "well-formed" or be validated against the IANA Language Subtag Registry.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 52
+      line: 87
   - label: lint-http-rules/src/helpers/language.rs
     section: § 2.1
     snippet: language-range   = (1*8ALPHA *("-" 1*8alphanum)) / "*"
@@ -1606,7 +1606,7 @@ sources:
     - file: lint-http-rules/src/helpers/language.rs
       line: 74
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 132
+      line: 167
 - label: RFC 4648
   url: https://www.rfc-editor.org/rfc/rfc4648.txt
   type: text/plain
@@ -1668,7 +1668,7 @@ sources:
     snippet: It is therefore incumbent upon implementations to conform to the syntax of addresses for the context in which they are used.
     cited_by:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 139
+      line: 222
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 3.2.1
     snippet: quoted-pair = ("\" (VCHAR / WSP)) / obs-qp
@@ -1784,7 +1784,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 34
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 156
+      line: 239
   - label: lint-http-rules/src/helpers/mailbox.rs (20)
     section: § 3.4
     snippet: mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list
@@ -1792,7 +1792,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 35
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 157
+      line: 240
   - label: lint-http-rules/src/helpers/mailbox.rs (21)
     section: § 3.4
     snippet: name-addr = [display-name] angle-addr
@@ -1812,7 +1812,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 52
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 138
+      line: 221
   - label: lint-http-rules/src/helpers/mailbox.rs (24)
     section: § 3.4.1
     snippet: The locally interpreted string is either a quoted-string or a dot-atom.
@@ -1856,7 +1856,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 37
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 171
+      line: 254
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.txt
   type: text/plain
@@ -1900,17 +1900,17 @@ sources:
     snippet: Can be specified using a 415 (Unsupported Media Type) response when the client sends a patch document format that the server does not support for the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 246
+      line: 292
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 211
+      line: 251
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 101
+      line: 147
   - label: accept_patch_header_valid (2)
     section: § 2.2
     snippet: Such a response SHOULD include an Accept-Patch response header as described in Section 3.1 to notify the client what patch document media types are supported.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 247
+      line: 293
   - label: accept_patch_header_valid (3)
     section: § 3
     snippet: A server can advertise its support for the PATCH method by adding it to the listing of allowed methods in the "Allow" OPTIONS response header defined in HTTP/1.1.
@@ -1922,7 +1922,7 @@ sources:
     snippet: The PATCH method MAY appear in the "Allow" header even if the Accept-Patch header is absent, in which case the list of allowed patch documents is not advertised.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 288
+      line: 334
   - label: Accept-Patch grammar
     section: § 3.1
     snippet: Accept-Patch = "Accept-Patch" ":" 1#media-type
@@ -1936,7 +1936,7 @@ sources:
     snippet: Accept-Patch SHOULD appear in the OPTIONS response for any resource that supports the use of the PATCH method.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 287
+      line: 333
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 51
   - label: accept_patch_header_valid (6)
@@ -1952,51 +1952,51 @@ sources:
     snippet: The presence of the Accept-Patch header in response to any method is an implicit indication that PATCH is allowed on the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 226
+      line: 272
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 172
+      line: 212
   - label: accept_patch_header_valid (8)
     section: § 3.1
     snippet: This specification introduces a new response header Accept-Patch used to specify the patch document formats accepted by the server.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 199
+      line: 245
   - label: patch_method_content_type_match
     section: § 3.1
     snippet: The presence of a specific patch document format in this header indicates that that specific format is allowed on the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 180
+      line: 220
   - label: patch_partial_update
     section: § 2
     snippet: Note that entity-headers contained in the request apply only to the contained patch document and MUST NOT be applied to the resource being modified.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 33
+      line: 79
   - label: patch_partial_update (2)
     section: § 2
     snippet: Servers MUST ensure that a received patch document is appropriate for the type of resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 100
+      line: 146
   - label: patch_partial_update (3)
     section: § 2
     snippet: The PATCH method requests that a set of changes described in the request entity be applied to the resource identified by the Request-URI.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 52
+      line: 98
   - label: patch_partial_update (4)
     section: § 2
     snippet: The set of changes is represented in a format called a "patch document" identified by a media type.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 99
+      line: 145
   - label: patch_partial_update (5)
     section: § 2
     snippet: Therefore, there is no single default patch document format that implementations are required to support.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 87
+      line: 133
 - label: RFC 6265
   url: https://www.rfc-editor.org/rfc/rfc6265.txt
   type: text/plain
@@ -2006,79 +2006,79 @@ sources:
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 61
+      line: 96
   - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 176
+      line: 211
   - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 99
+      line: 134
   - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 87
+      line: 122
   - label: cookie_attribute_consistent (5)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 151
+      line: 186
   - label: cookie_attribute_consistent (6)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 152
+      line: 187
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_matching.rs
-      line: 104
+      line: 126
   - label: cookie_domain_matching (2)
     section: § 5.4
     snippet: The request-uri's path path-matches the cookie's path.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_matching.rs
-      line: 114
+      line: 136
   - label: cookie_domain_valid
     section: § 5.2.3
     snippet: If the attribute-value is empty, the behavior is undefined.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 51
+      line: 67
   - label: cookie_domain_valid (2)
     section: § 5.2.3
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 65
+      line: 81
   - label: cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 132
+      line: 154
   - label: cookie_lifecycle (2)
     section: § 5.3
     snippet: The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 183
+      line: 205
   - label: cookie_lifecycle (3)
     section: § 5.4
     snippet: Cookies with longer paths are listed before cookies with shorter paths.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 91
+      line: 113
   - label: lint-http-rules/src/helpers/cookie.rs
     section: § 4.1.1
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'
@@ -2128,7 +2128,7 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 197
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 57
+      line: 79
   - label: lint-http-rules/src/helpers/cookie.rs (6)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.
@@ -2156,47 +2156,47 @@ sources:
     snippet: content-disposition = "Content-Disposition" ":" disposition-type *( ";" disposition-parm )
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_parameter_valid.rs
-      line: 37
+      line: 66
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 43
+      line: 77
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 122
+      line: 156
   - label: content_disposition_token_valid
     section: § 1
     snippet: This document does not apply to Content-Disposition header fields appearing in payload bodies transmitted over HTTP, such as when using the media type "multipart/form-data" ([RFC2388]).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 24
+      line: 58
   - label: content_disposition_token_valid (2)
     section: § 4
     snippet: The Content-Disposition response header field is used to convey additional information about how to process the response payload, and also can be used to attach additional metadata, such as the filename to use when saving the response payload locally.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 23
+      line: 57
   - label: content_disposition_token_valid (3)
     section: § 4.1
     snippet: Note that due to the rules for implied linear whitespace (Section 2.1 of [RFC2616]), OPTIONAL whitespace can appear between words (token or quoted-string) and separator characters.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 55
+      line: 89
   - label: content_disposition_token_valid (4)
     section: § 4.1
     snippet: disp-ext-type       = token
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 71
+      line: 105
   - label: content_disposition_token_valid (5)
     section: § 4.1
     snippet: disposition-type = "inline" | "attachment" | disp-ext-type
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 57
+      line: 91
   - label: content_disposition_token_valid (6)
     section: § 4.2
     snippet: Unknown or unhandled disposition types SHOULD be handled by recipients the same way as "attachment" (see also [RFC2183], Section 2.8).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 72
+      line: 106
 - label: RFC 6335
   url: https://www.rfc-editor.org/rfc/rfc6335.txt
   type: text/plain
@@ -2372,7 +2372,7 @@ sources:
     snippet: A client requests extensions by including a |Sec-WebSocket-Extensions| header field, which follows the normal rules for HTTP header fields (see [RFC2616], Section 4.2) and the value of the header field is defined by the following ABNF [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
-      line: 246
+      line: 274
   - label: sec_websocket_extensions_syntax (2)
     section: § 9.1
     snippet: Any extension-token used MUST be a registered token (see Section 11.4).
@@ -2434,13 +2434,13 @@ sources:
     snippet: An HTTP/1.1 or higher GET request
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 204
+      line: 250
   - label: sec_websocket_headers_consistent (7)
     section: § 4.2.1
     snippet: the server MUST stop processing the client's handshake and return an HTTP response with an appropriate error code (such as 400 Bad Request)
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
-      line: 205
+      line: 251
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 65
   - label: Sec-WebSocket-Protocol
@@ -2488,7 +2488,7 @@ sources:
     snippet: ABNF rules with the "-Client" suffix in the name are only used in requests sent by the client to the server; ABNF rules with the "-Server" suffix in the name are only used in responses sent by the server to the client.
     cited_by:
     - file: lint-http-rules/src/rules/sec_websocket_version_advertised.rs
-      line: 103
+      line: 139
   - label: sec_websocket_version_advertised (4)
     section: § 4.3
     snippet: This section is using ABNF syntax/rules from Section 2.1 of [RFC2616], including the "implied *LWS rule".
@@ -2500,25 +2500,25 @@ sources:
     snippet: A client MUST close a connection if it detects a masked frame.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_masking.rs
-      line: 77
+      line: 109
   - label: websocket_frame_masking (2)
     section: § 5.1
     snippet: A server MUST NOT mask any frames that it sends to the client.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_masking.rs
-      line: 64
+      line: 96
   - label: websocket_frame_masking (3)
     section: § 5.1
     snippet: The server MUST close the connection upon receiving a frame that is not masked.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_masking.rs
-      line: 71
+      line: 103
   - label: websocket_frame_masking (4)
     section: § 5.1
     snippet: To avoid confusing network intermediaries (such as intercepting proxies) and for security reasons that are further discussed in Section 10.3, a client MUST mask all frames that it sends to the server (see Section 5.3 for further details).
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_masking.rs
-      line: 63
+      line: 95
   - label: websocket_frame_opcode_sequence
     section: § 11.8
     snippet: The opcode is an integer number between 0 and 15, inclusive.
@@ -2642,31 +2642,31 @@ sources:
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 121
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 116
+      line: 141
   - label: websocket_frame_rsv_bits
     section: § 5.2
     snippet: If a nonzero value is received and none of the negotiated extensions defines the meaning of such a nonzero value, the receiving endpoint MUST _Fail the WebSocket Connection_.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 115
+      line: 140
   - label: websocket_frame_rsv_bits (2)
     section: § 5.2
     snippet: MUST be 0 unless an extension is negotiated that defines meanings for non-zero values.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 114
+      line: 139
   - label: websocket_frame_rsv_bits (3)
     section: § 5.2
     snippet: 'RSV1, RSV2, RSV3:  1 bit each'
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 89
+      line: 114
   - label: frame-rsv1 production
     section: § 5.2
     snippet: frame-rsv1 = %x0 / %x1 ; 1 bit in length, MUST be 0 unless ; negotiated otherwise
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
-      line: 72
+      line: 97
   - label: websocket_handshake_valid
     section: § 4.1
     snippet: If the response includes a |Sec-WebSocket-Extensions| header field and this header field indicates the use of an extension that was not present in the client's handshake (the server has indicated an extension not requested by the client), the client MUST _Fail the WebSocket Connection_.
@@ -2702,13 +2702,13 @@ sources:
     snippet: If the status code received from the server is not 101, the client handles the response per HTTP [RFC2616] procedures.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 401
+      line: 447
   - label: websocket_handshake_valid (7)
     section: § 4.1
     snippet: In particular, the client might perform authentication if it receives a 401 status code; the server might redirect the client using a 3xx status code (but clients are not required to follow them), etc.  Otherwise, proceed as follows.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 402
+      line: 448
   - label: websocket_handshake_valid (8)
     section: § 4.2.1
     snippet: A |Sec-WebSocket-Key| header field with a base64-encoded (see Section 4 of [RFC4648]) value that, when decoded, is 16 bytes in length.
@@ -2732,7 +2732,7 @@ sources:
     snippet: A Status-Line with a 101 response code as per RFC 2616 [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 408
+      line: 454
   - label: websocket_handshake_valid (12)
     section: § 4.2.2
     snippet: A |Connection| header field with value "Upgrade".
@@ -2762,19 +2762,19 @@ sources:
     snippet: If the requested service is not available, the server MUST send an appropriate HTTP error code (such as 404 Not Found) and abort the WebSocket handshake.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 407
+      line: 453
   - label: websocket_handshake_valid (17)
     section: § 4.2.2
     snippet: If the server chooses to accept the incoming connection, it MUST reply with a valid HTTP response indicating the following.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 403
+      line: 449
   - label: websocket_handshake_valid (18)
     section: § 4.2.2
     snippet: If the server does not wish to accept this connection, it MUST return an appropriate HTTP error code (e.g., 403 Forbidden) and abort the WebSocket handshake described in this section.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 406
+      line: 452
   - label: websocket_handshake_valid (19)
     section: § 4.2.2
     snippet: If this version does not match a version understood by the server, the server MUST abort the WebSocket handshake described in this section and instead send an appropriate HTTP error code (such as 426 Upgrade Required) and a |Sec-WebSocket-Version| header field indicating the version(s) the server is capable of understanding.
@@ -2792,13 +2792,13 @@ sources:
     snippet: The server MAY redirect the client using a 3xx status code [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 405
+      line: 451
   - label: websocket_handshake_valid (22)
     section: § 4.2.2
     snippet: The server can perform additional client authentication, for example, by returning a 401 status code with the corresponding |WWW-Authenticate| header field as described in [RFC2616].
     cited_by:
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
-      line: 404
+      line: 450
   - label: websocket_handshake_valid (23)
     section: § 4.2.2
     snippet: The value chosen MUST be derived from the client's handshake, specifically by selecting one of the values from the |Sec-WebSocket-Protocol| field that the server is willing to use for this connection (if any).
@@ -2848,37 +2848,37 @@ sources:
     snippet: The client MUST implement CSRF protection for its redirection URI.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 77
+      line: 100
   - label: oauth2_code_flow (2)
     section: § 10.12
     snippet: The client SHOULD utilize the "state" request parameter to deliver this value
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 78
+      line: 101
   - label: oauth2_code_flow (3)
     section: § 4.1.1
     snippet: RECOMMENDED.  An opaque value used by the client to maintain state between the request and callback.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 76
+      line: 99
   - label: oauth2_code_flow (4)
     section: § 4.1.1
     snippet: REQUIRED.  Value MUST be set to "code".
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 68
+      line: 91
   - label: oauth2_code_flow (5)
     section: § 4.1.2
     snippet: REQUIRED if the "state" parameter was present in the client authorization request.  The exact value received from the client.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 97
+      line: 120
   - label: oauth2_code_flow (6)
     section: § 4.1.2
     snippet: REQUIRED.  The authorization code generated by the authorization server.
     cited_by:
     - file: lint-http-rules/src/rules/oauth2_code_flow.rs
-      line: 92
+      line: 115
 - label: RFC 6750
   url: https://www.rfc-editor.org/rfc/rfc6750.txt
   type: text/plain
@@ -2888,7 +2888,7 @@ sources:
     snippet: credentials = "Bearer" 1*SP b64token
     cited_by:
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 47
+      line: 63
   - label: bearer b64token grammar
     section: § 2.1
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
@@ -2904,37 +2904,37 @@ sources:
     snippet: All directives MUST appear only once in an STS header field.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 150
+      line: 184
   - label: strict_transport_security_valid (2)
     section: § 6.1
     snippet: UAs MUST ignore any STS header field containing directives, or other header field value data, that does not conform to the syntax defined in this specification.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 33
+      line: 67
   - label: strict_transport_security_valid (3)
     section: § 6.1
     snippet: directive-name            = token
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 75
+      line: 109
   - label: strict_transport_security_valid (4)
     section: § 6.1
     snippet: directive-value           = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 131
+      line: 165
   - label: strict_transport_security_valid (5)
     section: § 6.1.1
     snippet: The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 84
+      line: 118
   - label: strict_transport_security_valid (6)
     section: § 6.1.2
     snippet: The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 112
+      line: 146
 - label: RFC 6838
   url: https://www.rfc-editor.org/rfc/rfc6838.txt
   type: text/plain
@@ -2944,61 +2944,61 @@ sources:
     snippet: it specified a suffix (in that case, "+xml") to be appended to the base subtype name.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 96
+      line: 118
   - label: link_header_valid
     section: § 4.2
     snippet: 'Type and subtype names MUST conform to the following ABNF:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1006
+      line: 1029
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 86
+      line: 114
   - label: link_header_valid (2)
     section: § 4.2
     snippet: restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1007
+      line: 1030
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 99
+      line: 127
   - label: link_header_valid (3)
     section: § 4.2
     snippet: restricted-name-chars = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "-" / "^" / "_"
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1008
+      line: 1031
   - label: link_header_valid (4)
     section: § 4.2
     snippet: restricted-name-chars =/ "+" ; Characters after last plus always ; specify a structured syntax suffix
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1010
+      line: 1033
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 94
+      line: 122
   - label: link_header_valid (5)
     section: § 4.2
     snippet: restricted-name-chars =/ "." ; Characters before first dot always ; specify a facet name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 1009
+      line: 1032
   - label: link_header_valid (6)
     section: § 4.2
     snippet: type-name = restricted-name subtype-name = restricted-name
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 983
+      line: 1006
   - label: media_type_suffix_valid
     section: § 4.2.8
     snippet: '"+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions.'
     cited_by:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 135
+      line: 163
   - label: media_type_suffix_valid (2)
     section: § 4.2.8
     snippet: By the same token, media types MUST NOT be given names incorporating suffixes for structured syntaxes they do not actually employ.
     cited_by:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 136
+      line: 164
 - label: RFC 7231
   url: https://www.rfc-editor.org/rfc/rfc7231.txt
   type: text/plain
@@ -3007,9 +3007,9 @@ sources:
     snippet: The Content-MD5 header field has been removed because it was inconsistently implemented with respect to partial responses.
     cited_by:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
-      line: 49
+      line: 71
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 478
+      line: 513
 - label: RFC 7234
   url: https://www.rfc-editor.org/rfc/rfc7234.txt
   type: text/plain
@@ -3019,51 +3019,51 @@ sources:
     snippet: Warning = 1#warning-value
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 313
+      line: 326
   - label: warning_header_syntax (2)
     section: § 5.5
     snippet: Warning header fields can in general be applied to any message, however some warn-codes are specific to caches and can only be applied to response messages.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 24
+      line: 99
   - label: warning_header_syntax (3)
     section: § 5.5
     snippet: Warnings are assigned three digit warn-codes.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 353
+      line: 366
   - label: warning_header_syntax (4)
     section: § 5.5
     snippet: warn-agent = ( uri-host [ ":" port ] ) / pseudonym
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 455
+      line: 468
   - label: warning_header_syntax (5)
     section: § 5.5
     snippet: warn-code = 3DIGIT warn-agent = ( uri-host [ ":" port ] ) / pseudonym
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 352
+      line: 365
   - label: warning_header_syntax (6)
     section: § 5.5
     snippet: warn-date = DQUOTE HTTP-date DQUOTE
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 414
+      line: 427
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 503
+      line: 516
   - label: warning_header_syntax (7)
     section: § 5.5
     snippet: warn-text = quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 390
+      line: 403
   - label: warning_header_syntax (8)
     section: § 5.5
     snippet: warning-value = warn-code SP warn-agent SP warn-text [ SP warn-date ]
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 346
+      line: 359
 - label: RFC 7239
   url: https://www.rfc-editor.org/rfc/rfc7239.txt
   type: text/plain
@@ -3079,7 +3079,7 @@ sources:
     snippet: '"Forwarded" is only for use in HTTP requests and is not to be used in HTTP responses.'
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 318
+      line: 358
   - label: forwarded_header_valid (3)
     section: § 4
     snippet: Each parameter MUST NOT occur more than once per field-value.
@@ -3163,13 +3163,13 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 93
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 300
+      line: 340
   - label: forwarded_header_valid (13)
     section: § 8.2
     snippet: This header field should never be copied into response messages by origin servers or intermediaries, as it can reveal the whole proxy chain to the client.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 319
+      line: 359
   - label: forwarded_header_valid (14)
     section: § 9
     snippet: New parameters and their values MUST conform with the forwarded-pair as defined in ABNF in Section 4.
@@ -3285,9 +3285,9 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
       line: 36
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 215
+      line: 273
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 217
+      line: 251
   - label: prefer_header_and_preference_applied (3)
     section: § 2
     snippet: If a server supports the optional application of a preference that might result in a variance to a cache's handling of a response entity, a Vary header field MUST be included in the response listing the Prefer header field regardless of whether the client actually used Prefer in the request.
@@ -3299,27 +3299,27 @@ sources:
     snippet: Preference-Applied = "Preference-Applied" ":" 1#applied-pref
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
-      line: 151
+      line: 203
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 140
+      line: 174
   - label: prefer_header_and_preference_applied (4)
     section: § 3
     snippet: The Preference-Applied response header MAY be included within a response message as an indication as to which Prefer tokens were honored by the server and applied to the processing of a request.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
-      line: 102
+      line: 154
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 112
+      line: 146
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 235
+      line: 269
   - label: prefer_header_and_preference_applied (5)
     section: § 3
     snippet: applied-pref = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
-      line: 163
+      line: 215
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 188
+      line: 222
   - label: prefer_header_and_preference_applied (6)
     section: § 4.1
     snippet: the server can honor the "respond-async" preference by returning a 202 (Accepted) response.
@@ -3363,13 +3363,13 @@ sources:
     snippet: '*( OWS ";" [ OWS parameter ] )'
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 178
+      line: 236
   - label: prefer_header_valid (2)
     section: § 2
     snippet: A client MAY use multiple instances of the Prefer header field in a single message, or it MAY use a single Prefer header field with multiple comma-separated preference tokens.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 123
+      line: 181
   - label: prefer_header_valid (3)
     section: § 2
     snippet: A server that does not recognize or is unable to comply with particular preference tokens in the Prefer header field of a request MUST ignore those tokens and continue processing instead of signaling an error.
@@ -3381,7 +3381,7 @@ sources:
     snippet: An optional set of parameters can be specified for any preference token.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 244
+      line: 302
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 73
   - label: prefer_header_valid (5)
@@ -3389,17 +3389,17 @@ sources:
     snippet: Empty or zero-length values on both the preference token and within parameters are equivalent to no value being specified at all.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 212
+      line: 270
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 22
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 222
+      line: 256
   - label: prefer_header_valid (6)
     section: § 2
     snippet: If any preference is specified more than once, only the first instance is to be considered.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 282
+      line: 340
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 89
   - label: prefer_header_valid (7)
@@ -3407,7 +3407,7 @@ sources:
     snippet: If multiple Prefer header fields are used, it is equivalent to a single Prefer header field with the comma-separated concatenation of all of the tokens.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 124
+      line: 182
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 41
   - label: prefer_header_valid (8)
@@ -3415,31 +3415,31 @@ sources:
     snippet: Prefer     = "Prefer" ":" 1#preference
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 132
+      line: 190
   - label: prefer_header_valid (9)
     section: § 2
     snippet: The Prefer request header field is used to indicate that particular server behaviors are preferred by the client but are not required for successful completion of the request.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 98
+      line: 156
   - label: prefer_header_valid (10)
     section: § 2
     snippet: To avoid any possible ambiguity, individual preference tokens SHOULD NOT appear multiple times within a single request.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 281
+      line: 339
   - label: prefer_header_valid (11)
     section: § 2
     snippet: parameter  = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 243
+      line: 301
   - label: prefer_header_valid (12)
     section: § 2
     snippet: preference = token [ BWS "=" BWS word ]
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 177
+      line: 235
   - label: prefer_header_valid (13)
     section: § 4
     snippet: The following subsections define an initial set of preferences.
@@ -3457,7 +3457,7 @@ sources:
     snippet: The "return=minimal" and "return=representation" preferences are mutually exclusive directives.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 283
+      line: 341
   - label: prefer_header_valid (16)
     section: § 4.2
     snippet: return = "return" BWS "=" BWS ("representation" / "minimal")
@@ -3475,7 +3475,7 @@ sources:
     snippet: The "handling=strict" and "handling=lenient" preferences are mutually exclusive directives.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 284
+      line: 342
   - label: prefer_header_valid (19)
     section: § 4.4
     snippet: handling = "handling" BWS "=" BWS ("strict" / "lenient")
@@ -3487,7 +3487,7 @@ sources:
     snippet: The syntax of the Preference-Applied header differs from that of the Prefer header in that parameters are not included.
     cited_by:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 180
+      line: 214
 - label: RFC 7301
   url: https://www.rfc-editor.org/rfc/rfc7301.txt
   type: text/plain
@@ -3515,7 +3515,7 @@ sources:
     snippet: In the event that the server supports no protocols that the client advertises, then the server SHALL respond with a fatal "no_application_protocol" alert.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 332
+      line: 384
   - label: alt_svc_protocol_registered (5)
     section: § 6
     snippet: 'Identification Sequence: The precise set of octet values that identifies the protocol.'
@@ -3543,13 +3543,13 @@ sources:
     snippet: The media types application/xml or text/xml, or a more specific media type (see Section 9.6), SHOULD be used.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 82
+      line: 110
   - label: problem_details_content_type (2)
     section: § 9.2
     snippet: The registration information for text/xml is in all respects the same as that given for application/xml above (Section 9.1), except that the "Type name" is "text".
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 83
+      line: 111
 - label: RFC 7578
   url: https://www.rfc-editor.org/rfc/rfc7578.txt
   type: text/plain
@@ -3559,13 +3559,13 @@ sources:
     snippet: The Content-Disposition header field MUST also contain an additional parameter of "name"; the value of the "name" parameter is the original field name from the form
     cited_by:
     - file: lint-http-rules/src/rules/form_data_content_disposition_valid.rs
-      line: 65
+      line: 81
   - label: form_data_content_disposition_valid (2)
     section: § 4.2
     snippet: where the disposition type is "form-data".
     cited_by:
     - file: lint-http-rules/src/rules/form_data_content_disposition_valid.rs
-      line: 56
+      line: 72
 - label: RFC 7616
   url: https://www.rfc-editor.org/rfc/rfc7616.txt
   type: text/plain
@@ -3575,49 +3575,49 @@ sources:
     snippet: A case-insensitive flag indicating that the previous request from the client was rejected because the nonce value was stale.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 249
+      line: 266
   - label: digest_auth_nonce_handling (2)
     section: § 3.3
     snippet: A string of data, specified by the server, that SHOULD be returned by the client unchanged in the Authorization header field of subsequent requests
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 183
+      line: 200
   - label: digest_auth_nonce_handling (3)
     section: § 3.3
     snippet: The nonce is opaque to the client.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 138
+      line: 155
   - label: digest_auth_nonce_handling (4)
     section: § 3.4
     snippet: if the same nc value is seen twice, then the request is a replay.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 238
+      line: 255
   - label: digest_auth_valid
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 140
+      line: 156
   - label: digest_auth_valid (2)
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque.'
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 139
+      line: 155
   - label: digest_auth_valid (3)
     section: § 3.4
     snippet: If a parameter or its value is improper, or required parameters are missing, the proper response is a 4xx error code.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 62
+      line: 78
   - label: cnonce
     section: § 3.4
     snippet: This parameter MUST be used by all implementations.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 104
+      line: 120
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 3.5
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
@@ -3633,7 +3633,7 @@ sources:
     snippet: The value is computed based on user-id and password as defined below.
     cited_by:
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 47
+      line: 63
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 2
     snippet: The user-id and password MUST NOT contain any control characters
@@ -3671,17 +3671,17 @@ sources:
     snippet: An HTTP(S) origin server can advertise the availability of alternative services to clients by adding an Alt-Svc header field to responses.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 80
+      line: 109
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 374
+      line: 426
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 201
+      line: 253
   - label: alt_svc_h3_advertisement_valid (2)
     section: § 3
     snippet: Each "alt-value" is followed by an OPTIONAL semicolon-separated list of additional parameters, each such "parameter" comprising a name and a value.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 263
+      line: 267
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 219
   - label: alt_svc_h3_advertisement_valid (3)
@@ -3703,7 +3703,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 321
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 252
+      line: 304
   - label: alt_svc_h3_advertisement_valid (5)
     section: § 3
     snippet: parameter     = token "=" ( token / quoted-string )
@@ -3711,7 +3711,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 37
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 262
+      line: 266
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 218
   - label: alt_svc_h3_advertisement_valid (6)
@@ -3719,13 +3719,13 @@ sources:
     snippet: The delta-seconds value indicates the number of seconds since the response was generated for which the alternative service is considered fresh.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 288
+      line: 292
   - label: alt_svc_header_syntax
     section: § 1.1
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 458
+      line: 510
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
@@ -3737,15 +3737,15 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 443
+      line: 495
   - label: alt_svc_header_syntax (4)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 391
+      line: 443
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 233
+      line: 285
   - label: alt_svc_header_syntax (5)
     section: § 3
     snippet: Consequently, the octet representing the percent character "%" (hex 25) MUST be percent-encoded as well.
@@ -3817,7 +3817,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 32
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 273
+      line: 325
   - label: alt_svc_header_syntax (16)
     section: § 3
     snippet: alternative   = protocol-id "=" alt-authority
@@ -3825,7 +3825,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 314
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 284
+      line: 336
   - label: alt_svc_header_syntax (17)
     section: § 3
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
@@ -3863,19 +3863,19 @@ sources:
     snippet: An Application Layer Protocol Negotiation (ALPN) protocol name, as per [RFC7301]
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 330
+      line: 382
   - label: alt_svc_protocol_registered (2)
     section: § 2
     snippet: The ALPN protocol name is used to identify the application protocol or suite of protocols used by the alternative service.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 331
+      line: 383
   - label: alt_svc_protocol_registered (3)
     section: § 2.4
     snippet: If the connection to the alternative service does not negotiate the expected protocol (for example, ALPN fails to negotiate h2, or an Upgrade request to h2c is not accepted), the connection to the alternative service MUST be considered to have failed.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 333
+      line: 385
   - label: alt_svc_protocol_registered (4)
     section: § 3
     snippet: ALPN protocol names are octet sequences with no additional constraints on format.
@@ -3919,17 +3919,17 @@ sources:
     snippet: Clients SHOULD NOT issue a conditional request during the response's freshness lifetime (e.g., upon a reload) unless explicitly overridden by the user (e.g., a force reload).
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 109
+      line: 125
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 106
+      line: 122
   - label: immutable_cache_never_stale (2)
     section: § 2
     snippet: The immutable extension only applies during the freshness lifetime of the stored response.
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 110
+      line: 126
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 105
+      line: 121
 - label: RFC 8259
   url: https://www.rfc-editor.org/rfc/rfc8259.txt
   type: text/plain
@@ -3939,21 +3939,21 @@ sources:
     snippet: The media type for JSON text is application/json.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 81
+      line: 109
   - label: problem_details_structure_valid
     section: § 2
     snippet: A JSON text is a serialized value.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 133
+      line: 161
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 162
+      line: 190
   - label: problem_details_structure_valid (2)
     section: § 8.1
     snippet: JSON text exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 163
+      line: 191
 - label: RFC 8288
   url: https://www.rfc-editor.org/rfc/rfc8288.txt
   type: text/plain
@@ -3963,175 +3963,175 @@ sources:
     snippet: 'This document uses the Augmented Backus-Naur Form (ABNF) [RFC5234] notation of [RFC7230], including the #rule, and explicitly includes the following rules from it'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 672
+      line: 695
   - label: link_header_valid (2)
     section: § 1.2
     snippet: The requirements regarding conformance and error handling highlighted in [RFC7230], Section 2.5 apply to this document.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 472
+      line: 495
   - label: link_header_valid (3)
     section: § 2.1.1
     snippet: Registered relation type names MUST conform to the reg-rel-type rule (see Section 3.3) and MUST be compared character by character in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 795
+      line: 818
   - label: link_header_valid (4)
     section: § 2.1.2
     snippet: When extension relation types are compared, they MUST be compared as strings (after converting to URIs if serialised in a different format) in a case-insensitive fashion, character by character.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 917
+      line: 940
   - label: link_header_valid (5)
     section: § 2.2
     snippet: The names of target attributes SHOULD conform to the token rule, but SHOULD NOT include any of the characters "%", "'", or "*", for portability across serialisations and MUST be compared in a case-insensitive fashion.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 695
+      line: 718
   - label: link_header_valid (6)
     section: § 3
     snippet: Individual link-params specify their syntax in terms of the value after any necessary unquoting
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 671
+      line: 694
   - label: link_header_valid (7)
     section: § 3
     snippet: 'Link       = #link-value link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 474
+      line: 497
   - label: link_header_valid (8)
     section: § 3
     snippet: Note that any link-param can be generated with values using either the token or the quoted-string syntax; therefore, recipients MUST be able to parse both forms.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 670
+      line: 693
   - label: link_header_valid (9)
     section: § 3
     snippet: The Link header field provides a means for serialising one or more links into HTTP headers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 34
+      line: 218
   - label: link_header_valid (10)
     section: § 3
     snippet: link-param = token BWS [ "=" BWS ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 669
+      line: 692
   - label: link_header_valid (11)
     section: § 3
     snippet: link-value = "<" URI-Reference ">" *( OWS ";" OWS link-param )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 542
+      line: 565
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 603
+      line: 626
   - label: link_header_valid (12)
     section: § 3.1
     snippet: Each link-value conveys one target IRI as a URI-Reference (after conversion to one, if necessary; see [RFC3987], Section 3.1) inside angle brackets ("<>").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 631
+      line: 654
   - label: link_header_valid (13)
     section: § 3.3
     snippet: Note that extension relation types are REQUIRED to be absolute URIs in Link header fields and MUST be quoted when they contain characters not allowed in tokens
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 916
+      line: 939
   - label: link_header_valid (14)
     section: § 3.3
     snippet: The rel parameter MUST be present but MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 595
+      line: 618
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 862
+      line: 885
   - label: link_header_valid (15)
     section: § 3.3
     snippet: The rel parameter can, however, contain multiple link relation types.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 878
+      line: 901
   - label: link_header_valid (16)
     section: § 3.3
     snippet: The relation type of a link conveyed in the Link header field is conveyed in the "rel" parameter's value.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 861
+      line: 884
   - label: link_header_valid (17)
     section: § 3.3
     snippet: ext-rel-type   = URI ; Section 3 of [RFC3986]
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 915
+      line: 938
   - label: link_header_valid (18)
     section: § 3.3
     snippet: reg-rel-type   = LOALPHA *( LOALPHA / DIGIT / "." / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 914
+      line: 937
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 960
+      line: 983
   - label: link_header_valid (19)
     section: § 3.3
     snippet: relation-type  = reg-rel-type / ext-rel-type
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 913
+      line: 936
   - label: link_header_valid (20)
     section: § 3.3
     snippet: relation-type *( 1*SP relation-type )
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 877
+      line: 900
   - label: link_header_valid (21)
     section: § 3.4.1
     snippet: Its value MUST be quoted if it contains a semicolon (";") or comma (",").
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 773
+      line: 796
   - label: link_header_valid (22)
     section: § 3.4.1
     snippet: 'The ABNF for the hreflang parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 741
+      line: 764
   - label: link_header_valid (23)
     section: § 3.4.1
     snippet: 'The ABNF for the media parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 772
+      line: 795
   - label: link_header_valid (24)
     section: § 3.4.1
     snippet: 'The ABNF for the type parameter''s value is:'
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 752
+      line: 775
   - label: link_header_valid (25)
     section: § 3.4.1
     snippet: The title attribute MUST NOT appear more than once in a given link; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 597
+      line: 620
   - label: link_header_valid (26)
     section: § 3.4.1
     snippet: The title* link-param MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 598
+      line: 621
   - label: link_header_valid (27)
     section: § 3.4.1
     snippet: The type attribute MUST NOT appear more than once in a given link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 599
+      line: 622
   - label: link_header_valid (28)
     section: § 3.4.1
     snippet: There MUST NOT be more than one media attribute in a link-value; occurrences after the first MUST be ignored by parsers.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 596
+      line: 619
 - label: RFC 8297
   url: https://www.rfc-editor.org/rfc/rfc8297.txt
   type: text/plain
@@ -4177,7 +4177,7 @@ sources:
     snippet: The 103 (Early Hints) informational status code indicates to the client that the server is likely to send a final response with the header fields included in the informational response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 90
+      line: 118
   - label: status_103_early_hints_before_final (8)
     section: § 2
     snippet: Typically, a server will include the header fields sent in a 103 (Early Hints) response in the final response as well.
@@ -4189,7 +4189,7 @@ sources:
     snippet: In particular, an HTTP/1.1 client that mishandles an informational response as a final response is likely to consider all responses to the succeeding requests sent over the same connection to be part of the final response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 127
+      line: 155
 - label: RFC 8441
   url: https://www.rfc-editor.org/rfc/rfc8441.txt
   type: text/plain
@@ -4199,13 +4199,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 200
+      line: 264
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 201
+      line: 265
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -4243,55 +4243,55 @@ sources:
     snippet: Absent other information, clients MAY send requests with safe HTTP methods ([RFC7231], Section 4.2.1) in early data when it is available and MUST NOT send unsafe methods (or methods whose safety is not known) in early data.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 174
+      line: 214
   - label: early_data_header_safe_method (2)
     section: § 5.1
     snippet: A request that is marked with Early-Data was sent in early data on a previous hop.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 162
+      line: 202
   - label: early_data_header_safe_method (3)
     section: § 5.1
     snippet: An intermediary MUST NOT remove this header field if it is present in a request.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 224
+      line: 264
   - label: early_data_header_safe_method (4)
     section: § 5.1
     snippet: An intermediary that forwards a request prior to the completion of the TLS handshake with its client MUST send it with the Early-Data header field set to "1" (i.e., it adds it if not present in the request).
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 188
+      line: 228
   - label: early_data_header_safe_method (5)
     section: § 5.1
     snippet: Early-Data MUST NOT appear in a Connection header field.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 225
+      line: 265
   - label: early_data_header_safe_method (6)
     section: § 5.1
     snippet: 'It has just one valid value: "1".'
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 203
+      line: 243
   - label: early_data_header_safe_method (7)
     section: § 5.1
     snippet: Multiple or invalid instances of the header field MUST be treated as equivalent to a single instance with a value of 1 by a server.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 161
+      line: 201
   - label: early_data_header_safe_method (8)
     section: § 5.1
     snippet: The Early-Data header field carries a single bit of information, and clients MUST include at most one instance.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 152
+      line: 192
   - label: early_data_header_safe_method (9)
     section: § 5.1
     snippet: The Early-Data request header field indicates that the request has been conveyed in early data and that a client understands the 425 (Too Early) status code.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 163
+      line: 203
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 5.1
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
@@ -4299,9 +4299,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 981
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 122
+      line: 162
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 233
+      line: 273
 - label: RFC 8594
   url: https://www.rfc-editor.org/rfc/rfc8594.txt
   type: text/plain
@@ -4311,9 +4311,9 @@ sources:
     snippet: The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future.
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 116
+      line: 144
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 36
+      line: 64
 - label: RFC 8615
   url: https://www.rfc-editor.org/rfc/rfc8615.txt
   type: text/plain
@@ -4323,79 +4323,79 @@ sources:
     snippet: Furthermore, defining well-known locations usurps the origin's control over its own URI space [RFC7320].
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 221
+      line: 291
   - label: well_known_uri_syntax (2)
     section: § 1
     snippet: To address these uses, this memo reserves a path prefix in HTTP, HTTPS, WebSocket (WS), and Secure WebSocket (WSS) URIs for these "well-known locations", "/.well-known/".
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 233
+      line: 303
   - label: well_known_uri_syntax (3)
     section: § 1
     snippet: Well-known URIs can also be used with other URI schemes, but only when those schemes' definitions explicitly allow it.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 125
+      line: 195
   - label: well_known_uri_syntax (4)
     section: § 3
     snippet: A well-known URI is a URI [RFC3986] whose path component begins with the characters "/.well-known/", provided that the scheme is explicitly defined to support well-known URIs.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 123
+      line: 193
   - label: well_known_uri_syntax (5)
     section: § 3
     snippet: Also, this specification does not define a format or media type for the resource located at "/.well-known/", and clients should not expect a resource to exist at that location.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 252
+      line: 322
   - label: well_known_uri_syntax (6)
     section: § 3
     snippet: Applications that wish to mint new well-known URIs MUST register them, following the procedures in Section 5.1, subject to the following requirements.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 93
+      line: 163
   - label: well_known_uri_syntax (7)
     section: § 3
     snippet: For example, "/.well-known/example" is a well-known URI, whereas "/foo/.well-known/example" is not.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 220
+      line: 290
   - label: well_known_uri_syntax (8)
     section: § 3
     snippet: Registered names MUST conform to the "segment-nz" production in [RFC3986].
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 250
+      line: 320
   - label: well_known_uri_syntax (9)
     section: § 3
     snippet: Registrations MAY also contain additional information, such as the syntax of additional path components, query strings, and/or fragment identifiers to be appended to the well-known URI
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 266
+      line: 336
   - label: well_known_uri_syntax (10)
     section: § 3
     snippet: This means they cannot contain the "/" character.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 265
+      line: 335
   - label: well_known_uri_syntax (11)
     section: § 3
     snippet: This specification updates the "http" [RFC7230] and "https" [RFC7230] schemes to support well-known URIs.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 124
+      line: 194
   - label: well_known_uri_syntax (12)
     section: § 3
     snippet: Well-known URIs are rooted in the top of the path's hierarchy; they are not well-known by definition in other parts of the path.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 219
+      line: 289
   - label: well_known_uri_syntax (13)
     section: § 5.2
     snippet: If a URI scheme explicitly has been specified to use well-known URIs as per Section 3, the value changes to a reference to that specification.
     cited_by:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 126
+      line: 196
 - label: RFC 9000
   url: https://www.rfc-editor.org/rfc/rfc9000.txt
   type: text/plain
@@ -4423,25 +4423,25 @@ sources:
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 61
+      line: 83
   - label: quic_transport_parameters_valid (2)
     section: § 18.2
     snippet: Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 148
+      line: 170
   - label: quic_transport_parameters_valid (3)
     section: § 18.2
     snippet: the initial flow control limit for locally initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 103
+      line: 125
   - label: quic_transport_parameters_valid (4)
     section: § 18.2
     snippet: the initial value for the maximum amount of data that can be sent on the connection
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 87
+      line: 109
 - label: RFC 9110
   url: https://www.rfc-editor.org/rfc/rfc9110.txt
   type: text/plain
@@ -4451,127 +4451,127 @@ sources:
     snippet: A user agent cannot rely on proactive negotiation preferences being consistently honored, since the origin server might not implement proactive negotiation for the requested resource or might decide that sending a response that doesn't conform to the user agent's preferences is better than sending a 406 (Not Acceptable) response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 45
+      line: 86
   - label: accept_and_content_type_negotiation (2)
     section: § 12.4.1
     snippet: For each of the content negotiation fields, a request that does not contain the field implies that the sender has no preference on that dimension of negotiation.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 86
+      line: 127
   - label: accept_and_content_type_negotiation (3)
     section: § 12.4.1
     snippet: If a content negotiation header field is present in a request and none of the available representations for the response can be considered acceptable according to it, the origin server can either honor the header field by sending a 406 (Not Acceptable) response or disregard the header field by treating the response as if it is not subject to content negotiation for that request header field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 44
+      line: 85
   - label: accept_and_content_type_negotiation (4)
     section: § 12.4.2
     snippet: If no "q" parameter is present, the default weight is 1.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 180
+      line: 221
   - label: accept_and_content_type_negotiation (5)
     section: § 12.4.2
     snippet: The weight is normalized to a real number in the range 0 through 1, where 0.001 is the least preferred and 1 is the most preferred; a value of 0 means "not acceptable".
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 179
+      line: 220
   - label: accept_and_content_type_negotiation (6)
     section: § 12.5.1
     snippet: 'Accept = #( media-range [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 55
+      line: 96
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 38
+      line: 72
   - label: accept_and_content_type_negotiation (7)
     section: § 12.5.1
     snippet: If more than one media range applies to a given type, the most specific reference has precedence.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 204
+      line: 245
   - label: accept_and_content_type_negotiation (8)
     section: § 12.5.1
     snippet: Recipients SHOULD process any parameter named "q" as weight, regardless of parameter ordering.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 156
+      line: 197
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 250
+      line: 284
   - label: accept_and_content_type_negotiation (9)
     section: § 12.5.1
     snippet: The "Accept" header field can be used by user agents to specify their preferences regarding response media types.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 22
+      line: 63
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 20
+      line: 54
   - label: accept_and_content_type_negotiation (10)
     section: § 12.5.1
     snippet: The asterisk "*" character is used to group media types into ranges, with "*/*" indicating all media types and "type/*" indicating all subtypes of that type.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 145
+      line: 186
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 97
+      line: 131
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 240
+      line: 249
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 192
+      line: 232
   - label: accept_and_content_type_negotiation (11)
     section: § 12.5.1
     snippet: The media-range can include media type parameters that are applicable to that range.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 203
+      line: 244
   - label: accept_and_content_type_negotiation (12)
     section: § 12.5.1
     snippet: media-range    = ( "*/*" / ( type "/" "*" ) / ( type "/" subtype ) ) parameters
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 144
+      line: 185
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 96
+      line: 130
   - label: accept_and_content_type_negotiation (13)
     section: § 15.5.7
     snippet: The 406 (Not Acceptable) status code indicates that the target resource does not have a current representation that would be acceptable to the user agent
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 78
+      line: 119
   - label: accept_and_content_type_negotiation (14)
     section: § 8.3
     snippet: Recipients often attempt to handle this error by using the last syntactically valid member of the list, leading to potential interoperability and security issues if different implementations have different error handling behaviors.
     cited_by:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 67
+      line: 108
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 59
+      line: 93
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 141
+      line: 181
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 51
+      line: 79
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 80
+      line: 108
   - label: accept_encoding_parameter_valid
     section: § 12.4.2
     snippet: The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 125
+      line: 153
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 249
+      line: 283
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 84
+      line: 112
   - label: accept_encoding_parameter_valid (2)
     section: § 12.4.2
     snippet: weight = OWS ";" OWS "q=" qvalue
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 39
+      line: 67
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 39
+      line: 67
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 123
+      line: 158
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 82
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -4581,99 +4581,99 @@ sources:
     snippet: 'Accept-Encoding  = #( codings [ weight ] ) codings          = content-coding / "identity" / "*"'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 38
+      line: 66
   - label: accept_encoding_parameter_valid (4)
     section: § 12.5.3
     snippet: An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 71
+      line: 99
   - label: accept_encoding_parameter_valid (5)
     section: § 12.5.3
     snippet: An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 49
+      line: 77
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 54
+      line: 76
   - label: accept_encoding_parameter_valid (6)
     section: § 12.5.3
     snippet: Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 104
+      line: 132
   - label: accept_encoding_parameter_valid (7)
     section: § 12.5.3
     snippet: The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 70
+      line: 98
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 67
+      line: 95
   - label: accept_encoding_parameter_valid (8)
     section: § 12.5.3
     snippet: The field value is evaluated the same way as in a request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 21
+      line: 49
   - label: accept_encoding_parameter_valid (9)
     section: § 12.5.3
     snippet: When sent by a user agent in a request, Accept-Encoding indicates the content codings acceptable in a response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 19
+      line: 47
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 46
+      line: 68
   - label: accept_encoding_parameter_valid (10)
     section: § 12.5.3
     snippet: When the Accept-Encoding header field is present in a response, it indicates what content codings the resource was willing to accept in the associated request.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 20
+      line: 48
   - label: accept_encoding_parameter_valid (11)
     section: § 8.4.1
     snippet: content-coding   = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 69
+      line: 97
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 48
+      line: 88
   - label: accept_encoding_present
     section: § 12.5.3
     snippet: 'Accept-Encoding = #( codings [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 48
+      line: 70
   - label: accept_encoding_present (2)
     section: § 12.5.3
     snippet: If no Accept-Encoding header field is in the request, any content coding is considered acceptable by the user agent.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 47
+      line: 69
   - label: accept_encoding_present (3)
     section: § 12.5.3
     snippet: If the representation has no content coding, then it is acceptable by default unless specifically excluded by the Accept-Encoding header field stating either "identity;q=0" or "*;q=0" without a more specific entry for "identity".
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 95
+      line: 117
   - label: accept_encoding_present (4)
     section: § 9.3.6
     snippet: Any 2xx (Successful) response indicates that the sender (and all inbound proxies) will switch to tunnel mode immediately after the response header section; data received after that header section is from the server identified by the request target.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 34
+      line: 56
   - label: accept_encoding_present (5)
     section: § 9.3.6
     snippet: The CONNECT method requests that the recipient establish a tunnel to the destination origin server identified by the request target and, if successful, thereafter restrict its behavior to blind forwarding of data, in both directions, until the tunnel is closed.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 33
+      line: 55
   - label: accept_header_media_type_syntax
     section: § 12.4.2
     snippet: A sender of qvalue MUST NOT generate more than three digits after the decimal point.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 258
+      line: 292
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 279
   - label: accept_header_media_type_syntax (2)
@@ -4681,35 +4681,35 @@ sources:
     snippet: Each media-range might be followed by optional applicable media type parameters (e.g., charset), followed by an optional "q" parameter for indicating a relative weight (Section 12.4.2).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 39
+      line: 73
   - label: accept_header_media_type_syntax (3)
     section: § 12.5.1
     snippet: Senders using weights SHOULD send "q" last (after all media-range parameters).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 188
+      line: 222
   - label: accept_header_media_type_syntax (4)
     section: § 12.5.1
     snippet: The accept extension grammar (accept-params, accept-ext) has been removed because it had a complicated definition, was not being used in practice, and is more easily deployed through new header fields.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 187
+      line: 221
   - label: accept_header_media_type_syntax (5)
     section: § 12.5.1
     snippet: When sent by a server in a response, Accept provides information about which content types are preferred in the content of a subsequent request to the same resource.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 21
+      line: 55
   - label: accept_header_media_type_syntax (6)
     section: § 5.6.2
     snippet: Tokens are short textual identifiers that do not include whitespace or delimiters.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 85
+      line: 119
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 228
+      line: 262
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 85
+      line: 125
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 75
   - label: accept_header_media_type_syntax (7)
@@ -4717,7 +4717,7 @@ sources:
     snippet: media-type = type "/" subtype parameters type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 124
+      line: 158
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 42
   - label: accept_language_weight_valid
@@ -4725,19 +4725,19 @@ sources:
     snippet: 'Accept-Language = #( language-range [ weight ] )'
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 38
+      line: 66
   - label: accept_language_weight_valid (2)
     section: § 12.5.4
     snippet: Each language-range can be given an associated quality value representing an estimate of the user's preference for the languages specified by that range, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 66
+      line: 94
   - label: accept_language_weight_valid (3)
     section: § 12.5.4
     snippet: The "Accept-Language" header field can be used by user agents to indicate the set of natural languages that are preferred in the response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 22
+      line: 50
   - label: accept_patch_header_valid
     section: § 10.2.1
     snippet: The "Allow" header field lists the set of methods advertised as supported by the target resource.
@@ -4751,19 +4751,19 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 46
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 155
+      line: 201
   - label: accept_patch_header_valid (2)
     section: § 15.5.16
     snippet: If the problem was caused by an unsupported content coding, the Accept-Encoding response header field (Section 12.5.3) ought to be used
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 249
+      line: 295
   - label: accept_patch_header_valid (3)
     section: § 15.5.16
     snippet: The format problem might be due to the request's indicated Content-Type or Content-Encoding, or as a result of inspecting the data directly.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 248
+      line: 294
   - label: accept_patch_header_valid (4)
     section: § 5.6.1.2
     snippet: 'Empty elements do not contribute to the count of elements present.  A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism.'
@@ -4779,11 +4779,11 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 147
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 142
+      line: 200
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 151
+      line: 185
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 314
+      line: 327
   - label: accept_patch_header_valid (6)
     section: § 9.1
     snippet: The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names.
@@ -4791,95 +4791,95 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 182
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 235
+      line: 281
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 74
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 168
+      line: 208
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 166
+      line: 194
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 206
+      line: 271
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 190
+      line: 254
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 82
+      line: 128
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 126
+      line: 166
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 51
+      line: 97
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 32
+      line: 60
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 83
+      line: 117
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 195
+      line: 242
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 174
+      line: 208
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 76
+      line: 116
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 71
+      line: 117
     - file: lint-http-rules/src/rules/status_3xx_vs_request_method.rs
-      line: 94
+      line: 140
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 47
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 76
+      line: 118
   - label: accept_patch_header_valid (7)
     section: § 9.3.7
     snippet: An OPTIONS request with an asterisk ("*") as the request target (Section 7.1) applies to the server in general rather than to a specific resource.
     cited_by:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 289
+      line: 335
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 133
+      line: 179
   - label: accept_ranges_and_206_consistent
     section: § 14
     snippet: Range requests are an OPTIONAL feature of HTTP, designed so that recipients not implementing this feature (or not supporting it for the target resource) can respond as if it is a normal GET request without impacting interoperability.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 55
+      line: 83
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 110
+      line: 138
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 60
+      line: 100
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 40
+      line: 74
   - label: accept_ranges_and_206_consistent (2)
     section: § 14.2
     snippet: If all of the preconditions are true, the server supports the Range header field for the target resource, the received Range field-value contains a valid ranges-specifier with a range-unit supported for that target resource, and that ranges-specifier is satisfiable with respect to the selected representation, the server SHOULD send a 206 (Partial Content) response with content containing one or more partial representations that correspond to the satisfiable range-spec(s) requested.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 99
+      line: 127
   - label: accept_ranges_and_206_consistent (3)
     section: § 14.3
     snippet: A client MAY generate range requests regardless of having received an Accept-Ranges field.  The information only provides advice for the sake of improving performance and reducing unnecessary network transfers.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 56
+      line: 84
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 111
+      line: 139
   - label: accept_ranges_and_206_consistent (4)
     section: § 14.3
     snippet: A server that does not support any kind of range request for the target resource MAY send
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 68
+      line: 96
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 119
+      line: 147
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 143
+      line: 183
   - label: accept_ranges_and_206_consistent (5)
     section: § 14.3
     snippet: The "Accept-Ranges" field in a response indicates whether an upstream server supports range requests for the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 32
+      line: 60
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 96
+      line: 124
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 23
+      line: 63
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 48
   - label: accept_ranges_and_206_consistent (6)
@@ -4887,67 +4887,67 @@ sources:
     snippet: to advise the client not to attempt a range request on the same request path.  The range unit "none" is reserved for this purpose.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 69
+      line: 97
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 93
+      line: 121
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 144
+      line: 184
   - label: accept_ranges_and_206_consistent (7)
     section: § 14.3
     snippet: to indicate that it supports byte range requests for that target resource, thereby encouraging its use by the client for future partial requests on the same request path.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 57
+      line: 85
   - label: accept_ranges_and_206_consistent (8)
     section: § 15.3.7
     snippet: 'A server that generates a 206 response MUST generate the following header fields, in addition to those required in the subsections below, if the field would have been sent in a 200 (OK) response to the same request: Date, Cache-Control, ETag, Expires, Content-Location, and Vary.'
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 58
+      line: 86
   - label: accept_ranges_and_206_consistent (9)
     section: § 15.3.7
     snippet: The 206 (Partial Content) status code indicates that the server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 38
+      line: 66
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 142
+      line: 170
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 84
+      line: 112
   - label: accept_ranges_on_partial_content (2)
     section: § 14.2
     snippet: An origin server MUST ignore a Range header field that contains a range unit it does not understand.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 139
+      line: 167
   - label: accept_ranges_on_partial_content (3)
     section: § 14.2
     snippet: The "Range" header field on a GET request modifies the method semantics to request transfer of only one or more subranges of the selected representation data (Section 8.1), rather than the entire selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 83
+      line: 111
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 20
+      line: 54
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 88
+      line: 122
   - label: accept_ranges_on_partial_content (4)
     section: § 14.3
     snippet: Conversely, a client MUST NOT assume that receiving an Accept-Ranges field means that future range requests will return partial responses.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 156
+      line: 184
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 181
+      line: 221
   - label: accept_ranges_on_partial_content (5)
     section: § 15.3.7
     snippet: A client MUST inspect a 206 response's Content-Type and Content-Range field(s) to determine what parts are enclosed and whether additional requests are needed.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
-      line: 157
+      line: 185
   - label: accept_ranges_on_partial_content (6)
     section: § A
     snippet: Range = ranges-specifier
@@ -4961,25 +4961,25 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 37
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 325
+      line: 335
   - label: acceptable-ranges grammar
     section: § 14.3
     snippet: acceptable-ranges = 1#range-unit
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 106
+      line: 146
   - label: accept_ranges_values_valid
     section: § 16.5.1
     snippet: The "HTTP Range Unit Registry" defines the namespace for the range unit names and refers to their corresponding specifications.
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 179
+      line: 219
   - label: tchar grammar
     section: § 5.6.2
     snippet: tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters
     cited_by:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 86
+      line: 126
   - label: allow_header_method_tokens_valid
     section: § 10.2
     snippet: The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources.
@@ -4989,11 +4989,11 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 45
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 20
+      line: 60
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 103
+      line: 143
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
-      line: 77
+      line: 105
   - label: allow_header_method_tokens_valid (2)
     section: § 10.2.1
     snippet: An empty Allow field value indicates that the resource allows no methods, which might occur in a 405 response if the resource has been temporarily disabled by configuration.
@@ -5003,7 +5003,7 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 43
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 117
+      line: 163
   - label: allow_header_method_tokens_valid (3)
     section: § 10.2.1
     snippet: The purpose of this field is strictly to inform the recipient of valid request methods associated with the resource.
@@ -5015,45 +5015,45 @@ sources:
     snippet: A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules.
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 166
+      line: 206
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 155
+      line: 219
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 303
+      line: 315
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 105
+      line: 188
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 21
+      line: 73
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 150
+      line: 162
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 431
+      line: 445
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 473
+      line: 496
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 69
+      line: 109
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 224
+      line: 282
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 161
+      line: 231
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 101
+      line: 148
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 175
+      line: 222
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 198
+      line: 232
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 213
+      line: 247
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 304
+      line: 338
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 110
+      line: 169
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 53
+      line: 99
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 102
+      line: 136
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 300
+      line: 313
   - label: Allow grammar, sender-expanded
     section: § A
     snippet: Allow = [ method *( OWS "," OWS method ) ]
@@ -5067,93 +5067,93 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 108
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 167
+      line: 231
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 141
+      line: 188
   - label: alt_svc_header_syntax
     section: § 3.7
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 375
+      line: 427
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 202
+      line: 254
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 139
+      line: 203
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 67
+      line: 113
   - label: auth_scheme_registered
     section: § 11.1
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 64
+      line: 86
   - label: auth_scheme_registered (2)
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 65
+      line: 87
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 92
+      line: 108
   - label: authentication_challenge_valid (2)
     section: § 11.5
     snippet: Recipients might have to support both token and quoted-string syntax for maximum interoperability with existing clients that have been accepting both notations for a long time.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 62
+      line: 78
   - label: authentication_challenge_valid (3)
     section: § 11.5
     snippet: These realms allow the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme and/or authorization database.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 91
+      line: 107
   - label: authentication_failure_loop
     section: § 15.5.2
     snippet: If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_failure_loop.rs
-      line: 59
+      line: 69
   - label: authentication_failure_loop (2)
     section: § 15.5.2
     snippet: The 401 (Unauthorized) status code indicates that the request has not been applied because it lacks valid authentication credentials for the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_failure_loop.rs
-      line: 32
+      line: 42
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 73
+      line: 113
   - label: authorization_credentials_present
     section: § 11.6.2
     snippet: Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested
     cited_by:
     - file: lint-http-rules/src/rules/authorization_credentials_present.rs
-      line: 36
+      line: 58
   - label: cache_coherence
     section: § 15.4.5
     snippet: there is no need for the server to transfer a representation of the target resource because the request indicates that the client, which made the request conditional, already has a valid representation
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 44
+      line: 72
   - label: cache_coherence (2)
     section: § 6.6.1
     snippet: The "Date" header field represents the date and time at which the message was originated
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 69
+      line: 97
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 47
+      line: 75
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 64
+      line: 92
   - label: cache_coherence (3)
     section: § 8.8.2
     snippet: The "Last-Modified" header field in a response provides a timestamp indicating the date and time at which the origin server believes the selected representation was last modified
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 56
+      line: 84
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 33
   - label: cache_validation_chain
@@ -5161,173 +5161,173 @@ sources:
     snippet: The "If-None-Match" header field makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource, when the field value is "*"
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 64
+      line: 86
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 104
+      line: 114
   - label: cached_validators_reused
     section: § 13.1.2
     snippet: When a client desires to update one or more stored responses that have entity tags, the client SHOULD generate an If-None-Match header field containing a list of those entity tags when making a GET request
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
-      line: 67
+      line: 83
   - label: cached_validators_reused (2)
     section: § 13.1.3
     snippet: 'If-Modified-Since is typically used for two distinct purposes: 1) to allow efficient updates of a cached representation that does not have an entity tag'
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
-      line: 68
+      line: 84
   - label: charset_present
     section: § 8.3.2
     snippet: HTTP uses "charset" names to indicate or negotiate the character encoding scheme
     cited_by:
     - file: lint-http-rules/src/rules/charset_present.rs
-      line: 51
+      line: 73
   - label: charset_registered
     section: § 8.3
     snippet: 'The "Content-Type" header field indicates the media type of the associated representation: either the representation enclosed in the message content or the selected representation, as determined by the message semantics.'
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 18
+      line: 46
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 18
+      line: 52
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 18
+      line: 46
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 20
+      line: 48
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 20
+      line: 42
   - label: charset_registered (2)
     section: § 8.3.2
     snippet: Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978].
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 164
+      line: 192
   - label: charset_registered (3)
     section: § 8.3.2
     snippet: In both cases, charset names are matched case-insensitively.
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 28
+      line: 56
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 165
+      line: 193
   - label: compression_and_transfer_encoding_consistent
     section: § 10.1.4
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 88
+      line: 128
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 121
+      line: 168
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 69
+      line: 97
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 10.1.4
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 89
+      line: 129
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 102
+      line: 149
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 51
+      line: 79
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 8.4
     snippet: An origin server MAY respond with a status code of 415 (Unsupported Media Type) if a representation in the request message has a content coding that is not acceptable.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 20
+      line: 60
   - label: compression_and_transfer_encoding_consistent (4)
     section: § 8.4
     snippet: 'Content-Encoding = #content-coding'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 47
+      line: 87
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 35
+      line: 51
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 52
+      line: 80
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 8.4
     snippet: If one or more encodings have been applied to a representation, the sender that applied the encodings MUST generate a Content-Encoding header field that lists the content codings in the order in which they were applied.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 143
+      line: 183
   - label: compression_and_transfer_encoding_consistent (6)
     section: § 8.4
     snippet: Such a content coding would only be listed if, for some bizarre reason, it is applied a second time to form the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 136
+      line: 176
   - label: compression_and_transfer_encoding_consistent (7)
     section: § 8.4
     snippet: Unlike Transfer-Encoding (Section 6.1 of [HTTP/1.1]), the codings listed in Content-Encoding are a characteristic of the representation; the representation is defined in terms of the coded form, and all other metadata about the representation is about the coded form unless otherwise noted in the metadata definition.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 120
+      line: 160
   - label: compression_and_transfer_encoding_consistent (8)
     section: § 8.4.1
     snippet: All content codings are case-insensitive and ought to be registered within the "HTTP Content Coding Registry",
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 67
+      line: 107
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 97
+      line: 125
   - label: conditional_headers_consistent
     section: § 13.1.3
     snippet: A recipient MUST ignore If-Modified-Since if the request contains an If-None-Match header field
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 41
+      line: 69
   - label: conditional_headers_consistent (2)
     section: § 13.1.3
     snippet: A recipient MUST ignore the If-Modified-Since header field if the received field value is not a valid HTTP-date, the field value has more than one member, or if the request method is neither GET nor HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 92
+      line: 120
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 110
+      line: 138
   - label: conditional_headers_consistent (3)
     section: § 13.1.4
     snippet: A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 48
+      line: 76
   - label: conditional_headers_consistent (4)
     section: § 13.1.4
     snippet: A recipient MUST ignore the If-Unmodified-Since header field if the received field value is not a valid HTTP-date (including when the field value appears to be a list of dates).
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 93
+      line: 121
   - label: conditional_headers_consistent (5)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 66
+      line: 94
   - label: conditional_headers_consistent (6)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 56
+      line: 84
   - label: conditional_request_handling
     section: § 13.1.2
     snippet: An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 82
+      line: 122
   - label: conditional_request_handling (2)
     section: § 13.1.3
     snippet: An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 114
+      line: 154
   - label: conditional_request_handling (3)
     section: § 13.2.2
     snippet: When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 115
+      line: 155
   - label: connection_header_tokens_valid
     section: § 7.6.1
     snippet: A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content.  For example, Cache-Control is never appropriate as a connection option (Section 5.2 of [CACHING]).
@@ -5341,7 +5341,7 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 23
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 83
+      line: 111
   - label: connection_header_tokens_valid (2)
     section: § 7.6.1
     snippet: The "Connection" header field allows the sender to list desired control options for the current connection.
@@ -5349,9 +5349,9 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 22
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 125
+      line: 160
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 200
+      line: 211
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 32
   - label: Connection grammar, sender-expanded
@@ -5365,137 +5365,137 @@ sources:
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 149
+      line: 183
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 83
+      line: 147
   - label: content_encoding_and_type_consistent
     section: § 15.4.5
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 102
+      line: 118
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 53
+      line: 81
   - label: content_encoding_registered (2)
     section: § 8.4
     snippet: Note that the coding named "identity" is reserved for its special role in Accept-Encoding and thus SHOULD NOT be included.
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 79
+      line: 107
   - label: content_encoding_registered (3)
     section: § 8.4.1
     snippet: content-coding = token
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
-      line: 86
+      line: 114
   - label: content_length_valid
     section: § 8.6
     snippet: The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_valid.rs
-      line: 34
+      line: 50
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 186
+      line: 214
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 106
+      line: 128
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 149
+      line: 177
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 110
+      line: 156
   - label: content_location_and_uri_consistent
     section: § 4.1
     snippet: A "partial-URI" rule is defined for protocol elements that can contain a relative URI but not a fragment component.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 152
+      line: 216
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 194
+      line: 264
   - label: content_location_and_uri_consistent (2)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 153
+      line: 217
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 195
+      line: 265
   - label: content_location_and_uri_consistent (3)
     section: § 8.7
     snippet: Content-Location = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 56
+      line: 120
   - label: content_location_and_uri_consistent (4)
     section: § 8.7
     snippet: For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 257
+      line: 321
   - label: content_location_and_uri_consistent (5)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its field value refers to a URI that differs from the target URI, then the origin server claims that the URI is an identifier for a different resource corresponding to the enclosed representation.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 256
+      line: 320
   - label: content_location_and_uri_consistent (6)
     section: § 8.7
     snippet: If Content-Location is included in a 2xx (Successful) response message and its value refers (after conversion to absolute form) to a URI that is the same as the target URI, then the recipient MAY consider the content to be a current representation of that resource at the time indicated by the message origination date.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 167
+      line: 231
   - label: content_location_and_uri_consistent (7)
     section: § 8.7
     snippet: In the latter case (Section 4), the referenced URI is relative to the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 195
+      line: 259
   - label: content_location_and_uri_consistent (8)
     section: § 8.7
     snippet: Such a claim can only be trusted if both identifiers share the same resource owner, which cannot be programmatically determined via HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 258
+      line: 322
   - label: content_location_and_uri_consistent (9)
     section: § 8.7
     snippet: The "Content-Location" header field references a URI that can be used as an identifier for a specific resource corresponding to the representation in this message's content.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 43
+      line: 107
   - label: content_location_and_uri_consistent (10)
     section: § 8.7
     snippet: The field value is either an absolute-URI or a partial-URI.
     cited_by:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 114
+      line: 178
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 151
+      line: 215
   - label: content_type_present
     section: § 15.3.6
     snippet: Since the 205 status code implies that no additional content will be provided, a server MUST NOT generate content in a 205 response.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 43
+      line: 71
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 67
+      line: 131
   - label: content_type_present (2)
     section: § 8.3
     snippet: A sender that generates a message containing content SHOULD generate a Content-Type header field in that message unless the intended media type of the enclosed representation is unknown to the sender.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 103
+      line: 131
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 65
+      line: 111
   - label: content_type_present (3)
     section: § 8.3
     snippet: Content-Type = media-type
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 104
+      line: 132
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 57
+      line: 91
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 35
   - label: content_type_present (4)
@@ -5503,41 +5503,41 @@ sources:
     snippet: If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([RFC2046], Section 4.5.1) or examine the data to determine its type.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 110
+      line: 138
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 102
+      line: 148
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 89
+      line: 117
   - label: content_type_present (5)
     section: § 8.3
     snippet: This "MIME sniffing" risks drawing incorrect conclusions about the data, which might expose the user to additional security risks (e.g., "privilege escalation").
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 111
+      line: 139
   - label: content_type_present (6)
     section: § 9.3.2
     snippet: The HEAD method is identical to GET except that the server MUST NOT send content in the response.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 54
+      line: 82
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 165
+      line: 193
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 75
+      line: 121
   - label: content_type_registered
     section: § 8.3.1
     snippet: Media types ought to be registered with IANA according to the procedures defined in [BCP13].
     cited_by:
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 72
+      line: 94
   - label: content_type_valid
     section: § 8.3
     snippet: Although Content-Type is defined as a singleton field, it is sometimes incorrectly generated multiple times, resulting in a combined field value that appears to be a list.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 58
+      line: 92
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 140
+      line: 180
   - label: context_fields_direction
     section: § 10.1
     snippet: The request header fields below provide additional information about the request context, including information about the user, user agent, and resource behind the request.
@@ -5545,13 +5545,13 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 14
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 32
+      line: 79
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 22
+      line: 105
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 55
+      line: 125
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 383
+      line: 459
   - label: context_fields_direction (2)
     section: § 10.1.1
     snippet: The "Expect" header field in a request indicates a certain set of behaviors (expectations) that need to be supported by the server in order to properly handle this request.
@@ -5559,7 +5559,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 15
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 48
+      line: 95
   - label: context_fields_direction (3)
     section: § 10.1.2
     snippet: The "From" header field contains an Internet email address for a human user who controls the requesting user agent.
@@ -5567,7 +5567,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 16
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 53
+      line: 136
   - label: context_fields_direction (4)
     section: § 10.1.3
     snippet: The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled).
@@ -5575,7 +5575,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 17
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 86
+      line: 156
   - label: context_fields_direction (5)
     section: § 10.1.4
     snippet: The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections.
@@ -5585,9 +5585,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 191
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 349
+      line: 425
     - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 384
+      line: 460
   - label: context_fields_direction (6)
     section: § 10.1.5
     snippet: The "User-Agent" header field contains information about the user agent originating the request
@@ -5595,9 +5595,9 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 19
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 22
+      line: 44
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 23
+      line: 39
   - label: context_fields_direction (7)
     section: § 10.2.2
     snippet: The "Location" header field is used in some responses to refer to a specific resource in relation to the response.
@@ -5605,9 +5605,9 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 47
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 66
+      line: 106
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
-      line: 100
+      line: 128
   - label: context_fields_direction (8)
     section: § 10.2.3
     snippet: Servers send the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request.
@@ -5615,11 +5615,11 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 48
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 29
+      line: 39
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
-      line: 68
+      line: 96
     - file: lint-http-rules/src/rules/retry_after_status_valid.rs
-      line: 92
+      line: 120
   - label: context_fields_direction (9)
     section: § 10.2.4
     snippet: The "Server" header field contains information about the software used by the origin server to handle the request
@@ -5631,7 +5631,7 @@ sources:
     snippet: An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1).
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 94
+      line: 122
   - label: early_data_header_safe_method
     section: § 16.1.1
     snippet: 'HTTP method registrations MUST include the following fields:'
@@ -5665,25 +5665,25 @@ sources:
     snippet: Request methods are considered "safe" if their defined semantics are essentially read-only; i.e., the client does not request, and does not expect, any state change on the origin server as a result of applying a safe method to a target resource.
     cited_by:
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
-      line: 175
+      line: 215
   - label: etag_or_last_modified_present
     section: § 8.8.2.1
     snippet: An origin server SHOULD send Last-Modified for any selected representation for which a last modification date can be reasonably and consistently determined
     cited_by:
     - file: lint-http-rules/src/rules/etag_or_last_modified_present.rs
-      line: 38
+      line: 54
   - label: etag_or_last_modified_present (2)
     section: § 8.8.3.1
     snippet: An origin server SHOULD send an ETag for any selected representation for which detection of changes can be reasonably and consistently determined
     cited_by:
     - file: lint-http-rules/src/rules/etag_or_last_modified_present.rs
-      line: 39
+      line: 55
   - label: etag_syntax
     section: § 8.8.3
     snippet: The "ETag" field in a response provides the current entity tag for the selected representation, as determined at the conclusion of handling the request.
     cited_by:
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 32
+      line: 48
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 34
   - label: expect_header_valid
@@ -5691,25 +5691,25 @@ sources:
     snippet: A "100-continue" expectation informs recipients that the client is about to send (presumably large) content in this request
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 123
+      line: 170
   - label: expect_header_valid (2)
     section: § 10.1.1
     snippet: A client MUST NOT generate a 100-continue expectation in a request that does not include content.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 122
+      line: 169
   - label: expect_header_valid (3)
     section: § 10.1.1
     snippet: A client that receives a 417 (Expectation Failed) status code in response to a request containing a 100-continue expectation SHOULD repeat that request without a 100-continue expectation, since the 417 response merely indicates that the response chain does not support expectations (e.g., it passes through an HTTP/1.0 server).
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 141
+      line: 188
   - label: expect_header_valid (4)
     section: § 10.1.1
     snippet: A server that receives an Expect field value containing a member other than 100-continue MAY respond with a 417 (Expectation Failed) status code to indicate that the unexpected expectation cannot be met.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 164
+      line: 211
   - label: expect_header_valid (5)
     section: § 10.1.1
     snippet: The Expect field value is case-insensitive.
@@ -5717,7 +5717,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 19
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 88
+      line: 135
   - label: expect_header_valid (6)
     section: § 10.1.1
     snippet: The only expectation defined by this specification is "100-continue" (with no defined parameters).
@@ -5729,99 +5729,99 @@ sources:
     snippet: expectation = token [ "=" ( token / quoted-string ) parameters ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 302
+      line: 314
   - label: expect_header_valid (8)
     section: § 15.5.18
     snippet: The 417 (Expectation Failed) status code indicates that the expectation given in the request's Expect header field (Section 10.1.1) could not be met by at least one of the inbound servers.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 140
+      line: 187
   - label: expect_header_valid (9)
     section: § 5.6.6
     snippet: '|  *Note:* Parameters do not allow whitespace (not even "bad" |  whitespace) around the "=" character.'
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 442
+      line: 454
   - label: expect_header_valid (10)
     section: § A
     snippet: Expect = [ expectation *( OWS "," OWS expectation ) ]
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 76
+      line: 123
   - label: expect_header_valid (11)
     section: § B.3
     snippet: List-based grammar for Expect has been restored for compatibility with RFC 2616.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 63
+      line: 110
   - label: expect_header_valid (12)
     section: § B.3
     snippet: Parameters in media type, media range, and expectation can be empty via one or more trailing semicolons.
     cited_by:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 413
+      line: 425
   - label: extension_headers_registered
     section: § 16.3
     snippet: Most fields are designed with the expectation that a recipient can safely ignore (but forward downstream) any field not recognized
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 151
+      line: 160
   - label: extension_headers_registered (2)
     section: § 16.3.2.1
     snippet: Field names ought not be prefixed with "X-"
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 113
+      line: 122
   - label: extension_headers_registered (3)
     section: § 5.1
     snippet: A proxy MUST forward unrecognized header fields unless the field name is listed in the Connection header field
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 149
+      line: 158
   - label: extension_headers_registered (4)
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 27
+      line: 61
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 173
+      line: 182
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 133
+      line: 161
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 270
+      line: 298
   - label: extension_headers_registered (5)
     section: § 5.1
     snippet: Other recipients SHOULD ignore unrecognized header and trailer fields
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 150
+      line: 159
   - label: from_header_email_syntax
     section: § 10.1.2
     snippet: The address ought to be machine-usable, as defined by "mailbox" in Section 3.4 of [RFC5322]
     cited_by:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 54
+      line: 137
   - label: head_response_headers_match_get
     section: § 12.5.5
     snippet: A Vary field value is either the wildcard member "*" or a list of request field names, known as the selecting header fields, that might have had a role in selecting the representation for this response.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 269
+      line: 297
   - label: head_response_headers_match_get (2)
     section: § 12.5.5
     snippet: To inform cache recipients that they MUST NOT use this response to satisfy a later request unless the later request has the same values for the listed header fields as the original request
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 276
+      line: 304
   - label: head_response_headers_match_get (3)
     section: § 15
     snippet: The status code of a response is a three-digit integer code that describes the result of the request and the semantics of the response, including whether the request was successful and what content is enclosed (if any).
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 194
+      line: 222
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 37
+      line: 71
   - label: head_response_headers_match_get (4)
     section: § 15.3.1
     snippet: The content sent in a 200 response depends on the request method.
@@ -5835,9 +5835,9 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 72
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 58
+      line: 86
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 82
+      line: 128
   - label: head_response_headers_match_get (6)
     section: § 8.8
     snippet: In responses to safe requests, validator fields describe the selected representation chosen by the origin server while handling the response.
@@ -5879,15 +5879,15 @@ sources:
     snippet: The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 160
+      line: 188
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 70
+      line: 98
   - label: field-name grammar
     section: § A
     snippet: field-name = token field-value = *field-content
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 145
+      line: 154
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 75
   - label: host_and_authority_consistent
@@ -5921,33 +5921,33 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 49
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 270
+      line: 340
   - label: host_header
     section: § 7.2
     snippet: A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 60
+      line: 94
   - label: http2_pseudo_headers_valid
     section: § 7.1
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 231
+      line: 295
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 107
+      line: 152
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 258
+      line: 292
   - label: http2_pseudo_headers_valid (2)
     section: § 7.1
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 232
+      line: 296
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 108
+      line: 153
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 229
+      line: 263
   - label: http2_pseudo_headers_valid (3)
     section: § 9.3.6
     snippet: A server MUST reject a CONNECT request that targets an empty or invalid port number, typically by responding with a 400 (Bad Request) status code.
@@ -5971,49 +5971,49 @@ sources:
     snippet: 'If-Match = "*" / #entity-tag'
     cited_by:
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 55
+      line: 71
   - label: if_match_etag_syntax (2)
     section: § 8.8.3
     snippet: etagc      = %x21 / %x23-7E / obs-text ; VCHAR except double quotes, plus obs-text
     cited_by:
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 78
+      line: 94
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 79
+      line: 95
   - label: if_modified_since_date_syntax
     section: § 13.1.3
     snippet: If-Modified-Since = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 64
+      line: 74
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 39
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 80
+      line: 90
   - label: if_modified_since_date_syntax (2)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 65
+      line: 75
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 64
+      line: 74
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 48
+      line: 58
   - label: if_none_match_etag_syntax
     section: § 13.1.2
     snippet: 'If-None-Match = "*" / #entity-tag'
     cited_by:
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 56
+      line: 72
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 103
+      line: 113
   - label: if_unmodified_since_date_syntax
     section: § 13.1.4
     snippet: If-Unmodified-Since = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 63
+      line: 73
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 40
   - label: keep_alive_header_valid
@@ -6021,61 +6021,61 @@ sources:
     snippet: Keep-Alive (Section 19.7.1 of [RFC2068])
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 413
+      line: 427
   - label: language_tag_syntax
     section: § 8.5
     snippet: 'Content-Language = #language-tag'
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 98
+      line: 133
   - label: language_tag_syntax (2)
     section: § 8.5
     snippet: The "Content-Language" header field describes the natural language(s) of the intended audience for the representation.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 20
+      line: 55
   - label: language_tag_syntax (3)
     section: § 8.5.1
     snippet: A language tag, as defined in [RFC5646], identifies a natural language spoken, written, or otherwise conveyed by human beings for communication of information to other human beings.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 54
+      line: 89
   - label: language_tag_syntax (4)
     section: § 8.5.1
     snippet: HTTP uses language tags within the Accept-Language and Content-Language header fields.  Accept-Language uses the broader language-range production defined in Section 12.5.4, whereas Content-Language uses the language-tag production defined below.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 51
+      line: 86
   - label: last_modified_rfc1123_syntax
     section: § 8.8.2
     snippet: Last-Modified = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 47
+      line: 57
   - label: link_header_valid
     section: § 5.6.3
     snippet: A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 687
+      line: 710
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 199
+      line: 257
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 265
+      line: 323
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 206
+      line: 240
   - label: link_header_valid (2)
     section: § 5.6.3
     snippet: A sender MUST NOT generate BWS in messages.
     cited_by:
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 686
+      line: 709
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 198
+      line: 256
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 264
+      line: 322
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 205
+      line: 239
   - label: lint-http-core/src/http_date.rs
     section: § 5.6.7
     snippet: A recipient that parses a timestamp value in an HTTP field MUST accept all three HTTP-date formats.
@@ -6089,7 +6089,7 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 80
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 523
+      line: 536
   - label: lint-http-core/src/http_date.rs (3)
     section: § 5.6.7
     snippet: HTTP-date = IMF-fixdate / obs-date
@@ -6109,13 +6109,13 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 82
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 67
+      line: 77
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 66
+      line: 76
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 50
+      line: 60
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 545
+      line: 558
   - label: lint-http-core/src/http_transaction.rs
     section: § 15
     snippet: 'A single request can have multiple associated responses: zero or more "interim" (non-final) responses with status codes in the "informational" (1xx) range, followed by exactly one "final" response with a status code in one of the other ranges.'
@@ -6141,9 +6141,9 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 77
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 158
+      line: 192
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 90
+      line: 149
   - label: lint-http-core/src/http_version.rs (3)
     section: § 2.5
     snippet: The first digit (major version) indicates the messaging syntax, whereas the second digit (minor version) indicates the highest minor version within that major version to which the sender is conformant (able to understand for future communication).
@@ -6163,9 +6163,9 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 42
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 127
+      line: 167
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 162
+      line: 202
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (2)
     section: § 11.7.2
     snippet: Unlike Authorization, the Proxy-Authorization header field applies only to the next inbound proxy that demanded authentication using the Proxy-Authenticate header field.
@@ -6227,9 +6227,9 @@ sources:
     - file: lint-http-proxy/src/proxy/websocket.rs
       line: 144
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
-      line: 55
+      line: 83
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 52
+      line: 116
   - label: lint-http-rules/src/helpers/accept_ranges.rs
     section: § 14.1
     snippet: All range unit names are case-insensitive and ought to be registered within the "HTTP Range Unit Registry", as defined in Section 16.5.1.
@@ -6243,13 +6243,13 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 47
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 178
+      line: 218
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 337
+      line: 347
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 54
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 223
+      line: 232
   - label: lint-http-rules/src/helpers/accept_ranges.rs (2)
     section: § 14.1
     snippet: Range units are intended to be extensible, as described in Section 16.5.
@@ -6259,9 +6259,9 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 80
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 291
+      line: 301
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 224
+      line: 233
   - label: Accept-Ranges grammar
     section: § 14.3
     snippet: Accept-Ranges     = acceptable-ranges acceptable-ranges = 1#range-unit
@@ -6275,7 +6275,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 61
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 180
+      line: 220
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 49
   - label: lint-http-rules/src/helpers/accept_ranges.rs (4)
@@ -6287,23 +6287,23 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 552
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
-      line: 62
+      line: 84
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 53
+      line: 87
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 292
+      line: 302
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 57
+      line: 79
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 240
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 175
+      line: 203
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 107
+      line: 154
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 53
+      line: 81
   - label: lint-http-rules/src/helpers/accept_ranges.rs (5)
     section: § 5.6.1.2
     snippet: In contrast, the following values would be invalid, since at least one non-empty element is required by the example-list production
@@ -6311,7 +6311,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 118
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 299
+      line: 309
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 125
   - label: lint-http-rules/src/helpers/auth.rs
@@ -6321,13 +6321,13 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 213
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 51
+      line: 73
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 32
+      line: 48
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 40
+      line: 56
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
-      line: 37
+      line: 53
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 11.3
     snippet: 'challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
@@ -6359,13 +6359,13 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 75
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 311
+      line: 321
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 141
+      line: 199
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 150
+      line: 184
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 241
+      line: 250
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -6397,7 +6397,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 49
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
-      line: 86
+      line: 114
   - label: lint-http-rules/src/helpers/content_range.rs (2)
     section: § 14.1.1
     snippet: 'The range unit name determines what kinds of range-spec are applicable to its own specifiers.  Hence, the following grammar is generic: each range unit is expected to specify requirements on when int-range, suffix-range, and other-range are allowed.'
@@ -6405,7 +6405,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 51
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 225
+      line: 234
   - label: ranges-specifier grammar
     section: § 14.1.1
     snippet: ranges-specifier = range-unit "=" range-set
@@ -6413,7 +6413,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 50
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 92
+      line: 126
   - label: lint-http-rules/src/helpers/content_range.rs (3)
     section: § 14.1.2
     snippet: In the byte-range syntax, first-pos, last-pos, and suffix-length are expressed as decimal number of octets.  Since there is no predefined limit to the length of content, recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows.
@@ -6421,7 +6421,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 197
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 376
+      line: 385
   - label: lint-http-rules/src/helpers/content_range.rs (4)
     section: § 14.4
     snippet: A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value.
@@ -6473,21 +6473,21 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 69
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 106
+      line: 140
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 434
+      line: 448
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 476
+      line: 499
     - file: lint-http-rules/src/rules/refresh_header_syntax.rs
-      line: 248
+      line: 282
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 334
+      line: 348
     - file: lint-http-rules/src/rules/trace_method_echo.rs
       line: 46
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 229
+      line: 240
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 302
+      line: 315
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 11.6.3
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
@@ -6507,9 +6507,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1841
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 151
+      line: 179
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 113
+      line: 141
   - label: Vary grammar
     section: § 12.5.5
     snippet: 'Vary = #( "*" / field-name )'
@@ -6517,7 +6517,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1113
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 39
+      line: 49
   - label: If-None-Match weak comparison
     section: § 13.1.2
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
@@ -6537,9 +6537,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 342
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 18
+      line: 52
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 18
+      line: 52
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.1
     snippet: Field names are case-insensitive
@@ -6557,17 +6557,17 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1639
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 38
+      line: 54
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 38
+      line: 54
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 60
+      line: 94
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 215
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 71
+      line: 93
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 79
+      line: 134
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6579,13 +6579,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1115
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 81
+      line: 110
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 408
+      line: 460
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 243
+      line: 295
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 181
+      line: 245
   - label: lint-http-rules/src/helpers/headers.rs (8)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
@@ -6593,11 +6593,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 180
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 105
+      line: 145
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 81
+      line: 115
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 293
+      line: 340
   - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.3
     snippet: Since it cannot be combined into a single field value, | recipients ought to handle "Set-Cookie" as a special case while | processing fields.
@@ -6613,37 +6613,37 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 89
+      line: 117
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 124
+      line: 158
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 60
+      line: 94
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 42
+      line: 64
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 75
+      line: 91
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 220
+      line: 285
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 76
+      line: 110
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 36
+      line: 46
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 45
+      line: 55
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 42
+      line: 52
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 42
+      line: 52
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 42
+      line: 52
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 247
+      line: 250
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 81
+      line: 91
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 43
+      line: 59
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 42
+      line: 58
   - label: lint-http-rules/src/helpers/headers.rs (11)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
@@ -6659,19 +6659,19 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 50
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 93
+      line: 176
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 248
+      line: 313
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 109
+      line: 149
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 84
-    - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 140
-    - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 118
+    - file: lint-http-rules/src/rules/redirect_chain_valid.rs
+      line: 180
+    - file: lint-http-rules/src/rules/referer_uri_valid.rs
+      line: 188
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 128
+      line: 183
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 43
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
@@ -6685,25 +6685,25 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 247
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 198
+      line: 226
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
-      line: 84
+      line: 148
     - file: lint-http-rules/src/rules/content_type_valid.rs
-      line: 81
+      line: 115
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 157
+      line: 185
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 51
+      line: 79
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 73
+      line: 95
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 157
+      line: 197
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 52
+      line: 74
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 182
+      line: 246
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 72
+      line: 88
   - label: lint-http-rules/src/helpers/headers.rs (13)
     section: § 5.5
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
@@ -6711,9 +6711,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1637
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 123
+      line: 157
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 249
+      line: 252
   - label: lint-http-rules/src/helpers/headers.rs (14)
     section: § 5.5
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
@@ -6721,7 +6721,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1638
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 250
+      line: 253
   - label: lint-http-rules/src/helpers/headers.rs (15)
     section: § 5.5
     snippet: field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
@@ -6739,53 +6739,53 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 86
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 315
+      line: 325
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 86
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 459
+      line: 511
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 115
+      line: 120
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 116
+      line: 121
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 65
+      line: 87
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 64
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 92
+      line: 139
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 223
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 83
+      line: 99
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 84
+      line: 100
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 492
+      line: 515
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 135
+      line: 140
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 154
+      line: 212
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 163
+      line: 197
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 250
+      line: 259
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 351
+      line: 365
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 67
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 77
+      line: 99
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 67
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 151
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 61
+      line: 71
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 254
+      line: 265
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 326
+      line: 339
   - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -6793,15 +6793,15 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 551
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 50
+      line: 78
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 52
+      line: 86
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
-      line: 45
+      line: 73
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 433
+      line: 485
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 484
+      line: 507
   - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
@@ -6811,7 +6811,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 589
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 178
+      line: 189
   - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
@@ -6823,7 +6823,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 76
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 56
+      line: 90
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 46
   - label: lint-http-rules/src/helpers/headers.rs (20)
@@ -6837,19 +6837,19 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 316
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
-      line: 291
+      line: 343
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 143
+      line: 148
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 118
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 384
+      line: 398
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 232
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 147
+      line: 194
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 207
+      line: 218
   - label: OWS grammar
     section: § 5.6.3
     snippet: OWS            = *( SP / HTAB )
@@ -6867,31 +6867,31 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2040
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 67
+      line: 101
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 312
+      line: 322
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 33
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 66
+      line: 106
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 97
+      line: 137
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 105
+      line: 139
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 45
+      line: 55
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 45
+      line: 55
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 124
+      line: 159
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 242
+      line: 251
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 467
+      line: 481
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 122
+      line: 169
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 70
+      line: 98
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 66
   - label: lint-http-rules/src/helpers/headers.rs (21)
@@ -6921,9 +6921,9 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 33
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 306
+      line: 353
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 524
+      line: 537
   - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
@@ -6935,9 +6935,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1477
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 408
+      line: 418
     - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 563
+      line: 586
   - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
@@ -6955,15 +6955,15 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 115
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 316
+      line: 330
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 303
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 84
+      line: 131
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 305
+      line: 352
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 33
+      line: 61
   - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
@@ -6971,11 +6971,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2330
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 157
+      line: 198
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 85
+      line: 113
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 217
+      line: 225
   - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
@@ -6985,7 +6985,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2065
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 378
+      line: 390
   - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 5.6.6
     snippet: parameter-name  = token
@@ -6997,9 +6997,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2247
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 227
+      line: 261
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 379
+      line: 391
   - label: parameter-value grammar
     section: § 5.6.6
     snippet: parameter-value = ( token / quoted-string )
@@ -7007,13 +7007,13 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2261
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 268
+      line: 302
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 91
+      line: 119
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 380
+      line: 392
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 223
+      line: 231
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
   - label: lint-http-rules/src/helpers/headers.rs (30)
@@ -7025,11 +7025,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2110
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 66
+      line: 100
     - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 377
+      line: 389
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 207
+      line: 215
   - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
@@ -7053,9 +7053,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 343
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 59
+      line: 93
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 35
+      line: 69
   - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
@@ -7065,25 +7065,25 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 44
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 69
+      line: 97
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 38
+      line: 60
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 171
+      line: 235
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 119
+      line: 165
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 91
+      line: 146
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 34
+      line: 80
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 215
+      line: 226
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 89
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 48
+      line: 70
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 58
+      line: 74
   - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
@@ -7097,23 +7097,23 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2192
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
-      line: 205
+      line: 246
     - file: lint-http-rules/src/rules/charset_present.rs
-      line: 43
+      line: 65
     - file: lint-http-rules/src/rules/content_type_registered.rs
-      line: 58
+      line: 80
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 28
+      line: 56
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 108
+      line: 136
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 184
+      line: 192
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 60
+      line: 88
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 94
+      line: 122
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 73
   - label: lint-http-rules/src/helpers/headers.rs (37)
@@ -7133,7 +7133,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 99
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
-      line: 70
+      line: 98
   - label: lint-http-rules/src/helpers/headers.rs (38)
     section: § 8.3.1
     snippet: type       = token subtype    = token
@@ -7159,11 +7159,11 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1961
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 58
+      line: 74
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 56
+      line: 72
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 57
+      line: 73
   - label: entity-tag grammar
     section: § 8.8.3
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
@@ -7183,7 +7183,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 33
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 55
+      line: 138
   - label: lint-http-rules/src/helpers/product.rs
     section: § 10.1.5
     snippet: The User-Agent field value consists of one or more product identifiers, each followed by zero or more comments (Section 5.6.5), which together identify the user agent software and its significant subproducts.
@@ -7191,9 +7191,9 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 87
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 55
+      line: 77
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 40
+      line: 56
   - label: lint-http-rules/src/helpers/product.rs (2)
     section: § 10.2.4
     snippet: Each product identifier consists of a name and optional version, as defined in Section 10.1.5.
@@ -7213,7 +7213,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 103
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 335
+      line: 346
   - label: lint-http-rules/src/helpers/product.rs (5)
     section: § 5.6.3
     snippet: The RWS rule is used when at least one linear whitespace octet is required to separate field tokens.
@@ -7221,7 +7221,7 @@ sources:
     - file: lint-http-rules/src/helpers/product.rs
       line: 102
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 334
+      line: 345
   - label: lint-http-rules/src/helpers/product.rs (6)
     section: § A
     snippet: Server = product *( RWS ( product / comment ) )
@@ -7255,9 +7255,9 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 381
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 163
+      line: 203
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 112
+      line: 171
   - label: Host grammar
     section: § 7.2
     snippet: Host = uri-host [ ":" port ]
@@ -7267,7 +7267,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 54
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 149
+      line: 183
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 112
   - label: lint-http-rules/src/helpers/uri.rs (2)
@@ -7277,11 +7277,11 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 383
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 167
+      line: 232
     - file: lint-http-rules/src/rules/host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 214
+      line: 278
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -7293,31 +7293,31 @@ sources:
     snippet: A Location field value cannot | allow a list of members because the comma list separator is a | valid data character within a URI-reference.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 90
+      line: 130
   - label: location_header_uri_valid (2)
     section: § 10.2.2
     snippet: If an invalid | message is sent with multiple Location field lines, a recipient | along the path might combine those field lines into one value.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 91
+      line: 131
   - label: Location grammar
     section: § 10.2.2
     snippet: Location = URI-reference
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 67
+      line: 107
   - label: location_header_uri_valid (3)
     section: § 16.3.2.2
     snippet: because URIs can include commas, it is not possible to reliably distinguish between a single value that includes a comma from two values
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 92
+      line: 132
   - label: location_header_uri_valid (4)
     section: § 5.5
     snippet: Fields that expect to contain a comma within a member, such as within an HTTP-date or URI-reference element, ought to be defined with delimiters around that element to distinguish any comma within that data from potential list separators.
     cited_by:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
-      line: 89
+      line: 129
   - label: location_on_redirect_present
     section: § 10.2.2
     snippet: For 201 (Created) responses, the Location value refers to the primary resource created by the request.
@@ -7325,7 +7325,7 @@ sources:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
       line: 28
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 77
+      line: 105
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 88
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -7335,7 +7335,7 @@ sources:
     snippet: For 3xx (Redirection) responses, the Location value refers to the preferred target resource for automatically redirecting the request.
     cited_by:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
-      line: 114
+      line: 172
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 30
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -7347,7 +7347,7 @@ sources:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
       line: 27
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 63
+      line: 91
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 89
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -7357,13 +7357,13 @@ sources:
     snippet: If a Location header field (Section 10.2.2) is provided, the user agent MAY automatically redirect its request to the URI referenced by the Location field value, even if the specific status code is not understood.
     cited_by:
     - file: lint-http-rules/src/rules/location_on_redirect_present.rs
-      line: 123
+      line: 181
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 78
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 45
     - file: lint-http-rules/src/rules/status_3xx_vs_request_method.rs
-      line: 81
+      line: 127
   - label: location_on_redirect_present (5)
     section: § 15.4.1
     snippet: For request methods other than HEAD, the server SHOULD generate content in the 300 response containing a list of representation metadata and URI reference(s) from which the user or user agent can choose the one most preferred.
@@ -7417,87 +7417,87 @@ sources:
     snippet: A recipient MAY ignore a Max-Forwards header field received with any other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 42
+      line: 76
   - label: max_forwards_numeric (2)
     section: § 7.6.2
     snippet: Each intermediary that receives a TRACE or OPTIONS request containing a Max-Forwards header field MUST check and update its value prior to forwarding the request.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 125
+      line: 159
   - label: max_forwards_numeric (3)
     section: § 7.6.2
     snippet: If the received value is zero (0), the intermediary MUST NOT forward the request; instead, the intermediary MUST respond as the final recipient.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 126
+      line: 160
   - label: Max-Forwards grammar
     section: § 7.6.2
     snippet: Max-Forwards = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 94
+      line: 128
   - label: max_forwards_numeric (4)
     section: § 7.6.2
     snippet: The "Max-Forwards" header field provides a mechanism with the TRACE (Section 9.3.8) and OPTIONS (Section 9.3.7) request methods to limit the number of times that the request is forwarded by proxies.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 19
+      line: 53
   - label: max_forwards_numeric (5)
     section: § 7.6.2
     snippet: The Max-Forwards value is a decimal integer indicating the remaining number of times this request message can be forwarded.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 124
+      line: 158
   - label: max_forwards_numeric (6)
     section: § 9.3.7
     snippet: A proxy MUST NOT generate a Max-Forwards header field while forwarding a request unless that request was received with a Max-Forwards field.
     cited_by:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
-      line: 127
+      line: 161
   - label: multipart_boundary_syntax
     section: § 5.6.6
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 245
+      line: 253
   - label: multipart_boundary_syntax (2)
     section: § 5.6.6
     snippet: Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 299
+      line: 307
   - label: multipart_boundary_syntax (3)
     section: § 5.6.6
     snippet: The quoted and unquoted values are equivalent.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 246
+      line: 254
   - label: multipart_boundary_syntax (4)
     section: § 8.3.3
     snippet: All multipart types share a common syntax, as defined in Section 5.1.1 of [RFC2046], and include a boundary parameter as part of the media type value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 182
+      line: 190
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 41
+      line: 63
   - label: multipart_content_type_and_body_consistent
     section: § 8.3.3
     snippet: HTTP message framing does not use the multipart boundary as an indicator of message body length, though it might be used by implementations that generate or process the content.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 42
+      line: 64
   - label: multipart_content_type_and_body_consistent (2)
     section: § 8.3.3
     snippet: The message body is itself a protocol element; a sender MUST generate only CRLF to represent line breaks between body parts.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
-      line: 231
+      line: 234
   - label: no_body_for_1xx_204_304
     section: § 15.3.5
     snippet: A 204 response is terminated by the end of the header section; it cannot contain content or trailers.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 53
+      line: 117
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 27
   - label: no_body_for_1xx_204_304 (2)
@@ -7505,37 +7505,37 @@ sources:
     snippet: A 304 response is terminated by the end of the header section; it cannot contain content or trailers.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 54
+      line: 118
   - label: no_body_for_1xx_204_304 (3)
     section: § 6.4
     snippet: This abstract definition of content reflects the data after it has been extracted from the message framing.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 77
+      line: 141
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 172
+      line: 200
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 131
+      line: 177
   - label: no_body_for_1xx_204_304 (4)
     section: § 6.4.1
     snippet: All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include content.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 47
+      line: 111
   - label: no_body_for_1xx_204_304 (5)
     section: § 8.6
     snippet: A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 15.4.5); a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a 200 (OK) response to the same request.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 141
+      line: 205
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 59
+      line: 87
   - label: no_body_for_1xx_204_304 (6)
     section: § 8.6
     snippet: A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 130
+      line: 194
   - label: no_connection_specific_fields
     section: § 7.6.1
     snippet: 'This includes but is not limited to:'
@@ -7565,23 +7565,23 @@ sources:
     snippet: An origin server MUST generate an Allow header field in a 405 (Method Not Allowed) response and MAY do so in any other response.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 149
+      line: 195
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 93
+      line: 139
   - label: options_method_capabilities (2)
     section: § 15.3
     snippet: The 2xx (Successful) class of status code indicates that the client's request was successfully received, understood, and accepted.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 140
+      line: 186
   - label: options_method_capabilities (3)
     section: § 9.3.7
     snippet: A client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 65
+      line: 111
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 104
+      line: 150
   - label: options_method_capabilities (4)
     section: § 9.3.7
     snippet: A server generating a successful response to OPTIONS SHOULD send any header that might indicate optional features implemented by the server and applicable to the target resource (e.g., Allow), including potential extensions not defined by this specification.
@@ -7589,37 +7589,37 @@ sources:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 42
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 150
+      line: 196
   - label: options_method_capabilities (5)
     section: § 9.3.7
     snippet: If the request target is not an asterisk, the OPTIONS request applies to the options that are available when communicating with the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 134
+      line: 180
   - label: options_method_capabilities (6)
     section: § 9.3.7
     snippet: The OPTIONS method requests information about the communication options available for the target resource, at either the origin server or an intervening intermediary.
     cited_by:
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
-      line: 81
+      line: 127
   - label: patch_method_content_type_match
     section: § 12.3
     snippet: When content negotiation preferences are sent in a server's response, the listed preferences are called "request content negotiation" because they intend to influence selection of an appropriate content for subsequent requests to that resource.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 209
+      line: 249
   - label: patch_method_content_type_match (2)
     section: § 12.4.3
     snippet: If no wildcard is present, values that are not explicitly mentioned in the field are considered unacceptable.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 210
+      line: 250
   - label: patch_method_content_type_match (3)
     section: § 12.4.3
     snippet: Most of these header fields, where indicated, define a wildcard value ("*") to select unspecified values.
     cited_by:
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
-      line: 191
+      line: 231
   - label: patch_method_content_type_match (4)
     section: § 8.3.1
     snippet: The presence or absence of a parameter might be significant to the processing of a media type, depending on its definition within the media type registry.
@@ -7631,23 +7631,23 @@ sources:
     snippet: Similarly, Section 3.1 of [RFC5789] defines the "Accept-Patch" response header field, which allows discovery of which content types are accepted in PATCH requests.
     cited_by:
     - file: lint-http-rules/src/rules/patch_partial_update.rs
-      line: 88
+      line: 134
   - label: post_creates_resource
     section: § 15.3.2
     snippet: The 201 (Created) status code indicates that the request has been fulfilled and has resulted in one or more new resources being created.
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 51
+      line: 79
   - label: post_creates_resource (2)
     section: § 5.1
     snippet: Field names are case-insensitive and ought to be registered within the "Hypertext Transfer Protocol (HTTP) Field Name Registry"; see Section 16.3.1.
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 62
+      line: 90
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 177
+      line: 188
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 208
+      line: 219
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 92
   - label: post_creates_resource (3)
@@ -7655,31 +7655,31 @@ sources:
     snippet: An origin server indicates response semantics by choosing an appropriate status code depending on the result of processing the POST request; almost all of the status codes defined by this specification could be received in a response to POST (the exceptions being 206 (Partial Content), 304 (Not Modified), and 416 (Range Not Satisfiable)).
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 40
+      line: 68
   - label: post_creates_resource (4)
     section: § 9.3.3
     snippet: If one or more resources has been created on the origin server as a result of successfully processing a POST request, the origin server SHOULD send a 201 (Created) response containing a Location header field that provides an identifier for the primary resource created (Section 10.2.2) and a representation that describes the status of the request while referring to the new resource(s).
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 76
+      line: 104
   - label: prefer_header_and_preference_applied
     section: § 9.1
     snippet: The method token is case-sensitive
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
-      line: 134
+      line: 186
   - label: prefer_header_and_preference_applied (2)
     section: § 9.2.3
     snippet: This specification defines caching semantics for GET, HEAD, and POST, although the overwhelming majority of cache implementations only support GET and HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
-      line: 132
+      line: 184
   - label: prefer_header_and_preference_applied (3)
     section: § 9.3.3
     snippet: Responses to POST requests are only cacheable when they include explicit freshness information
     cited_by:
     - file: lint-http-rules/src/rules/prefer_header_and_preference_applied.rs
-      line: 133
+      line: 185
   - label: problem_details_structure_valid
     section: § 8.1
     snippet: The representation data is in a format and encoding defined by the representation metadata header fields.
@@ -7703,13 +7703,13 @@ sources:
     snippet: The "Content-Encoding" header field indicates what content codings have been applied to the representation, beyond those inherent in the media type, and thus what decoding mechanisms have to be applied in order to obtain data in the media type referenced by the Content-Type header field.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 116
+      line: 144
   - label: proxy_connection_discouraged
     section: § 7.6.1
     snippet: Note that some versions of HTTP prohibit the use of fields for such information, and therefore do not allow the Connection field.
     cited_by:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 57
+      line: 79
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 153
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -7719,209 +7719,209 @@ sources:
     snippet: If the representation data has a content coding applied, each byte range is calculated with respect to the encoded sequence of bytes, not the sequence of underlying bytes that would be obtained after decoding.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 237
+      line: 265
   - label: range_and_content_range_consistent (2)
     section: § 14.1.2
     snippet: The first-pos value in a bytes int-range gives the offset of the first byte in a range.  The last-pos value gives the offset of the last byte in the range; that is, the byte positions specified are inclusive.  Byte offsets start at zero.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 224
+      line: 252
   - label: range_and_content_range_consistent (3)
     section: § 14.4
     snippet: 'A server generating a 416 (Range Not Satisfiable) response to a byte-range request SHOULD send a Content-Range header field with an unsatisfied-range value, as in the following example:'
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 309
+      line: 337
   - label: range_and_content_range_consistent (4)
     section: § 14.4
     snippet: If a 206 (Partial Content) response contains a Content-Range header field with a range unit (Section 14.1) that the recipient does not understand, the recipient MUST NOT attempt to recombine it with a stored representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 225
+      line: 253
   - label: range_and_content_range_consistent (5)
     section: § 14.4
     snippet: The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 149
+      line: 177
   - label: range_and_content_range_consistent (6)
     section: § 14.4
     snippet: The Content-Range header field has no meaning for status codes that do not explicitly describe its semantic.  For this specification, only the 206 (Partial Content) and 416 (Range Not Satisfiable) status codes describe a meaning for Content-Range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 99
+      line: 127
   - label: range_and_content_range_consistent (7)
     section: § 14.4
     snippet: The complete-length in a 416 response indicates the current length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 327
+      line: 355
   - label: range_and_content_range_consistent (8)
     section: § 14.5
     snippet: Some origin servers support PUT of a partial representation when the user agent sends a Content-Range header field (Section 14.4) in the request, though such support is inconsistent and depends on private agreements with user agents.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 292
+      line: 320
   - label: range_and_content_range_consistent (9)
     section: § 15.3.7
     snippet: A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 236
+      line: 264
   - label: range_and_content_range_consistent (10)
     section: § 15.3.7.1
     snippet: If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 193
+      line: 221
   - label: range_and_content_range_consistent (11)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 174
+      line: 202
   - label: range_and_content_range_consistent (12)
     section: § 15.3.7.2
     snippet: If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content, as defined in Section 14.6, and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 160
+      line: 188
   - label: range_and_content_range_consistent (13)
     section: § 15.3.7.2
     snippet: To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 162
+      line: 190
   - label: range_and_content_range_consistent (14)
     section: § 15.3.7.2
     snippet: Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 187
+      line: 215
   - label: range_and_content_range_consistent (15)
     section: § 15.5.17
     snippet: A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation (Section 14.4).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 308
+      line: 336
   - label: range_and_content_range_consistent (16)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 291
+      line: 319
   - label: range_header_syntax
     section: § 14.1.1
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 106
+      line: 140
   - label: range_header_syntax (2)
     section: § 14.1.1
     snippet: An int-range is invalid if the last-pos value is present and less than the first-pos.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 349
+      line: 358
   - label: int-range position grammar
     section: § 14.1.1
     snippet: first-pos     = 1*DIGIT last-pos      = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 305
+      line: 314
   - label: int-range grammar
     section: § 14.1.1
     snippet: int-range     = first-pos "-" [ last-pos ]
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 325
+      line: 334
   - label: other-range grammar
     section: § 14.1.1
     snippet: other-range   = 1*( %x21-2B / %x2D-7E )
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 57
+      line: 91
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 266
+      line: 275
   - label: range-set grammar
     section: § 14.1.1
     snippet: range-set        = 1#range-spec
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 230
+      line: 239
   - label: suffix-length grammar
     section: § 14.1.1
     snippet: suffix-length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 309
+      line: 318
   - label: suffix-range grammar
     section: § 14.1.1
     snippet: suffix-range  = "-" suffix-length
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 308
+      line: 317
   - label: range_header_syntax (3)
     section: § 14.1.2
     snippet: A client can limit the number of bytes requested without knowing the size of the selected representation.  If the last-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 341
+      line: 350
   - label: range_header_syntax (4)
     section: § 14.1.2
     snippet: A client can refer to the last N bytes (N > 0) of the selected representation using a suffix-range.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 313
+      line: 322
   - label: range_header_syntax (5)
     section: § 14.1.2
     snippet: Each byte range is expressed as an integer range at some offset, relative to either the beginning (int-range) or end (suffix-range) of the representation data.  Byte ranges do not use the other-range specifier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 300
+      line: 309
   - label: range_header_syntax (6)
     section: § 14.1.2
     snippet: 'For a GET request, a valid bytes range-spec is satisfiable if it is either:'
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 130
+      line: 164
   - label: range_header_syntax (7)
     section: § 14.1.2
     snippet: The "bytes" range unit is used to express subranges of a representation data's octet sequence.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 278
+      line: 287
   - label: a bytes range-set the section prints with a leading space
     section: § 14.1.2
     snippet: bytes= 0-999, 4500-5499, -1000
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 227
+      line: 236
   - label: range_header_syntax (8)
     section: § 14.2
     snippet: A client that is requesting multiple ranges SHOULD list those ranges in ascending order (the order in which they would typically be received in a complete representation) unless there is a specific need to request a later part earlier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 132
+      line: 166
   - label: range_header_syntax (9)
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.  For this specification, GET is the only method for which range handling is defined.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 131
+      line: 165
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 82
+      line: 116
   - label: range_header_syntax (10)
     section: § 14.2
     snippet: An origin server MUST ignore a Range header field that contains a range unit it does not understand.  A proxy MAY discard a Range header field that contains a range unit it does not understand.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 226
+      line: 235
   - label: Range grammar
     section: § 14.2
     snippet: Range = ranges-specifier
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 91
+      line: 125
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 37
   - label: range_request_and_caching
@@ -7929,43 +7929,43 @@ sources:
     snippet: A valid entity-tag can be distinguished from a valid HTTP-date by examining the first three characters for a DQUOTE.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 184
+      line: 218
   - label: range_request_and_caching (2)
     section: § 13.1.5
     snippet: Note that the If-Range comparison is by exact match, including when the validator is an HTTP-date, and so it differs from the "earlier than or equal to" comparison used when evaluating an If-Unmodified-Since conditional.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 201
+      line: 235
   - label: range_request_and_caching (3)
     section: § 13.1.5
     snippet: Range header field containing an HTTP-date unless the client has no entity tag for the corresponding representation and the date is a strong validator in the sense defined by Section 8.8.2.2.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 195
+      line: 229
   - label: range_request_and_caching (4)
     section: § 15.3.7.3
     snippet: A client that has received multiple partial responses to GET requests on a target resource MAY combine those responses into a larger continuous range if they share the same strong validator.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 95
+      line: 129
   - label: range_request_and_caching (5)
     section: § 15.3.7.3
     snippet: These ranges can only be safely combined if they all have in common the same strong validator (Section 8.8.1).
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 136
+      line: 170
   - label: redirect_chain_valid
     section: § 10.2.2
     snippet: If the Location value provided in a 3xx (Redirection) response does not have a fragment component, a user agent MUST process the redirection as if the value inherits the fragment component of the URI reference used to generate the target URI (i.e., the redirection inherits the original reference's fragment, if any).
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 173
+      line: 213
   - label: redirect_chain_valid (2)
     section: § 10.2.2
     snippet: When it has the form of a relative reference ([URI], Section 4.2), the final value is computed by resolving it against the target URI ([URI], Section 5).
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 164
+      line: 204
   - label: redirect_chain_valid (3)
     section: § 15
     snippet: However, a client MUST understand the class of any status code, as indicated by the first digit, and treat an unrecognized status code as being equivalent to the x00 status code of that class.
@@ -7975,13 +7975,13 @@ sources:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 44
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 68
+      line: 102
   - label: redirect_chain_valid (4)
     section: § 15.4
     snippet: A client SHOULD detect and intervene in cyclical redirections (i.e., "infinite" redirection loops).
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 239
+      line: 279
   - label: redirect_chain_valid (5)
     section: § 15.4.1
     snippet: the target resource has more than one representation, each with its own more specific identifier
@@ -8043,7 +8043,7 @@ sources:
     snippet: The type of relationship is defined by the combination of request method and status code semantics.
     cited_by:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
-      line: 84
+      line: 112
   - label: redirect_status_and_location_valid (2)
     section: § 15
     snippet: A client that receives a response with an invalid status code SHOULD process the response as if it had a 5xx (Server Error) status code.
@@ -8051,79 +8051,79 @@ sources:
     - file: lint-http-rules/src/rules/redirect_status_and_location_valid.rs
       line: 53
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 80
+      line: 114
   - label: referer_uri_valid
     section: § 10.1.3
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 193
+      line: 263
   - label: referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 322
+      line: 392
   - label: referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 142
+      line: 212
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 87
+      line: 157
   - label: referer_uri_valid (4)
     section: § 17.9
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 327
+      line: 397
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 140
+      line: 210
   - label: referer_uri_valid (5)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 268
+      line: 338
   - label: referer_uri_valid (6)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 325
+      line: 395
   - label: referer_uri_valid (7)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 324
+      line: 394
   - label: referer_uri_valid (8)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 269
+      line: 339
   - label: referer_uri_valid (9)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 326
+      line: 396
   - label: referer_uri_valid (10)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 323
+      line: 393
   - label: request_method_token_valid
     section: § 9.1
     snippet: All such methods ought to be registered within the "Hypertext Transfer Protocol (HTTP) Method Registry", as described in Section 16.1.
@@ -8135,13 +8135,13 @@ sources:
     snippet: An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 203
+      line: 250
   - label: request_method_token_valid (3)
     section: § 9.1
     snippet: By convention, standardized methods are defined in all-uppercase US-ASCII letters.
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 196
+      line: 243
   - label: absolute-path
     section: § 4.1
     snippet: absolute-path = 1*( "/" segment )
@@ -8153,69 +8153,69 @@ sources:
     snippet: For CONNECT (Section 9.3.6), the request target is the host name and port number of the tunnel destination, separated by a colon.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 236
+      line: 270
   - label: request_target_form_valid (2)
     section: § 7.1
     snippet: For historical reasons, the parsed target URI components, collectively referred to as the "request target", are sent within the message control data and the Host header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 159
+      line: 193
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 40
+      line: 99
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 43
+      line: 89
   - label: request_target_form_valid (3)
     section: § 7.1
     snippet: There are two unusual cases for which the request target components are in a method-specific form
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 228
+      line: 262
   - label: request_target_form_valid (4)
     section: § 7.1
     snippet: This reconstruction is specific to each major protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 160
+      line: 194
   - label: request_target_no_fragment
     section: § 4.2.5
     snippet: Some protocol elements that refer to a URI allow inclusion of a fragment, while others do not.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 92
+      line: 151
   - label: request_target_no_fragment (2)
     section: § 4.2.5
     snippet: They are distinguished by use of the ABNF rule for elements where fragment is allowed; otherwise, a specific rule that excludes fragments is used.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 93
+      line: 152
   - label: request_target_no_fragment (3)
     section: § 7.1
     snippet: The target URI excludes the reference's fragment component, if any, since fragment identifiers are reserved for client-side processing
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 113
+      line: 172
   - label: request_target_no_fragment (4)
     section: § 7.1
     snippet: To perform an action on a "target resource", the client sends a request message containing enough components of its parsed target URI to enable recipients to identify that same resource.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 21
+      line: 80
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 21
+      line: 67
   - label: request_uri_percent_encoding_valid
     section: § 4.1
     snippet: The definitions of "URI-reference", "absolute-URI", "relative-part", "authority", "port", "host", "path-abempty", "segment", and "query" are adopted from the URI generic syntax.
     cited_by:
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 52
+      line: 98
   - label: request_version_method_valid
     section: § 9.3.1
     snippet: A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 58
+      line: 98
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 84
+      line: 124
   - label: request_version_method_valid (2)
     section: § 9.3.1
     snippet: Although request message framing is independent of the method used, content received in a GET request has no generally defined semantics, cannot alter the meaning or target of the request
@@ -8227,25 +8227,25 @@ sources:
     snippet: An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 111
+      line: 151
   - label: request_version_method_valid (4)
     section: § 9.3.2
     snippet: A client SHOULD NOT generate content in a HEAD request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 86
+      line: 126
   - label: request_version_method_valid (5)
     section: § 9.3.5
     snippet: A client SHOULD NOT generate content in a DELETE request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 88
+      line: 128
   - label: request_version_method_valid (6)
     section: § 9.3.6
     snippet: A CONNECT request message does not have content.
     cited_by:
     - file: lint-http-rules/src/rules/request_version_method_valid.rs
-      line: 94
+      line: 134
   - label: request_version_method_valid (7)
     section: § 9.3.6
     snippet: The interpretation of data sent after the header section of the CONNECT request message is specific to the version of HTTP in use.
@@ -8257,19 +8257,19 @@ sources:
     snippet: As a result, a sender MUST NOT forward a message with a Content-Length header field value that is known to be incorrect.
     cited_by:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 138
+      line: 166
   - label: retry_after_date_or_delay
     section: § 10.2.3
     snippet: A delay-seconds value is a non-negative decimal integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 58
+      line: 68
   - label: retry_after_date_or_delay (2)
     section: § 10.2.3
     snippet: Retry-After = HTTP-date / delay-seconds
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 42
+      line: 52
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 43
   - label: retry_after_status_valid
@@ -8301,39 +8301,39 @@ sources:
     snippet: newly defined fields SHOULD limit their values to visible US-ASCII octets (VCHAR), SP, and HTAB
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 53
+      line: 63
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
-      line: 50
+      line: 60
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 50
+      line: 60
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 50
+      line: 60
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 46
+      line: 68
     - file: lint-http-rules/src/rules/x_frame_options_value_valid.rs
-      line: 51
+      line: 67
     - file: lint-http-rules/src/rules/x_xss_protection_value_valid.rs
-      line: 50
+      line: 66
   - label: server_header_product_valid
     section: § 10.2.4
     snippet: An origin server MAY generate a Server header field in its responses.
     cited_by:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 19
+      line: 41
   - label: server_header_product_valid (2)
     section: § 5.3
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers)
     cited_by:
     - file: lint-http-rules/src/rules/server_header_product_valid.rs
-      line: 47
+      line: 69
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 67
+      line: 83
   - label: hash rule expansion
     section: § 5.6.1
     snippet: '#element => [ 1#element ]'
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 333
+      line: 347
   - label: singleton_fields_not_repeated
     section: § 10.1.5
     snippet: User-Agent = product *( RWS ( product / comment ) )
@@ -8369,7 +8369,7 @@ sources:
     snippet: 'such as an ABNF rule of #(values) defined in Section 5.6.1'
     cited_by:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
-      line: 248
+      line: 251
   - label: singleton_fields_not_repeated (6)
     section: § 6.6.1
     snippet: The "Date" header field represents the date and time at which the message was originated, having the same semantics as the Origination Date Field (orig-date) defined in Section 3.6.1 of [RFC5322].
@@ -8381,61 +8381,61 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field (Section 7.8), for a change in the application protocol being used on this connection.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 50
+      line: 78
   - label: status_101_switching_protocols (2)
     section: § 15.2.2
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 137
+      line: 165
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 180
+      line: 208
   - label: status_101_switching_protocols (3)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 123
+      line: 151
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 166
+      line: 194
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 195
+      line: 223
   - label: status_101_switching_protocols (4)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 75
+      line: 103
   - label: status_101_switching_protocols (5)
     section: § 7.8
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 155
+      line: 183
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 104
+      line: 132
   - label: status_103_early_hints_before_final (2)
     section: § 15.2
     snippet: The 1xx (Informational) class of status code indicates an interim response for communicating connection status or request progress prior to completing the requested action and sending a final response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 126
+      line: 154
   - label: status_200_vs_204_body_consistent
     section: § 15.3.1
     snippet: Aside from responses to CONNECT, a 200 response is expected to contain message content unless the message framing explicitly indicates that the content has zero length.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 63
+      line: 109
   - label: status_200_vs_204_body_consistent (2)
     section: § 15.3.1
     snippet: For CONNECT, there is no content because the successful result is a tunnel, which begins immediately after the 200 response header section.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 91
+      line: 137
   - label: status_200_vs_204_body_consistent (3)
     section: § 15.3.1
     snippet: If some aspect of the request indicates a preference for no content upon success, the origin server ought to send a 204 (No Content) response instead.
@@ -8447,7 +8447,7 @@ sources:
     snippet: The 200 (OK) status code indicates that the request has succeeded.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 62
+      line: 108
   - label: status_200_vs_204_body_consistent (5)
     section: § 15.3.5
     snippet: The 204 (No Content) status code indicates that the server has successfully fulfilled the request and that there is no additional content to send in the response content.
@@ -8459,13 +8459,13 @@ sources:
     snippet: 2xx (Successful) responses to a CONNECT request method (Section 9.3.6) switch the connection to tunnel mode instead of having content.
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 92
+      line: 138
   - label: status_200_vs_204_body_consistent (7)
     section: § 6.4.1
     snippet: Responses to the HEAD request method (Section 9.3.2) never include content; the associated response header fields indicate only what their values would have been if the request method had been GET (Section 9.3.1).
     cited_by:
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 76
+      line: 122
   - label: status_3xx_vs_request_method
     section: § 15.4
     snippet: 307 | (Temporary Redirect) and 308 (Permanent Redirect) [RFC7538] | were later added to unambiguously indicate method-preserving | redirects, and status codes 301 and 302 have been adjusted to | allow a POST request to be redirected as GET.
@@ -8489,77 +8489,77 @@ sources:
     snippet: If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field.
     cited_by:
     - file: lint-http-rules/src/rules/status_3xx_vs_request_method.rs
-      line: 103
+      line: 149
   - label: status_405_allow_valid
     section: § 10.2.1
     snippet: The actual set of allowed methods is defined by the origin server at the time of each request.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 156
+      line: 202
   - label: status_405_allow_valid (2)
     section: § 15.5.6
     snippet: The 405 (Method Not Allowed) status code indicates that the method received in the request-line is known by the origin server but not supported by the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 154
+      line: 200
   - label: status_405_allow_valid (3)
     section: § 15.5.6
     snippet: The origin server MUST generate an Allow header field in a 405 response containing a list of the target resource's currently supported methods.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 118
+      line: 164
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 153
+      line: 199
   - label: status_405_allow_valid (4)
     section: § 9.1
     snippet: However, the set of allowed methods can change dynamically.
     cited_by:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
-      line: 157
+      line: 203
   - label: status_426_upgrade_valid
     section: § 15.5.22
     snippet: The 426 (Upgrade Required) status code indicates that the server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 127
+      line: 182
   - label: status_426_upgrade_valid (2)
     section: § 15.5.22
     snippet: The server MUST send an Upgrade header field in a 426 response to indicate the required protocol(s) (Section 7.8).
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 20
+      line: 75
   - label: status_426_upgrade_valid (3)
     section: § 7.8
     snippet: A server MAY send an Upgrade header field in any other response to advertise that it implements support for upgrading to the listed protocols, in order of descending preference, when appropriate for a future request.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 40
+      line: 95
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
-      line: 183
+      line: 239
   - label: status_426_upgrade_valid (4)
     section: § 7.8
     snippet: A server that sends a 426 (Upgrade Required) response MUST send an Upgrade header field to indicate the acceptable protocols, in order of descending preference.
     cited_by:
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 126
+      line: 181
   - label: status_and_caching_semantics
     section: § 15.1
     snippet: Responses with status codes that are defined as heuristically cacheable (e.g., 200, 203, 204, 206, 300, 301, 308, 404, 405, 410, 414, and 501 in this specification) can be reused by a cache with heuristic expiration unless otherwise indicated by the method definition or explicit cache controls
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 38
+      line: 54
   - label: status_code_semantics
     section: § 11.6.1
     snippet: A proxy forwarding a response MUST NOT modify any WWW-Authenticate header fields in that response.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 81
+      line: 121
   - label: status_code_semantics (2)
     section: § 11.6.1
     snippet: A server MAY generate a WWW-Authenticate header field in other response messages to indicate that supplying credentials (or different credentials) might affect the response.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 118
+      line: 158
   - label: status_code_semantics (3)
     section: § 11.6.1
     snippet: Furthermore, the header field itself can occur multiple times.
@@ -8571,17 +8571,17 @@ sources:
     snippet: The "WWW-Authenticate" response header field indicates the authentication scheme(s) and parameters applicable to the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 67
+      line: 107
     - file: lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
-      line: 36
+      line: 52
   - label: status_code_semantics (5)
     section: § 11.7.1
     snippet: A proxy MUST send at least one Proxy-Authenticate header field in each 407 (Proxy Authentication Required) response that it generates.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 69
+      line: 109
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 129
+      line: 169
   - label: status_code_semantics (6)
     section: § 11.7.1
     snippet: Note that the parsing considerations for WWW-Authenticate apply to this header field as well; see Section 11.6.1 for details.
@@ -8593,71 +8593,71 @@ sources:
     snippet: The "Proxy-Authenticate" header field consists of at least one challenge that indicates the authentication scheme(s) and parameters applicable to the proxy for this request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 68
+      line: 108
   - label: status_code_semantics (8)
     section: § 15.5.2
     snippet: The server generating a 401 response MUST send a WWW-Authenticate header field (Section 11.6.1) containing at least one challenge applicable to the target resource.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 82
+      line: 122
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 103
+      line: 143
   - label: status_code_semantics (9)
     section: § 15.5.8
     snippet: The 407 (Proxy Authentication Required) status code is similar to 401 (Unauthorized), but it indicates that the client needs to authenticate itself in order to use a proxy for this request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 120
+      line: 160
   - label: status_code_semantics (10)
     section: § 15.5.8
     snippet: The proxy MUST send a Proxy-Authenticate header field (Section 11.7.1) containing a challenge applicable to that proxy for the request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 128
+      line: 168
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 141
+      line: 181
   - label: status_code_semantics (11)
     section: § A
     snippet: Proxy-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 140
+      line: 180
   - label: status_code_semantics (12)
     section: § A
     snippet: WWW-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
     cited_by:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
-      line: 102
+      line: 142
   - label: status_code_valid_range
     section: § 15
     snippet: All valid status codes are within the range of 100 to 599, inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 58
+      line: 92
   - label: status_code_valid_range (2)
     section: § 15
     snippet: Implementations often use three-digit integer values outside of that range (i.e., 600..999) for internal communication of non-HTTP status (e.g., library errors).
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 92
+      line: 126
   - label: status_code_valid_range (3)
     section: § 15
     snippet: Values outside the range 100..599 are invalid.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 59
+      line: 93
   - label: status_code_valid_range (4)
     section: § 15.1
     snippet: All such status codes ought to be registered within the "Hypertext Transfer Protocol (HTTP) Status Code Registry", as described in Section 16.2.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 69
+      line: 103
   - label: status_code_valid_range (5)
     section: § 16.2.2
     snippet: New status codes are required to fall under one of the categories defined in Section 15.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 60
+      line: 94
   - label: te_header_valid
     section: § 10.1.4
     snippet: A sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1) to inform intermediaries not to forward this field.
@@ -8671,7 +8671,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 26
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 341
+      line: 388
   - label: te_header_valid (3)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.  A sender MUST NOT generate BWS in messages.  A recipient MUST parse for such bad whitespace and remove it before interpreting the protocol element.
@@ -8697,7 +8697,7 @@ sources:
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements: enough to handle common mistakes by senders that merge values, but not so much that they could be used as a denial-of-service mechanism'
     cited_by:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 86
+      line: 108
   - label: trace_method_echo
     section: § 11.6.2
     snippet: Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested.
@@ -8715,15 +8715,15 @@ sources:
     snippet: A client MUST NOT generate fields in a TRACE request containing sensitive data that might be disclosed by the response.
     cited_by:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 105
+      line: 147
   - label: trace_method_echo (4)
     section: § 9.3.8
     snippet: A client MUST NOT send content in a TRACE request.
     cited_by:
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 61
+      line: 103
     - file: lint-http-rules/src/rules/trace_method_echo.rs
-      line: 93
+      line: 135
   - label: trace_method_echo (5)
     section: § 9.3.8
     snippet: For example, it would be foolish for a user agent to send stored user credentials (Section 11) or cookies [COOKIE] in a TRACE request.
@@ -8741,7 +8741,7 @@ sources:
     snippet: A sender that intends to generate one or more trailer fields in a message SHOULD generate a Trailer header field in the header section of that message to indicate which fields might be present in the trailers.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 261
+      line: 272
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 90
   - label: trailer_fields_valid (3)
@@ -8749,7 +8749,7 @@ sources:
     snippet: When a field aside from Connection is used to supply control information for or about the current connection, the sender MUST list the corresponding field name within the Connection header field.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
-      line: 241
+      line: 252
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
       line: 42
   - label: trailer_header_valid
@@ -8763,7 +8763,7 @@ sources:
     snippet: Fields that describe the message itself, such as when and how the message has been generated, can appear in both requests and responses.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 136
+      line: 182
   - label: Trailer grammar
     section: § A
     snippet: Trailer = [ field-name *( OWS "," OWS field-name ) ]
@@ -8775,7 +8775,7 @@ sources:
     snippet: 'TE                 = #t-codings t-codings          = "trailers" / ( transfer-coding [ weight ] ) transfer-coding    = token *( OWS ";" OWS transfer-parameter ) transfer-parameter = token BWS "=" BWS ( token / quoted-string )'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 232
+      line: 279
   - label: upgrade_and_connection_consistent
     section: § 7.6.1
     snippet: In contrast, a connection-specific field received without a corresponding connection option usually indicates that the field has been improperly forwarded by an intermediary and ought to be ignored by the recipient.
@@ -8809,13 +8809,13 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 136
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 243
+      line: 254
   - label: upgrade_header_syntax (3)
     section: § 7.8
     snippet: A client MAY send a list of protocol names in the Upgrade header field of a request to invite the server to switch to one or more of the named protocols, in order of descending preference, before sending the final response.
     cited_by:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
-      line: 182
+      line: 238
   - label: protocol grammar
     section: § 7.8
     snippet: protocol = protocol-name ["/" protocol-version] protocol-name = token protocol-version = token
@@ -8827,143 +8827,143 @@ sources:
     snippet: A user agent SHOULD send a User-Agent header field in each request unless specifically configured not to do so.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 42
+      line: 64
   - label: user_agent_present (2)
     section: § 3.5
     snippet: The term "user agent" refers to any of the various client programs that initiate a request.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_present.rs
-      line: 23
+      line: 45
   - label: user_agent_token_valid
     section: § 10.1.5
     snippet: A sender SHOULD NOT generate information in product-version that is not a version identifier
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 51
+      line: 67
   - label: user_agent_token_valid (2)
     section: § 10.1.5
     snippet: A sender SHOULD limit generated product identifiers to what is necessary to identify the product; a sender MUST NOT generate advertising or other nonessential information within the product identifier.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 50
+      line: 66
   - label: user_agent_token_valid (3)
     section: § 10.1.5
     snippet: A user agent SHOULD NOT generate a User-Agent header field containing needlessly fine-grained detail and SHOULD limit the addition of subproducts by third parties.
     cited_by:
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
-      line: 52
+      line: 68
   - label: vary_header_valid
     section: § 12.5.5
     snippet: The "Vary" header field in a response describes what parts of a request message, aside from the method and target URI, might have influenced the origin server's process for selecting the content of this response.
     cited_by:
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 34
+      line: 44
   - label: via_header_syntax
     section: § 4.1
     snippet: port = <port, see [URI], Section 3.2.3>
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 387
+      line: 398
   - label: via_header_syntax (2)
     section: § 5.6.3
     snippet: OWS = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 195
+      line: 206
   - label: via_header_syntax (3)
     section: § 7.6.3
     snippet: A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 35
+      line: 90
   - label: via_header_syntax (4)
     section: § 7.6.3
     snippet: A sender MAY generate comments to identify the software of each recipient, analogous to the User-Agent and Server header fields.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 415
+      line: 426
   - label: via_header_syntax (5)
     section: § 7.6.3
     snippet: An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message and MAY send a Via header field in forwarded response messages.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 40
+      line: 95
   - label: via_header_syntax (6)
     section: § 7.6.3
     snippet: For brevity, the protocol-name is omitted when the received protocol is HTTP.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 307
+      line: 318
   - label: via_header_syntax (7)
     section: § 7.6.3
     snippet: However, comments in Via are optional, and a recipient MAY remove them prior to forwarding the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 416
+      line: 427
   - label: via_header_syntax (8)
     section: § 7.6.3
     snippet: However, if the real host is considered to be sensitive information, a sender MAY replace it with a pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 365
+      line: 376
   - label: via_header_syntax (9)
     section: § 7.6.3
     snippet: The "Via" header field indicates the presence of intermediate protocols and recipients between the user agent and the server (on requests) or between the origin server and the client (on responses)
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 21
+      line: 76
   - label: via_header_syntax (10)
     section: § 7.6.3
     snippet: The received-by portion is normally the host and optional port number of a recipient server or client that subsequently forwarded the message.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 364
+      line: 375
   - label: via_header_syntax (11)
     section: § 7.6.3
     snippet: 'Via = #( received-protocol RWS received-by [ RWS comment ] )'
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 242
+      line: 253
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 298
+      line: 309
   - label: via_header_syntax (12)
     section: § 7.6.3
     snippet: received-by = pseudonym [ ":" port ] pseudonym = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 362
+      line: 373
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 481
+      line: 494
   - label: via_header_syntax (13)
     section: § 7.6.3
     snippet: received-protocol = [ protocol-name "/" ] protocol-version
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 304
+      line: 315
   - label: via_header_syntax (14)
     section: § 7.8
     snippet: protocol-name = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 305
+      line: 316
   - label: via_header_syntax (15)
     section: § 7.8
     snippet: protocol-version = token
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 306
+      line: 317
   - label: via_header_syntax (16)
     section: § B.2
     snippet: For simplicity, we have removed uri-host from the received-by production because it can be encompassed by the existing grammar for pseudonym.
     cited_by:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 363
+      line: 374
   - label: warning_header_syntax
     section: § 5.6.7
     snippet: Prior to 1995, there were three different formats commonly used by servers to communicate timestamps.
     cited_by:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 544
+      line: 557
 - label: RFC 9111
   url: https://www.rfc-editor.org/rfc/rfc9111.txt
   type: text/plain
@@ -8973,17 +8973,17 @@ sources:
     snippet: If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648 (2^31) or the greatest positive integer it can conveniently represent.
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 59
+      line: 69
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 301
+      line: 305
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 167
+      line: 172
   - label: age_header_numeric (2)
     section: § 5.1
     snippet: Although it is defined as a singleton header field, a cache encountering a message with a list-based Age field value SHOULD use the first member of the field value, discarding subsequent ones.
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 38
+      line: 48
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 45
   - label: age_header_numeric (3)
@@ -8991,33 +8991,33 @@ sources:
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 17
+      line: 27
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 75
+      line: 91
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 79
+      line: 95
   - label: age_header_numeric (4)
     section: § 5.1
     snippet: The Age field value is a non-negative integer, representing time in seconds
     cited_by:
     - file: lint-http-rules/src/rules/age_header_numeric.rs
-      line: 58
+      line: 68
   - label: alt_svc_h3_advertisement_valid
     section: § 1.2.2
     snippet: The delta-seconds rule specifies a non-negative integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 290
+      line: 294
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 152
+      line: 157
   - label: delta-seconds
     section: § 1.2.2
     snippet: delta-seconds  = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 289
+      line: 293
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 597
+      line: 611
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 51
   - label: cache_coherence
@@ -9025,157 +9025,157 @@ sources:
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server
     cited_by:
     - file: lint-http-rules/src/rules/cache_coherence.rs
-      line: 108
+      line: 136
   - label: cache_control_and_pragma_consistent
     section: § 5.4
     snippet: However, support for Cache-Control is now widespread.  As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
-      line: 69
+      line: 79
   - label: cache_control_and_pragma_consistent (2)
     section: § 5.4
     snippet: The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
-      line: 32
+      line: 42
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 39
+      line: 49
   - label: cache_control_directive_valid
     section: § 5.2
     snippet: The "Cache-Control" header field is used to list directives for caches along the request/response chain.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 29
+      line: 39
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 29
+      line: 39
   - label: cache_control_directive_valid (2)
     section: § 5.2
     snippet: cache-directive = token [ "=" ( token / quoted-string ) ]
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 122
+      line: 127
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 124
+      line: 129
   - label: cache_control_directive_valid (3)
     section: § 5.2.2.7
     snippet: If a qualified private response directive is present, with an argument that lists one or more field names
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 174
+      line: 179
   - label: cache_control_present
     section: § 4.2.2
     snippet: Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_present.rs
-      line: 36
+      line: 52
   - label: cache_validation_chain
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 135
+      line: 157
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 169
+      line: 191
   - label: cache_validation_chain (2)
     section: § 4.3.1
     snippet: MUST send the relevant entity tags (using If-Match, If-None-Match, or If-Range) if the entity tags were provided in the stored response(s) being validated.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 94
+      line: 116
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 157
+      line: 191
   - label: cache_validation_chain (3)
     section: § 4.3.1
     snippet: SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 100
+      line: 122
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 130
+      line: 164
   - label: caching_directive_interaction
     section: § 4.2.1
     snippet: 'When there is more than one value present for a given directive (e.g., two Expires header field lines or multiple Cache-Control: max-age directives), either the first occurrence should be used or the response should be considered stale.'
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 123
+      line: 145
   - label: caching_directive_interaction (2)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 113
+      line: 135
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 155
+      line: 171
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 181
+      line: 197
   - label: caching_directive_interaction (3)
     section: § 5.2.2.7
     snippet: The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user).
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 98
+      line: 120
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 89
+      line: 99
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 124
+      line: 134
   - label: caching_directive_interaction (4)
     section: § 5.2.2.9
     snippet: The public response directive indicates that a cache MAY store the response even if it would otherwise be prohibited, subject to the constraints defined in Section 3.
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 97
+      line: 119
   - label: expires_and_cache_control_consistent
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 144
+      line: 160
   - label: expires_and_cache_control_consistent (2)
     section: § 5.3
     snippet: A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired").
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 108
+      line: 124
   - label: expires_and_cache_control_consistent (3)
     section: § 5.3
     snippet: If a response includes a Cache-Control header field with the max-age directive (Section 5.2.2.1), a recipient MUST ignore the Expires header field.
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 143
+      line: 159
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 157
+      line: 173
   - label: expires_and_cache_control_consistent (4)
     section: § 5.3
     snippet: The Expires field value is an HTTP-date timestamp, as defined in Section 5.6.7 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 40
+      line: 56
   - label: immutable_cache_never_stale
     section: § 5.2
     snippet: Cache directives are identified by a token, to be compared case-insensitively
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 195
+      line: 198
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 204
+      line: 207
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 159
+      line: 162
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 262
+      line: 265
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 56
+      line: 66
   - label: immutable_cache_never_stale (2)
     section: § 5.2.2.4
     snippet: the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 182
+      line: 185
   - label: immutable_cache_never_stale (3)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 181
+      line: 184
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 4.1
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
@@ -9183,9 +9183,9 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1116
     - file: lint-http-rules/src/rules/vary_and_cache_consistent.rs
-      line: 47
+      line: 63
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 176
+      line: 186
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or * If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
@@ -9203,107 +9203,107 @@ sources:
     snippet: A "fresh" response is one whose age has not yet exceeded its freshness lifetime
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 110
+      line: 126
   - label: max_age_directive_valid (2)
     section: § 4.2
     snippet: When a response is fresh, it can be used to satisfy subsequent requests without contacting the origin server, thereby improving efficiency
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 118
+      line: 134
   - label: max_age_directive_valid (3)
     section: § 4.3
     snippet: it can use the conditional request mechanism
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 134
+      line: 150
   - label: max_age_directive_valid (4)
     section: § 5.2.2.1
     snippet: The max-age response directive indicates that the response is to be considered stale after its age is greater than the specified number of seconds.
     cited_by:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
-      line: 109
+      line: 125
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 56
+      line: 72
   - label: must_revalidate_enforced
     section: § 4.2
     snippet: A "fresh" response is one whose age has not yet exceeded its freshness lifetime. Conversely, a "stale" response is one where it has.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 109
+      line: 137
   - label: must_revalidate_enforced (2)
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 101
+      line: 129
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 83
+      line: 99
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 41
+      line: 51
     - file: lint-http-rules/src/rules/s_max_age_enforced.rs
-      line: 92
+      line: 102
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 59
+      line: 69
   - label: must_revalidate_enforced (3)
     section: § 5.2.2.2
     snippet: The must-revalidate response directive indicates that once the response has become stale, a cache MUST NOT reuse that response to satisfy another request until it has been successfully validated by the origin, as defined by Section 4.3.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 115
+      line: 143
   - label: no_cache_revalidation
     section: § 5.2.2.4
     snippet: The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 87
+      line: 103
   - label: no_cache_revalidation (2)
     section: § 5.2.2.4
     snippet: The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request
     cited_by:
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 156
+      line: 159
   - label: pragma_token_valid
     section: § 5.4
     snippet: As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 64
+      line: 74
   - label: range_request_and_caching
     section: § 3.3
     snippet: A cache MAY complete a stored incomplete response by making a subsequent range request (Section 14.2 of [HTTP]) and combining the successful response with the stored response, as defined in Section 3.4.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 94
+      line: 128
   - label: range_request_and_caching (2)
     section: § 3.4
     snippet: A cache MAY combine these ranges into a single stored response, and reuse that response to satisfy later requests, if they all share the same strong validator
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 137
+      line: 171
   - label: range_request_and_caching (3)
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields.  These contain validator metadata sourced from a stored response(s) that has the same URI.
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 110
+      line: 144
   - label: range_request_and_caching (4)
     section: § 4.3.1
     snippet: MAY send the Last-Modified value (using If-Unmodified-Since or If-Range) if the request is for a subrange, a single stored response is being validated, and that response contains only a Last-Modified value (not an entity tag).
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 131
+      line: 165
   - label: range_request_and_caching (5)
     section: § 4.3.1
     snippet: Typically, this will include only the stored response(s) that has the same cache key, although a cache is allowed to validate a response that it cannot choose with the request header fields it is sending
     cited_by:
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
-      line: 111
+      line: 145
   - label: s_max_age_enforced
     section: § 5.2.2.10
     snippet: The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires header field.
     cited_by:
     - file: lint-http-rules/src/rules/s_max_age_enforced.rs
-      line: 101
+      line: 111
   - label: singleton_fields_not_repeated
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server.
@@ -9317,25 +9317,25 @@ sources:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 46
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 77
+      line: 93
   - label: status_and_caching_semantics
     section: § 3
     snippet: A cache MUST NOT store a response to a request unless
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 88
+      line: 104
   - label: status_and_caching_semantics (2)
     section: § 5.2.2.10
     snippet: The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 57
+      line: 73
   - label: vary_header_cache_valid
     section: § 4.1
     snippet: the cache MUST NOT use that stored response without revalidation unless all the presented request header fields nominated by that Vary field value match those fields in the original request
     cited_by:
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
-      line: 197
+      line: 207
 - label: RFC 9112
   url: https://www.rfc-editor.org/rfc/rfc9112.txt
   type: text/plain
@@ -9345,149 +9345,149 @@ sources:
     snippet: If any transfer coding other than chunked is applied to a request's content, the sender MUST apply chunked as the final transfer coding to ensure that the message is properly framed.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 21
+      line: 61
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 174
+      line: 202
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 119
+      line: 159
   - label: compression_and_transfer_encoding_consistent (3)
     section: § 7
     snippet: All transfer-coding names are case-insensitive and ought to be registered within the HTTP Transfer Coding registry, as defined in Section 7.3.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 98
+      line: 138
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 39
+      line: 86
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 179
+      line: 226
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 266
+      line: 313
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 75
+      line: 103
   - label: compression_and_transfer_encoding_consistent (4)
     section: § 7.2
     snippet: 'The following transfer coding names for compression are defined by the same algorithm as their corresponding content coding:'
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 129
+      line: 169
   - label: compression_and_transfer_encoding_consistent (5)
     section: § 7.3
     snippet: Names of transfer codings MUST NOT overlap with names of content codings (Section 8.4.1 of [HTTP]) unless the encoding transformation is identical, as is the case for the compression codings defined in Section 7.2.
     cited_by:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
-      line: 128
+      line: 168
   - label: content_length_vs_transfer_encoding
     section: § 6.2
     snippet: A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 30
+      line: 46
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 78
+      line: 100
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 129
+      line: 157
   - label: content_length_vs_transfer_encoding (2)
     section: § 6.3
     snippet: An intermediary that chooses to forward the message MUST first remove the received Content-Length field and process the Transfer-Encoding
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 39
+      line: 55
   - label: content_length_vs_transfer_encoding (3)
     section: § 6.3
     snippet: If a message is received with both a Transfer-Encoding and a Content-Length header field, the Transfer-Encoding overrides the Content-Length.
     cited_by:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
-      line: 38
+      line: 54
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 184
+      line: 212
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 61
+      line: 83
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 124
+      line: 152
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 107
+      line: 153
   - label: content_transfer_encoding_valid
     section: § B.5
     snippet: HTTP does not use the Content-Transfer-Encoding field of MIME.
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 87
+      line: 109
   - label: content_transfer_encoding_valid (2)
     section: § B.5
     snippet: Proxies and gateways from MIME-compliant protocols to HTTP need to remove any Content-Transfer-Encoding prior to delivering the response message to an HTTP client.
     cited_by:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
-      line: 88
+      line: 110
   - label: content_type_present
     section: § 6.3
     snippet: Any 2xx (Successful) response to a CONNECT request implies that the connection will become a tunnel immediately after the empty line that concludes the header fields.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 59
+      line: 87
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 111
+      line: 139
   - label: content_type_present (2)
     section: § 6.3
     snippet: Any response to a HEAD request and any response with a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status code is always terminated by the first empty line after the header fields, regardless of the header fields present in the message, and thus cannot contain a message body or trailer section.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 35
+      line: 63
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 60
+      line: 124
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 53
+      line: 81
   - label: content_type_present (3)
     section: § 6.3
     snippet: Otherwise, this is a response message without a declared message body length, so the message body length is determined by the number of octets received prior to the server closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/content_type_present.rs
-      line: 81
+      line: 109
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 144
+      line: 172
   - label: head_response_headers_match_get
     section: § 6.1
     snippet: This indication is not required, however, because any recipient on the response chain (including the origin server) can remove transfer codings when they are not needed.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 219
+      line: 247
   - label: head_response_headers_match_get (2)
     section: § 6.1
     snippet: Transfer-Encoding MAY be sent in a response to a HEAD request or in a 304 (Not Modified) response (Section 15.4.5 of [HTTP]) to a GET request, neither of which includes a message body, to indicate that the origin server would have applied a transfer coding to the message body if the request had been an unconditional GET.
     cited_by:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
-      line: 218
+      line: 246
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 171
+      line: 235
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 213
+      line: 241
   - label: host_and_authority_consistent
     section: § 3.2.2
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 168
+      line: 233
   - label: host_header
     section: § 3.2
     snippet: A client MUST send a Host header field (Section 7.2 of [HTTP]) in all HTTP/1.1 request messages.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 61
+      line: 95
   - label: host_header (2)
     section: § 3.2
     snippet: If the authority component is missing or undefined for the target URI, then a client MUST send a Host header field with an empty field value.
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 112
+      line: 146
   - label: host_header (3)
     section: § 3.2
     snippet: If the target URI includes an authority component, then a client MUST send a field value for Host that is identical to that authority component, excluding any userinfo subcomponent and its "@" delimiter (Section 4.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 121
+      line: 155
   - label: authority-form
     section: § 3.2.3
     snippet: authority-form = uri-host ":" port
@@ -9501,33 +9501,33 @@ sources:
     snippet: Conformance criteria and considerations regarding error handling are defined in Section 2 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 151
+      line: 163
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 111
+      line: 170
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 101
+      line: 135
   - label: http_version_syntax (2)
     section: § 3
     snippet: A request-line begins with a method token, followed by a single space (SP), the request-target, and another single space (SP), and ends with the protocol version.
     cited_by:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 39
+      line: 91
   - label: http_version_syntax (3)
     section: § 4
     snippet: The first line of a response message is the status-line, consisting of the protocol version, a space (SP), the status code, and another space and ending with an OPTIONAL textual phrase describing the status code.
     cited_by:
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 40
+      line: 92
   - label: if_modified_since_date_syntax
     section: § 5
     snippet: field-line   = field-name ":" OWS field-value OWS
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 66
+      line: 76
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 65
+      line: 75
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
-      line: 49
+      line: 59
   - label: HTTP-version
     section: § 2.3
     snippet: HTTP-version  = HTTP-name "/" DIGIT "." DIGIT
@@ -9537,9 +9537,9 @@ sources:
     - file: lint-http-core/src/http_version.rs
       line: 103
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 162
+      line: 196
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 91
+      line: 150
   - label: lint-http-core/src/http_version.rs
     section: § 2.3
     snippet: HTTP-version is case-sensitive.
@@ -9555,9 +9555,9 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 63
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 142
+      line: 154
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 161
+      line: 195
   - label: HTTP-name
     section: § A
     snippet: HTTP-name = %x48.54.54.50 ; HTTP
@@ -9571,7 +9571,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 48
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 43
+      line: 65
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
@@ -9579,7 +9579,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 387
     - file: lint-http-rules/src/rules/host_header.rs
-      line: 77
+      line: 111
   - label: request-target forms
     section: § 3.2
     snippet: request-target = origin-form / absolute-form / authority-form / asterisk-form
@@ -9591,7 +9591,7 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 13
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
-      line: 139
+      line: 209
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 3.3
     snippet: If the request-target is in authority-form, the target URI's authority component is the request-target.  Otherwise, the target URI's authority component is the field value of the Host header field.
@@ -9611,117 +9611,117 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 384
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 87
+      line: 115
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 227
+      line: 267
   - label: no_body_for_1xx_204_304
     section: § 6.1
     snippet: A server MUST NOT send a Transfer-Encoding header field in any response with a status code of 1xx (Informational) or 204 (No Content).
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 170
+      line: 234
   - label: post_creates_resource
     section: § 3.3
     snippet: Otherwise, the target URI's combined path and query component is the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/post_creates_resource.rs
-      line: 88
+      line: 116
   - label: problem_details_structure_valid
     section: § 6.3
     snippet: If a valid Content-Length header field is present without Transfer-Encoding, its decimal value defines the expected message body length in octets.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 185
+      line: 213
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 56
+      line: 78
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 125
+      line: 153
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
-      line: 109
+      line: 155
   - label: proxy_connection_discouraged
     section: § C.2.2
     snippet: As a result, clients are encouraged not to send the Proxy-Connection header field in any requests.
     cited_by:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 28
+      line: 50
   - label: proxy_connection_discouraged (2)
     section: § C.2.2
     snippet: One attempted solution was the introduction of a Proxy-Connection header field, targeted specifically at proxies.  In practice, this was also unworkable, because proxies are often deployed in multiple layers, bringing about the same problem discussed above.
     cited_by:
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
-      line: 82
+      line: 104
   - label: redirect_chain_valid
     section: § 3.3
     snippet: Otherwise, if the request is received over a secured connection, the target URI's scheme is "https"; if not, the scheme is "http".
     cited_by:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
-      line: 228
+      line: 268
   - label: request_body_length_accuracy
     section: § 6.2
     snippet: For messages that do include content, the Content-Length field value provides the framing information necessary for determining where the data (and message) ends.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 89
+      line: 111
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 139
+      line: 167
   - label: request_body_length_accuracy (2)
     section: § 6.2
     snippet: When a message does not have a Transfer-Encoding header field, a Content-Length header field (Section 8.6 of [HTTP]) can provide the anticipated size, as a decimal number of octets, for potential content.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 77
+      line: 99
   - label: request_body_length_accuracy (3)
     section: § 6.3
     snippet: If a Transfer-Encoding header field is present and the chunked transfer coding (Section 7.1) is the final encoding, the message body length is determined by reading and decoding the chunked data until the transfer coding indicates the data is complete.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 62
+      line: 84
   - label: request_body_length_accuracy (4)
     section: § 6.3
     snippet: If the sender closes the connection or the recipient times out before the indicated number of octets are received, the recipient MUST consider the message to be incomplete and close the connection.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 90
+      line: 112
   - label: request_body_length_accuracy (5)
     section: § 6.3
     snippet: The length of a message body is determined by one of the following (in order of precedence)
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 48
+      line: 70
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 41
+      line: 69
   - label: request_target_form_valid
     section: § 3.2
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 197
+      line: 231
   - label: request_target_form_valid (2)
     section: § 3.2
     snippet: No whitespace is allowed in the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 195
+      line: 229
   - label: request_target_form_valid (3)
     section: § 3.2
     snippet: Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 214
+      line: 248
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 305
+      line: 339
   - label: request_target_form_valid (4)
     section: § 3.2
     snippet: Unfortunately, some user agents fail to properly encode or exclude whitespace found in hypertext references, resulting in those disallowed characters being sent as the request-target in a malformed request-line.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 196
+      line: 230
   - label: request_target_form_valid (5)
     section: § 3.2.1
     snippet: When making a request directly to an origin server, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send only the absolute path and query components of the target URI as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 296
+      line: 330
   - label: origin-form
     section: § 3.2.1
     snippet: origin-form    = absolute-path [ "?" query ]
@@ -9729,19 +9729,19 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 62
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 97
+      line: 156
   - label: request_target_form_valid (6)
     section: § 3.2.2
     snippet: A server MUST accept the absolute-form in requests even though most HTTP/1.1 clients will only send the absolute-form to a proxy.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 298
+      line: 332
   - label: request_target_form_valid (7)
     section: § 3.2.2
     snippet: When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below), a client MUST send the target URI in "absolute-form" as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 297
+      line: 331
   - label: absolute-form
     section: § 3.2.2
     snippet: absolute-form  = absolute-URI
@@ -9749,45 +9749,45 @@ sources:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 63
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 96
+      line: 155
   - label: request_target_form_valid (8)
     section: § 3.2.3
     snippet: It consists of only the uri-host and port number of the tunnel destination, separated by a colon (":").
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 237
+      line: 271
   - label: request_target_form_valid (9)
     section: § 3.2.3
     snippet: The "authority-form" of request-target is only used for CONNECT requests
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 269
+      line: 303
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 282
+      line: 316
   - label: request_target_form_valid (10)
     section: § 3.2.3
     snippet: The client obtains the host and port from the target URI's authority component, except that it sends the scheme's default port if the target URI elides the port.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 245
+      line: 279
   - label: request_target_form_valid (11)
     section: § 3.2.3
     snippet: When making a CONNECT request to establish a tunnel through one or more proxies, a client MUST send only the host and port of the tunnel destination as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 238
+      line: 272
   - label: request_target_form_valid (12)
     section: § 3.2.4
     snippet: The "asterisk-form" of request-target is only used for a server-wide OPTIONS request
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 259
+      line: 293
   - label: request_target_form_valid (13)
     section: § 3.2.4
     snippet: When a client wishes to request OPTIONS for the server as a whole, as opposed to a specific named resource of that server, the client MUST send only "*" (%x2A) as the request-target.
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 260
+      line: 294
   - label: asterisk-form
     section: § A
     snippet: asterisk-form = "*" authority = <authority, see [URI], Section 3.2>
@@ -9799,25 +9799,25 @@ sources:
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
     cited_by:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 112
+      line: 140
   - label: status_code_valid_range
     section: § 4
     snippet: A client SHOULD ignore the reason-phrase content because it is not a reliable channel for information
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 38
+      line: 72
   - label: status_code_valid_range (2)
     section: § 4
     snippet: The status-code element is a 3-digit integer code describing the result of the server's attempt to understand and satisfy the client's corresponding request.
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 100
+      line: 134
   - label: status_code_valid_range (3)
     section: § 4
     snippet: status-code    = 3DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/status_code_valid_range.rs
-      line: 81
+      line: 115
   - label: te_header_valid
     section: § 7.3
     snippet: The TE header field (Section 10.1.4 of [HTTP]) uses a pseudo-parameter named "q" as the rank value when multiple transfer codings are acceptable.
@@ -9831,7 +9831,7 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 42
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 340
+      line: 387
   - label: te_header_valid (3)
     section: § 7.4
     snippet: Since the TE header field only applies to the immediate connection, a sender of TE MUST also send a "TE" connection option within the Connection header field (Section 7.6.1 of [HTTP]) in order to prevent the TE header field from being forwarded by intermediaries that do not support its semantics.
@@ -9845,85 +9845,85 @@ sources:
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 260
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 233
+      line: 280
   - label: transfer_coding_registered
     section: § 6.1
     snippet: A server that receives a request message with a transfer coding it does not understand SHOULD respond with 501 (Not Implemented).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 254
+      line: 301
   - label: transfer_coding_registered (2)
     section: § 6.1
     snippet: 'Transfer-Encoding = #transfer-coding'
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 316
+      line: 363
   - label: transfer_coding_registered (3)
     section: § 7.1
     snippet: The chunked coding does not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 205
+      line: 252
   - label: transfer_coding_registered (4)
     section: § 7.1
     snippet: Their presence SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 206
+      line: 253
   - label: transfer_coding_registered (5)
     section: § 7.2
     snippet: The compression codings do not define any parameters.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 196
+      line: 243
   - label: transfer_coding_registered (6)
     section: § 7.2
     snippet: The presence of parameters with any of these compression codings SHOULD be treated as an error.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 197
+      line: 244
   - label: transfer_coding_registered (7)
     section: § 7.3
     snippet: The "HTTP Transfer Coding Registry" defines the namespace for transfer coding names.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 94
+      line: 141
   - label: transfer_coding_registered (8)
     section: § 7.4
     snippet: A client MUST NOT send the chunked transfer coding name in TE; chunked is always acceptable for HTTP/1.1 recipients.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 176
+      line: 223
   - label: transfer_coding_registered (9)
     section: § 7.4
     snippet: The keyword "trailers" indicates that the sender will not discard trailer fields, as described in Section 6.5 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
-      line: 131
+      line: 178
   - label: transfer_encoding_chunked_final
     section: § 6.1
     snippet: A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed).
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 114
+      line: 142
   - label: transfer_encoding_chunked_final (2)
     section: § 6.1
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 129
+      line: 157
   - label: transfer_encoding_chunked_final (3)
     section: § 9.6
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 149
+      line: 177
   - label: transfer_encoding_chunked_final (4)
     section: § 9.6
     snippet: The "close" connection option is defined as a signal that the sender will close this connection after completion of the response.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 84
+      line: 112
 - label: RFC 9113
   url: https://www.rfc-editor.org/rfc/rfc9113.txt
   type: text/plain
@@ -9933,119 +9933,119 @@ sources:
     snippet: HTTP/2 implementations SHOULD validate field names and values according to their definitions in Sections 5.1 and 5.5 of [HTTP], respectively, and treat messages that contain prohibited characters as malformed
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 134
+      line: 143
   - label: host_and_authority_consistent
     section: § 8.3.1
     snippet: A request in asterisk form (for OPTIONS) includes the value '*' for the ":path" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 205
+      line: 270
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 230
+      line: 294
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 163
+      line: 197
   - label: host_and_authority_consistent (2)
     section: § 8.3.1
     snippet: A server SHOULD treat a request as malformed if it contains a Host header field that identifies an entity that differs from the entity in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 324
+      line: 389
   - label: host_and_authority_consistent (3)
     section: § 8.3.1
     snippet: An origin server can apply any normalization method, whereas other servers MUST perform scheme-based normalization (see Section 6.2.3 of [RFC3986]) of the two fields.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 302
+      line: 367
   - label: host_and_authority_consistent (4)
     section: § 8.3.1
     snippet: Clients MUST NOT generate a request with a Host header field that differs from the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 142
+      line: 207
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 323
+      line: 388
   - label: host_and_authority_consistent (5)
     section: § 8.3.1
     snippet: The ":authority" pseudo-header field conveys the authority portion (Section 3.2 of [RFC3986]) of the target URI (Section 7.1 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 188
+      line: 253
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 262
+      line: 326
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 301
+      line: 366
   - label: http2_pseudo_headers_valid
     section: § 8.2.1
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 180
+      line: 244
   - label: http2_pseudo_headers_valid (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 168
+      line: 232
   - label: http2_pseudo_headers_valid (3)
     section: § 8.3.1
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 301
+      line: 365
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 267
+      line: 331
   - label: http2_pseudo_headers_valid (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 242
+      line: 306
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 163
+      line: 227
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 142
+      line: 189
   - label: http2_pseudo_headers_valid (7)
     section: § 8.3.1
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 261
+      line: 325
   - label: http2_pseudo_headers_valid (8)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 241
+      line: 305
   - label: http2_pseudo_headers_valid (9)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 346
+      line: 410
   - label: http2_pseudo_headers_valid (10)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 347
+      line: 411
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 206
+      line: 270
   - label: http2_pseudo_headers_valid (12)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
@@ -10059,13 +10059,13 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 20
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 205
+      line: 269
   - label: http2_pseudo_headers_valid (14)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 191
+      line: 255
   - label: lint-http-core/src/http_version.rs
     section: § 8.3.1
     snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"
@@ -10083,7 +10083,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 71
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 143
+      line: 155
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 8.3.2
     snippet: HTTP/2 responses implicitly have a protocol version of "2.0".
@@ -10105,13 +10105,13 @@ sources:
     snippet: An endpoint MUST NOT generate an HTTP/2 message containing connection-specific header fields.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 180
+      line: 244
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 150
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 268
+      line: 307
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 63
+      line: 118
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 154
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -10147,21 +10147,21 @@ sources:
     snippet: Note that request targets for CONNECT or asterisk-form OPTIONS requests never include authority information
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 164
+      line: 198
   - label: request_target_no_fragment
     section: § 8.3.1
     snippet: The ":path" pseudo-header field includes the path and query parts of the target URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 98
+      line: 157
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 44
+      line: 90
   - label: status_101_switching_protocols
     section: § 8.6
     snippet: HTTP/2 does not support the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 90
+      line: 118
 - label: RFC 9114
   url: https://www.rfc-editor.org/rfc/rfc9114.txt
   type: text/plain
@@ -10171,121 +10171,121 @@ sources:
     snippet: An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
-      line: 134
+      line: 163
   - label: extension_headers_registered
     section: § 4.2
     snippet: A request or response containing uppercase characters in field names MUST be treated as malformed
     cited_by:
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
-      line: 165
+      line: 174
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 120
+      line: 129
   - label: header_field_names_token_valid
     section: § 4.2
     snippet: Properties of HTTP field names and values are discussed in more detail in Section 5.1 of [HTTP]
     cited_by:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
-      line: 135
+      line: 144
   - label: host_and_authority_consistent
     section: § 4.3.1
     snippet: If both fields are present, they MUST contain the same value.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 303
+      line: 368
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 325
+      line: 390
   - label: host_and_authority_consistent (2)
     section: § 4.3.1
     snippet: If the :scheme pseudo-header field identifies a scheme that has a mandatory authority component (including "http" and "https"), the request MUST contain either an :authority pseudo-header field or a Host header field.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 219
+      line: 284
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 266
+      line: 331
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 131
+      line: 176
   - label: host_and_authority_consistent (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
     cited_by:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
-      line: 267
+      line: 332
   - label: http3_goaway_semantics
     section: § 5.2
     snippet: Endpoints MUST NOT initiate new requests or promise new pushes on the connection after receipt of a GOAWAY frame from the peer.
     cited_by:
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 101
+      line: 111
   - label: http3_goaway_semantics (2)
     section: § 5.2
     snippet: Receiving a GOAWAY containing a larger identifier than previously received MUST be treated as a connection error of type H3_ID_ERROR.
     cited_by:
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 66
+      line: 76
   - label: http3_goaway_semantics (3)
     section: § 5.2
     snippet: The server sends a client-initiated bidirectional stream ID; the client sends a push ID.
     cited_by:
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 59
+      line: 69
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 94
+      line: 104
   - label: http3_max_push_id
     section: § 7.2.7
     snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 62
+      line: 78
   - label: http3_max_push_id (2)
     section: § 7.2.7
     snippet: A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED.
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 47
+      line: 63
   - label: http3_max_push_id (3)
     section: § 7.2.7
     snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 92
+      line: 108
   - label: http3_pseudo_headers_valid
     section: § 4.3.1
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 40
+      line: 85
   - label: http3_pseudo_headers_valid (2)
     section: § 4.3.1
     snippet: The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 155
+      line: 200
   - label: http3_pseudo_headers_valid (3)
     section: § 4.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 116
+      line: 161
   - label: http3_pseudo_headers_valid (4)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 188
+      line: 233
   - label: http3_pseudo_headers_valid (5)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 189
+      line: 234
   - label: http3_pseudo_headers_valid (6)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 55
+      line: 100
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 91
+      line: 136
   - label: http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document
@@ -10297,41 +10297,41 @@ sources:
     snippet: A SETTINGS frame MUST be sent as the first frame of each control stream (see Section 6.2.1) by each peer, and it MUST NOT be sent subsequently
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 69
+      line: 91
   - label: http3_settings_frame (3)
     section: § 7.2.4
     snippet: An implementation MUST ignore any parameter with an identifier it does not understand
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 126
+      line: 148
   - label: http3_settings_frame (4)
     section: § 7.2.4
     snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 63
+      line: 85
   - label: http3_settings_frame (5)
     section: § 7.2.4
     snippet: The same setting identifier MUST NOT occur more than once in the SETTINGS frame
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 110
+      line: 132
   - label: http3_settings_frame (6)
     section: § 7.2.4.1
     snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 92
+      line: 114
   - label: http3_status_code_valid
     section: § 4.5
     snippet: HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
-      line: 45
+      line: 73
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 105
+      line: 133
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
-      line: 64
+      line: 119
   - label: lint-http-core/src/http_version.rs
     section: § 4.3.1
     snippet: HTTP/3 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
@@ -10341,7 +10341,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 76
     - file: lint-http-rules/src/rules/http_version_syntax.rs
-      line: 144
+      line: 156
   - label: lint-http-core/src/http_version.rs (2)
     section: § 4.3.1
     snippet: HTTP/3 requests implicitly have a protocol version of "3.0".
@@ -10365,7 +10365,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 125
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 52
+      line: 74
   - label: lint-http-proxy/src/h3_instrument.rs (3)
     section: § 7.2.6
     snippet: The GOAWAY frame (type=0x07) is used to initiate graceful shutdown of an HTTP/3 connection by either endpoint.
@@ -10373,7 +10373,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 131
     - file: lint-http-rules/src/rules/http3_goaway_semantics.rs
-      line: 42
+      line: 52
   - label: lint-http-proxy/src/h3_instrument.rs (4)
     section: § 7.2.7
     snippet: The MAX_PUSH_ID frame (type=0x0d) is used by clients to control the number of server pushes that the server can initiate.
@@ -10381,7 +10381,7 @@ sources:
     - file: lint-http-proxy/src/h3_instrument.rs
       line: 128
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 37
+      line: 53
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 4.3.2
     snippet: HTTP/3 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.
@@ -10399,13 +10399,13 @@ sources:
     snippet: Interim responses do not contain content or trailer sections.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 185
+      line: 249
   - label: no_body_for_1xx_204_304 (2)
     section: § 4.1
     snippet: Transfer codings (see Section 7 of [HTTP/1.1]) are not defined for HTTP/3; the Transfer-Encoding header field MUST NOT be used.
     cited_by:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
-      line: 181
+      line: 245
   - label: no_connection_specific_fields
     section: § 4.2
     snippet: An endpoint MUST NOT generate an HTTP/3 field section containing connection-specific fields; any message containing connection-specific fields MUST be treated as malformed.
@@ -10439,41 +10439,41 @@ sources:
     snippet: HTTP/3 does not use server-initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 104
+      line: 126
   - label: quic_transport_parameters_valid (2)
     section: § 6.1
     snippet: In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 71
+      line: 93
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 119
+      line: 141
   - label: quic_transport_parameters_valid (3)
     section: § 6.2
     snippet: Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 133
+      line: 155
   - label: request_method_token_valid
     section: § 4.3.1
     snippet: '":method":  Contains the HTTP method (Section 9 of [HTTP])'
     cited_by:
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
-      line: 143
+      line: 190
   - label: request_target_form_valid
     section: § 4.3.1
     snippet: An OPTIONS request that does not include a path component includes the value * (ASCII 0x2a) for the :path pseudo-header field
     cited_by:
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
-      line: 165
+      line: 199
   - label: request_target_no_fragment
     section: § 4.3.1
     snippet: Contains the path and query parts of the target URI
     cited_by:
     - file: lint-http-rules/src/rules/request_target_no_fragment.rs
-      line: 99
+      line: 158
     - file: lint-http-rules/src/rules/request_uri_percent_encoding_valid.rs
-      line: 45
+      line: 91
 - label: RFC 9218
   url: https://www.rfc-editor.org/rfc/rfc9218.txt
   type: text/plain
@@ -10483,19 +10483,19 @@ sources:
     snippet: the server is expected to control the cacheability or the applicability of the cached response by using header fields that control the caching behavior (e.g., Cache-Control, Vary)
     cited_by:
     - file: lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
-      line: 72
+      line: 88
   - label: priority_header_syntax
     section: § 4
     snippet: For both the Priority header field and the PRIORITY_UPDATE frame, the set of priority parameters is encoded as a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 256
+      line: 266
   - label: priority_header_syntax (2)
     section: § 4
     snippet: Receivers parse the Dictionary as described in Section 4.2 of [STRUCTURED-FIELDS].
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 257
+      line: 267
   - label: priority_header_syntax (3)
     section: § 4
     snippet: When receiving an HTTP request that does not carry these priority parameters, a server SHOULD act as if their default values were specified.
@@ -10507,49 +10507,49 @@ sources:
     snippet: Where the Dictionary is successfully parsed, this document places the additional requirement that unknown priority parameters, priority parameters with out-of-range values, or values of unexpected types MUST be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 304
+      line: 314
   - label: priority_header_syntax (5)
     section: § 4.1
     snippet: The urgency (u) parameter value is Integer (see Section 3.3.1 of [STRUCTURED-FIELDS]), between 0 and 7 inclusive, in descending order of priority.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 327
+      line: 337
   - label: priority_header_syntax (6)
     section: § 4.1
     snippet: between 0 and 7 inclusive, in descending order of priority. The default is 3.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 349
+      line: 359
   - label: priority_header_syntax (7)
     section: § 4.2
     snippet: The default value of the incremental parameter is false (0).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 361
+      line: 371
   - label: priority_header_syntax (8)
     section: § 4.2
     snippet: The incremental (i) parameter value is Boolean (see Section 3.3.6 of [STRUCTURED-FIELDS]).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 358
+      line: 368
   - label: priority_header_syntax (9)
     section: § 4.3
     snippet: Since unknown priority parameters are ignored, new priority parameters should not change the interpretation of, or modify, the urgency (see Section 4.1) or incremental (see Section 4.2) priority parameters in a way that is not backwards compatible or fallback safe.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 380
+      line: 390
   - label: priority_header_syntax (10)
     section: § 4.3.1
     snippet: New priority parameters can be defined by registering them in the "HTTP Priority" registry.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 379
+      line: 389
   - label: priority_header_syntax (11)
     section: § 5
     snippet: The Priority HTTP header field is a Dictionary that carries priority parameters (see Section 4).
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 102
+      line: 142
   - label: priority_header_syntax (12)
     section: § 8
     snippet: The absence of a priority parameter in an HTTP response indicates the server's disinterest in changing the client-provided value.
@@ -10581,65 +10581,65 @@ sources:
     snippet: If the response is still a representation of a resource, for example, it's often preferable to describe the relevant details in that application's format.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 87
+      line: 115
   - label: problem_details_content_type (2)
     section: § 1
     snippet: Problem details can be used with any HTTP status code, but they most naturally fit the semantics of 4xx and 5xx responses.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 37
+      line: 65
   - label: problem_details_content_type (3)
     section: § 1
     snippet: This specification's aim is to define common error formats for applications that need one so that they aren't required to define their own or, worse, tempted to redefine the semantics of existing HTTP status codes.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 100
+      line: 128
   - label: problem_details_content_type (4)
     section: § 3
     snippet: When serialized in a JSON document, that format is identified with the "application/problem+json" media type.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 67
+      line: 95
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 103
+      line: 131
   - label: problem_details_content_type (5)
     section: § 4
     snippet: Problem details are intended to avoid the necessity of establishing new "fault" or "error" document formats, not to replace existing domain-specific formats.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 88
+      line: 116
   - label: problem_details_content_type (6)
     section: § B
     snippet: The media type for this format is "application/problem+xml".
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
-      line: 68
+      line: 96
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 104
+      line: 132
   - label: problem_details_structure_valid
     section: § 3
     snippet: The canonical model for problem details is a JSON [JSON] object.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 151
+      line: 179
   - label: problem_details_structure_valid (2)
     section: § 3.1
     snippet: Problem detail objects can have the following members.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 146
+      line: 174
   - label: problem_details_structure_valid (3)
     section: § 3.1.1
     snippet: When this member is not present, its value is assumed to be "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 147
+      line: 175
   - label: problem_details_structure_valid (4)
     section: § 4.2.1
     snippet: Consequently, any problem details object not carrying an explicit "type" member implicitly uses this URI.
     cited_by:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
-      line: 148
+      line: 176
 - label: RFC 9530
   url: https://www.rfc-editor.org/rfc/rfc9530.txt
   type: text/plain
@@ -10649,44 +10649,44 @@ sources:
     snippet: The Content-Digest HTTP field can be used in requests and responses
     cited_by:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
-      line: 32
+      line: 54
   - label: digest_header_syntax
     snippet: This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 260
+      line: 295
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 286
+      line: 321
   - label: digest_header_syntax (2)
     section: § 2
     snippet: 'It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 129
+      line: 164
   - label: digest_header_syntax (3)
     section: § 2
     snippet: key conveys the hashing algorithm (see Section 5) used to compute the digest;
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 149
+      line: 184
   - label: digest_header_syntax (4)
     section: § 2
     snippet: value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 161
+      line: 196
   - label: digest_header_syntax (5)
     section: § 4
     snippet: 'Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 192
+      line: 227
   - label: digest_header_syntax (6)
     section: § 4
     snippet: value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 216
+      line: 251
 - label: RFC 9651
   url: https://www.rfc-editor.org/rfc/rfc9651.txt
   type: text/plain
@@ -10696,9 +10696,9 @@ sources:
     snippet: their serialization in textual HTTP fields is similar to that of Integers, distinguished from them with a leading "@".
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 64
+      line: 86
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 64
+      line: 92
   - label: lint-http-rules/src/helpers/structured_fields.rs
     section: § 3.1.2
     snippet: Note that parameters are ordered, and parameter keys cannot contain uppercase letters.
@@ -10742,7 +10742,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 414
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 44
+      line: 66
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 35
   - label: lint-http-rules/src/helpers/structured_fields.rs (8)
@@ -10752,7 +10752,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 452
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 239
+      line: 242
   - label: lint-http-rules/src/helpers/structured_fields.rs (9)
     section: § 4.2
     snippet: The parsing algorithms for both types allow tab characters, since these might be used to combine field lines by some implementations.
@@ -10856,9 +10856,9 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 481
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 220
+      line: 223
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 333
+      line: 343
   - label: lint-http-rules/src/helpers/structured_fields.rs (26)
     section: § 4.2.2
     snippet: No structured data has been found; return dictionary (which is empty).
@@ -10866,9 +10866,9 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 457
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 69
+      line: 91
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 247
+      line: 250
   - label: lint-http-rules/src/helpers/structured_fields.rs (27)
     section: § 4.2.3
     snippet: Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
@@ -10912,7 +10912,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 619
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 414
+      line: 417
   - label: lint-http-rules/src/helpers/structured_fields.rs (34)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not lcalpha or "*", fail parsing.
@@ -10920,7 +10920,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 225
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 390
+      line: 393
   - label: lint-http-rules/src/helpers/structured_fields.rs (35)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not one of lcalpha, DIGIT, "_", "-", ".", or "*", return output_string.
@@ -11066,23 +11066,23 @@ sources:
     snippet: As with Lists, an empty Dictionary is represented by omitting the entire field.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 70
+      line: 92
   - label: permissions_policy_directives_valid (2)
     section: § 3.2
     snippet: Member keys cannot contain uppercase characters.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 347
+      line: 350
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 460
+      line: 463
   - label: permissions_policy_directives_valid (3)
     section: § 4.2
     snippet: If parsing fails, either the entire field value MUST be ignored (i.e., treated as if the field were not present in the section), or alternatively the complete HTTP message MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 90
+      line: 112
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 264
+      line: 274
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 65
   - label: permissions_policy_directives_valid (4)
@@ -11090,7 +11090,7 @@ sources:
     snippet: When generating input_bytes, parsers MUST combine all field lines in the same section (header or trailer) that case-insensitively match the field name into one comma-separated field-value, as per Section 5.2 of [HTTP]; this assures that the entire field value is processed correctly.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 36
+      line: 58
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 61
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
@@ -11100,50 +11100,50 @@ sources:
     snippet: Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 258
+      line: 261
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 279
+      line: 289
   - label: priority_header_syntax
     section: § 3.3.1
     snippet: While it is possible to serialize Integers with leading zeros (e.g., "0002", "-01") and signed zero ("-0"), these distinctions may not be preserved by implementations.
     cited_by:
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
-      line: 328
+      line: 338
   - label: structured_headers_valid
     snippet: This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 126
+      line: 154
   - label: structured_headers_valid (2)
     section: § 4.2
     snippet: Given an array of bytes as input_bytes that represent the chosen field's field-value (which is empty if that field is not present) and field_type (one of "dictionary", "list", or "item"), return the parsed field value.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 227
+      line: 230
   - label: structured_headers_valid (3)
     section: § 4.2
     snippet: If field_type is "dictionary", let output be the result of running Parsing a Dictionary (Section 4.2.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 259
+      line: 262
   - label: structured_headers_valid (4)
     section: § 4.2
     snippet: If field_type is "item", let output be the result of running Parsing an Item (Section 4.2.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 252
+      line: 255
   - label: structured_headers_valid (5)
     section: § 4.2
     snippet: If field_type is "list", let output be the result of running Parsing a List (Section 4.2.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 254
+      line: 257
   - label: structured_headers_valid (6)
     section: § 4.2.1
     snippet: No structured data has been found; return members (which is empty).
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 246
+      line: 249
 - label: RFC 9745
   url: https://www.rfc-editor.org/rfc/rfc9745.txt
   type: text/plain
@@ -11153,20 +11153,20 @@ sources:
     snippet: The Deprecation HTTP response header field allows a server to communicate to a client application that the resource in the context of the message will be or has been deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 29
+      line: 51
   - label: deprecation_header_syntax (2)
     section: § 2.1
     snippet: Deprecation is an Item Structured Header Field; its value MUST be a Date as per Section 3.3.7 of [RFC9651].
     cited_by:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 41
+      line: 63
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
-      line: 63
+      line: 85
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 63
+      line: 91
   - label: sunset_and_deprecation_consistent
     section: § 4
     snippet: The timestamp given in the Sunset HTTP header field MUST NOT be earlier than the one given in the Deprecation header field.
     cited_by:
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 102
+      line: 130


### PR DESCRIPTION
A finding cites a specification by holding a reference to one the rule declares, and until now those lived as anonymous literals inside `specifications()` — citable only by index. Each rule's references are now named consts above its impl, and `specifications()` is built from exactly those, so a citation and the docs cannot come to name different text: change the section in one place and both move.

Purely structural, and the docs prove it. `cargo xtask gendocs` regenerates every rules page byte-identically, which is the gate `docs_match_generated` runs — the values did not change, only where they are written. 193 rules; the one that imported `SpecRef` into the function and wrote the short form now reads like the other 192.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
