### PR TITLE
The request facts are computed once and every record reads from them

### DIFF
--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -29,29 +29,36 @@ use super::tee_body::{self, CapturedBody};
 use super::upstream_h3::H3Failure;
 use super::{boxed_full, BoxError, ClientBody, ResponseBody, Shared};
 
-/// The post-front-half request inputs both transports compute, ready for the
-/// shared upstream exchange.
-pub(super) struct ProxiedRequest {
+/// The request-side facts every transaction record needs: computed once by the
+/// transport front half, consumed by the exchange, the WebSocket handshake,
+/// and every error path.
+pub(super) struct RequestFacts {
     pub method: Method,
-    /// Absolute URI used for the upstream request line.
-    pub uri: Uri,
     /// Value recorded in `tx.request.uri` — the transport's original request
-    /// target (H1 keeps the possibly origin-form `req.uri()`; not `uri`).
+    /// target (H1 keeps the possibly origin-form `req.uri()`).
     pub uri_str: String,
     /// Original client request headers; suppression is applied only when
     /// building the upstream request.
     pub headers: HeaderMap,
     /// Request version string ("HTTP/1.1", "HTTP/3.0", …).
     pub version: String,
+    pub client_id: ClientIdentifier,
+    pub connection_id: Uuid,
+    pub sequence_number: u32,
+}
+
+/// The post-front-half request inputs both transports compute, ready for the
+/// shared upstream exchange.
+pub(super) struct ProxiedRequest {
+    pub facts: RequestFacts,
+    /// Absolute URI used for the upstream request line.
+    pub uri: Uri,
     /// The request body, already wrapped so it streams to the upstream while a
     /// bounded prefix is teed for capture (H3 wraps a buffered body).
     pub body: ClientBody,
     /// Resolves with the teed request-body capture (prefix, total length,
     /// trailers) once the body has finished streaming to the upstream.
     pub body_done: oneshot::Receiver<CapturedBody>,
-    pub client_id: ClientIdentifier,
-    pub connection_id: Uuid,
-    pub sequence_number: u32,
 }
 
 /// What the transport should deliver to the client. Headers are already
@@ -76,41 +83,23 @@ pub(super) async fn exchange(
     started: Instant,
 ) -> ProxiedResponse {
     let ProxiedRequest {
-        method,
+        facts,
         uri,
-        uri_str,
-        headers,
-        version,
         body,
         body_done,
-        client_id,
-        connection_id,
-        sequence_number,
     } = req;
 
-    let upstream_req = match build_upstream_request(&method, &uri, &headers, body, shared) {
-        Ok(r) => r,
-        Err(e) => {
-            error!("failed to build upstream request: {}", e);
-            let duration = started.elapsed().as_millis() as u64;
-            record_exchange_error(
-                shared,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &headers,
-                &version,
-                connection_id,
-                sequence_number,
-                500,
-                None,
-                duration,
-                body_done.await.ok().as_ref(),
-            )
-            .await;
-            return error_response(500, format!("request build error: {}", e));
-        }
-    };
+    let upstream_req =
+        match build_upstream_request(&facts.method, &uri, &facts.headers, body, shared) {
+            Ok(r) => r,
+            Err(e) => {
+                error!("failed to build upstream request: {}", e);
+                let duration = started.elapsed().as_millis() as u64;
+                record_exchange_error(shared, &facts, 500, duration, body_done.await.ok().as_ref())
+                    .await;
+                return error_response(500, format!("request build error: {}", e));
+            }
+        };
 
     // Choose the upstream transport at this single seam: HTTP/3 when the origin
     // authority is on the H3 allowlist (capability-driven, opt-in) and not
@@ -159,7 +148,7 @@ pub(super) async fn exchange(
                 if pre_request {
                     h3.record_failure(&authority);
                 }
-                if pre_request || method.is_idempotent() {
+                if pre_request || facts.method.is_idempotent() {
                     warn!(%authority, error = %error, "h3 upstream unavailable; falling back to H1/H2");
                     forward_via_hyper(shared, *request).await
                 } else {
@@ -192,21 +181,8 @@ pub(super) async fn exchange(
         Ok(r) => r,
         Err(e) => {
             let duration = started.elapsed().as_millis() as u64;
-            record_exchange_error(
-                shared,
-                &client_id,
-                method.as_str(),
-                &uri_str,
-                &headers,
-                &version,
-                connection_id,
-                sequence_number,
-                502,
-                None,
-                duration,
-                body_done.await.ok().as_ref(),
-            )
-            .await;
+            record_exchange_error(shared, &facts, 502, duration, body_done.await.ok().as_ref())
+                .await;
             return error_response(502, format!("upstream error: {}", e));
         }
     };
@@ -247,6 +223,15 @@ pub(super) async fn exchange(
     // (already sent upstream) and the response body (just read by the client) —
     // so each `body_length` reflects the real total and each captured body is a
     // bounded prefix.
+    let RequestFacts {
+        method,
+        uri_str,
+        headers,
+        version,
+        client_id,
+        connection_id,
+        sequence_number,
+    } = facts;
     let shared = shared.clone();
     tokio::spawn(async move {
         let (req_cap, resp_cap) = tokio::join!(body_done, done_rx);
@@ -435,86 +420,74 @@ pub(super) fn into_response(proxied: ProxiedResponse) -> hyper::Response<Respons
 /// Record an error transaction from inside [`exchange`] (build / upstream
 /// failure), using whatever request-body prefix the tee captured before the
 /// request was dropped.
-#[allow(clippy::too_many_arguments)]
 async fn record_exchange_error(
     shared: &Arc<Shared>,
-    client_id: &ClientIdentifier,
-    method: &str,
-    uri_str: &str,
-    headers: &HeaderMap,
-    version: &str,
-    connection_id: Uuid,
-    sequence_number: u32,
+    facts: &RequestFacts,
     status: u16,
-    response_headers: Option<HeaderMap>,
     duration_ms: u64,
     req_captured: Option<&CapturedBody>,
 ) {
     record_error_transaction(
         shared,
-        client_id,
-        method,
-        uri_str,
-        headers,
-        version,
-        status,
-        response_headers,
-        duration_ms,
-        req_captured.map(|c| c.prefix.clone()),
-        connection_id,
-        sequence_number,
-        req_captured.is_some_and(|c| c.truncated),
-        false,
+        facts,
+        ErrorFacts {
+            status,
+            duration_ms,
+            req_body: req_captured.map(|c| c.prefix.clone()),
+            request_body_over_limit: req_captured.is_some_and(|c| c.truncated),
+            ..Default::default()
+        },
     )
     .await;
+}
+
+/// The response-side facts of a failed exchange: everything
+/// [`record_error_transaction`] cannot read from the request facts.
+#[derive(Default)]
+pub(super) struct ErrorFacts {
+    pub status: u16,
+    pub duration_ms: u64,
+    pub response_headers: Option<HeaderMap>,
+    pub req_body: Option<Bytes>,
+    pub request_body_over_limit: bool,
+    pub response_body_over_limit: bool,
 }
 
 /// Build a minimal `HttpTransaction` (request + response status only) and route
 /// it through the full pipeline (lint → state record → capture), so error
 /// exchanges are linted and enter `TransactionHistory` like any other traffic.
 /// Used on the error paths where the upstream exchange never completes
-/// normally. Shared by both transports; the caller supplies the transport's
-/// version string, connection id, and sequence number.
-#[allow(clippy::too_many_arguments)]
+/// normally. Shared by both transports and the WebSocket handshake.
 pub(super) async fn record_error_transaction(
     shared: &Arc<Shared>,
-    client_id: &ClientIdentifier,
-    method: &str,
-    uri_str: &str,
-    req_headers: &HeaderMap,
-    version: &str,
-    status: u16,
-    response_headers: Option<HeaderMap>,
-    duration_ms: u64,
-    req_body: Option<Bytes>,
-    connection_id: Uuid,
-    sequence_number: u32,
-    request_body_over_limit: bool,
-    response_body_over_limit: bool,
+    facts: &RequestFacts,
+    err: ErrorFacts,
 ) {
     let mut tx = crate::http_transaction::HttpTransaction::new(
-        client_id.clone(),
-        method.to_string(),
-        uri_str.to_string(),
+        facts.client_id.clone(),
+        facts.method.as_str().to_string(),
+        facts.uri_str.clone(),
     );
-    tx.request.headers = req_headers.clone();
-    tx.request.version = version.to_string();
-    if let Some(b) = req_body {
+    tx.request.headers = facts.headers.clone();
+    tx.request.version = facts.version.clone();
+    if let Some(b) = err.req_body {
         tx.request.body_length = Some(b.len() as u64);
         tx.request_body = Some(b);
     }
-    tx.request_body_over_limit = request_body_over_limit;
-    tx.response_body_over_limit = response_body_over_limit;
+    tx.request_body_over_limit = err.request_body_over_limit;
+    tx.response_body_over_limit = err.response_body_over_limit;
     tx.response = Some(crate::http_transaction::ResponseInfo {
-        status,
-        version: version.to_string(),
-        headers: response_headers.unwrap_or_default(),
+        status: err.status,
+        version: facts.version.clone(),
+        headers: err.response_headers.unwrap_or_default(),
         body_length: None,
         trailers: None,
     });
-    tx.timing = crate::http_transaction::TimingInfo { duration_ms };
-    tx.connection_id = Some(connection_id);
-    tx.sequence_number = Some(sequence_number);
+    tx.timing = crate::http_transaction::TimingInfo {
+        duration_ms: err.duration_ms,
+    };
+    tx.connection_id = Some(facts.connection_id);
+    tx.sequence_number = Some(facts.sequence_number);
     // Lint, record to state, and capture — error exchanges are real traffic.
     shared.pipeline().commit(tx).await;
 }

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -15,7 +15,7 @@ use tracing::{error, warn};
 use super::body::{collect_limited, CollectLimitedError};
 use super::connect::handle_connect;
 use super::exchange::{
-    exchange, record_error_transaction, upstream_request_builder, ProxiedRequest,
+    exchange, record_error_transaction, upstream_request_builder, ErrorFacts, ProxiedRequest,
 };
 use super::hop_by_hop::format_http_version;
 use super::tee_body;
@@ -168,6 +168,19 @@ where
     // Capture request version before moving `req` into body.
     let req_version = format_http_version(req.version());
 
+    // Every request allocates exactly one sequence number and produces exactly
+    // one transaction record, whichever path ends up writing it — the exchange,
+    // the WebSocket handshake, or an error.
+    let facts = super::exchange::RequestFacts {
+        method,
+        uri_str,
+        headers: req_headers,
+        version: req_version,
+        client_id,
+        connection_id: conn_metadata.id,
+        sequence_number: conn_metadata.next_sequence_number(),
+    };
+
     // Extract the client OnUpgrade before consuming the request body; for
     // WebSocket upgrades we need it to reach the upgraded client IO later.
     let client_on_upgrade = if is_ws_upgrade {
@@ -194,44 +207,29 @@ where
                     Ok((bytes, trailers)) => (bytes, trailers),
                     Err(CollectLimitedError::OverLimit) => {
                         warn!("request body exceeds max_body_bytes ({})", max_body_bytes);
-                        let duration = started.elapsed().as_millis() as u64;
                         record_error_transaction(
                             &shared,
-                            &client_id,
-                            method.as_str(),
-                            &uri_str,
-                            &req_headers,
-                            &req_version,
-                            413,
-                            None,
-                            duration,
-                            None,
-                            conn_metadata.id,
-                            conn_metadata.next_sequence_number(),
-                            true,
-                            false,
+                            &facts,
+                            ErrorFacts {
+                                status: 413,
+                                duration_ms: started.elapsed().as_millis() as u64,
+                                request_body_over_limit: true,
+                                ..Default::default()
+                            },
                         )
                         .await;
                         return Ok(error_resp(413, "request body exceeds max_body_bytes"));
                     }
                     Err(CollectLimitedError::Other(e)) => {
                         error!("failed to collect request body: {}", e);
-                        let duration = started.elapsed().as_millis() as u64;
                         record_error_transaction(
                             &shared,
-                            &client_id,
-                            method.as_str(),
-                            &uri_str,
-                            &req_headers,
-                            &req_version,
-                            500,
-                            None,
-                            duration,
-                            None,
-                            conn_metadata.id,
-                            conn_metadata.next_sequence_number(),
-                            false,
-                            false,
+                            &facts,
+                            ErrorFacts {
+                                status: 500,
+                                duration_ms: started.elapsed().as_millis() as u64,
+                                ..Default::default()
+                            },
                         )
                         .await;
                         return Ok(error_resp(500, "request body collect error"));
@@ -246,50 +244,43 @@ where
             // session tungstenite cannot read is a session it kills. The
             // capture records `req_headers` as received, offer included; see
             // `websocket::without_extension_negotiation`.
-            let upstream_headers = super::websocket::without_extension_negotiation(&req_headers);
-            let upstream_req =
-                match upstream_request_builder(&method, &uri, &upstream_headers, &shared, false)
-                    .body(Full::new(body_bytes.clone()))
-                {
-                    Ok(r) => r,
-                    Err(e) => {
-                        error!("failed to build upstream request: {}", e);
-                        let duration = started.elapsed().as_millis() as u64;
-                        record_error_transaction(
-                            &shared,
-                            &client_id,
-                            method.as_str(),
-                            &uri_str,
-                            &req_headers,
-                            &req_version,
-                            500,
-                            None,
-                            duration,
-                            Some(body_bytes.clone()),
-                            conn_metadata.id,
-                            conn_metadata.next_sequence_number(),
-                            false,
-                            false,
-                        )
-                        .await;
-                        return Ok(error_resp(500, &format!("request build error: {}", e)));
-                    }
-                };
+            let upstream_headers = super::websocket::without_extension_negotiation(&facts.headers);
+            let upstream_req = match upstream_request_builder(
+                &facts.method,
+                &uri,
+                &upstream_headers,
+                &shared,
+                false,
+            )
+            .body(Full::new(body_bytes.clone()))
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("failed to build upstream request: {}", e);
+                    record_error_transaction(
+                        &shared,
+                        &facts,
+                        ErrorFacts {
+                            status: 500,
+                            duration_ms: started.elapsed().as_millis() as u64,
+                            req_body: Some(body_bytes.clone()),
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+                    return Ok(error_resp(500, &format!("request build error: {}", e)));
+                }
+            };
             return handle_websocket_upgrade(
                 upstream_req,
                 client_on_upgrade,
                 &uri,
                 &scheme,
                 &started,
-                &client_id,
-                &method,
-                &uri_str,
-                &req_headers,
-                &req_version,
+                facts,
                 body_bytes,
                 req_trailers,
                 shared,
-                conn_metadata,
             )
             .await;
         }
@@ -306,16 +297,10 @@ where
     let (body, body_done_rx) = tee_body::tee(inner, prefix_cap);
 
     let pr = ProxiedRequest {
-        method,
+        facts,
         uri,
-        uri_str,
-        headers: req_headers,
-        version: req_version,
         body,
         body_done: body_done_rx,
-        client_id,
-        connection_id: conn_metadata.id,
-        sequence_number: conn_metadata.next_sequence_number(),
     };
 
     let proxied = exchange(pr, &shared, started).await;

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -382,22 +382,24 @@ async fn handle_h3_request(
 
     // Run the shared exchange core (forward, collect, lint, capture).
     let pr = ProxiedRequest {
-        method,
+        facts: super::exchange::RequestFacts {
+            method,
+            uri_str,
+            headers: req_headers,
+            // The version number RFC 9114 § 4.3.1 states for a request that has
+            // nowhere to carry one. Rendered through the shared function rather
+            // than written here: every other capture site funnels through it, and
+            // this one holding its own literal is how the workspace came to need
+            // the spelling corrected in two files instead of one.
+            // cite(RFC 9114 § 4.3.1): "HTTP/3 requests implicitly have a protocol version of "3.0"."
+            version: format_http_version(hyper::Version::HTTP_3),
+            client_id,
+            connection_id: conn_metadata.id,
+            sequence_number: stream_id as u32,
+        },
         uri,
-        uri_str,
-        headers: req_headers,
-        // The version number RFC 9114 § 4.3.1 states for a request that has
-        // nowhere to carry one. Rendered through the shared function rather
-        // than written here: every other capture site funnels through it, and
-        // this one holding its own literal is how the workspace came to need
-        // the spelling corrected in two files instead of one.
-        // cite(RFC 9114 § 4.3.1): "HTTP/3 requests implicitly have a protocol version of "3.0"."
-        version: format_http_version(hyper::Version::HTTP_3),
         body,
         body_done: body_done_rx,
-        client_id,
-        connection_id: conn_metadata.id,
-        sequence_number: stream_id as u32,
     };
     let proxied = exchange(pr, &shared, started).await;
 

--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -8,14 +8,14 @@
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
-use hyper::{Method, Request, Response, Uri};
+use hyper::{Request, Response, Uri};
 use hyper_util::rt::TokioIo;
 use std::convert::Infallible;
 use std::sync::Arc;
 use tokio::time::Instant;
 use tracing::{debug, error};
 
-use crate::proxy::exchange::record_error_transaction;
+use crate::proxy::exchange::{record_error_transaction, ErrorFacts, RequestFacts};
 use crate::proxy::hop_by_hop::format_http_version;
 use crate::proxy::{boxed_full, BoxError, ResponseBody, Shared};
 
@@ -31,15 +31,10 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
     uri: &Uri,
     scheme: &hyper::http::uri::Scheme,
     started: &Instant,
-    client_id: &crate::state::ClientIdentifier,
-    method: &Method,
-    uri_str: &str,
-    req_headers: &hyper::HeaderMap,
-    req_version: &str,
+    facts: RequestFacts,
     body_bytes: Bytes,
     req_trailers: Option<hyper::HeaderMap>,
     shared: Arc<Shared>,
-    conn_metadata: Arc<crate::connection::ConnectionMetadata>,
 ) -> Result<Response<ResponseBody>, Infallible> {
     // Connect directly to upstream with upgrade support, reusing the shared
     // outbound TLS config (loaded once at startup).
@@ -48,18 +43,7 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
             Ok(s) => s,
             Err(e) => {
                 error!("websocket upstream connect error: {}", e);
-                record_handshake_failure(
-                    &shared,
-                    client_id,
-                    method,
-                    uri_str,
-                    req_headers,
-                    req_version,
-                    &body_bytes,
-                    &conn_metadata,
-                    started,
-                )
-                .await;
+                record_handshake_failure(&shared, &facts, &body_bytes, started).await;
                 return Ok(upstream_error_response(&e));
             }
         };
@@ -69,18 +53,7 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
         Ok(r) => r,
         Err(e) => {
             error!("websocket upstream request error: {}", e);
-            record_handshake_failure(
-                &shared,
-                client_id,
-                method,
-                uri_str,
-                req_headers,
-                req_version,
-                &body_bytes,
-                &conn_metadata,
-                started,
-            )
-            .await;
+            record_handshake_failure(&shared, &facts, &body_bytes, started).await;
             return Ok(upstream_error_response(&e));
         }
     };
@@ -92,12 +65,12 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
 
     // Record the HTTP transaction (the 101 handshake)
     let mut tx = crate::http_transaction::HttpTransaction::new(
-        client_id.clone(),
-        method.as_str().to_string(),
-        uri_str.to_string(),
+        facts.client_id.clone(),
+        facts.method.as_str().to_string(),
+        facts.uri_str.clone(),
     );
-    tx.request.headers = req_headers.clone();
-    tx.request.version = req_version.to_string();
+    tx.request.headers = facts.headers.clone();
+    tx.request.version = facts.version.clone();
     tx.request.body_length = Some(body_bytes.len() as u64);
     tx.request.trailers = req_trailers;
     tx.request_body = Some(body_bytes);
@@ -122,8 +95,8 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
     tx.timing = crate::http_transaction::TimingInfo {
         duration_ms: duration,
     };
-    tx.connection_id = Some(conn_metadata.id);
-    tx.sequence_number = Some(conn_metadata.next_sequence_number());
+    tx.connection_id = Some(facts.connection_id);
+    tx.sequence_number = Some(facts.sequence_number);
     if status == 101 {
         tx.was_upgraded = true;
         tx.upgrade_protocol = headers
@@ -160,7 +133,7 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
         // lets it close promptly on shutdown. The permit is best-effort —
         // an already-upgraded connection can't be rejected if we're at capacity.
         let captures_clone = shared.captures.clone();
-        let connection_id = conn_metadata.id;
+        let connection_id = facts.connection_id;
         let pe_pipeline = shared.protocol_event_pipeline();
         let relay_permit = shared.semaphore.clone().try_acquire_owned().ok();
         if relay_permit.is_none() {
@@ -232,36 +205,23 @@ fn upstream_error_response(e: impl std::fmt::Display) -> Response<ResponseBody> 
 
 /// Record a transaction for a WebSocket handshake that failed before the
 /// upstream produced any response, so the request is not silently lost. Routes
-/// through the pipeline (lint → state → capture) and consumes one sequence
-/// number, matching the success path.
-#[allow(clippy::too_many_arguments)]
+/// through the pipeline (lint → state → capture) with the request's one
+/// sequence number, matching the success path.
 async fn record_handshake_failure(
     shared: &Arc<Shared>,
-    client_id: &crate::state::ClientIdentifier,
-    method: &Method,
-    uri_str: &str,
-    req_headers: &hyper::HeaderMap,
-    req_version: &str,
+    facts: &RequestFacts,
     body_bytes: &Bytes,
-    conn_metadata: &crate::connection::ConnectionMetadata,
     started: &Instant,
 ) {
-    let duration = started.elapsed().as_millis() as u64;
     record_error_transaction(
         shared,
-        client_id,
-        method.as_str(),
-        uri_str,
-        req_headers,
-        req_version,
-        502,
-        None,
-        duration,
-        Some(body_bytes.clone()),
-        conn_metadata.id,
-        conn_metadata.next_sequence_number(),
-        false,
-        false,
+        facts,
+        ErrorFacts {
+            status: 502,
+            duration_ms: started.elapsed().as_millis() as u64,
+            req_body: Some(body_bytes.clone()),
+            ..Default::default()
+        },
     )
     .await;
 }
@@ -324,6 +284,23 @@ mod tests {
         )
     }
 
+    /// The request facts the handshake tests share: a GET from one test
+    /// client, carrying the headers under test.
+    fn test_facts(uri: &Uri, headers: hyper::HeaderMap) -> RequestFacts {
+        RequestFacts {
+            method: hyper::Method::GET,
+            uri_str: uri.to_string(),
+            headers,
+            version: "HTTP/1.1".to_string(),
+            client_id: crate::state::ClientIdentifier::new(
+                "127.0.0.1".parse().unwrap(),
+                "test".to_string(),
+            ),
+            connection_id: uuid::Uuid::new_v4(),
+            sequence_number: 0,
+        }
+    }
+
     /// Whether a captured transaction's request headers (serialized as ordered
     /// `[name, value]` pairs) contain `name`.
     fn captured_request_has_header(v: &serde_json::Value, name: &str) -> bool {
@@ -383,12 +360,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
-            "127.0.0.1:12345".parse()?,
-        ));
         let started = Instant::now();
-        let client_id =
-            crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
         let mut req_headers = hyper::HeaderMap::new();
         req_headers.insert("x-test", "1".parse()?);
 
@@ -398,15 +370,10 @@ mod tests {
             &uri,
             &hyper::http::uri::Scheme::HTTP,
             &started,
-            &client_id,
-            &Method::GET,
-            &uri.to_string(),
-            &req_headers,
-            "HTTP/1.1",
+            test_facts(&uri, req_headers),
             Bytes::new(),
             None,
             shared,
-            conn_metadata,
         )
         .await?;
 
@@ -462,12 +429,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
-            "127.0.0.1:12345".parse()?,
-        ));
         let started = Instant::now();
-        let client_id =
-            crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
 
         let resp = handle_websocket_upgrade(
             upstream_req,
@@ -475,15 +437,10 @@ mod tests {
             &uri,
             &hyper::http::uri::Scheme::HTTP,
             &started,
-            &client_id,
-            &Method::GET,
-            &uri.to_string(),
-            &hyper::HeaderMap::new(),
-            "HTTP/1.1",
+            test_facts(&uri, hyper::HeaderMap::new()),
             Bytes::new(),
             None,
             shared,
-            conn_metadata,
         )
         .await?;
 
@@ -532,12 +489,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
-            "127.0.0.1:12345".parse()?,
-        ));
         let started = Instant::now();
-        let client_id =
-            crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
 
         let resp = handle_websocket_upgrade(
             upstream_req,
@@ -545,15 +497,10 @@ mod tests {
             &uri,
             &hyper::http::uri::Scheme::HTTP,
             &started,
-            &client_id,
-            &Method::GET,
-            &uri.to_string(),
-            &hyper::HeaderMap::new(),
-            "HTTP/1.1",
+            test_facts(&uri, hyper::HeaderMap::new()),
             Bytes::new(),
             None,
             shared,
-            conn_metadata,
         )
         .await?;
 
@@ -640,12 +587,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
-            "127.0.0.1:12345".parse()?,
-        ));
         let started = Instant::now();
-        let client_id =
-            crate::state::ClientIdentifier::new("127.0.0.1".parse().unwrap(), "test".to_string());
         let mut req_headers = hyper::HeaderMap::new();
         req_headers.insert("x-test", "1".parse()?);
 
@@ -655,15 +597,10 @@ mod tests {
             &uri,
             &hyper::http::uri::Scheme::HTTP,
             &started,
-            &client_id,
-            &Method::GET,
-            &uri.to_string(),
-            &req_headers,
-            "HTTP/1.1",
+            test_facts(&uri, req_headers),
             Bytes::new(),
             None,
             shared,
-            conn_metadata,
         )
         .await?;
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6155,7 +6155,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 380
+      line: 365
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 11.7.1
     snippet: Unlike WWW-Authenticate, the Proxy-Authenticate header field applies only to the next outbound client on the response chain.
@@ -6225,7 +6225,7 @@ sources:
     snippet: A 1xx response is terminated by the end of the header section; it cannot contain content or trailers.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/handshake.rs
-      line: 118
+      line: 91
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
       line: 83
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs


### PR DESCRIPTION
A RequestFacts struct (method, target, headers, version, client, connection, sequence number) is built once per request by each transport front half; ProxiedRequest wraps it, and record_error_transaction shrinks from fourteen arguments to the facts plus an ErrorFacts of what the failure adds. The three near-identical WebSocket error blocks in the H1 handler collapse to one call each, the WebSocket handshake takes the facts instead of seven loose fields, and the sequence number is allocated exactly once per request whichever path ends up writing its one transaction record.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
