### PR TITLE
Every proxy error response comes from one builder and names its media…

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -55,8 +55,8 @@ pub(super) struct ProxiedRequest {
 }
 
 /// What the transport should deliver to the client. Headers are already
-/// hop-by-hop filtered (with the 101 carve-out); they are empty for
-/// proxy-generated error responses. The body streams: for a successful
+/// hop-by-hop filtered (with the 101 carve-out); proxy-generated error
+/// responses carry only a `Content-Type`. The body streams: for a successful
 /// exchange it tees a bounded prefix into the transaction (committed at
 /// stream-end); for a proxy error it is the buffered error message.
 pub(super) struct ProxiedResponse {
@@ -393,12 +393,43 @@ pub(super) fn filter_response_headers(headers: &HeaderMap, status: u16) -> Heade
     out
 }
 
-fn error_response(status: u16, body: String) -> ProxiedResponse {
+/// Build the plaintext error reply shared by every proxy error path: status,
+/// a `Content-Type` describing the message, and the message.
+///
+/// The `Content-Type` is not decoration. These responses carry a line of US-ASCII
+/// text and used to carry no media type at all, which is exactly what
+/// `content_type_present` reports -- RFC 9110 § 8.3 leaves such a
+/// recipient to assume `application/octet-stream` or to sniff the bytes. A proxy
+/// that lints for a missing Content-Type should not be answering with one.
+pub(super) fn error_response(status: u16, body: String) -> ProxiedResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        hyper::header::CONTENT_TYPE,
+        hyper::header::HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
     ProxiedResponse {
         status,
-        headers: HeaderMap::new(),
+        headers,
         body: boxed_full(Bytes::from(body)),
     }
+}
+
+/// Convert a [`ProxiedResponse`] into the hyper response the H1/H2 transport
+/// hands back to the client. (The H3 transport drives the body itself and does
+/// not come through here.)
+pub(super) fn into_response(proxied: ProxiedResponse) -> hyper::Response<ResponseBody> {
+    let mut resp_builder = hyper::Response::builder().status(proxied.status);
+    for (name, value) in proxied.headers.iter() {
+        resp_builder = resp_builder.header(name, value);
+    }
+    // The streaming body can't be cloned, so fall back to a fresh error
+    // response if building fails (it shouldn't: status + filtered headers are
+    // valid). The fallback's own build cannot fail the same way -- its status
+    // and header are constants -- so the recursion is one level deep.
+    resp_builder.body(proxied.body).unwrap_or_else(|e| {
+        error!("failed to build client response: {}", e);
+        into_response(error_response(502, "failed to build response".to_string()))
+    })
 }
 
 /// Record an error transaction from inside [`exchange`] (build / upstream

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -114,21 +114,11 @@ where
     handle_http_logic(req, shared, conn_metadata, scheme).await
 }
 
-/// Build a boxed plaintext error response: status, a `Content-Type` describing
-/// the message, and the message.
-///
-/// The `Content-Type` is not decoration. These responses carry a line of US-ASCII
-/// text and used to carry no media type at all, which is exactly what
-/// `content_type_present` reports -- RFC 9110 § 8.3 leaves such a
-/// recipient to assume `application/octet-stream` or to sniff the bytes. A proxy
-/// that lints for a missing Content-Type should not be answering with one.
+/// Build a boxed plaintext error response. Thin wrapper over the one shared
+/// builder, [`super::exchange::error_response`], which owns the rationale for
+/// the `Content-Type` these responses carry.
 pub(super) fn error_resp(status: u16, msg: &str) -> Response<ResponseBody> {
-    let body = Bytes::from(msg.to_string());
-    Response::builder()
-        .status(status)
-        .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .body(boxed_full(body.clone()))
-        .unwrap_or_else(|_| Response::new(boxed_full(body)))
+    super::exchange::into_response(super::exchange::error_response(status, msg.to_string()))
 }
 
 async fn handle_http_logic<B>(
@@ -330,17 +320,7 @@ where
 
     let proxied = exchange(pr, &shared, started).await;
 
-    let mut resp_builder = Response::builder().status(proxied.status);
-    for (name, value) in proxied.headers.iter() {
-        resp_builder = resp_builder.header(name, value);
-    }
-    // The streaming body can't be cloned, so fall back to a fresh error
-    // response if building fails (it shouldn't: status + filtered headers are
-    // valid).
-    Ok(resp_builder.body(proxied.body).unwrap_or_else(|e| {
-        error!("failed to build client response: {}", e);
-        error_resp(502, "failed to build response")
-    }))
+    Ok(super::exchange::into_response(proxied))
 }
 
 #[cfg(test)]

--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -221,13 +221,13 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
 }
 
 /// Build the 502 returned to the client when a WebSocket upstream handshake
-/// fails (connect or request-send error).
+/// fails (connect or request-send error), through the one shared error-response
+/// builder.
 fn upstream_error_response(e: impl std::fmt::Display) -> Response<ResponseBody> {
-    let body = boxed_full(Bytes::from(format!("websocket upstream error: {}", e)));
-    Response::builder()
-        .status(502)
-        .body(body)
-        .unwrap_or_else(|_| Response::new(boxed_full(Bytes::from("upstream error"))))
+    crate::proxy::exchange::into_response(crate::proxy::exchange::error_response(
+        502,
+        format!("websocket upstream error: {}", e),
+    ))
 }
 
 /// Record a transaction for a WebSocket handshake that failed before the


### PR DESCRIPTION
… type

Three disagreeing builders become one: exchange::error_response now carries the Content-Type whose rationale previously lived only on http::error_resp, and a new exchange::into_response converts any ProxiedResponse into the hyper response the H1/H2 transport delivers. http::error_resp and the WebSocket handshake's 502 delegate to the shared pair, so the WebSocket error path and the H3 transport now answer with a Content-Type too.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
