### PR TITLE
The WebSocket session record reaches the capture file through the pip…

### DIFF
--- a/lint-http-proxy/src/proxy/pipeline.rs
+++ b/lint-http-proxy/src/proxy/pipeline.rs
@@ -10,10 +10,11 @@
 //! the transaction, so callers that go through `commit` cannot reorder the
 //! steps, re-commit, or mutate the transaction after capture. Error exchanges
 //! route through `commit` too (`record_error_transaction`), so they are linted
-//! and recorded like any other traffic. The raw stores and capture writer stay
-//! reachable for the records that are not `HttpTransaction`s (the WebSocket
-//! *session* capture writes directly), so the pipeline centralizes the
-//! invariant rather than making bypass impossible.
+//! and recorded like any other traffic. The WebSocket *session* record goes
+//! through [`ProtocolEventPipeline::commit_session`] — its violations were
+//! already collected frame by frame through `commit`, so the session write is
+//! capture routing, and routing it here means no proxy record reaches the
+//! capture file except through a pipeline.
 
 use std::sync::Arc;
 
@@ -63,11 +64,20 @@ impl TransactionPipeline {
 pub(super) struct ProtocolEventPipeline {
     engine: Arc<PreparedEngine>,
     store: Arc<ProtocolEventStore>,
+    captures: CaptureWriter,
 }
 
 impl ProtocolEventPipeline {
-    pub(super) fn new(engine: Arc<PreparedEngine>, store: Arc<ProtocolEventStore>) -> Self {
-        Self { engine, store }
+    pub(super) fn new(
+        engine: Arc<PreparedEngine>,
+        store: Arc<ProtocolEventStore>,
+        captures: CaptureWriter,
+    ) -> Self {
+        Self {
+            engine,
+            store,
+            captures,
+        }
     }
 
     /// Lint `event`, then record it — in that order. Returns the violations
@@ -76,6 +86,19 @@ impl ProtocolEventPipeline {
         let violations = self.engine.lint_protocol_event(event, &self.store);
         self.store.record_event(event);
         violations
+    }
+
+    /// Write a finished WebSocket session record to the capture file. There is
+    /// no session-level lint to run: every frame was linted through [`commit`]
+    /// as it was relayed and the collected violations ride on the session —
+    /// this is the one place the record reaches the capture, documented as
+    /// routing rather than a bypass.
+    ///
+    /// [`commit`]: ProtocolEventPipeline::commit
+    pub(super) async fn commit_session(&self, session: crate::websocket_session::WebSocketSession) {
+        if let Err(e) = self.captures.write_websocket_session(session).await {
+            warn!(error = %e, "failed to write websocket session capture");
+        }
     }
 }
 
@@ -89,7 +112,11 @@ impl Shared {
     }
 
     pub(super) fn protocol_event_pipeline(&self) -> ProtocolEventPipeline {
-        ProtocolEventPipeline::new(self.engine.clone(), self.protocol_event_store.clone())
+        ProtocolEventPipeline::new(
+            self.engine.clone(),
+            self.protocol_event_store.clone(),
+            self.captures.clone(),
+        )
     }
 }
 

--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -203,7 +203,6 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
         // counts the live session against `max_connections` (and makes the
         // drain barrier wait for it), the token lets it close promptly on
         // shutdown.
-        let captures_clone = shared.captures.clone();
         let connection_id = facts.connection_id;
         let pe_pipeline = shared.protocol_event_pipeline();
         let relay_shutdown = shared.shutdown.clone();
@@ -224,7 +223,6 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
                 TokioIo::new(client_io),
                 TokioIo::new(server_io),
                 tx_id,
-                captures_clone,
                 connection_id,
                 negotiated,
                 pe_pipeline,

--- a/lint-http-proxy/src/proxy/websocket/relay.rs
+++ b/lint-http-proxy/src/proxy/websocket/relay.rs
@@ -9,9 +9,7 @@
 use std::sync::Arc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::error;
 
-use crate::capture::CaptureWriter;
 use crate::proxy::pipeline::ProtocolEventPipeline;
 
 /// Build the protocol event for a single relayed WebSocket frame, stamped with
@@ -30,16 +28,15 @@ fn ws_frame_event(
 /// Relay WebSocket messages between client and server, recording each message
 /// for capture. Uses tokio-tungstenite for proper RFC 6455 frame parsing.
 ///
-/// The eighth parameter is what the handshake settled about extensions, and it
-/// is passed rather than re-read because the `101` this session came from is
-/// gone by the time the relay runs — the same reason `tx_id` is passed. Its
-/// caller carries the same allow, for the same reason.
+/// The extensions parameter is what the handshake settled, and it is passed
+/// rather than re-read because the `101` this session came from is gone by
+/// the time the relay runs — the same reason `tx_id` is passed. The pipeline
+/// carries lint, the event store, and the capture writer alike.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn relay_websocket(
     client_io: impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
     server_io: impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
     tx_id: uuid::Uuid,
-    captures: CaptureWriter,
     connection_id: uuid::Uuid,
     extensions: crate::protocol_event::NegotiatedExtensions,
     pipeline: ProtocolEventPipeline,
@@ -100,7 +97,7 @@ pub(super) async fn relay_websocket(
     let msgs_s2c = messages.clone();
     let viols_s2c = violations.clone();
     let close_s2c = close_code.clone();
-    let pipe_s2c = pipeline;
+    let pipe_s2c = pipeline.clone();
     let s2c = async move {
         while let Some(result) = server_read.next().await {
             match result {
@@ -156,9 +153,7 @@ pub(super) async fn relay_websocket(
         Err(arc) => arc.lock().await.clone(),
     };
 
-    if let Err(e) = captures.write_websocket_session(session).await {
-        error!("failed to write websocket session: {}", e);
-    }
+    pipeline.commit_session(session).await;
 }
 
 fn message_to_info(
@@ -223,6 +218,7 @@ fn message_to_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capture::CaptureWriter;
     use std::sync::Arc as StdArc;
     use uuid::Uuid;
 
@@ -269,7 +265,7 @@ mod tests {
         assert_eq!(unmasked.masked, Some(false));
     }
 
-    fn test_pe_pipeline() -> ProtocolEventPipeline {
+    fn test_pe_pipeline(captures: &CaptureWriter) -> ProtocolEventPipeline {
         let cfg = crate::config::Config::default();
         let engine = StdArc::new(crate::engine::PreparedEngine::new(&cfg).unwrap());
         ProtocolEventPipeline::new(
@@ -277,6 +273,7 @@ mod tests {
             StdArc::new(crate::protocol_event_store::ProtocolEventStore::new(
                 300, 100,
             )),
+            captures.clone(),
         )
     }
 
@@ -358,10 +355,9 @@ mod tests {
                 proxy_client_side,
                 proxy_server_side,
                 tx_id,
-                cw_clone,
                 uuid::Uuid::new_v4(),
                 crate::protocol_event::NegotiatedExtensions::NoneAccepted,
-                test_pe_pipeline(),
+                test_pe_pipeline(&cw_clone),
                 tokio_util::sync::CancellationToken::new(),
             )
             .await;
@@ -480,10 +476,9 @@ mod tests {
                 proxy_client_side,
                 proxy_server_side,
                 tx_id,
-                cw_clone,
                 uuid::Uuid::new_v4(),
                 crate::protocol_event::NegotiatedExtensions::NoneAccepted,
-                test_pe_pipeline(),
+                test_pe_pipeline(&cw_clone),
                 tokio_util::sync::CancellationToken::new(),
             )
             .await;
@@ -572,10 +567,9 @@ mod tests {
                 proxy_client_side,
                 proxy_server_side,
                 tx_id,
-                cw_clone,
                 uuid::Uuid::new_v4(),
                 crate::protocol_event::NegotiatedExtensions::NoneAccepted,
-                test_pe_pipeline(),
+                test_pe_pipeline(&cw_clone),
                 tokio_util::sync::CancellationToken::new(),
             )
             .await;
@@ -626,10 +620,9 @@ mod tests {
                 proxy_client_side,
                 proxy_server_side,
                 tx_id,
-                cw_clone,
                 uuid::Uuid::new_v4(),
                 crate::protocol_event::NegotiatedExtensions::NoneAccepted,
-                test_pe_pipeline(),
+                test_pe_pipeline(&cw_clone),
                 shutdown_relay,
             )
             .await;
@@ -730,10 +723,9 @@ mod tests {
                 proxy_client_side,
                 proxy_server_side,
                 tx_id,
-                cw_clone,
                 uuid::Uuid::new_v4(),
                 crate::protocol_event::NegotiatedExtensions::NoneAccepted,
-                test_pe_pipeline(),
+                test_pe_pipeline(&cw_clone),
                 tokio_util::sync::CancellationToken::new(),
             )
             .await;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2294,7 +2294,7 @@ sources:
     snippet: '%x0 denotes a continuation frame * %x1 denotes a text frame * %x2 denotes a binary frame * %x3-7 are reserved for further non-control frames * %x8 denotes a connection close * %x9 denotes a ping * %xA denotes a pong'
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/relay.rs
-      line: 179
+      line: 174
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 4.1
     snippet: (as a string, not base64-decoded) with the string


### PR DESCRIPTION
…eline

ProtocolEventPipeline carries the capture writer and gains commit_session, the one place a finished session is written. The relay stops taking its own CaptureWriter, and the pipeline module doc stops admitting a bypass: no proxy record reaches the capture file except through a pipeline. Session violations were already collected frame by frame through commit, so this is capture routing, not a lint change.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
