### PR TITLE
The untested upgrade paths get their tests

### DIFF
--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -672,4 +672,134 @@ mod tests {
         let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
+
+    /// At max_connections, the upgrade is refused before the origin is
+    /// dialed: an explicit 503, recorded through the pipeline, instead of an
+    /// uncounted relay session.
+    #[tokio::test]
+    async fn handle_websocket_upgrade_refuses_at_capacity() -> anyhow::Result<()> {
+        let cfg = StdArc::new(crate::config::Config::default());
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+
+        // Hold every permit: the proxy is at capacity.
+        let total = shared.semaphore.available_permits();
+        let _hold = shared
+            .semaphore
+            .clone()
+            .acquire_many_owned(total as u32)
+            .await?;
+
+        let fake_on_upgrade = hyper::upgrade::on(
+            Request::builder()
+                .method("GET")
+                .uri("http://fake/")
+                .body(Full::new(Bytes::new()).boxed())
+                .unwrap(),
+        );
+        // Port 1 would refuse the dial, but capacity is checked first, so the
+        // origin is never contacted at all.
+        let uri: Uri = "http://127.0.0.1:1/ws".parse()?;
+        let started = Instant::now();
+        let resp = handle_websocket_upgrade(
+            WsUpgradeRequest {
+                facts: test_facts(&uri, hyper::HeaderMap::new()),
+                uri: uri.clone(),
+                fallback_scheme: hyper::http::uri::Scheme::HTTP,
+                body: Bytes::new(),
+                trailers: None,
+                client_on_upgrade: fake_on_upgrade,
+            },
+            shared,
+            started,
+        )
+        .await?;
+        assert_eq!(resp.status().as_u16(), 503);
+
+        cw.flush().await?;
+        let content = tokio::fs::read_to_string(&tmp).await?;
+        let v: serde_json::Value = serde_json::from_str(content.trim())?;
+        assert_eq!(v["response"]["status"].as_u64(), Some(503));
+
+        let _ = tokio::fs::remove_file(&tmp).await;
+        Ok(())
+    }
+
+    /// A 101 whose client-side upgrade never completes: the relay task ends
+    /// without a session record and releases its permit, so a failed upgrade
+    /// cannot leak capacity.
+    #[tokio::test]
+    async fn handle_websocket_upgrade_failed_upgrade_releases_the_permit() -> anyhow::Result<()> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        let server_task = tokio::spawn(async move {
+            if let Ok((socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = socket.readable().await;
+                let _ = socket.try_read(&mut buf);
+                let resp = b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n";
+                let _ = socket.try_write(resp);
+                // Hold the socket open long enough for the upgrade attempt.
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        });
+
+        let cfg = StdArc::new(crate::config::Config::default());
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+        let total = shared.semaphore.available_permits();
+
+        // An OnUpgrade whose request is dropped immediately: the client half
+        // of the upgrade fails after the upstream half succeeded.
+        let fake_on_upgrade = hyper::upgrade::on(
+            Request::builder()
+                .method("GET")
+                .uri("http://fake/")
+                .body(Full::new(Bytes::new()).boxed())
+                .unwrap(),
+        );
+
+        let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
+        let started = Instant::now();
+        let resp = handle_websocket_upgrade(
+            WsUpgradeRequest {
+                facts: test_facts(&uri, hyper::HeaderMap::new()),
+                uri: uri.clone(),
+                fallback_scheme: hyper::http::uri::Scheme::HTTP,
+                body: Bytes::new(),
+                trailers: None,
+                client_on_upgrade: fake_on_upgrade,
+            },
+            shared.clone(),
+            started,
+        )
+        .await?;
+        assert_eq!(resp.status().as_u16(), 101);
+
+        // The relay task fails its try_join and returns; the permit comes back.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while shared.semaphore.available_permits() != total {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the failed upgrade's permit was not released"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // The capture holds the 101 transaction and nothing else — there is
+        // no session record for a session that never started.
+        cw.flush().await?;
+        let content = tokio::fs::read_to_string(&tmp).await?;
+        let lines: Vec<_> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "expected only the 101 transaction: {content}"
+        );
+        let v: serde_json::Value = serde_json::from_str(lines[0])?;
+        assert_eq!(v["type"].as_str(), Some("http_transaction"));
+        assert_eq!(v["response"]["status"].as_u64(), Some(101));
+
+        let _ = server_task.await;
+        let _ = tokio::fs::remove_file(&tmp).await;
+        Ok(())
+    }
 }

--- a/lint-http-proxy/tests/proxy_websocket_relay.rs
+++ b/lint-http-proxy/tests/proxy_websocket_relay.rs
@@ -201,3 +201,162 @@ async fn websocket_upgrade_through_proxy_captures_session() -> anyhow::Result<()
     let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
