### PR TITLE
The proxy reads Upgrade as the list its own citation says it is

### DIFF
--- a/lint-http-proxy/src/proxy/websocket/mod.rs
+++ b/lint-http-proxy/src/proxy/websocket/mod.rs
@@ -20,27 +20,29 @@ pub(super) use handshake::{handle_websocket_upgrade, WsUpgradeRequest};
 /// Check if a request is a WebSocket upgrade request.
 ///
 /// A WebSocket handshake requires `Connection: Upgrade` (as a distinct token,
-/// possibly alongside others) and `Upgrade: websocket`.
+/// possibly alongside others) and an `Upgrade` list containing `websocket`.
 ///
-/// Both sentences say "include", not "equal", and that is the whole reason the
-/// two checks are shaped differently. Connection is a token list, so `include`
-/// means membership -- `Connection: keep-alive, Upgrade` is a valid handshake
-/// and a string compare would reject it, which is why this asks
-/// `parse_connection_tokens` rather than looking at the field value. The
-/// keyword and the token are also matched case-insensitively, which the
-/// document establishes elsewhere for each field rather than here.
+/// Both sentences say "include", not "equal", so both checks are membership
+/// tests -- `Connection: keep-alive, Upgrade` is a valid handshake, and so is
+/// `Upgrade: websocket, h2c`: a client may offer several protocols in
+/// preference order and `websocket` among them is an offer this proxy can
+/// serve. The `Upgrade` field is read through the same list reader the rules
+/// use (joined across however many lines carry it), so the proxy routes
+/// exactly the handshakes the rules would lint as handshakes. The keyword and
+/// the token are matched case-insensitively, which the document establishes
+/// elsewhere for each field rather than here.
 ///
 // cite(RFC 6455 § 4.1): "The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword."
 // cite(RFC 6455 § 4.1): "The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token."
 pub(super) fn is_websocket_upgrade<B>(req: &Request<B>) -> bool {
     let connection_tokens = parse_connection_tokens(req.headers().get(hyper::header::CONNECTION));
     let has_upgrade = connection_tokens.contains("upgrade");
-    let is_websocket = req
-        .headers()
-        .get(hyper::header::UPGRADE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.eq_ignore_ascii_case("websocket"))
-        .unwrap_or(false);
+    let is_websocket =
+        crate::helpers::headers::combined_field_value_as_written(req.headers(), "upgrade")
+            .is_some_and(|upgrade| {
+                crate::helpers::headers::list_members(&upgrade)
+                    .any(|m| m.eq_ignore_ascii_case("websocket"))
+            });
     has_upgrade && is_websocket
 }
 
@@ -227,6 +229,12 @@ mod tests {
     // The sentence is cited where the splitting happens, in `parse_connection_tokens`.
     #[case(Some("super-upgrade"), Some("websocket"), false)]
     #[case(Some("upgrades"), Some("websocket"), false)]
+    // Upgrade is a list too, and § 4.1 says "include": `websocket` among other
+    // offered protocols is a handshake this proxy can serve, whichever position
+    // it holds. A keyword that merely contains "websocket" is not a member.
+    #[case(Some("Upgrade"), Some("websocket, h2c"), true)]
+    #[case(Some("Upgrade"), Some("h2c, websocket"), true)]
+    #[case(Some("Upgrade"), Some("websockets"), false)]
     fn is_websocket_upgrade_negative(
         #[case] connection: Option<&str>,
         #[case] upgrade: Option<&str>,
@@ -243,5 +251,20 @@ mod tests {
         }
         let req = builder.body(Full::new(Bytes::new()).boxed()).unwrap();
         assert_eq!(is_websocket_upgrade(&req), expected);
+    }
+
+    /// An `Upgrade` list split across field lines is one list; the membership
+    /// test reads the joined value the way the rules do.
+    #[test]
+    fn is_websocket_upgrade_reads_a_multi_line_upgrade_field() {
+        let req = Request::builder()
+            .method("GET")
+            .uri("http://example.com/ws")
+            .header("connection", "Upgrade")
+            .header("upgrade", "h2c")
+            .header("upgrade", "websocket")
+            .body(Full::new(Bytes::new()).boxed())
+            .unwrap();
+        assert!(is_websocket_upgrade(&req));
     }
 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2264,7 +2264,7 @@ sources:
     - file: lint-http-core/src/protocol_event.rs
       line: 71
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 96
+      line: 98
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 250
   - label: lint-http-proxy/src/proxy/websocket/mod.rs
@@ -2272,7 +2272,7 @@ sources:
     snippet: The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 34
+      line: 36
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 24
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
@@ -2280,7 +2280,7 @@ sources:
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 33
+      line: 35
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 110
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (3)
@@ -2288,7 +2288,7 @@ sources:
     snippet: Note that like other HTTP header fields, this header field MAY be split or combined across multiple lines.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 65
+      line: 67
   - label: lint-http-proxy/src/proxy/websocket/relay.rs
     section: § 5.2
     snippet: '%x0 denotes a continuation frame * %x1 denotes a text frame * %x2 denotes a binary frame * %x3-7 are reserved for further non-control frames * %x8 denotes a connection close * %x9 denotes a ping * %xA denotes a pong'


### PR DESCRIPTION
is_websocket_upgrade cited the sentence whose value MUST *include* the websocket keyword, then compared the whole field value; the rules crate already read the same sentence as list membership, so the two disagreed on what a handshake is. The proxy now reads Upgrade through the shared list helpers, joined across field lines, which means an offer like "Upgrade: websocket, h2c" routes to the WebSocket path instead of being proxied as a plain request.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
