### PR TITLE
A hundred and seventy-three findings now name their sentence

### DIFF
--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -156,7 +156,7 @@ impl Rule for AcceptEncodingParameterValid {
                                     let val = nv.next();
 
                                     if !name.eq_ignore_ascii_case("q") {
-                                        return Some(self.violation(ctx.severity, format!(
+                                        return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
                                             "'{}' is not a weight, and a weight is the only thing an Accept-Encoding coding may carry (member '{}')",
                                             param, part
                                         )));
@@ -178,7 +178,7 @@ impl Rule for AcceptEncodingParameterValid {
 
                                     // cite(RFC 9110 § 12.4.2): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"
                                     if !crate::helpers::headers::valid_qvalue(v) {
-                                        return Some(self.violation(ctx.severity, format!(
+                                        return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
                                                 "Invalid qvalue '{}' in Accept-Encoding member '{}'",
                                                 v, part
                                             )));

--- a/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -130,7 +130,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                     // cite(RFC 9110 § 12.5.1): "media-range    = ( "*/*" / ( type "/" "*" ) / ( type "/" subtype ) ) parameters"
                     // cite(RFC 9110 § 12.5.1): "The asterisk "*" character is used to group media types into ranges, with "*/*" indicating all media types and "type/*" indicating all subtypes of that type."
                     if media == "*" {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9110_12_5_1,
                             ctx.severity,
                             format!("Invalid media-range '*' in {} header", hdr),
                         ));
@@ -160,7 +161,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             if let Some(c) =
                                 crate::helpers::token::find_invalid_token_char(parsed.type_)
                             {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_9110_8_3_1,
                                     ctx.severity,
                                     format!(
                                         "Invalid token '{}' in media type '{}' of {}",
@@ -221,7 +223,7 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         // cite(RFC 9110 § 12.5.1): "The accept extension grammar (accept-params, accept-ext) has been removed because it had a complicated definition, was not being used in practice, and is more easily deployed through new header fields."
                         // cite(RFC 9110 § 12.5.1): "Senders using weights SHOULD send "q" last (after all media-range parameters)."
                         if weight_seen {
-                            return Some(self.violation(ctx.severity, format!(
+                            return Some(self.cited(&RFC_9110_12_5_1, ctx.severity, format!(
                                     "Parameter '{}' follows the weight in {} header: the weight closes a media-range, and the extension parameters that once came after it were removed from the grammar",
                                     p, hdr
                                 )));
@@ -291,7 +293,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             // the same bound, and it is senders this rule reports.
                             // cite(RFC 9110 § 12.4.2): "A sender of qvalue MUST NOT generate more than three digits after the decimal point."
                             if !crate::helpers::headers::valid_qvalue(v) {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_9110_12_4_2,
                                     ctx.severity,
                                     format!("Invalid qvalue '{}' in {} header", v, hdr),
                                 ));

--- a/lint-http-rules/src/rules/accept_language_weight_valid.rs
+++ b/lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -115,7 +115,7 @@ impl Rule for AcceptLanguageWeightValid {
                         let val_opt = nv.next();
 
                         if !name.eq_ignore_ascii_case("q") {
-                            return Some(self.violation(ctx.severity, format!(
+                            return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
                                     "'{}' is not a weight, and a weight is the only thing an Accept-Language range may carry (member '{}')",
                                     param, member
                                 )));
@@ -140,7 +140,8 @@ impl Rule for AcceptLanguageWeightValid {
 
                         // cite(RFC 9110 § 12.4.2): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"
                         if !crate::helpers::headers::valid_qvalue(val) {
-                            return Some(self.violation(
+                            return Some(self.cited(
+                                &RFC_9110_12_4_2,
                                 ctx.severity,
                                 format!(
                                     "Invalid qvalue '{}' in Accept-Language member '{}'",

--- a/lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
+++ b/lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
@@ -96,7 +96,7 @@ impl Rule for AcceptRangesAnd206Consistent {
             // cite(RFC 9110 § 14.3): "A server that does not support any kind of range request for the target resource MAY send"
             // cite(RFC 9110 § 14.3): "to advise the client not to attempt a range request on the same request path.  The range unit "none" is reserved for this purpose."
             if advertised.advertises("none") {
-                return Some(self.violation(ctx.severity, "Accept-Ranges: none says this resource supports no kind of range request, in the very response that fulfilled one (206 Partial Content)".into()));
+                return Some(self.cited(&RFC_9110_14_3, ctx.severity, "Accept-Ranges: none says this resource supports no kind of range request, in the very response that fulfilled one (206 Partial Content)".into()));
             }
 
             // A unit that could not be read may be the one the Content-Range names,
@@ -126,7 +126,7 @@ impl Rule for AcceptRangesAnd206Consistent {
             //
             // cite(RFC 9110 § 14.2): "If all of the preconditions are true, the server supports the Range header field for the target resource, the received Range field-value contains a valid ranges-specifier with a range-unit supported for that target resource, and that ranges-specifier is satisfiable with respect to the selected representation, the server SHOULD send a 206 (Partial Content) response with content containing one or more partial representations that correspond to the satisfiable range-spec(s) requested."
             if !advertised.advertises(unit) {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9110_14_2, ctx.severity, format!(
                         "Content-Range describes a range in '{}', a unit this response's Accept-Ranges does not advertise (advice: nothing requires the two to agree)",
                         unit
                     )));

--- a/lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
+++ b/lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
@@ -146,7 +146,7 @@ impl Rule for AcceptRangesOnPartialContent {
             //
             // cite(RFC 9110 § 14.3): "A server that does not support any kind of range request for the target resource MAY send"
             if advertised.advertises("none") {
-                return Some(self.violation(ctx.severity, "Previous response for this resource sent Accept-Ranges: none, advising against a range request on the same request path, and this request sends Range anyway (advice: nothing forbids it)".into()));
+                return Some(self.cited(&RFC_9110_14_3, ctx.severity, "Previous response for this resource sent Accept-Ranges: none, advising against a range request on the same request path, and this request sends Range anyway (advice: nothing forbids it)".into()));
             }
 
             // A field line that could not be read may have been the one naming this
@@ -166,7 +166,7 @@ impl Rule for AcceptRangesOnPartialContent {
             //
             // cite(RFC 9110 § 14.2): "An origin server MUST ignore a Range header field that contains a range unit it does not understand."
             if !advertised.advertises(&unit) {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9110_14_2, ctx.severity, format!(
                         "Range asks in '{}', a unit the previous response for this resource did not advertise, so a server that does not understand it will ignore the field and send the whole representation (advice: nothing forbids it)",
                         unit
                     )));

--- a/lint-http-rules/src/rules/accept_ranges_values_valid.rs
+++ b/lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -125,7 +125,7 @@ impl Rule for AcceptRangesValuesValid {
                 // cite(RFC 9110 § 5.6.2): "Tokens are short textual identifiers that do not include whitespace or delimiters."
                 // cite(RFC 9110 § 5.6.2, label: tchar grammar): "tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA ; any VCHAR, except delimiters"
                 let Ok(value) = hv.to_str() else {
-                    out.push(self.violation(ctx.severity, "Accept-Ranges holds an octet no range-unit admits: a range unit name is a token, whose characters are all visible US-ASCII".into()));
+                    out.push(self.cited(&RFC_9110_5_6_2, ctx.severity, "Accept-Ranges holds an octet no range-unit admits: a range unit name is a token, whose characters are all visible US-ASCII".into()));
                     unreadable = true;
                     break;
                 };

--- a/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
+++ b/lint-http-rules/src/rules/access_control_allow_credentials_when_origin.rs
@@ -103,7 +103,7 @@ impl Rule for AccessControlAllowCredentialsWhenOrigin {
             // cite(Fetch § 4.10): "If request’s credentials mode is not "include" and origin is `*`, then return success."
             // cite(Fetch § 4.10): "If credentials is `true`, then return success."
             if acc_val.eq_ignore_ascii_case("true") && acao_has_star {
-                return Some(self.violation(ctx.severity, "Access-Control-Allow-Credentials must not be 'true' when Access-Control-Allow-Origin is '*'".into()));
+                return Some(self.cited(&FETCH_4_10, ctx.severity, "Access-Control-Allow-Credentials must not be 'true' when Access-Control-Allow-Origin is '*'".into()));
             }
 
             None

--- a/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
+++ b/lint-http-rules/src/rules/access_control_allow_origin_valid.rs
@@ -69,7 +69,7 @@ impl Rule for AccessControlAllowOriginValid {
             // header carries one value — an echoed origin, `null`, or `*` — not a list.
             // cite(Fetch § 3.3.3): "Indicates whether the response can be shared, via returning the literal value of the `Origin` request header (which can be `null`) or `*` in a response."
             if acao_count > 1 {
-                return Some(self.violation(ctx.severity, "Multiple Access-Control-Allow-Origin header fields present; only a single value ('*' or a single origin) is allowed".into()));
+                return Some(self.cited(&FETCH_3_3_3, ctx.severity, "Multiple Access-Control-Allow-Origin header fields present; only a single value ('*' or a single origin) is allowed".into()));
             }
 
             // There is a single header field; validate its single value semantics and origin syntax.

--- a/lint-http-rules/src/rules/age_header_numeric.rs
+++ b/lint-http-rules/src/rules/age_header_numeric.rs
@@ -47,16 +47,16 @@ impl Rule for AgeHeaderNumeric {
             // no such check exists yet, and adding one would be a behavior change.
             // cite(RFC 9111 § 5.1): "Although it is defined as a singleton header field, a cache encountering a message with a list-based Age field value SHOULD use the first member of the field value, discarding subsequent ones."
             for val in resp.headers.get_all("age").iter() {
-                let s =
-                    match val.to_str() {
-                        Ok(s) => s.trim(),
-                        Err(_) => {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Age header contains non-UTF8 value".into(),
-                            ))
-                        }
-                    };
+                let s = match val.to_str() {
+                    Ok(s) => s.trim(),
+                    Err(_) => {
+                        return Some(self.cited(
+                            &RFC_9111_5_1,
+                            ctx.severity,
+                            "Age header contains non-UTF8 value".into(),
+                        ))
+                    }
+                };
 
                 // Age must be a non-negative integer (delta-seconds). Match the grammar
                 // directly rather than via an integer parse: `u64::from_str` accepts a

--- a/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
+++ b/lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
@@ -162,7 +162,7 @@ impl Rule for AltSvcH3AdvertisementValid {
                 // valid advertisement of the shipped protocol.
                 // cite(RFC 9114 § 3.1.1): "An HTTP origin can advertise the availability of an equivalent HTTP/3 endpoint via the Alt-Svc HTTP response header field or the HTTP/2 ALTSVC frame ([ALTSVC]) using the "h3" ALPN token."
                 if proto_lower.starts_with("h3-") {
-                    return Some(self.violation(
+                    return Some(self.cited(&RFC_9114_3_1_1,
                         ctx.severity,
                         format!(
                             "Alt-Svc uses draft HTTP/3 protocol identifier '{}'; use the final 'h3' token instead (RFC 9114 §3.1.1)",

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -494,7 +494,7 @@ impl Rule for AltSvcHeaderSyntax {
             // for this state: `clear` is the whole field value or it is nothing.
             // cite(RFC 7838 § 3): "A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services)."
             if members.contains(&CLEAR) {
-                return Some(self.violation(
+                return Some(self.cited(&RFC_7838_3,
                     severity,
                     format!(
                         "Alt-Svc response carries both the keyword `clear` and alternative services ('{}'). `Alt-Svc = clear / 1#alt-value` is an alternation, so a value holding both derives from neither half -- the document calls this an invalid reply and has a client invalidate the alternatives named beside the keyword",

--- a/lint-http-rules/src/rules/authentication_failure_loop.rs
+++ b/lint-http-rules/src/rules/authentication_failure_loop.rs
@@ -68,7 +68,7 @@ impl Rule for AuthenticationFailureLoop {
             // retry-and-re-present; the cite is the nearest governing sentence, not a bound.
             // cite(RFC 9110 § 15.5.2): "If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information."
             if consecutive_401s >= 3 {
-                Some(self.violation(ctx.severity, format!(
+                Some(self.cited(&RFC_9110_15_5_2, ctx.severity, format!(
                         "Authentication failure loop detected: client has received {} consecutive 401 Unauthorized challenges for this origin.",
                         consecutive_401s + 1
                     )))

--- a/lint-http-rules/src/rules/authorization_credentials_present.rs
+++ b/lint-http-rules/src/rules/authorization_credentials_present.rs
@@ -57,14 +57,16 @@ impl Rule for AuthorizationCredentialsPresent {
                         // reasoning and the §11.4 structure cite.
                         // cite(RFC 9110 § 11.6.2): "Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested"
                         if let Err(msg) = crate::helpers::auth::validate_authorization_syntax(s) {
-                            return Some(self.violation(
+                            return Some(self.cited(
+                                &RFC_9110_11_6_2,
                                 ctx.severity,
                                 format!("Invalid Authorization header: {}", msg),
                             ));
                         }
                     }
                     Err(_) => {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9110_11_6_2,
                             ctx.severity,
                             "Authorization header contains non-UTF8 value".into(),
                         ))

--- a/lint-http-rules/src/rules/basic_auth_base64_valid.rs
+++ b/lint-http-rules/src/rules/basic_auth_base64_valid.rs
@@ -64,7 +64,8 @@ impl Rule for BasicAuthBase64Valid {
                             if let Err(msg) =
                                 crate::helpers::auth::validate_basic_credentials(creds)
                             {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_7617_2,
                                     ctx.severity,
                                     format!("Invalid Basic credentials: {} (RFC 7617)", msg),
                                 ));

--- a/lint-http-rules/src/rules/bearer_token_syntax.rs
+++ b/lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -63,7 +63,8 @@ impl Rule for BearerTokenSyntax {
                     // cite(RFC 6750 § 2.1): "credentials = "Bearer" 1*SP b64token"
                     let creds = parts.next().map(|r| r.trim()).unwrap_or("");
                     if creds.is_empty() {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_6750_2_1,
                             ctx.severity,
                             "Authorization: Bearer missing token".into(),
                         ));

--- a/lint-http-rules/src/rules/cache_coherence.rs
+++ b/lint-http-rules/src/rules/cache_coherence.rs
@@ -136,7 +136,8 @@ impl Rule for CacheCoherence {
             // cite(RFC 9111 § 4.2.4): "A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server"
             if let Some(prev_max) = max_prev {
                 if curr_time < prev_max {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9111_4_2_4,
                         ctx.severity,
                         format!(
                             "response for '{}' appears stale ({} < previous {})",

--- a/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
+++ b/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
@@ -79,7 +79,7 @@ impl Rule for CacheControlAndPragmaConsistent {
             // cite(RFC 9111 § 5.4): "However, support for Cache-Control is now widespread.  As a result, this specification deprecates Pragma."
             if let Some(resp) = &tx.response {
                 if resp.headers.contains_key("pragma") {
-                    return Some(self.violation(ctx.severity, "Response contains 'Pragma' header; its meaning in responses was never specified and Pragma is deprecated — use 'Cache-Control' instead (RFC 9111 §5.4)".into()));
+                    return Some(self.cited(&RFC_9111_5_4, ctx.severity, "Response contains 'Pragma' header; its meaning in responses was never specified and Pragma is deprecated — use 'Cache-Control' instead (RFC 9111 §5.4)".into()));
                 }
             }
 

--- a/lint-http-rules/src/rules/cache_control_present.rs
+++ b/lint-http-rules/src/rules/cache_control_present.rs
@@ -57,7 +57,8 @@ impl Rule for CacheControlPresent {
                 // same advice applies to those too. 200 is the overwhelmingly common case and
                 // the least noisy to flag; widening the set is a behavior change, left out.
                 if resp.status == 200 && !resp.headers.contains_key("cache-control") {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9111_4_2_2,
                         ctx.severity,
                         "Response 200 without Cache-Control header".into(),
                     ));

--- a/lint-http-rules/src/rules/cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/cache_validation_chain.rs
@@ -155,7 +155,7 @@ impl Rule for CacheValidationChain {
                             .as_deref()
                             .unwrap_or("<non-UTF8 If-None-Match>");
                         // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
-                        return Some(self.violation(ctx.severity, format!(
+                        return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
                                 "Conditional request uses If-None-Match '{}' which does not match most recent validator '{}' from history; cache validation chain may be broken",
                                 reported.trim(),
                                 etag
@@ -190,7 +190,7 @@ impl Rule for CacheValidationChain {
                         // a stale Last-Modified signals a broken chain.
                         // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
                         if mismatch {
-                            return Some(self.violation(ctx.severity, format!(
+                            return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
                                     "Conditional request uses If-Modified-Since '{}' which does not match most recent Last-Modified '{}' from history; cache validation chain may be broken",
                                     ims_str,
                                     lm_str

--- a/lint-http-rules/src/rules/charset_present.rs
+++ b/lint-http-rules/src/rules/charset_present.rs
@@ -109,7 +109,8 @@ impl Rule for CharsetPresent {
                         // not have.
                         // cite(MDN Content-Type): "Indicates the character encoding standard used. The value is case insensitive but lowercase is preferred."
                         if !has_charset {
-                            return Some(self.violation(
+                            return Some(self.cited(
+                                &MDN_CONTENT_TYPE,
                                 ctx.severity,
                                 "Text-based Content-Type header missing charset parameter.".into(),
                             ));

--- a/lint-http-rules/src/rules/conditional_headers_consistent.rs
+++ b/lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -83,7 +83,7 @@ impl Rule for ConditionalHeadersConsistent {
                 // If-Range exists
                 // cite(RFC 9110 § 13.1.5): "A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field."
                 if req.headers.get("range").is_none() {
-                    return Some(self.violation(ctx.severity, "If-Range present in request without Range header; If-Range MUST only be used with Range requests".into()));
+                    return Some(self.cited(&RFC_9110_13_1_5, ctx.severity, "If-Range present in request without Range header; If-Range MUST only be used with Range requests".into()));
                 }
 
                 // Validate If-Range content: if it's an entity-tag, it MUST NOT be weak.
@@ -93,7 +93,8 @@ impl Rule for ConditionalHeadersConsistent {
                     let trimmed = s.trim();
                     // cite(RFC 9110 § 13.1.5): "A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak."
                     if trimmed.starts_with("W/") {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9110_13_1_5,
                             ctx.severity,
                             "If-Range MUST not contain a weak entity-tag (W/...)".into(),
                         ));

--- a/lint-http-rules/src/rules/content_disposition_token_valid.rs
+++ b/lint-http-rules/src/rules/content_disposition_token_valid.rs
@@ -77,7 +77,8 @@ impl Rule for ContentDispositionTokenValid {
                 // cite(RFC 6266 § 4.1): "content-disposition = "Content-Disposition" ":" disposition-type *( ";" disposition-parm )"
                 let s = val.trim();
                 if s.is_empty() {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_6266_4_1,
                         ctx.severity,
                         format!("{} header value must not be empty", hdr_name),
                     ));
@@ -90,7 +91,8 @@ impl Rule for ContentDispositionTokenValid {
                 let dispo = s.split(';').next().unwrap().trim();
                 // cite(RFC 6266 § 4.1): "disposition-type = "inline" | "attachment" | disp-ext-type"
                 if dispo.is_empty() {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_6266_4_1,
                         ctx.severity,
                         format!("{} header disposition-type must not be empty", hdr_name),
                     ));

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -129,7 +129,7 @@ impl Rule for ContentEncodingAndTypeConsistent {
                 let is_no_body_status =
                     (100..200).contains(&status) || status == 204 || status == 304;
                 if is_no_body_status && resp.headers.contains_key("content-encoding") {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9110_15_4_5, ctx.severity, format!(
                             "Response {} carries no content, so it should not send Content-Encoding",
                             status
                         )));

--- a/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
+++ b/lint-http-rules/src/rules/content_location_and_uri_consistent.rs
@@ -321,7 +321,7 @@ impl Rule for ContentLocationAndUriConsistent {
                     // cite(RFC 9110 § 8.7): "For a response to a GET or HEAD request, this is an indication that the target URI refers to a resource that is subject to content negotiation and the Content-Location field value is a more specific identifier for the selected representation."
                     // cite(RFC 9110 § 8.7): "Such a claim can only be trusted if both identifiers share the same resource owner, which cannot be programmatically determined via HTTP."
                     if !matches {
-                        return Some(self.violation(ctx.severity, "Content-Location identifies a different resource than the request target; RFC 9110 §8.7 permits this (a negotiated variant, a 201 pointing at the created resource, or a report on a POST), so confirm it is deliberate".into()));
+                        return Some(self.cited(&RFC_9110_8_7, ctx.severity, "Content-Location identifies a different resource than the request target; RFC 9110 §8.7 permits this (a negotiated variant, a 201 pointing at the created resource, or a report on a POST), so confirm it is deliberate".into()));
                     }
                 }
             }

--- a/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
+++ b/lint-http-rules/src/rules/content_transfer_encoding_valid.rs
@@ -112,7 +112,7 @@ impl Rule for ContentTransferEncodingValid {
                 let hv = headers.get_all("content-transfer-encoding").iter().next()?;
                 let shown = hv.to_str().unwrap_or("<non-UTF-8>");
                 let detail = describe_value(shown).map(|d| format!("; {}", d));
-                Some(self.violation(ctx.severity, format!(
+                Some(self.cited(&RFC_9112_B_5, ctx.severity, format!(
                         "Content-Transfer-Encoding: {} present in {}; HTTP does not use this field and a gateway is required to remove it{}",
                         shown.trim(),
                         which,

--- a/lint-http-rules/src/rules/content_type_present.rs
+++ b/lint-http-rules/src/rules/content_type_present.rs
@@ -138,7 +138,8 @@ impl Rule for ContentTypePresent {
             // cite(RFC 9110 § 8.3): "If a Content-Type header field is not present, the recipient MAY either assume a media type of "application/octet-stream" ([RFC2046], Section 4.5.1) or examine the data to determine its type."
             // cite(RFC 9110 § 8.3): "This "MIME sniffing" risks drawing incorrect conclusions about the data, which might expose the user to additional security risks (e.g., "privilege escalation")."
             if has_content {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9110_8_3,
                     ctx.severity,
                     "Response contains content but no Content-Type header".into(),
                 ));

--- a/lint-http-rules/src/rules/content_type_registered.rs
+++ b/lint-http-rules/src/rules/content_type_registered.rs
@@ -123,7 +123,8 @@ impl Rule for ContentTypeRegistered {
                         }
                     }
 
-                    Some(self.violation(
+                    Some(self.cited(
+                        &RFC_6838_4_2_8,
                         ctx.severity,
                         format!("Unrecognized media type '{}' in {} header", full, hdr_name),
                     ))

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -95,7 +95,8 @@ impl Rule for CookieAttributeConsistent {
 
                     // cite(RFC 6265 § 4.1.1): "cookie-pair       = cookie-name "=" cookie-value cookie-name       = token"
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_6265_4_1_1,
                             ctx.severity,
                             format!("Set-Cookie cookie-name contains invalid character: '{}'", c),
                         ));
@@ -121,7 +122,8 @@ impl Rule for CookieAttributeConsistent {
                             // The grammar admits no "=" — the attribute is its own presence.
                             // cite(RFC 6265 § 4.1.1): "secure-av         = "Secure""
                             if val_opt.is_some() && !val_opt.unwrap().is_empty() {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_6265_4_1_1,
                                     ctx.severity,
                                     "Set-Cookie attribute 'Secure' must not have a value".into(),
                                 ));
@@ -133,7 +135,8 @@ impl Rule for CookieAttributeConsistent {
                         if key.eq_ignore_ascii_case("httponly") {
                             // cite(RFC 6265 § 4.1.1): "httponly-av       = "HttpOnly""
                             if val_opt.is_some() && !val_opt.unwrap().is_empty() {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_6265_4_1_1,
                                     ctx.severity,
                                     "Set-Cookie attribute 'HttpOnly' must not have a value".into(),
                                 ));
@@ -186,7 +189,8 @@ impl Rule for CookieAttributeConsistent {
                             // cite(RFC 6265 § 5.2.2): "If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av."
                             // cite(RFC 6265 § 5.2.2): "If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av."
                             if v.parse::<i64>().is_err() {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_6265_5_2_2,
                                     ctx.severity,
                                     format!(
                                     "Set-Cookie attribute 'Max-Age' is not a valid integer: '{}'",
@@ -210,7 +214,8 @@ impl Rule for CookieAttributeConsistent {
                             };
                             // cite(RFC 6265 § 4.1.1): "expires-av        = "Expires=" sane-cookie-date"
                             if !crate::http_date::is_valid_http_date(v) {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_6265_4_1_1,
                                     ctx.severity,
                                     format!(
                                     "Set-Cookie attribute 'Expires' is not a valid HTTP-date: '{}'",

--- a/lint-http-rules/src/rules/cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/cookie_domain_matching.rs
@@ -125,7 +125,7 @@ impl Rule for CookieDomainMatching {
                 // failing the domain requirement was never eligible to be sent.
                 // cite(RFC 6265 § 5.4): "Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:"
                 if domain_mismatch {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_6265_5_4, ctx.severity, format!(
                             "Cookie '{}' with value '{}' was set for a different domain and should not be sent to host '{}'",
                             name, value, req_host
                         )));
@@ -135,7 +135,8 @@ impl Rule for CookieDomainMatching {
                 // path-match predicate itself is the helper's (§5.1.4).
                 // cite(RFC 6265 § 5.4): "The request-uri's path path-matches the cookie's path."
                 if path_mismatch {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_6265_5_4,
                         ctx.severity,
                         format!(
                             "Cookie '{}' with value '{}' is not valid for path '{}'",

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -66,7 +66,8 @@ impl Rule for CookieDomainValid {
                     if key.eq_ignore_ascii_case("domain") {
                         // cite(RFC 6265 § 5.2.3): "If the attribute-value is empty, the behavior is undefined."
                         if val.is_empty() {
-                            return Some(self.violation(
+                            return Some(self.cited(
+                                &RFC_6265_5_2_3,
                                 ctx.severity,
                                 "Set-Cookie attribute 'Domain' requires a value".into(),
                             ));
@@ -80,11 +81,12 @@ impl Rule for CookieDomainValid {
                                 // not), so the server should send the registry form without it.
                                 // cite(RFC 6265 § 5.2.3): "Let cookie-domain be the attribute-value without the leading %x2E (".") character."
                                 if val.starts_with('.') {
-                                    return Some(self.violation(ctx.severity, "Set-Cookie 'Domain' attribute uses a leading '.' which is deprecated; prefer the registry form without leading dot".into()));
+                                    return Some(self.cited(&RFC_6265_5_2_3, ctx.severity, "Set-Cookie 'Domain' attribute uses a leading '.' which is deprecated; prefer the registry form without leading dot".into()));
                                 }
                             }
                             Err(e) => {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_6265_5_2_3,
                                     ctx.severity,
                                     format!("Invalid Set-Cookie Domain attribute '{}': {}", val, e),
                                 ));

--- a/lint-http-rules/src/rules/cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/cookie_lifecycle.rs
@@ -203,7 +203,7 @@ impl Rule for CookieLifecycle {
                         // still sending it has a store the user agent was required to have
                         // emptied.
                         // cite(RFC 6265 § 5.3): "The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store."
-                        return Some(self.violation(ctx.severity, format!(
+                        return Some(self.cited(&RFC_6265_5_3, ctx.severity, format!(
                                 "Cookie '{}' was previously set but is expired or removed and should not be sent",
                                 name
                             )));

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -80,7 +80,8 @@ impl Rule for CookiePathValid {
                         let v = match val_opt {
                             Some(v) => v,
                             None => {
-                                return Some(self.violation(
+                                return Some(self.cited(
+                                    &RFC_6265_5_2_4,
                                     ctx.severity,
                                     "Set-Cookie attribute 'Path' requires a value".into(),
                                 ))

--- a/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_embedder_policy_valid.rs
@@ -93,7 +93,7 @@ impl Rule for CrossOriginEmbedderPolicyValid {
                 return None;
             }
 
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&HTML_7_1_4, ctx.severity, format!(
                     "Cross-Origin-Embedder-Policy value '{}' does not enable cross-origin isolation (use 'require-corp' or 'credentialless')",
                     val
                 )))

--- a/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_opener_policy_valid.rs
@@ -100,7 +100,8 @@ impl Rule for CrossOriginOpenerPolicyValid {
                 return None;
             }
 
-            Some(self.violation(
+            Some(self.cited(
+                &HTML_7_1_3_1,
                 ctx.severity,
                 format!(
                     "Cross-Origin-Opener-Policy contains unsupported value: '{}'",

--- a/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
+++ b/lint-http-rules/src/rules/cross_origin_resource_policy_valid.rs
@@ -92,7 +92,8 @@ impl Rule for CrossOriginResourcePolicyValid {
                 return None;
             }
 
-            Some(self.violation(
+            Some(self.cited(
+                &FETCH_3_7,
                 ctx.severity,
                 format!(
                     "Cross-Origin-Resource-Policy contains unsupported value: '{}'",

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -74,13 +74,15 @@ impl Rule for DateAndTimeHeadersConsistent {
                     // rule's concern. This rule's own claim is only what Date *is*:
                     // cite(RFC 9110 § 6.6.1): "The "Date" header field represents the date and time at which the message was originated"
                     if crate::http_date::parse_http_date_to_datetime(s).is_err() {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9110_6_6_1,
                             ctx.severity,
                             "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
                         ));
                     }
                 } else {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9110_6_6_1,
                         ctx.severity,
                         "Date header contains non-UTF8 bytes and is invalid".into(),
                     ));
@@ -93,7 +95,8 @@ impl Rule for DateAndTimeHeadersConsistent {
                 if let Some(hv) = resp.headers.get_all("date").iter().next() {
                     if let Ok(s) = hv.to_str() {
                         if crate::http_date::parse_http_date_to_datetime(s).is_err() {
-                            return Some(self.violation(
+                            return Some(self.cited(
+                                &RFC_9110_6_6_1,
                                 ctx.severity,
                                 "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
                             ));
@@ -147,7 +150,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                                 Ok(s) => match crate::http_date::parse_http_date_to_datetime(s) {
                                     Ok(sunset_dt) => {
                                         if sunset_dt <= date_dt - skew {
-                                            return Some(self.violation(ctx.severity, format!(
+                                            return Some(self.cited(&RFC_8594_3, ctx.severity, format!(
                                                     "Sunset header '{}' is before or equal to Date '{}'; Sunset should indicate a future shutdown date",
                                                     s, date_str
                                                 )));

--- a/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
+++ b/lint-http-rules/src/rules/digest_auth_nonce_handling.rs
@@ -203,7 +203,8 @@ impl Rule for DigestAuthNonceHandling {
                 {
                     if o != expected {
                         return Some(
-                            self.violation(
+                            self.cited(
+                                &RFC_7616_3_3,
                                 ctx.severity,
                                 "Digest Authorization opaque does not match most recent challenge"
                                     .into(),
@@ -254,7 +255,8 @@ impl Rule for DigestAuthNonceHandling {
                     // signature of a replay, which nc exists to let the server detect.
                     // cite(RFC 7616 § 3.4): "if the same nc value is seen twice, then the request is a replay."
                     if current_nc <= highest {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_7616_3_4,
                             ctx.severity,
                             "Digest Authorization nonce-count did not increase".into(),
                         ));
@@ -270,7 +272,7 @@ impl Rule for DigestAuthNonceHandling {
                         && highest == 0
                         && current_nc != 1
                     {
-                        return Some(self.violation(ctx.severity, "Digest Authorization with new nonce after stale challenge must reset nc to 00000001".into()));
+                        return Some(self.cited(&RFC_7616_3_3, ctx.severity, "Digest Authorization with new nonce after stale challenge must reset nc to 00000001".into()));
                     }
                 }
             }

--- a/lint-http-rules/src/rules/digest_auth_valid.rs
+++ b/lint-http-rules/src/rules/digest_auth_valid.rs
@@ -162,7 +162,7 @@ impl Rule for DigestAuthValid {
 
                                     let quoted = v.starts_with('"');
                                     if MUST_QUOTE.contains(&k.as_str()) && !quoted {
-                                        return Some(self.violation(ctx.severity, format!(
+                                        return Some(self.cited(&RFC_7616_3_4, ctx.severity, format!(
                                                 "Digest Authorization sends '{k}' unquoted, and RFC 7616 \u{a7}3.4 admits only the quoted string syntax for it (\"a sender MUST only generate the quoted string syntax for the following parameters: username, realm, nonce, uri, response, cnonce, and opaque\")"
                                             )));
                                     }

--- a/lint-http-rules/src/rules/early_data_header_safe_method.rs
+++ b/lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -227,7 +227,7 @@ impl Rule for EarlyDataHeaderSafeMethod {
                 // has an intermediary write the field: it adds one only where there is none.
                 // cite(RFC 8470 § 5.1): "An intermediary that forwards a request prior to the completion of the TLS handshake with its client MUST send it with the Early-Data header field set to "1" (i.e., it adds it if not present in the request)."
                 if instances > 1 {
-                    return Some(self.violation(
+                    return Some(self.cited(&RFC_8470_5_1,
                         config.severity,
                         format!(
                             "Request carries {instances} Early-Data header field lines, and a client may send at most one — the field holds a single bit. A server reads them as one instance with the value 1, so the extra lines change nothing about the request; an intermediary marking early data adds the field only when it is not already there"
@@ -244,7 +244,7 @@ impl Rule for EarlyDataHeaderSafeMethod {
                 if let Some(hv) = tx.request.headers.get(FIELD) {
                     let written = hv.as_bytes();
                     if written != b"1" {
-                        return Some(self.violation(
+                        return Some(self.cited(&RFC_8470_5_1,
                             config.severity,
                             format!(
                                 "Early-Data header field carries {}, and the field has exactly one valid value, \"1\". A server treats an invalid instance as though it said 1, so the request is marked as early data all the same — the value is simply wrong",
@@ -272,7 +272,7 @@ impl Rule for EarlyDataHeaderSafeMethod {
             if let Some(resp) = &tx.response {
                 // cite(RFC 8470 § 5.1): "An Early-Data header field MUST NOT be included in responses or request trailers."
                 if resp.headers.contains_key(FIELD) {
-                    return Some(self.violation(
+                    return Some(self.cited(&RFC_8470_5_1,
                         config.severity,
                         "Response carries an Early-Data header field. The field is a request header field: it tells a server that a request reached it through early data, and a response has nothing to mark".to_string(),
                     ));

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -73,7 +73,7 @@ impl Rule for EtagSyntax {
                 // the conditional fields that do take it.
                 // cite(RFC 9110 § 8.8.3): "An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator."
                 if t == "*" {
-                    return Some(self.violation(ctx.severity, "ETag header value '*' is invalid for responses; ETag must be an entity-tag"
+                    return Some(self.cited(&RFC_9110_8_8_3, ctx.severity, "ETag header value '*' is invalid for responses; ETag must be an entity-tag"
                                 .into()));
                 }
 
@@ -90,7 +90,7 @@ impl Rule for EtagSyntax {
             // exception does not apply, and a sender must emit at most one ETag field line.
             // cite(RFC 9110 § 5.3): "a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list"
             if count > 1 {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9110_5_3, ctx.severity, format!(
                         "Multiple ETag header fields present ({}); ETag must be a single entity-tag",
                         count
                     )));

--- a/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
+++ b/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
@@ -124,7 +124,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
             // cite(RFC 9111 § 5.3): "A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired")."
             if expires_dt.is_none() {
                 if cc_max_age.unwrap_or(-1) > 0 || cc_s_maxage.unwrap_or(-1) > 0 {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9111_5_3, ctx.severity, format!(
                             "Expires '{}' is not a valid HTTP-date, so a cache MUST read it as already expired, but Cache-Control max-age/s-maxage says the response is still fresh — values are contradictory (RFC 9111 §5.3)",
                             expires_raw
                         )));
@@ -174,7 +174,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
             if (cc_max_age.unwrap_or(-1) > 0 || cc_s_maxage.unwrap_or(-1) > 0)
                 && expires <= date_ref
             {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9111_5_3, ctx.severity, format!(
                         "Response contains Cache-Control max-age/s-maxage but Expires {} is not in the future relative to Date {} — values are contradictory (RFC 9111 §4.2, §5.3)",
                         expires, date_ref
                     )));

--- a/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
+++ b/lint-http-rules/src/rules/form_data_content_disposition_valid.rs
@@ -80,7 +80,8 @@ impl Rule for FormDataContentDispositionValid {
                 // value is a linter judgement rather than a quoted requirement.
                 // cite(RFC 7578 § 4.2): "The Content-Disposition header field MUST also contain an additional parameter of "name"; the value of the "name" parameter is the original field name from the form"
                 if params_part.is_empty() {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_7578_4_2,
                         ctx.severity,
                         "Content-Disposition: 'form-data' missing 'name' parameter".into(),
                     ));

--- a/lint-http-rules/src/rules/host_header.rs
+++ b/lint-http-rules/src/rules/host_header.rs
@@ -154,7 +154,7 @@ impl Rule for HostHeader {
             // field value is neither: it is a `uri-host` and a port.
             // cite(RFC 9112 § 3.2): "If the target URI includes an authority component, then a client MUST send a field value for Host that is identical to that authority component, excluding any userinfo subcomponent and its "@" delimiter (Section 4.2 of [HTTP])."
             if s.contains('@') {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9112_3_2, ctx.severity, format!(
                         "Host field value '{}' carries a userinfo subcomponent and its '@' delimiter",
                         s
                     )));
@@ -169,7 +169,7 @@ impl Rule for HostHeader {
             if s.parse::<std::net::Ipv6Addr>().is_ok()
                 || crate::helpers::ipv6::looks_like_unbracketed_ipv6_with_port(s)
             {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_3986_3_2_2, ctx.severity, format!(
                         "IPv6 literal '{}' in a Host field value must be enclosed in square brackets",
                         s
                     )));
@@ -182,7 +182,8 @@ impl Rule for HostHeader {
             // the whole of what RFC 3986 §3.2.3 says a port looks like.
             // cite(RFC 9110 § 7.2, label: Host grammar): "Host = uri-host [ ":" port ]"
             if let Err(msg) = crate::helpers::uri::validate_host_and_optional_port(s) {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9110_7_2,
                     ctx.severity,
                     format!("Host field value '{}' is not a host and port: {}", s, msg),
                 ));

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -305,7 +305,7 @@ impl Rule for Http2PseudoHeadersValid {
                     // cite(RFC 9113 § 8.3.1): "This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'."
                     // cite(RFC 9113 § 8.3.1): "All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5)."
                     if crate::helpers::uri::extract_path_from_request_target(target).is_none() {
-                        return Some(self.violation(ctx.severity, format!(
+                        return Some(self.cited(&RFC_9113_8_3_1, ctx.severity, format!(
                                 "Request target '{}' carries no path, and every non-CONNECT request \
                                  sends exactly one ':path': an 'http' or 'https' URI with no path \
                                  component sends '/'",
@@ -330,7 +330,8 @@ impl Rule for Http2PseudoHeadersValid {
                 // anybody serves: this pseudo-header is deliberately open.
                 // cite(RFC 9113 § 8.3.1): "":scheme" is not restricted to "http" and "https" schemed URIs."
                 if let Some(msg) = crate::helpers::uri::validate_scheme_if_present(target) {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9113_8_3_1,
                         ctx.severity,
                         format!("Request target's scheme is not a scheme name: {msg}"),
                     ));
@@ -368,7 +369,7 @@ impl Rule for Http2PseudoHeadersValid {
                 {
                     let shown = crate::helpers::uri::userinfo_password_withheld(&authority)
                         .unwrap_or_else(|| authority.to_string());
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9113_8_3_1, ctx.severity, format!(
                             "Authority '{}' of an '{scheme}' target carries the deprecated userinfo \
                              subcomponent and its '@' delimiter",
                             crate::helpers::headers::shown_in_finding(&shown)

--- a/lint-http-rules/src/rules/http3_max_push_id.rs
+++ b/lint-http-rules/src/rules/http3_max_push_id.rs
@@ -62,7 +62,8 @@ impl ProtocolRule for Http3MaxPushId {
             // the origin sent to this proxy, which as the receiving client must reject.
             // cite(RFC 9114 § 7.2.7): "A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED."
             if direction == MessageDirection::Server {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9114_7_2_7,
                     ctx.severity,
                     format!(
                         "HTTP/3 MAX_PUSH_ID (push_id {}) sent by a server; a server MUST NOT \
@@ -82,7 +83,8 @@ impl ProtocolRule for Http3MaxPushId {
                 } = &prev.kind
                 {
                     if current < *prev_id {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9114_7_2_7,
                             ctx.severity,
                             format!(
                                 "HTTP/3 MAX_PUSH_ID {} decreased from previous {} \

--- a/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
@@ -85,7 +85,8 @@ impl Rule for Http3PseudoHeadersValid {
             // cite(RFC 9114 § 4.3.1): "All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4."
             let method = tx.request.method.trim();
             if method.is_empty() {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9114_4_3_1,
                     ctx.severity,
                     "HTTP/3 request missing required ':method' pseudo-header".into(),
                 ));
@@ -100,7 +101,7 @@ impl Rule for Http3PseudoHeadersValid {
                 // cite(RFC 9114 § 4.4): "The :authority pseudo-header field contains the host and port to connect to"
                 let uri_trimmed = tx.request.uri.trim();
                 if uri_trimmed.is_empty() {
-                    return Some(self.violation(ctx.severity, "HTTP/3 CONNECT request missing required ':authority' pseudo-header or Host header"
+                    return Some(self.cited(&RFC_9114_4_4, ctx.severity, "HTTP/3 CONNECT request missing required ':authority' pseudo-header or Host header"
                                 .into()));
                 }
                 let authority =
@@ -140,7 +141,7 @@ impl Rule for Http3PseudoHeadersValid {
                 {
                     let shown = crate::helpers::uri::userinfo_password_withheld(&authority)
                         .unwrap_or(authority);
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9114_4_4, ctx.severity, format!(
                             "HTTP/3 CONNECT ':authority' '{}' carries a userinfo subcomponent and its '@' delimiter: the field is only the host and port to connect to",
                             crate::helpers::headers::shown_in_finding(&shown)
                         )));
@@ -154,7 +155,7 @@ impl Rule for Http3PseudoHeadersValid {
                 let uri_trimmed = tx.request.uri.trim();
                 if uri_trimmed == "*" {
                     if !method.eq_ignore_ascii_case("OPTIONS") {
-                        return Some(self.violation(ctx.severity, "Asterisk ('*') request-target is only permitted with OPTIONS method"
+                        return Some(self.cited(&RFC_9110_7_1, ctx.severity, "Asterisk ('*') request-target is only permitted with OPTIONS method"
                                     .into()));
                     }
                 } else {
@@ -163,7 +164,8 @@ impl Rule for Http3PseudoHeadersValid {
                         crate::helpers::uri::extract_path_from_request_target(uri_trimmed)
                             .is_some();
                     if !has_path {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9114_4_3_1,
                             ctx.severity,
                             "HTTP/3 request missing required ':path' pseudo-header".into(),
                         ));
@@ -179,7 +181,8 @@ impl Rule for Http3PseudoHeadersValid {
                 let has_host = tx.request.headers.contains_key("host");
                 if authority.is_none() && !has_host {
                     return Some(
-                        self.violation(
+                        self.cited(
+                            &RFC_9114_4_3_1,
                             ctx.severity,
                             "HTTP/3 request must include ':authority' pseudo-header or Host header"
                                 .into(),
@@ -206,7 +209,7 @@ impl Rule for Http3PseudoHeadersValid {
                         {
                             let shown = crate::helpers::uri::userinfo_password_withheld(&authority)
                                 .unwrap_or(authority);
-                            return Some(self.violation(ctx.severity, format!(
+                            return Some(self.cited(&RFC_9114_4_3_1, ctx.severity, format!(
                                     "HTTP/3 ':authority' '{}' of an '{scheme}' target includes the deprecated userinfo subcomponent and its '@' delimiter",
                                     crate::helpers::headers::shown_in_finding(&shown)
                                 )));

--- a/lint-http-rules/src/rules/http3_settings_frame.rs
+++ b/lint-http-rules/src/rules/http3_settings_frame.rs
@@ -114,7 +114,8 @@ impl ProtocolRule for Http3SettingsFrame {
             // cite(RFC 9114 § 7.2.4.1): "These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR"
             for &(id, _) in settings {
                 if RESERVED_SETTING_IDS.contains(&id) {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9114_7_2_4_1,
                         ctx.severity,
                         format!(
                             "HTTP/3 SETTINGS contains reserved HTTP/2 setting identifier \
@@ -132,7 +133,8 @@ impl ProtocolRule for Http3SettingsFrame {
             // cite(RFC 9114 § 7.2.4): "The same setting identifier MUST NOT occur more than once in the SETTINGS frame"
             for (i, &(id, _)) in settings.iter().enumerate() {
                 if settings[..i].iter().any(|&(prev_id, _)| prev_id == id) {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9114_7_2_4,
                         ctx.severity,
                         format!(
                             "HTTP/3 SETTINGS contains setting identifier 0x{:02X} more \

--- a/lint-http-rules/src/rules/http3_status_code_valid.rs
+++ b/lint-http-rules/src/rules/http3_status_code_valid.rs
@@ -72,7 +72,7 @@ impl Rule for Http3StatusCodeValid {
             // § 4.5 is the only place RFC 9114 mentions 101 at all.
             // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
             if resp.status == 101 {
-                return Some(self.violation(ctx.severity, "HTTP/3 does not support 101 (Switching Protocols); use extended CONNECT instead"
+                return Some(self.cited(&RFC_9114_4_5, ctx.severity, "HTTP/3 does not support 101 (Switching Protocols); use extended CONNECT instead"
                             .into()));
             }
 

--- a/lint-http-rules/src/rules/immutable_cache_never_stale.rs
+++ b/lint-http-rules/src/rules/immutable_cache_never_stale.rs
@@ -125,7 +125,7 @@ impl Rule for ImmutableCacheNeverStale {
             // cite(RFC 8246 § 2): "Clients SHOULD NOT issue a conditional request during the response's freshness lifetime (e.g., upon a reload) unless explicitly overridden by the user (e.g., a force reload)."
             // cite(RFC 8246 § 2): "The immutable extension only applies during the freshness lifetime of the stored response."
             if has_conditional && current_age < freshness_lifetime {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_8246_2, ctx.severity, format!(
                         "Unnecessary revalidation of immutable response while still fresh (age {} < freshness {})",
                         current_age, freshness_lifetime
                     )));

--- a/lint-http-rules/src/rules/immutable_requires_freshness.rs
+++ b/lint-http-rules/src/rules/immutable_requires_freshness.rs
@@ -121,7 +121,7 @@ impl Rule for ImmutableRequiresFreshness {
             // cite(RFC 8246 § 2): "The immutable extension only applies during the freshness lifetime of the stored response."
             // cite(RFC 8246 § 2): "Clients SHOULD NOT issue a conditional request during the response's freshness lifetime (e.g., upon a reload) unless explicitly overridden by the user (e.g., a force reload)."
             if let (true, Some(conflict)) = (found_immutable, conflicting) {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_8246_2, ctx.severity, format!(
                         "Cache-Control pairs 'immutable' with '{}', which leaves the response no freshness lifetime; 'immutable' only applies during one, so it has no effect here",
                         conflict
                     )));

--- a/lint-http-rules/src/rules/language_tag_syntax.rs
+++ b/lint-http-rules/src/rules/language_tag_syntax.rs
@@ -88,7 +88,8 @@ impl Rule for LanguageTagSyntax {
             let check_tag = |hdr: &str, tag: &str| -> Option<Violation> {
                 // cite(RFC 9110 § 8.5.1): "A language tag, as defined in [RFC5646], identifies a natural language spoken, written, or otherwise conveyed by human beings for communication of information to other human beings."
                 if let Err(e) = crate::helpers::language::validate_language_tag(tag) {
-                    return Some(self.violation(
+                    return Some(self.cited(
+                        &RFC_9110_8_5_1,
                         ctx.severity,
                         format!("Invalid language tag '{}' in {}: {}", tag, hdr, e),
                     ));

--- a/lint-http-rules/src/rules/max_age_directive_valid.rs
+++ b/lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -132,7 +132,7 @@ impl Rule for MaxAgeDirectiveValid {
                     // — which is what this reports. (`immutable` is the one directive that
                     // turns this into a SHOULD NOT, and that is a separate rule.)
                     // cite(RFC 9111 § 4.2): "When a response is fresh, it can be used to satisfy subsequent requests without contacting the origin server, thereby improving efficiency"
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9111_4_2, ctx.severity, format!(
                             "Request revalidated resource while response is still fresh (age {} < max-age {})",
                             current_age, max_age
                         )));
@@ -148,7 +148,7 @@ impl Rule for MaxAgeDirectiveValid {
                     // unconditionally is legal — it just discards the validator already held
                     // and the 304 it could have earned.
                     // cite(RFC 9111 § 4.3): "it can use the conditional request mechanism"
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9111_4_3, ctx.severity, format!(
                             "Stale cached entry (age {} >= max-age {}) refetched without a conditional request, though a validator was available to revalidate with",
                             current_age, max_age
                         )));

--- a/lint-http-rules/src/rules/media_type_suffix_valid.rs
+++ b/lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -126,7 +126,7 @@ impl Rule for MediaTypeSuffixValid {
                     // the bare-trailing-"+" check below, on the same reasoning.
                     // cite(RFC 6838 § 4.2): "restricted-name = restricted-name-first *126restricted-name-chars restricted-name-first  = ALPHA / DIGIT"
                     if subtype.starts_with('+') {
-                        return Some(self.violation(ctx.severity, format!(
+                        return Some(self.cited(&RFC_6838_4_2, ctx.severity, format!(
                                 "Media type '{}/{}' in {} is a structured suffix with no base subtype name",
                                 parsed.type_, parsed.subtype, hdr_name
                             )));
@@ -163,7 +163,7 @@ impl Rule for MediaTypeSuffixValid {
                     // cite(RFC 6838 § 4.2.8): ""+suffix" constructs for as-yet unregistered structured syntaxes SHOULD NOT be used, given the possibility of conflicts with future suffix definitions."
                     // cite(RFC 6838 § 4.2.8): "By the same token, media types MUST NOT be given names incorporating suffixes for structured syntaxes they do not actually employ."
                     if !config.allowed.contains(&suffix) {
-                        return Some(self.violation(ctx.severity, format!(
+                        return Some(self.cited(&RFC_6838_4_2_8, ctx.severity, format!(
                                         "Unrecognized structured syntax suffix '+{}' in media type '{}/{}' (header '{}')",
                                         suffix, parsed.type_, parsed.subtype, hdr_name
                                     )));

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -981,6 +981,43 @@ severity = "warn"
         Ok(())
     }
 
+    /// A ratchet on citation coverage, not a target: `cite` is optional by
+    /// design, and a finding whose sentence nobody has read yet is meant to
+    /// carry none rather than a guess. What this pins is the direction —
+    /// attaching a citation is progress that cannot be undone by accident, and
+    /// the number tells whoever reads the catalogue next how much is left.
+    ///
+    /// Raise the floor when a batch lands. If this fails downward, a `cited()`
+    /// site became a `violation()` one: say why in the commit or put it back.
+    #[test]
+    fn citation_coverage_does_not_regress() {
+        /// Finding sites that name the specification sentence they enforce, out
+        /// of 583. The rest are the per-rule reading that has not happened yet.
+        const FLOOR: usize = 173;
+
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
+        let mut cited = 0;
+        let mut uncited = 0;
+        for entry in std::fs::read_dir(&dir).expect("cannot read src/rules") {
+            let path = entry.expect("a directory entry").path();
+            if path.extension().is_none_or(|e| e != "rs")
+                || path.file_name().is_some_and(|n| n == "mod.rs")
+            {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("a rule file");
+            // Before the test module: a fixture is not a finding site.
+            let body = src.split("#[cfg(test)]").next().unwrap_or(&src);
+            cited += body.matches("self.cited(").count();
+            uncited += body.matches("self.violation(").count();
+        }
+        assert!(
+            cited >= FLOOR,
+            "citation coverage fell to {cited}/{} findings, below the floor of {FLOOR}",
+            cited + uncited
+        );
+    }
+
     #[test]
     fn every_rule_file_is_registered() {
         // Deleting the hand-maintained `RULES` const removed the single place

--- a/lint-http-rules/src/rules/must_revalidate_enforced.rs
+++ b/lint-http-rules/src/rules/must_revalidate_enforced.rs
@@ -142,7 +142,7 @@ impl Rule for MustRevalidateEnforced {
                     resp.headers.contains_key("etag") || resp.headers.contains_key("last-modified");
                 // cite(RFC 9111 § 5.2.2.2): "The must-revalidate response directive indicates that once the response has become stale, a cache MUST NOT reuse that response to satisfy another request until it has been successfully validated by the origin, as defined by Section 4.3."
                 if has_validator {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9111_5_2_2_2, ctx.severity, format!(
                             "Cached response with 'must-revalidate' directive is stale (age {} >= freshness {}) and was reused without conditional request",
                             current_age, freshness_lifetime
                         )));

--- a/lint-http-rules/src/rules/no_cache_revalidation.rs
+++ b/lint-http-rules/src/rules/no_cache_revalidation.rs
@@ -102,7 +102,7 @@ impl Rule for NoCacheRevalidation {
 
             // cite(RFC 9111 § 5.2.2.4): "The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response"
             if !has_conditional {
-                return Some(self.violation(ctx.severity, "Possible reuse of response marked 'no-cache' without conditional revalidation: subsequent request lacked If-None-Match/If-Modified-Since despite earlier no-cache response with a validator".into()));
+                return Some(self.cited(&RFC_9111_5_2_2_4, ctx.severity, "Possible reuse of response marked 'no-cache' without conditional revalidation: subsequent request lacked If-None-Match/If-Modified-Since despite earlier no-cache response with a validator".into()));
             }
 
             None

--- a/lint-http-rules/src/rules/no_connection_specific_fields.rs
+++ b/lint-http-rules/src/rules/no_connection_specific_fields.rs
@@ -191,7 +191,8 @@ impl NoConnectionSpecificFields {
         // cite(RFC 9110 § 10.1.4): "The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections."
         if direction == Direction::Response {
             if headers.contains_key("te") {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9110_10_1_4,
                     severity,
                     format!(
                         "{} response carries a TE header field; the exception {} makes is \

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -170,7 +170,8 @@ impl Rule for NoStoreEnforced {
                         // stored the thing it was told not to store.
                         // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."
                         if no_store_etags.contains(&normalized) {
-                            return Some(self.violation(
+                            return Some(self.cited(
+                                &RFC_9111_5_2_2_5,
                                 ctx.severity,
                                 format!(
                                     "Conditional request uses ETag '{}' from a no-store response",
@@ -201,7 +202,7 @@ impl Rule for NoStoreEnforced {
                                 .values()
                                 .any(|lm_dt| lm_dt == &candidate_dt.unwrap()))
                     {
-                        return Some(self.violation(ctx.severity, format!(
+                        return Some(self.cited(&RFC_9111_5_2_2_5, ctx.severity, format!(
                                 "Conditional request uses Last-Modified '{}' from a no-store response",
                                 candidate
                             )));

--- a/lint-http-rules/src/rules/options_method_capabilities.rs
+++ b/lint-http-rules/src/rules/options_method_capabilities.rs
@@ -152,7 +152,7 @@ impl Rule for OptionsMethodCapabilities {
             crate::helpers::headers::content_evidence(&tx.request.headers, tx.request.body_length)
         {
             if !tx.request.headers.contains_key("content-type") {
-                out.push(self.violation(ctx.severity, format!(
+                out.push(self.cited(&RFC_9110_9_3_7, ctx.severity, format!(
                             "OPTIONS request carries content ({evidence}) with no Content-Type header field; RFC 9110 § 9.3.7 says a client that generates an OPTIONS request containing content MUST send a valid Content-Type header field describing the representation media type"
                         )));
             }

--- a/lint-http-rules/src/rules/origin_isolated_header_valid.rs
+++ b/lint-http-rules/src/rules/origin_isolated_header_valid.rs
@@ -78,7 +78,8 @@ impl Rule for OriginIsolatedHeaderValid {
             // Must not be a comma-separated list
             // cite(HTML § 7.1.2): "This header is a structured header whose value must be a boolean."
             if crate::helpers::headers::list_members(val).count() != 1 {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &HTML_7_1_2,
                     ctx.severity,
                     "Origin-Agent-Cluster must be a single value".into(),
                 ));
@@ -93,7 +94,7 @@ impl Rule for OriginIsolatedHeaderValid {
                 return None;
             }
 
-            Some(self.violation(ctx.severity, format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", val)))
+            Some(self.cited(&HTML_7_1_2, ctx.severity, format!("Origin-Agent-Cluster header value '{}' is invalid: expected '?1' to request an origin-keyed agent cluster", val)))
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/origin_matching_for_cors.rs
+++ b/lint-http-rules/src/rules/origin_matching_for_cors.rs
@@ -109,7 +109,7 @@ impl Rule for OriginMatchingForCors {
                     "access-control-allow-credentials",
                 ) {
                     if cred.trim().eq_ignore_ascii_case("true") {
-                        return Some(self.violation(ctx.severity, "Access-Control-Allow-Origin '*' is not allowed when Access-Control-Allow-Credentials is true".into()));
+                        return Some(self.cited(&FETCH_4_10, ctx.severity, "Access-Control-Allow-Origin '*' is not allowed when Access-Control-Allow-Credentials is true".into()));
                     }
                 }
                 return None;
@@ -120,7 +120,8 @@ impl Rule for OriginMatchingForCors {
             // case normalisation is applied on either side.
             // cite(Fetch § 4.10): "If the result of byte-serializing a request origin with request is not origin, then return failure."
             if acao_val != origin {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &FETCH_4_10,
                     ctx.severity,
                     format!(
                         "Access-Control-Allow-Origin '{}' does not match request Origin '{}'",

--- a/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
@@ -65,7 +65,8 @@ impl Rule for PermissionsPolicyDirectivesValid {
             // is consulted -- so the whole field goes.
             // cite(RFC 9651 § 4.2): "Convert input_bytes into an ASCII string input_string; if conversion fails, fail parsing."
             let Ok(v) = hv.to_str() else {
-                return vec![self.violation(
+                return vec![self.cited(
+                    &RFC_9651_4_2,
                     ctx.severity,
                     "Permissions-Policy contains a byte outside ASCII, so the field \
                                   fails Structured Fields parsing and every directive in it is \

--- a/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
+++ b/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
@@ -87,7 +87,7 @@ impl Rule for PriorityAndCacheabilityConsistent {
             // the Priority expectation nor the Vary half of the check.)
             // cite(RFC 9218 § 5): "the server is expected to control the cacheability or the applicability of the cached response by using header fields that control the caching behavior (e.g., Cache-Control, Vary)"
             if !has_cache_control && !has_vary {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9218_5, ctx.severity, format!(
                         "Response includes Priority header ('{}') but lacks Cache-Control or Vary to control cacheability; origin servers emitting Priority should control cacheability per RFC 9218 §5",
                         priority
                     )));

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -98,7 +98,7 @@ impl Rule for PrivateCacheVisibility {
                                             // representation directly from the origin share it legitimately.
                                             // cite(RFC 9111 § 5.2.2.7): "The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user)."
                                             if val_norm == normalized {
-                                                return Some(self.violation(ctx.severity, format!(
+                                                return Some(self.cited(&RFC_9111_5_2_2_7, ctx.severity, format!(
                                                         "Validator '{}' from a private response seen by a different client",
                                                         member
                                                     )));
@@ -133,7 +133,7 @@ impl Rule for PrivateCacheVisibility {
                                                 // Same heuristic + cite as the ETag branch above.
                                                 // cite(RFC 9111 § 5.2.2.7): "The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user)."
                                                 if val_dt == candidate_dt {
-                                                    return Some(self.violation(ctx.severity, format!(
+                                                    return Some(self.cited(&RFC_9111_5_2_2_7, ctx.severity, format!(
                                                             "Validator '{}' from a private response seen by a different client",
                                                             candidate
                                                         )));

--- a/lint-http-rules/src/rules/problem_details_content_type.rs
+++ b/lint-http-rules/src/rules/problem_details_content_type.rs
@@ -126,7 +126,7 @@ impl Rule for ProblemDetailsContentType {
             // for, an application with no error format of its own. So the finding is
             // advice and the message says so.
             // cite(RFC 9457 § 1): "This specification's aim is to define common error formats for applications that need one so that they aren't required to define their own or, worse, tempted to redefine the semantics of existing HTTP status codes."
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9457_1, ctx.severity, format!(
                     "Error response carries the generic media type '{}'; problem details (RFC 9457) would describe the error in a machine-readable form, as 'application/problem+json' or 'application/problem+xml'. Advisory: no RFC requires them, and an application that already has an error format of its own should keep using it",
                     ct_str
                 )))

--- a/lint-http-rules/src/rules/proxy_connection_discouraged.rs
+++ b/lint-http-rules/src/rules/proxy_connection_discouraged.rs
@@ -102,7 +102,7 @@ impl Rule for ProxyConnectionDiscouraged {
             // several, so it reproduces the problem it was meant to solve.
             //
             // cite(RFC 9112 § C.2.2): "One attempted solution was the introduction of a Proxy-Connection header field, targeted specifically at proxies.  In practice, this was also unworkable, because proxies are often deployed in multiple layers, bringing about the same problem discussed above."
-            Some(self.violation(
+            Some(self.cited(&RFC_9112_C_2_2,
                 ctx.severity,
                 format!(
                     "Request carries a Proxy-Connection header field: '{}'. RFC 9112 Appendix C.2.2 \

--- a/lint-http-rules/src/rules/quic_transport_parameters_valid.rs
+++ b/lint-http-rules/src/rules/quic_transport_parameters_valid.rs
@@ -93,7 +93,8 @@ impl ProtocolRule for QuicTransportParametersValid {
             // cite(RFC 9114 § 6.1): "In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window."
             if params.initial_max_streams_bidi == Some(0) {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9114_6_1,
                         ctx.severity,
                         "QUIC initial_max_streams_bidi is 0; HTTP/3 requires at least one \
                          bidirectional stream for request/response exchange (RFC 9114 §6.1)"
@@ -109,7 +110,8 @@ impl ProtocolRule for QuicTransportParametersValid {
             // cite(RFC 9000 § 18.2): "the initial value for the maximum amount of data that can be sent on the connection"
             if params.initial_max_data == Some(0) {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9000_18_2,
                         ctx.severity,
                         "QUIC initial_max_data is 0; no data can be transferred on this \
                          connection (RFC 9000 §18.2)"
@@ -141,7 +143,8 @@ impl ProtocolRule for QuicTransportParametersValid {
             // cite(RFC 9114 § 6.1): "In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window."
             if params.initial_max_stream_data_bidi_remote == Some(0) {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9114_6_1,
                         ctx.severity,
                         "QUIC initial_max_stream_data_bidi_remote is 0; request streams \
                          cannot carry data (RFC 9114 §6.1)"
@@ -155,7 +158,8 @@ impl ProtocolRule for QuicTransportParametersValid {
             // cite(RFC 9114 § 6.2): "Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked."
             if params.initial_max_stream_data_uni == Some(0) {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9114_6_2,
                         ctx.severity,
                         "QUIC initial_max_stream_data_uni is 0; HTTP/3 unidirectional streams \
                          (control, QPACK) cannot carry data (RFC 9114 §6.2)"
@@ -171,7 +175,8 @@ impl ProtocolRule for QuicTransportParametersValid {
             match params.max_idle_timeout_ms {
                 Some(0) | None => {
                     return Some(
-                        self.violation(
+                        self.cited(
+                            &RFC_9000_18_2,
                             ctx.severity,
                             "QUIC max_idle_timeout is 0 or absent; connections may remain \
                              idle indefinitely, consuming server resources (RFC 9000 §18.2)"

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -169,7 +169,7 @@ impl Rule for RangeAndContentRangeConsistent {
             // well-formed satisfied Content-Range could reach it.
             // cite(RFC 9110 § 15.3.7): "The 206 (Partial Content) status code indicates that the server is successfully fulfilling a range request for the target resource by transferring one or more parts of the selected representation."
             if status == 206 && !has_range_request {
-                return Some(self.violation(config.severity, "206 Partial Content response received but request did not include a Range header"
+                return Some(self.cited(&RFC_9110_15_3_7, config.severity, "206 Partial Content response received but request did not include a Range header"
                             .into()));
             }
 
@@ -189,7 +189,7 @@ impl Rule for RangeAndContentRangeConsistent {
                 if response_is_multipart_byteranges(&resp.headers) {
                     // cite(RFC 9110 § 15.3.7.2): "To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead)."
                     if cr.is_some() {
-                        return Some(self.violation(config.severity, "multipart/byteranges 206 response must not carry a Content-Range header field in its header section (each body part carries its own)".into()));
+                        return Some(self.cited(&RFC_9110_15_3_7_2, config.severity, "multipart/byteranges 206 response must not carry a Content-Range header field in its header section (each body part carries its own)".into()));
                     }
 
                     // One requested range may not be answered with a multipart
@@ -353,11 +353,12 @@ impl Rule for RangeAndContentRangeConsistent {
                         // because it is about a field the server chose to send rather
                         // than about one the spec asked it for.
                         // cite(RFC 9110 § 14.4): "The complete-length in a 416 response indicates the current length of the selected representation."
-                        return Some(self.violation(config.severity, "416 response should use the '*/complete-length' form in Content-Range"
+                        return Some(self.cited(&RFC_9110_14_4, config.severity, "416 response should use the '*/complete-length' form in Content-Range"
                                     .into()));
                     }
                     Err(e) => {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9110_14_4,
                             config.severity,
                             format!("Invalid Content-Range header '{}': {}", cr, e),
                         ));

--- a/lint-http-rules/src/rules/range_header_syntax.rs
+++ b/lint-http-rules/src/rules/range_header_syntax.rs
@@ -139,7 +139,8 @@ impl Rule for RangeHeaderSyntax {
             //
             // cite(RFC 9110 § 14.1.1): "A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit."
             if let Err(e) = validate_range_set(&unit, range_set) {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9110_14_1_1,
                     ctx.severity,
                     format!("Invalid Range header '{}': {}", value, e),
                 ));

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -194,7 +194,7 @@ impl Rule for RangeRequestAndCaching {
             }
 
             let Some(raw_if_range) = req.headers.get("if-range") else {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
                         "Range request for a resource this client holds a 206 of, whose stored entity tag is {stored_etag}, carries none of If-Range, If-Match or If-None-Match; the entity tags of the stored response being validated have to be sent in one of those three"
                     )));
             };
@@ -227,14 +227,14 @@ impl Rule for RangeRequestAndCaching {
                 // The client was given an entity tag for this representation, so the
                 // date is the one validator it was not permitted to choose.
                 // cite(RFC 9110 § 13.1.5): "Range header field containing an HTTP-date unless the client has no entity tag for the corresponding representation and the date is a strong validator in the sense defined by Section 8.8.2.2."
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9110_13_1_5, ctx.severity, format!(
                         "If-Range carries the date '{if_range}' although entity tag {stored_etag} was provided for this representation; a date is only permitted there when the client has no entity tag"
                     )));
             }
 
             // cite(RFC 9110 § 13.1.5): "Note that the If-Range comparison is by exact match, including when the validator is an HTTP-date, and so it differs from the "earlier than or equal to" comparison used when evaluating an If-Unmodified-Since conditional."
             if if_range != stored_etag {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9110_13_1_5, ctx.severity, format!(
                         "If-Range entity tag {if_range} is not {stored_etag}, the tag most recently provided for this representation; a server still holding that tag will ignore Range and send the whole representation"
                     )));
             }

--- a/lint-http-rules/src/rules/redirect_chain_valid.rs
+++ b/lint-http-rules/src/rules/redirect_chain_valid.rs
@@ -277,7 +277,7 @@ impl Rule for RedirectChainValid {
             }
 
             // cite(RFC 9110 § 15.4): "A client SHOULD detect and intervene in cyclical redirections (i.e., "infinite" redirection loops)."
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9110_15_4, ctx.severity, format!(
                     "Location '{}' resolves to '{}', the target URI of the request it answers, so the response redirects the client to where it already was: {}. A client that follows it issues the same request again — RFC 9110 §15.4 asks one to detect and intervene in cyclical redirections, and this is the shortest one there is",
                     value.escape_debug(),
                     location_path_and_query.escape_debug(),

--- a/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
+++ b/lint-http-rules/src/rules/redirect_status_and_location_valid.rs
@@ -128,7 +128,7 @@ impl Rule for RedirectStatusAndLocationValid {
             // cite(RFC 9110 § 10.2.2): "The "Location" header field is used in some responses to refer to a specific resource in relation to the response."
             resp.headers.get_all("location").iter().next()?;
 
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9110_10_2_2, ctx.severity, format!(
                     "Response with status {status} carries a Location header field. RFC 9110 §10.2.2 \
                      defines what the value refers to on a 201 (Created) response and on a 3xx \
                      (Redirection) response, and on no other status — so on a {status} the field has \

--- a/lint-http-rules/src/rules/refresh_header_syntax.rs
+++ b/lint-http-rules/src/rules/refresh_header_syntax.rs
@@ -290,7 +290,8 @@ impl Rule for RefreshHeaderSyntax {
             // for the `meta` pragma's content attribute; this is the sentence that
             // makes it this field's requirement too.
             refresh_value_error(value).map(|why| {
-                self.violation(
+                self.cited(
+                    &HTML_SPECULATIVE_LOADING_7_8,
                     ctx.severity,
                     format!("Refresh header value '{value}': {why}"),
                 )

--- a/lint-http-rules/src/rules/request_method_token_valid.rs
+++ b/lint-http-rules/src/rules/request_method_token_valid.rs
@@ -248,7 +248,7 @@ impl Rule for RequestMethodTokenValid {
                     // is worth saying at all: the request does not fail to parse, it simply
                     // asks for a method nobody defined.
                     // cite(RFC 9110 § 9.1): "An origin server that receives a request method that is unrecognized or not implemented SHOULD respond with the 501 (Not Implemented) status code."
-                    return Some(self.violation(
+                    return Some(self.cited(&RFC_9110_9_1,
                         config.severity,
                         format!(
                             "Method token '{m}' is '{folded}' written in another case. The method token is case-sensitive, so a server matching method names sees an unrecognized method here rather than '{folded}', and ought to answer 501 (Not Implemented); by convention a standardized method is defined in all-uppercase US-ASCII letters"

--- a/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
+++ b/lint-http-rules/src/rules/request_origin_header_present_for_cors.rs
@@ -93,7 +93,8 @@ impl Rule for RequestOriginHeaderPresentForCors {
                             if crate::helpers::headers::get_header_str(headers, "origin").is_none()
                             {
                                 return Some(
-                                    self.violation(
+                                    self.cited(
+                                        &FETCH_3_2,
                                         ctx.severity,
                                         "Cross-origin absolute-form request missing Origin header"
                                             .into(),

--- a/lint-http-rules/src/rules/request_version_method_valid.rs
+++ b/lint-http-rules/src/rules/request_version_method_valid.rs
@@ -133,7 +133,7 @@ impl Rule for RequestVersionMethodValid {
                 // method's definition rather than that a modal was disobeyed.
                 // cite(RFC 9110 § 9.3.6): "A CONNECT request message does not have content."
                 "CONNECT" => {
-                    return request_declares_content(&tx.request).then(|| self.violation(ctx.severity, "CONNECT request declares content in its header section; RFC 9110 § 9.3.6 defines a CONNECT request message as having none".into()));
+                    return request_declares_content(&tx.request).then(|| self.cited(&RFC_9110_9_3_6, ctx.severity, "CONNECT request declares content in its header section; RFC 9110 § 9.3.6 defines a CONNECT request message as having none".into()));
                 }
 
                 _ => return None,
@@ -149,7 +149,7 @@ impl Rule for RequestVersionMethodValid {
             // agreement is not something to rely on, and names why: the request
             // chain. So the finding stands and `description()` states the limit.
             // cite(RFC 9110 § 9.3.1): "An origin server SHOULD NOT rely on private agreements to receive content, since participants in HTTP communication are often unaware of intermediaries along the request chain."
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9110_9_3_1, ctx.severity, format!(
                     "{} request carries content; RFC 9110 {}, and content received in one has no generally defined semantics",
                     method, sentence
                 )))

--- a/lint-http-rules/src/rules/retry_after_date_or_delay.rs
+++ b/lint-http-rules/src/rules/retry_after_date_or_delay.rs
@@ -54,7 +54,8 @@ impl Rule for RetryAfterDateOrDelay {
                 let s = match val.to_str() {
                     Ok(s) => s.trim(),
                     Err(_) => {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_9110_10_2_3,
                             ctx.severity,
                             "Retry-After header contains non-UTF8 value".into(),
                         ))

--- a/lint-http-rules/src/rules/retry_after_status_valid.rs
+++ b/lint-http-rules/src/rules/retry_after_status_valid.rs
@@ -118,7 +118,7 @@ impl Rule for RetryAfterStatusValid {
             // it, which is an interoperability observation and not a requirement.
             // `description()` says the same where an operator reads it.
             // cite(RFC 9110 § 10.2.3): "Servers send the "Retry-After" header field to indicate how long the user agent ought to wait before making a follow-up request."
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9110_10_2_3, ctx.severity, format!(
                     "Retry-After arrived on status {status}, which neither RFC 9110 nor RFC 6585 pairs with \
                      this field; the two documents pair it with any 3xx redirection, 413 Content Too Large, \
                      429 Too Many Requests, and 503 Service Unavailable. No requirement forbids sending it \

--- a/lint-http-rules/src/rules/s_max_age_enforced.rs
+++ b/lint-http-rules/src/rules/s_max_age_enforced.rs
@@ -110,7 +110,7 @@ impl Rule for SMaxAgeEnforced {
             // assumes the observed client is private, which cannot be verified from traffic).
             // cite(RFC 9111 § 5.2.2.10): "The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires header field."
             if has_conditional && current_age >= s_max_age && current_age < max_age {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9111_5_2_2_10, ctx.severity, format!(
                         "Resource revalidated after s-maxage={} but before max-age={} (age {}) — private caches must ignore s-maxage and use max-age for freshness",
                         s_max_age, max_age, current_age
                     )));

--- a/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
@@ -74,7 +74,11 @@ impl Rule for SecFetchDestValueValid {
             // An empty value cannot be a token.
             // cite(Fetch Metadata § 2.1): "It is a Structured Field whose value MUST be a token."
             if val.is_empty() {
-                return Some(self.violation(ctx.severity, "Sec-Fetch-Dest header is empty".into()));
+                return Some(self.cited(
+                    &FETCH_METADATA_2_1,
+                    ctx.severity,
+                    "Sec-Fetch-Dest header is empty".into(),
+                ));
             }
 
             // Token must not contain invalid token chars. This checks the HTTP `token`
@@ -83,7 +87,8 @@ impl Rule for SecFetchDestValueValid {
             // message a bad value gets.
             // cite(Fetch Metadata § 2.1): "It is a Structured Field whose value MUST be a token."
             if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &FETCH_METADATA_2_1,
                     ctx.severity,
                     format!(
                         "Sec-Fetch-Dest header contains invalid token character: '{}'",

--- a/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
@@ -72,7 +72,11 @@ impl Rule for SecFetchSiteValueValid {
             // sibling sections carry, but the constraint is the same).
             // cite(Fetch Metadata § 2.3): "It is a Structured Field whose value is a token."
             if val.is_empty() {
-                return Some(self.violation(ctx.severity, "Sec-Fetch-Site header is empty".into()));
+                return Some(self.cited(
+                    &FETCH_METADATA_2_3,
+                    ctx.severity,
+                    "Sec-Fetch-Site header is empty".into(),
+                ));
             }
 
             // Token must not contain invalid token chars. This checks the HTTP `token`
@@ -81,7 +85,8 @@ impl Rule for SecFetchSiteValueValid {
             // message a bad value gets.
             // cite(Fetch Metadata § 2.3): "It is a Structured Field whose value is a token."
             if let Some(c) = crate::helpers::token::find_invalid_token_char(val) {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &FETCH_METADATA_2_3,
                     ctx.severity,
                     format!(
                         "Sec-Fetch-Site header contains invalid token character: '{}'",

--- a/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
+++ b/lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
@@ -71,7 +71,11 @@ impl Rule for SecFetchUserValueValid {
             // An empty value cannot be an sf-boolean.
             // cite(Fetch Metadata § 2.4): "It is a Structured Field whose value is a boolean."
             if val.is_empty() {
-                return Some(self.violation(ctx.severity, "Sec-Fetch-User header is empty".into()));
+                return Some(self.cited(
+                    &FETCH_METADATA_2_4,
+                    ctx.severity,
+                    "Sec-Fetch-User header is empty".into(),
+                ));
             }
 
             // The canonical serialization for a structured-boolean true is `?1`. `?0` is a

--- a/lint-http-rules/src/rules/status_101_switching_protocols.rs
+++ b/lint-http-rules/src/rules/status_101_switching_protocols.rs
@@ -80,7 +80,7 @@ impl Rule for Status101SwitchingProtocols {
                 for prev in history.iter() {
                     if let Some(prev_resp) = &prev.response {
                         if prev_resp.status == 101 {
-                            return Some(self.violation(ctx.severity, "HTTP traffic after 101 Switching Protocols on the same connection; \
+                            return Some(self.cited(&RFC_9110_15_2_2, ctx.severity, "HTTP traffic after 101 Switching Protocols on the same connection; \
                                      the connection should have been handed off to the upgraded protocol"
                                         .into()));
                         }
@@ -109,7 +109,7 @@ impl Rule for Status101SwitchingProtocols {
                 crate::http_version::parse(&tx.request.version),
                 Ok(crate::http_version::HttpVersion { major: 1, minor: 0 })
             ) {
-                return Some(self.violation(ctx.severity, "101 Switching Protocols must not be sent in response to an HTTP/1.0 request; \
+                return Some(self.cited(&RFC_9110_7_8, ctx.severity, "101 Switching Protocols must not be sent in response to an HTTP/1.0 request; \
                          Upgrade is not supported in HTTP/1.0 (RFC 9110 §7.8)"
                             .into()));
             }
@@ -120,7 +120,8 @@ impl Rule for Status101SwitchingProtocols {
             // — this version carries no version field — and neither listing them nor
             // guessing which one arrives is the question. The major digit is.
             if crate::http_version::is_major(&tx.request.version, 2) {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9113_8_6,
                     ctx.severity,
                     "101 Switching Protocols must not be sent over HTTP/2 (RFC 9113 §8.6)".into(),
                 ));
@@ -132,7 +133,8 @@ impl Rule for Status101SwitchingProtocols {
             // `http3_status_code_valid`; checked here for completeness.
             // cite(RFC 9114 § 4.5): "HTTP/3 does not support the HTTP Upgrade mechanism (Section 7.8 of [HTTP]) or the 101 (Switching Protocols) informational status code (Section 15.2.2 of [HTTP])."
             if crate::http_version::is_major(&tx.request.version, 3) {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9114_4_5,
                     ctx.severity,
                     "101 Switching Protocols must not be sent over HTTP/3 (RFC 9114 §4.5)".into(),
                 ));
@@ -151,7 +153,8 @@ impl Rule for Status101SwitchingProtocols {
             // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
             if req_upgrade_combined.is_none() {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9110_7_8,
                         ctx.severity,
                         "Server sent 101 Switching Protocols but the request did not include an \
                          Upgrade header (RFC 9110 §7.8)"
@@ -167,7 +170,8 @@ impl Rule for Status101SwitchingProtocols {
                 crate::helpers::headers::get_all_header_values(&resp.headers, "upgrade");
             if resp_upgrade_combined.is_none() {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9110_15_2_2,
                         ctx.severity,
                         "101 Switching Protocols response missing required Upgrade header \
                          (RFC 9110 §15.2.2)"
@@ -194,7 +198,8 @@ impl Rule for Status101SwitchingProtocols {
             // cite(RFC 9110 § 7.8): "A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field."
             if offered.is_empty() {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9110_7_8,
                         ctx.severity,
                         "Server sent 101 Switching Protocols but the request Upgrade header \
                          contains no protocol tokens (RFC 9110 §7.8)"
@@ -208,7 +213,8 @@ impl Rule for Status101SwitchingProtocols {
             // cite(RFC 9110 § 15.2.2): "The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response."
             if chosen_list.is_empty() {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9110_15_2_2,
                         ctx.severity,
                         "101 Switching Protocols response Upgrade header contains no protocol \
                          tokens (RFC 9110 §15.2.2)"
@@ -224,7 +230,8 @@ impl Rule for Status101SwitchingProtocols {
             let all_matched = chosen_list.iter().all(|c| offered.contains(c));
 
             if !all_matched {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9110_7_8,
                     ctx.severity,
                     format!(
                         "101 response Upgrade '{}' was not offered by the client's Upgrade '{}' \

--- a/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
+++ b/lint-http-rules/src/rules/status_103_early_hints_before_final.rs
@@ -135,7 +135,8 @@ impl Rule for Status103EarlyHintsBeforeFinal {
                 Ok(crate::http_version::HttpVersion { major: 1, minor: 0 })
             ) {
                 return Some(
-                    self.violation(
+                    self.cited(
+                        &RFC_9110_15_2,
                         ctx.severity,
                         "103 (Early Hints) answering an HTTP/1.0 request: HTTP/1.0 defined no \
                               1xx status codes, so a server must not send one to that client"

--- a/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
+++ b/lint-http-rules/src/rules/status_3xx_vs_request_method.rs
@@ -147,7 +147,7 @@ impl Rule for Status3xxVsRequestMethod {
             // the message from there. The 303 clause is §9.3.3's MAY, and it travels with
             // the condition that sentence puts on it.
             // cite(RFC 9110 § 9.3.3): "If the result of processing a POST would be equivalent to a representation of an existing resource, an origin server MAY redirect the user agent to that resource by sending a 303 (See Other) response with the existing resource's identifier in the Location field."
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9110_9_3_3, ctx.severity, format!(
                     "{status} response to a POST request: for historical reasons a user agent MAY \
                      change the method to GET before following this redirect (RFC 9110 {section}), so \
                      the response does not say which method reaches the Location. Send {alternative} \

--- a/lint-http-rules/src/rules/status_426_upgrade_valid.rs
+++ b/lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -149,7 +149,7 @@ impl Rule for Status426UpgradeValid {
                     .as_ref()
                     .is_some_and(|trailers| trailers.contains_key("upgrade"));
 
-                return Some(self.violation(
+                return Some(self.cited(&RFC_9110_6_5_1,
                     ctx.severity,
                     format!(
                         "426 Upgrade Required with no Upgrade header field. The status says the server \

--- a/lint-http-rules/src/rules/status_and_caching_semantics.rs
+++ b/lint-http-rules/src/rules/status_and_caching_semantics.rs
@@ -102,7 +102,7 @@ impl Rule for StatusAndCachingSemantics {
             // None of the storability signals §3 requires are present, and the status is not
             // heuristically cacheable — so a cache cannot store this response.
             // cite(RFC 9111 § 3): "A cache MUST NOT store a response to a request unless"
-            Some(self.violation(ctx.severity, format!(
+            Some(self.cited(&RFC_9111_3, ctx.severity, format!(
                     "Response {} is not cacheable by default and lacks explicit freshness information (Cache-Control: max-age/s-maxage or Expires)",
                     status
                 )))

--- a/lint-http-rules/src/rules/status_code_semantics.rs
+++ b/lint-http-rules/src/rules/status_code_semantics.rs
@@ -201,7 +201,7 @@ impl Rule for StatusCodeSemantics {
             // an operator reads it.
             // cite(RFC 9110 § 11.7.1): "Unlike WWW-Authenticate, the Proxy-Authenticate header field applies only to the next outbound client on the response chain."
             if resp.headers.contains_key("proxy-authenticate") {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_9110_11_7_1, ctx.severity, format!(
                         "Proxy-Authenticate arrived on status {status}; RFC 9110 pairs this field \
                          with 407 Proxy Authentication Required, the one response a proxy MUST send \
                          it in. No requirement forbids it here — the field's definition puts no \

--- a/lint-http-rules/src/rules/strict_transport_security_valid.rs
+++ b/lint-http-rules/src/rules/strict_transport_security_valid.rs
@@ -69,7 +69,8 @@ impl Rule for StrictTransportSecurityValid {
                 let v = match hv.to_str() {
                     Ok(s) => s.trim(),
                     Err(_) => {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_6797_6_1,
                             ctx.severity,
                             "Strict-Transport-Security header contains non-UTF8 value".into(),
                         ));
@@ -108,7 +109,7 @@ impl Rule for StrictTransportSecurityValid {
 
                     // cite(RFC 6797 § 6.1): "directive-name            = token"
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-                        return Some(self.violation(ctx.severity, format!("Strict-Transport-Security directive name contains invalid character: '{}'", c)));
+                        return Some(self.cited(&RFC_6797_6_1, ctx.severity, format!("Strict-Transport-Security directive name contains invalid character: '{}'", c)));
                     }
 
                     let lname = name.to_ascii_lowercase();
@@ -169,7 +170,7 @@ impl Rule for StrictTransportSecurityValid {
                                     if let Err(e) =
                                         crate::helpers::headers::validate_quoted_string(vpart)
                                     {
-                                        return Some(self.violation(ctx.severity, format!("Invalid quoted-string in Strict-Transport-Security directive value: {}", e)));
+                                        return Some(self.cited(&RFC_6797_6_1, ctx.severity, format!("Invalid quoted-string in Strict-Transport-Security directive value: {}", e)));
                                     }
                                 } else if let Some(c) =
                                     crate::helpers::token::find_invalid_token_char(vpart)
@@ -183,13 +184,14 @@ impl Rule for StrictTransportSecurityValid {
 
                 // cite(RFC 6797 § 6.1): "All directives MUST appear only once in an STS header field."
                 if max_age_count > 1 {
-                    return Some(self.violation(ctx.severity, "Strict-Transport-Security MUST NOT contain multiple 'max-age' directives"
+                    return Some(self.cited(&RFC_6797_6_1, ctx.severity, "Strict-Transport-Security MUST NOT contain multiple 'max-age' directives"
                                 .into()));
                 }
 
                 if !saw_max_age {
                     return Some(
-                        self.violation(
+                        self.cited(
+                            &RFC_6797_6_1,
                             ctx.severity,
                             "Strict-Transport-Security header missing required 'max-age' directive"
                                 .into(),

--- a/lint-http-rules/src/rules/structured_headers_valid.rs
+++ b/lint-http-rules/src/rules/structured_headers_valid.rs
@@ -70,7 +70,8 @@ impl StructuredHeadersValid {
         msg: &str,
         severity: crate::lint::Severity,
     ) -> Violation {
-        self.violation(
+        self.cited(
+            &RFC_9651_4_2,
             severity,
             format!(
                 "The {} header '{}' fails Structured Fields parsing, so a recipient discards \

--- a/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
+++ b/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
@@ -67,7 +67,8 @@ impl Rule for SunsetAndDeprecationConsistent {
                 Some(s) => match crate::http_date::parse_http_date_to_datetime(s) {
                     Ok(dt) => Some((s.to_string(), dt)),
                     Err(_) => {
-                        return Some(self.violation(
+                        return Some(self.cited(
+                            &RFC_8594_3,
                             ctx.severity,
                             "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into(),
                         ));
@@ -133,7 +134,7 @@ impl Rule for SunsetAndDeprecationConsistent {
             {
                 let allowed_skew = chrono::Duration::seconds(60);
                 if dep_dt > sun_dt + allowed_skew {
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9745_4, ctx.severity, format!(
                             "Deprecation '{}' indicates a time after Sunset '{}'; the Sunset timestamp must not be earlier than Deprecation (RFC 9745 §4)",
                             dep_raw, sun_raw
                         )));

--- a/lint-http-rules/src/rules/trace_method_echo.rs
+++ b/lint-http-rules/src/rules/trace_method_echo.rs
@@ -136,7 +136,7 @@ impl Rule for TraceMethodEcho {
         if let Some(evidence) =
             crate::helpers::headers::content_evidence(&tx.request.headers, tx.request.body_length)
         {
-            out.push(self.violation(ctx.severity, format!(
+            out.push(self.cited(&RFC_9110_9_3_8, ctx.severity, format!(
                         "TRACE request carries content ({evidence}); RFC 9110 § 9.3.8 says a client MUST NOT send content in a TRACE request"
                     )));
         }

--- a/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
+++ b/lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
@@ -142,7 +142,8 @@ impl Rule for TransferEncodingChunkedFinal {
             // cite(RFC 9112 § 6.1): "A sender MUST NOT apply the chunked transfer coding more than once to a message body (i.e., chunking an already chunked message is not allowed)."
             let chunked_count = codings.iter().filter(|c| *c == "chunked").count();
             if chunked_count > 1 {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9112_6_1,
                     ctx.severity,
                     format!(
                         "The chunked transfer coding must not be applied more than once: \
@@ -207,7 +208,8 @@ impl Rule for TransferEncodingChunkedFinal {
                 && codings.iter().any(|c| c != "chunked")
                 && codings.last().map(String::as_str) != Some("chunked")
             {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &RFC_9112_6_1,
                     ctx.severity,
                     format!(
                         "A request that applies any transfer coding other than chunked must apply \

--- a/lint-http-rules/src/rules/vary_header_cache_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -207,7 +207,7 @@ impl Rule for VaryHeaderCacheValid {
                 // cite(RFC 9111 § 4.1): "the cache MUST NOT use that stored response without revalidation unless all the presented request header fields nominated by that Vary field value match those fields in the original request"
                 if past_val != curr_val {
                     let reported_validator = matched_validator.as_deref().unwrap_or("<unknown>");
-                    return Some(self.violation(ctx.severity, format!(
+                    return Some(self.cited(&RFC_9111_4_1, ctx.severity, format!(
                             "Conditional request with validator '{}' differs in Vary field '{}'; cache key must incorporate all Vary dimensions",
                             reported_validator, field
                         )));

--- a/lint-http-rules/src/rules/vary_header_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_valid.rs
@@ -48,16 +48,16 @@ impl Rule for VaryHeaderValid {
             // are each "*" or a field-name.
             // cite(RFC 9110 § 12.5.5): "Vary = #( "*" / field-name )"
             for hv in resp.headers.get_all("vary").iter() {
-                let s =
-                    match hv.to_str() {
-                        Ok(s) => s,
-                        Err(_) => {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Vary header contains non-UTF8 value".into(),
-                            ))
-                        }
-                    };
+                let s = match hv.to_str() {
+                    Ok(s) => s,
+                    Err(_) => {
+                        return Some(self.cited(
+                            &RFC_9110_12_5_5,
+                            ctx.severity,
+                            "Vary header contains non-UTF8 value".into(),
+                        ))
+                    }
+                };
 
                 // Vary is a `#`-list, so an entirely empty value is a legal zero-element
                 // list (the degenerate "does not vary" case), not a malformed header.

--- a/lint-http-rules/src/rules/via_header_syntax.rs
+++ b/lint-http-rules/src/rules/via_header_syntax.rs
@@ -89,13 +89,13 @@ impl Rule for ViaHeaderSyntax {
         let finding = || -> Option<Violation> {
             // cite(RFC 9110 § 7.6.3): "A proxy MUST send an appropriate Via header field, as described below, in each message that it forwards."
             if let Some(err) = judge(&tx.request.headers, "Request") {
-                return Some(self.violation(ctx.severity, err));
+                return Some(self.cited(&RFC_9110_7_6_3, ctx.severity, err));
             }
 
             // cite(RFC 9110 § 7.6.3): "An HTTP-to-HTTP gateway MUST send an appropriate Via header field in each inbound request message and MAY send a Via header field in forwarded response messages."
             if let Some(resp) = &tx.response {
                 if let Some(err) = judge(&resp.headers, "Response") {
-                    return Some(self.violation(ctx.severity, err));
+                    return Some(self.cited(&RFC_9110_7_6_3, ctx.severity, err));
                 }
             }
 

--- a/lint-http-rules/src/rules/websocket_frame_masking.rs
+++ b/lint-http-rules/src/rules/websocket_frame_masking.rs
@@ -114,7 +114,11 @@ impl ProtocolRule for WebsocketFrameMasking {
                 _ => return None,
             };
 
-            Some(self.violation(ctx.severity, format!("A WebSocket frame where {defect}")))
+            Some(self.cited(
+                &RFC_6455_5_1,
+                ctx.severity,
+                format!("A WebSocket frame where {defect}"),
+            ))
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
+++ b/lint-http-rules/src/rules/websocket_frame_rsv_bits.rs
@@ -113,7 +113,7 @@ impl ProtocolRule for WebsocketFrameRsvBits {
             //
             // cite(RFC 6455 § 5.2): "RSV1, RSV2, RSV3:  1 bit each"
             if *rsv > 0b111 {
-                return Some(self.violation(ctx.severity, format!(
+                return Some(self.cited(&RFC_6455_5_2, ctx.severity, format!(
                         "A WebSocket frame the {sender} sent records the reserved bits as {rsv:#05b}, \
                          and the frame header holds three of them — one bit each — so no frame on any \
                          wire carried this value"

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -53,7 +53,7 @@ impl Rule for WwwAuthenticateChallengeSyntax {
                         let challenges = match crate::helpers::auth::split_and_group_challenges(s) {
                             Ok(c) => c,
                             Err(msg) => {
-                                return Some(self.violation(ctx.severity, msg));
+                                return Some(self.cited(&RFC_9110_11_6_1, ctx.severity, msg));
                             }
                         };
 

--- a/lint-http-rules/src/rules/x_content_type_options_present.rs
+++ b/lint-http-rules/src/rules/x_content_type_options_present.rs
@@ -118,7 +118,7 @@ impl Rule for XContentTypeOptionsPresent {
             {
                 let first = xcto.split(',').next().unwrap_or("").trim();
                 if !first.eq_ignore_ascii_case("nosniff") {
-                    return Some(self.violation(config.severity, format!(
+                    return Some(self.cited(&FETCH_3_6, config.severity, format!(
                             "X-Content-Type-Options value '{}' does not enable nosniff (the value must be `nosniff`, case-insensitive)",
                             xcto.trim()
                         )));

--- a/lint-http-rules/src/rules/x_frame_options_value_valid.rs
+++ b/lint-http-rules/src/rules/x_frame_options_value_valid.rs
@@ -90,7 +90,8 @@ impl Rule for XFrameOptionsValueValid {
             // the generic unsupported-value one.
             // cite(HTML Speculative Loading § 7.7): "In particular, HTTP Header Field X-Frame-Options specified an `ALLOW-FROM` variant of the header, but that is not to be implemented."
             if val.len() >= 10 && val[..10].eq_ignore_ascii_case("ALLOW-FROM") {
-                return Some(self.violation(
+                return Some(self.cited(
+                    &HTML_SPECULATIVE_LOADING_7_7,
                     ctx.severity,
                     format!(
                         "X-Frame-Options: ALLOW-FROM is obsolete and not implemented by browsers \

--- a/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
+++ b/lint-http-rules/src/rules/x_xss_protection_value_valid.rs
@@ -94,7 +94,8 @@ impl Rule for XXssProtectionValueValid {
                 return None;
             }
 
-            Some(self.violation(
+            Some(self.cited(
+                &MDN_X_XSS_PROTECTION,
                 ctx.severity,
                 format!("X-XSS-Protection contains unsupported value: '{}'", val),
             ))

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -84,7 +84,7 @@ sources:
     snippet: 'A destination type is one of: the empty string, "audio", "audioworklet", "document", "embed", "font", "frame", "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script", "serviceworker", "sharedworker", "style", "text", "track", "video", "webidentity", "worker", or "xslt".'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 103
+      line: 108
   - label: timing_allow_origin_valid
     section: § 3.2
     snippet: origin-or-null = serialized-origin / %s"null" ; case-sensitive
@@ -142,7 +142,7 @@ sources:
     snippet: values that are not the structured header boolean true value (i.e., `?1`) will be ignored.
     cited_by:
     - file: lint-http-rules/src/rules/origin_isolated_header_valid.rs
-      line: 91
+      line: 92
 - label: HTML Links
   url: https://html.spec.whatwg.org/multipage/links.html
   type: text/html
@@ -445,17 +445,17 @@ sources:
     snippet: If r’s destination is the empty string, set header’s value to the string "empty"
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 106
+      line: 111
   - label: sec_fetch_dest_value_valid (3)
     section: § 2.1
     snippet: In order to support forward-compatibility with as-yet-unknown request types, servers SHOULD ignore this header if it contains an invalid value.
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 101
+      line: 106
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
       line: 95
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 96
+      line: 101
   - label: sec_fetch_dest_value_valid (4)
     section: § 2.1
     snippet: It is a Structured Field whose value MUST be a token.
@@ -463,7 +463,7 @@ sources:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
       line: 75
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 84
+      line: 88
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
       line: 72
     - file: lint-http-rules/src/rules/sec_fetch_mode_value_valid.rs
@@ -473,7 +473,7 @@ sources:
     snippet: Valid Sec-Fetch-Dest values include the set of valid request destinations defined by [Fetch].
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_dest_value_valid.rs
-      line: 102
+      line: 107
   - label: sec_fetch_mode_value_valid
     section: § 2.2
     snippet: HTTP request header exposes a request’s mode to a server
@@ -499,18 +499,18 @@ sources:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
       line: 73
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 82
+      line: 86
   - label: sec_fetch_site_value_valid (3)
     section: § 2.3
     snippet: Valid Sec-Fetch-Site values include "cross-site", "same-origin", "same-site", and "none".
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_site_value_valid.rs
-      line: 97
+      line: 102
   - label: sec_fetch_user_value_valid
     snippet: 'Sec-Fetch-User = sf-boolean Note: The header is delivered only for navigation requests, and only when its value is true.'
     cited_by:
     - file: lint-http-rules/src/rules/sec_fetch_user_value_valid.rs
-      line: 80
+      line: 84
   - label: sec_fetch_user_value_valid (2)
     section: § 2.4
     snippet: HTTP request header exposes whether or not a navigation request was triggered by user activation.
@@ -671,33 +671,33 @@ sources:
     snippet: Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 365
+      line: 366
   - label: permissions_policy_directives_valid (2)
     section: § 5.2
     snippet: Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 116
+      line: 117
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 349
+      line: 350
   - label: permissions_policy_directives_valid (3)
     section: § 5.2
     snippet: The Member Names must be Tokens.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 462
+      line: 463
   - label: permissions_policy_directives_valid (4)
     section: § 5.2
     snippet: 'The Member Values represent allowlists, and must be one of:'
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 348
+      line: 349
   - label: permissions_policy_directives_valid (5)
     section: § 6.1
     snippet: The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 120
+      line: 121
 - label: draft-ietf-httpbis-rfc6265bis
   url: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis
   type: text/html
@@ -707,13 +707,13 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 155
+      line: 158
   - label: cookie_attribute_consistent (2)
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 281
+      line: 286
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
@@ -1606,7 +1606,7 @@ sources:
     - file: lint-http-rules/src/helpers/language.rs
       line: 74
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 167
+      line: 168
 - label: RFC 4648
   url: https://www.rfc-editor.org/rfc/rfc4648.txt
   type: text/plain
@@ -1650,7 +1650,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 35
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 241
+      line: 242
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 70
   - label: lint-http-rules/src/helpers/mailbox.rs
@@ -2012,31 +2012,31 @@ sources:
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 211
+      line: 215
   - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 134
+      line: 136
   - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 122
+      line: 123
   - label: cookie_attribute_consistent (5)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 186
+      line: 189
   - label: cookie_attribute_consistent (6)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 187
+      line: 190
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
@@ -2060,7 +2060,7 @@ sources:
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 81
+      line: 82
   - label: cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
@@ -2160,7 +2160,7 @@ sources:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 77
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 156
+      line: 158
   - label: content_disposition_token_valid
     section: § 1
     snippet: This document does not apply to Content-Disposition header fields appearing in payload bodies transmitted over HTTP, such as when using the media type "multipart/form-data" ([RFC2388]).
@@ -2178,25 +2178,25 @@ sources:
     snippet: Note that due to the rules for implied linear whitespace (Section 2.1 of [RFC2616]), OPTIONAL whitespace can appear between words (token or quoted-string) and separator characters.
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 89
+      line: 90
   - label: content_disposition_token_valid (4)
     section: § 4.1
     snippet: disp-ext-type       = token
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 105
+      line: 107
   - label: content_disposition_token_valid (5)
     section: § 4.1
     snippet: disposition-type = "inline" | "attachment" | disp-ext-type
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 91
+      line: 92
   - label: content_disposition_token_valid (6)
     section: § 4.2
     snippet: Unknown or unhandled disposition types SHOULD be handled by recipients the same way as "attachment" (see also [RFC2183], Section 2.8).
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 106
+      line: 108
 - label: RFC 6335
   url: https://www.rfc-editor.org/rfc/rfc6335.txt
   type: text/plain
@@ -2904,7 +2904,7 @@ sources:
     snippet: All directives MUST appear only once in an STS header field.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 184
+      line: 185
   - label: strict_transport_security_valid (2)
     section: § 6.1
     snippet: UAs MUST ignore any STS header field containing directives, or other header field value data, that does not conform to the syntax defined in this specification.
@@ -2916,25 +2916,25 @@ sources:
     snippet: directive-name            = token
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 109
+      line: 110
   - label: strict_transport_security_valid (4)
     section: § 6.1
     snippet: directive-value           = token | quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 165
+      line: 166
   - label: strict_transport_security_valid (5)
     section: § 6.1.1
     snippet: The REQUIRED "max-age" directive specifies the number of seconds, after the reception of the STS header field, during which the UA regards the host (from whom the message was received) as a Known HSTS Host.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 118
+      line: 119
   - label: strict_transport_security_valid (6)
     section: § 6.1.2
     snippet: The OPTIONAL "includeSubDomains" directive is a valueless directive which, if present (i.e., it is "asserted"), signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host's domain name.
     cited_by:
     - file: lint-http-rules/src/rules/strict_transport_security_valid.rs
-      line: 146
+      line: 147
 - label: RFC 6838
   url: https://www.rfc-editor.org/rfc/rfc6838.txt
   type: text/plain
@@ -3575,7 +3575,7 @@ sources:
     snippet: A case-insensitive flag indicating that the previous request from the client was rejected because the nonce value was stale.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 266
+      line: 268
   - label: digest_auth_nonce_handling (2)
     section: § 3.3
     snippet: A string of data, specified by the server, that SHOULD be returned by the client unchanged in the Authorization header field of subsequent requests
@@ -3593,7 +3593,7 @@ sources:
     snippet: if the same nc value is seen twice, then the request is a replay.
     cited_by:
     - file: lint-http-rules/src/rules/digest_auth_nonce_handling.rs
-      line: 255
+      line: 256
   - label: digest_auth_valid
     section: § 3.4
     snippet: 'For historical reasons, a sender MUST NOT generate the quoted string syntax for the following parameters: algorithm, qop, and nc.'
@@ -4189,7 +4189,7 @@ sources:
     snippet: In particular, an HTTP/1.1 client that mishandles an informational response as a final response is likely to consider all responses to the succeeding requests sent over the same connection to be part of the final response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 155
+      line: 156
 - label: RFC 8441
   url: https://www.rfc-editor.org/rfc/rfc8441.txt
   type: text/plain
@@ -4311,7 +4311,7 @@ sources:
     snippet: The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future.
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 144
+      line: 147
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
       line: 64
 - label: RFC 8615
@@ -4429,19 +4429,19 @@ sources:
     snippet: Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 170
+      line: 174
   - label: quic_transport_parameters_valid (3)
     section: § 18.2
     snippet: the initial flow control limit for locally initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 125
+      line: 127
   - label: quic_transport_parameters_valid (4)
     section: § 18.2
     snippet: the initial value for the maximum amount of data that can be sent on the connection
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 109
+      line: 110
 - label: RFC 9110
   url: https://www.rfc-editor.org/rfc/rfc9110.txt
   type: text/plain
@@ -4497,7 +4497,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 197
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 284
+      line: 286
   - label: accept_and_content_type_negotiation (9)
     section: § 12.5.1
     snippet: The "Accept" header field can be used by user agents to specify their preferences regarding response media types.
@@ -4559,7 +4559,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 153
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 283
+      line: 285
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 112
   - label: accept_encoding_parameter_valid (2)
@@ -4571,7 +4571,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 67
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 158
+      line: 159
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 82
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -4673,7 +4673,7 @@ sources:
     snippet: A sender of qvalue MUST NOT generate more than three digits after the decimal point.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 292
+      line: 294
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 279
   - label: accept_header_media_type_syntax (2)
@@ -4687,13 +4687,13 @@ sources:
     snippet: Senders using weights SHOULD send "q" last (after all media-range parameters).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 222
+      line: 224
   - label: accept_header_media_type_syntax (4)
     section: § 12.5.1
     snippet: The accept extension grammar (accept-params, accept-ext) has been removed because it had a complicated definition, was not being used in practice, and is more easily deployed through new header fields.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 221
+      line: 223
   - label: accept_header_media_type_syntax (5)
     section: § 12.5.1
     snippet: When sent by a server in a response, Accept provides information about which content types are preferred in the content of a subsequent request to the same resource.
@@ -4707,7 +4707,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 119
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 262
+      line: 264
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 125
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -4717,7 +4717,7 @@ sources:
     snippet: media-type = type "/" subtype parameters type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 158
+      line: 159
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 42
   - label: accept_language_weight_valid
@@ -5147,7 +5147,7 @@ sources:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
       line: 75
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 92
+      line: 94
   - label: cache_coherence (3)
     section: § 8.8.2
     snippet: The "Last-Modified" header field in a response provides a timestamp indicating the date and time at which the origin server believes the selected representation was last modified
@@ -5283,9 +5283,9 @@ sources:
     snippet: A recipient MUST ignore the If-Modified-Since header field if the received field value is not a valid HTTP-date, the field value has more than one member, or if the request method is neither GET nor HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 120
+      line: 121
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 138
+      line: 139
   - label: conditional_headers_consistent (3)
     section: § 13.1.4
     snippet: A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
@@ -5297,7 +5297,7 @@ sources:
     snippet: A recipient MUST ignore the If-Unmodified-Since header field if the received field value is not a valid HTTP-date (including when the field value appears to be a list of dates).
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 121
+      line: 122
   - label: conditional_headers_consistent (5)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.
@@ -5365,7 +5365,7 @@ sources:
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
     cited_by:
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 183
+      line: 185
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 147
   - label: content_encoding_and_type_consistent
@@ -5631,7 +5631,7 @@ sources:
     snippet: An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1).
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 122
+      line: 125
   - label: early_data_header_safe_method
     section: § 16.1.1
     snippet: 'HTTP method registrations MUST include the following fields:'
@@ -5935,7 +5935,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 295
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 152
+      line: 153
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 292
   - label: http2_pseudo_headers_valid (2)
@@ -5945,7 +5945,7 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 296
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 153
+      line: 154
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 263
   - label: http2_pseudo_headers_valid (3)
@@ -6027,7 +6027,7 @@ sources:
     snippet: 'Content-Language = #language-tag'
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 133
+      line: 134
   - label: language_tag_syntax (2)
     section: § 8.5
     snippet: The "Content-Language" header field describes the natural language(s) of the intended audience for the representation.
@@ -6249,7 +6249,7 @@ sources:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 54
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 232
+      line: 233
   - label: lint-http-rules/src/helpers/accept_ranges.rs (2)
     section: § 14.1
     snippet: Range units are intended to be extensible, as described in Section 16.5.
@@ -6261,7 +6261,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 301
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 233
+      line: 234
   - label: Accept-Ranges grammar
     section: § 14.3
     snippet: Accept-Ranges     = acceptable-ranges acceptable-ranges = 1#range-unit
@@ -6365,7 +6365,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 184
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 250
+      line: 251
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -6405,7 +6405,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 51
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 234
+      line: 235
   - label: ranges-specifier grammar
     section: § 14.1.1
     snippet: ranges-specifier = range-unit "=" range-set
@@ -6421,7 +6421,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 197
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 385
+      line: 386
   - label: lint-http-rules/src/helpers/content_range.rs (4)
     section: § 14.4
     snippet: A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value.
@@ -6563,7 +6563,7 @@ sources:
     - file: lint-http-rules/src/rules/max_forwards_numeric.rs
       line: 94
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 215
+      line: 216
     - file: lint-http-rules/src/rules/proxy_connection_discouraged.rs
       line: 93
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
@@ -6613,9 +6613,9 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 117
+      line: 118
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 158
+      line: 160
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 94
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
@@ -6711,7 +6711,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 1637
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
-      line: 157
+      line: 159
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 252
   - label: lint-http-rules/src/helpers/headers.rs (14)
@@ -6769,7 +6769,7 @@ sources:
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
       line: 197
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 259
+      line: 260
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 365
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6883,9 +6883,9 @@ sources:
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
       line: 55
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 159
+      line: 160
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 251
+      line: 252
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
       line: 481
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6997,7 +6997,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2247
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 261
+      line: 263
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 391
   - label: parameter-value grammar
@@ -7007,7 +7007,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 2261
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 302
+      line: 305
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 119
     - file: lint-http-rules/src/rules/expect_header_valid.rs
@@ -7547,7 +7547,7 @@ sources:
     snippet: t-codings = "trailers" / ( transfer-coding [ weight ] )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 239
+      line: 240
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 99
   - label: no_connection_specific_fields (2)
@@ -7555,7 +7555,7 @@ sources:
     snippet: transfer-parameter = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 240
+      line: 241
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 59
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -7821,19 +7821,19 @@ sources:
     snippet: An int-range is invalid if the last-pos value is present and less than the first-pos.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 358
+      line: 359
   - label: int-range position grammar
     section: § 14.1.1
     snippet: first-pos     = 1*DIGIT last-pos      = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 314
+      line: 315
   - label: int-range grammar
     section: § 14.1.1
     snippet: int-range     = first-pos "-" [ last-pos ]
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 334
+      line: 335
   - label: other-range grammar
     section: § 14.1.1
     snippet: other-range   = 1*( %x21-2B / %x2D-7E )
@@ -7841,73 +7841,73 @@ sources:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 91
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 275
+      line: 276
   - label: range-set grammar
     section: § 14.1.1
     snippet: range-set        = 1#range-spec
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 239
+      line: 240
   - label: suffix-length grammar
     section: § 14.1.1
     snippet: suffix-length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 318
+      line: 319
   - label: suffix-range grammar
     section: § 14.1.1
     snippet: suffix-range  = "-" suffix-length
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 317
+      line: 318
   - label: range_header_syntax (3)
     section: § 14.1.2
     snippet: A client can limit the number of bytes requested without knowing the size of the selected representation.  If the last-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 350
+      line: 351
   - label: range_header_syntax (4)
     section: § 14.1.2
     snippet: A client can refer to the last N bytes (N > 0) of the selected representation using a suffix-range.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 322
+      line: 323
   - label: range_header_syntax (5)
     section: § 14.1.2
     snippet: Each byte range is expressed as an integer range at some offset, relative to either the beginning (int-range) or end (suffix-range) of the representation data.  Byte ranges do not use the other-range specifier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 309
+      line: 310
   - label: range_header_syntax (6)
     section: § 14.1.2
     snippet: 'For a GET request, a valid bytes range-spec is satisfiable if it is either:'
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 164
+      line: 165
   - label: range_header_syntax (7)
     section: § 14.1.2
     snippet: The "bytes" range unit is used to express subranges of a representation data's octet sequence.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 287
+      line: 288
   - label: a bytes range-set the section prints with a leading space
     section: § 14.1.2
     snippet: bytes= 0-999, 4500-5499, -1000
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 236
+      line: 237
   - label: range_header_syntax (8)
     section: § 14.2
     snippet: A client that is requesting multiple ranges SHOULD list those ranges in ascending order (the order in which they would typically be received in a complete representation) unless there is a specific need to request a later part earlier.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 166
+      line: 167
   - label: range_header_syntax (9)
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.  For this specification, GET is the only method for which range handling is defined.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 165
+      line: 166
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 116
   - label: range_header_syntax (10)
@@ -7915,7 +7915,7 @@ sources:
     snippet: An origin server MUST ignore a Range header field that contains a range unit it does not understand.  A proxy MAY discard a Range header field that contains a range unit it does not understand.
     cited_by:
     - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 235
+      line: 236
   - label: Range grammar
     section: § 14.2
     snippet: Range = ranges-specifier
@@ -8263,7 +8263,7 @@ sources:
     snippet: A delay-seconds value is a non-negative decimal integer, representing time in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/retry_after_date_or_delay.rs
-      line: 68
+      line: 69
   - label: retry_after_date_or_delay (2)
     section: § 10.2.3
     snippet: Retry-After = HTTP-date / delay-seconds
@@ -8387,19 +8387,19 @@ sources:
     snippet: The server MUST generate an Upgrade header field in the response that indicates which protocol(s) will be in effect after this response.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 165
+      line: 168
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 208
+      line: 213
   - label: status_101_switching_protocols (3)
     section: § 7.8
     snippet: A server MUST NOT switch to a protocol that was not indicated by the client in the corresponding request's Upgrade header field.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 151
+      line: 153
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 194
+      line: 198
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 223
+      line: 229
   - label: status_101_switching_protocols (4)
     section: § 7.8
     snippet: A server that receives an Upgrade header field in an HTTP/1.0 request MUST ignore that Upgrade field.
@@ -8411,7 +8411,7 @@ sources:
     snippet: Although protocol names are registered with a preferred case, recipients SHOULD use case-insensitive comparison when matching each protocol-name to supported protocols.
     cited_by:
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 183
+      line: 187
   - label: status_103_early_hints_before_final
     section: § 15.2
     snippet: Since HTTP/1.0 did not define any 1xx status codes, a server MUST NOT send a 1xx response to an HTTP/1.0 client.
@@ -8423,7 +8423,7 @@ sources:
     snippet: The 1xx (Informational) class of status code indicates an interim response for communicating connection status or request progress prior to completing the requested action and sending a final response.
     cited_by:
     - file: lint-http-rules/src/rules/status_103_early_hints_before_final.rs
-      line: 154
+      line: 155
   - label: status_200_vs_204_body_consistent
     section: § 15.3.1
     snippet: Aside from responses to CONNECT, a 200 response is expected to contain message content unless the message framing explicitly indicates that the content has zero length.
@@ -9107,7 +9107,7 @@ sources:
     - file: lint-http-rules/src/rules/no_store_enforced.rs
       line: 171
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 197
+      line: 198
   - label: caching_directive_interaction (3)
     section: § 5.2.2.7
     snippet: The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user).
@@ -9161,7 +9161,7 @@ sources:
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 162
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 265
+      line: 266
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
       line: 66
   - label: immutable_cache_never_stale (2)
@@ -9347,7 +9347,7 @@ sources:
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 61
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 202
+      line: 203
   - label: compression_and_transfer_encoding_consistent (2)
     section: § 6.1
     snippet: Unlike Content-Encoding (Section 8.4.1 of [HTTP]), Transfer-Encoding is a property of the message, not of the representation.
@@ -9463,7 +9463,7 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 235
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 241
+      line: 243
   - label: host_and_authority_consistent
     section: § 3.2.2
     snippet: When an origin server receives a request with an absolute-form of request-target, the origin server MUST ignore the received Host header field (if any) and instead use the host information of the request-target.
@@ -9911,13 +9911,13 @@ sources:
     snippet: If any transfer coding other than chunked is applied to a response's content, the sender MUST either apply chunked as the final transfer coding or terminate the message by closing the connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 157
+      line: 158
   - label: transfer_encoding_chunked_final (3)
     section: § 9.6
     snippet: A sender SHOULD send a Connection header field (Section 7.6.1 of [HTTP]) containing the "close" connection option when it intends to close a connection.
     cited_by:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
-      line: 177
+      line: 178
   - label: transfer_encoding_chunked_final (4)
     section: § 9.6
     snippet: The "close" connection option is defined as a signal that the sender will close this connection after completion of the response.
@@ -9995,7 +9995,7 @@ sources:
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 365
+      line: 366
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
@@ -10033,13 +10033,13 @@ sources:
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 410
+      line: 411
   - label: http2_pseudo_headers_valid (10)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 411
+      line: 412
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
@@ -10109,7 +10109,7 @@ sources:
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 150
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
-      line: 307
+      line: 308
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 118
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -10203,7 +10203,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 331
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 176
+      line: 178
   - label: host_and_authority_consistent (3)
     section: § 4.3.1
     snippet: If these fields are present, they MUST NOT be empty.
@@ -10235,7 +10235,7 @@ sources:
     snippet: A MAX_PUSH_ID frame cannot reduce the maximum push ID; receipt of a MAX_PUSH_ID frame that contains a smaller value than previously received MUST be treated as a connection error of type H3_ID_ERROR
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 78
+      line: 79
   - label: http3_max_push_id (2)
     section: § 7.2.7
     snippet: A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of a MAX_PUSH_ID frame as a connection error of type H3_FRAME_UNEXPECTED.
@@ -10247,7 +10247,7 @@ sources:
     snippet: The maximum push ID is unset when an HTTP/3 connection is created, meaning that a server cannot push until it receives a MAX_PUSH_ID frame
     cited_by:
     - file: lint-http-rules/src/rules/http3_max_push_id.rs
-      line: 108
+      line: 110
   - label: http3_pseudo_headers_valid
     section: § 4.3.1
     snippet: All HTTP/3 requests MUST include exactly one value for the :method, :scheme, and :path pseudo-header fields, unless the request is a CONNECT request; see Section 4.4.
@@ -10259,33 +10259,33 @@ sources:
     snippet: The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 200
+      line: 203
   - label: http3_pseudo_headers_valid (3)
     section: § 4.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of / (ASCII 0x2f).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 161
+      line: 162
   - label: http3_pseudo_headers_valid (4)
     section: § 4.3.2
     snippet: For responses, a single ":status" pseudo-header field is defined that carries the HTTP status code; see Section 15 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 233
+      line: 236
   - label: http3_pseudo_headers_valid (5)
     section: § 4.3.2
     snippet: This pseudo-header field MUST be included in all responses; otherwise, the response is malformed (see Section 4.1.2).
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 234
+      line: 237
   - label: http3_pseudo_headers_valid (6)
     section: § 4.4
     snippet: The :authority pseudo-header field contains the host and port to connect to
     cited_by:
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 100
+      line: 101
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
-      line: 136
+      line: 137
   - label: http3_settings_frame
     section: § 11.2.2
     snippet: The entries in Table 3 are registered by this document
@@ -10303,7 +10303,7 @@ sources:
     snippet: An implementation MUST ignore any parameter with an identifier it does not understand
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 148
+      line: 150
   - label: http3_settings_frame (4)
     section: § 7.2.4
     snippet: SETTINGS frames always apply to an entire HTTP/3 connection, never a single stream
@@ -10315,7 +10315,7 @@ sources:
     snippet: The same setting identifier MUST NOT occur more than once in the SETTINGS frame
     cited_by:
     - file: lint-http-rules/src/rules/http3_settings_frame.rs
-      line: 132
+      line: 133
   - label: http3_settings_frame (6)
     section: § 7.2.4.1
     snippet: These reserved settings MUST NOT be sent, and their receipt MUST be treated as a connection error of type H3_SETTINGS_ERROR
@@ -10329,7 +10329,7 @@ sources:
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
       line: 73
     - file: lint-http-rules/src/rules/status_101_switching_protocols.rs
-      line: 133
+      line: 134
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 119
   - label: lint-http-core/src/http_version.rs
@@ -10439,7 +10439,7 @@ sources:
     snippet: HTTP/3 does not use server-initiated bidirectional streams
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 126
+      line: 128
   - label: quic_transport_parameters_valid (2)
     section: § 6.1
     snippet: In order to permit these streams to open, an HTTP/3 server SHOULD configure non-zero minimum values for the number of permitted streams and the initial stream flow-control window.
@@ -10447,13 +10447,13 @@ sources:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
       line: 93
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 141
+      line: 143
   - label: quic_transport_parameters_valid (3)
     section: § 6.2
     snippet: Endpoints that excessively restrict the number of streams or the flow-control window of these streams will increase the chance that the remote peer reaches the limit early and becomes blocked.
     cited_by:
     - file: lint-http-rules/src/rules/quic_transport_parameters_valid.rs
-      line: 155
+      line: 158
   - label: request_method_token_valid
     section: § 4.3.1
     snippet: '":method":  Contains the HTTP method (Section 9 of [HTTP])'
@@ -10698,7 +10698,7 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 86
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 92
+      line: 93
   - label: lint-http-rules/src/helpers/structured_fields.rs
     section: § 3.1.2
     snippet: Note that parameters are ordered, and parameter keys cannot contain uppercase letters.
@@ -10752,7 +10752,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 452
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 242
+      line: 243
   - label: lint-http-rules/src/helpers/structured_fields.rs (9)
     section: § 4.2
     snippet: The parsing algorithms for both types allow tab characters, since these might be used to combine field lines by some implementations.
@@ -10856,7 +10856,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 481
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 223
+      line: 224
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 343
   - label: lint-http-rules/src/helpers/structured_fields.rs (26)
@@ -10866,9 +10866,9 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 457
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 91
+      line: 92
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 250
+      line: 251
   - label: lint-http-rules/src/helpers/structured_fields.rs (27)
     section: § 4.2.3
     snippet: Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
@@ -10912,7 +10912,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 619
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 417
+      line: 418
   - label: lint-http-rules/src/helpers/structured_fields.rs (34)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not lcalpha or "*", fail parsing.
@@ -10920,7 +10920,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 225
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 393
+      line: 394
   - label: lint-http-rules/src/helpers/structured_fields.rs (35)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not one of lcalpha, DIGIT, "_", "-", ".", or "*", return output_string.
@@ -11066,21 +11066,21 @@ sources:
     snippet: As with Lists, an empty Dictionary is represented by omitting the entire field.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 92
+      line: 93
   - label: permissions_policy_directives_valid (2)
     section: § 3.2
     snippet: Member keys cannot contain uppercase characters.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 350
+      line: 351
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 463
+      line: 464
   - label: permissions_policy_directives_valid (3)
     section: § 4.2
     snippet: If parsing fails, either the entire field value MUST be ignored (i.e., treated as if the field were not present in the section), or alternatively the complete HTTP message MUST be treated as malformed.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 112
+      line: 113
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 274
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
@@ -11100,7 +11100,7 @@ sources:
     snippet: Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 261
+      line: 262
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 289
   - label: priority_header_syntax
@@ -11113,37 +11113,37 @@ sources:
     snippet: This document describes a set of data types and associated algorithms that are intended to make it easier and safer to define and handle HTTP header and trailer fields,
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 154
+      line: 155
   - label: structured_headers_valid (2)
     section: § 4.2
     snippet: Given an array of bytes as input_bytes that represent the chosen field's field-value (which is empty if that field is not present) and field_type (one of "dictionary", "list", or "item"), return the parsed field value.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 230
+      line: 231
   - label: structured_headers_valid (3)
     section: § 4.2
     snippet: If field_type is "dictionary", let output be the result of running Parsing a Dictionary (Section 4.2.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 262
+      line: 263
   - label: structured_headers_valid (4)
     section: § 4.2
     snippet: If field_type is "item", let output be the result of running Parsing an Item (Section 4.2.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 255
+      line: 256
   - label: structured_headers_valid (5)
     section: § 4.2
     snippet: If field_type is "list", let output be the result of running Parsing a List (Section 4.2.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 257
+      line: 258
   - label: structured_headers_valid (6)
     section: § 4.2.1
     snippet: No structured data has been found; return members (which is empty).
     cited_by:
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
-      line: 249
+      line: 250
 - label: RFC 9745
   url: https://www.rfc-editor.org/rfc/rfc9745.txt
   type: text/plain
@@ -11163,10 +11163,10 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 85
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 91
+      line: 92
   - label: sunset_and_deprecation_consistent
     section: § 4
     snippet: The timestamp given in the Sunset HTTP header field MUST NOT be earlier than the one given in the Deprecation header field.
     cited_by:
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 130
+      line: 131


### PR DESCRIPTION
Every finding site whose adjacent `// cite` names exactly one of its rule's declared references now builds through `cited()` instead of `violation()`, so the report says which sentence was broken and links the text. 173 of 583 sites.

The oracle is deliberately narrow, because a wrong citation is worse than none. A site qualifies only when the comment block above it holds exactly one `cite` target and that target is one the rule declares. Two cites in the block is a judgment call about which sentence the finding enforces, and a cite naming a section the rule does not declare is a supporting quote rather than the requirement — RFC 5234's "ABNF strings are case insensitive" explains a comparison, it is not what the TE finding reports. Both are left alone. So is a `let violation = |message|` closure: one citation there would attach one sentence to every finding built through it.

The `debug_assert` inside `cited()` checks each attachment against the rule's own `specifications()`, and the whole suite runs in debug — 6,393 tests pass, so all 173 name text their rule declares.

The remaining 410 sites keep `cite: None`, which is what the field's default is for. A ratchet test pins the floor so the direction cannot reverse by accident, and its constant is the count of what has been read so far.