+
+/// The wss:// composition, previously untested end to end: CONNECT to the
+/// proxy, TLS-MITM inside the tunnel with the proxy's own CA, then a
+/// WebSocket upgrade and echo over the TLS client leg. The origin leg stays
+/// plain TCP (the inner request names an absolute http:// target), so the
+/// test needs no origin-side trust store.
+#[tokio::test]
+async fn websocket_upgrade_through_connect_mitm_tunnel() -> anyhow::Result<()> {
+    use rustls::pki_types::pem::PemObject;
+
+    let ws_addr = start_ws_echo_server().await;
+
+    let mut cfg = Config::default();
+    cfg.tls.enabled = true;
+    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
+    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
+    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
+    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    // CONNECT to the proxy; the authority names the MITM certificate's domain.
+    let mut tcp = tokio::net::TcpStream::connect(proxy_addr).await?;
+    tcp.write_all(b"CONNECT wsecho.test:443 HTTP/1.1\r\nHost: wsecho.test:443\r\n\r\n")
+        .await?;
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 1024];
+    loop {
+        let n = tcp.read(&mut tmp).await?;
+        if n == 0 {
+            anyhow::bail!("proxy closed connection during CONNECT");
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    assert!(
+        String::from_utf8_lossy(&buf).starts_with("HTTP/1.1 2"),
+        "CONNECT refused: {}",
+        String::from_utf8_lossy(&buf)
+    );
+
+    // TLS handshake inside the tunnel, trusting the proxy's CA; http/1.1 only
+    // so the upgrade request is spoken over the protocol it belongs to.
+    let mut root_store = rustls::RootCertStore::empty();
+    let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_file_iter(&cert_path)?
+        .collect::<Result<Vec<_>, _>>()?;
+    root_store.add_parsable_certificates(certs);
+    let mut client_cfg = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    client_cfg.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_cfg));
+    let server_name = rustls::pki_types::ServerName::try_from("wsecho.test".to_string())?;
+    let mut tls = connector.connect(server_name, tcp).await?;
+
+    // The WebSocket handshake through the tunnel.
+    let ws_key = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        uuid::Uuid::new_v4().as_bytes(),
+    );
+    let req = format!(
+        "GET http://127.0.0.1:{port}/ws HTTP/1.1\r\n\
+         Host: 127.0.0.1:{port}\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: websocket\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: {ws_key}\r\n\
+         \r\n",
+        port = ws_addr.port(),
+    );
+    tls.write_all(req.as_bytes()).await?;
+
+    let mut buf = Vec::new();
+    loop {
+        let n = tls.read(&mut tmp).await?;
+        if n == 0 {
+            anyhow::bail!("proxy closed the tunnel before the upgrade response");
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let resp_str = String::from_utf8_lossy(&buf);
+    assert!(resp_str.contains("101"), "expected 101, got: {resp_str}");
+
+    // Echo a message over the upgraded TLS stream.
+    let ws = tokio_tungstenite::WebSocketStream::from_raw_socket(
+        tls,
+        tokio_tungstenite::tungstenite::protocol::Role::Client,
+        None,
+    )
+    .await;
+    let (mut write, mut read) = ws.split();
+    write
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            "tunneled".into(),
+        ))
+        .await?;
+    let msg = tokio::time::timeout(std::time::Duration::from_secs(5), read.next())
+        .await?
+        .unwrap()?;
+    assert_eq!(
+        msg,
+        tokio_tungstenite::tungstenite::Message::Text("tunneled".into())
+    );
+    write
+        .send(tokio_tungstenite::tungstenite::Message::Close(None))
+        .await?;
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), read.next()).await;
+    drop(write);
+    drop(read);
+
+    // Both the 101 transaction and the linked session land in the capture.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let content = loop {
+        let content = tokio::fs::read_to_string(&captures_path)
+            .await
+            .unwrap_or_default();
+        if content
+            .lines()
+            .filter(|l| l.contains("websocket_session"))
+            .count()
+            >= 1
+            || std::time::Instant::now() > deadline
+        {
+            break content;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    };
+    let mut tx_id = String::new();
+    let mut found_session = false;
+    for line in content.lines().filter(|l| !l.trim().is_empty()) {
+        let v: serde_json::Value = serde_json::from_str(line)?;
+        if v["type"].as_str() == Some("http_transaction")
+            && v["response"]["status"].as_u64() == Some(101)
+        {
+            assert_eq!(v["was_upgraded"].as_bool(), Some(true));
+            tx_id = v["id"].as_str().unwrap_or("").to_string();
+        }
+        if v["type"].as_str() == Some("websocket_session") {
+            found_session = true;
+            assert!(!v["messages"].as_array().unwrap().is_empty());
+            if !tx_id.is_empty() {
+                assert_eq!(v["transaction_id"].as_str(), Some(tx_id.as_str()));
+            }
+        }
+    }
+    assert!(!tx_id.is_empty(), "no 101 transaction captured: {content}");
+    assert!(found_session, "no websocket session captured: {content}");
+
+    handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    let _ = tokio::fs::remove_file(&cert_path).await;
+    let _ = tokio::fs::remove_file(&key_path).await;
+    Ok(())
+}


### PR DESCRIPTION
Three gaps the audit named: the wss:// composition (CONNECT, TLS-MITM with the proxy's CA, then a WebSocket upgrade and echo over the TLS client leg) runs end to end in an integration test; a 101 whose client-side upgrade fails is shown to release its permit and leave no session record; and a proxy at max_connections is shown to refuse the upgrade with a recorded 503 before the origin is dialed.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
