### PR TITLE
Each relay direction gets an observer that owns its own record

### DIFF
--- a/lint-http-proxy/src/capture.rs
+++ b/lint-http-proxy/src/capture.rs
@@ -717,6 +717,7 @@ mod tests {
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         });
         session.duration_ms = 100;
         session.close_code = Some(1000);
@@ -755,6 +756,7 @@ mod tests {
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         });
 
         // Write a transaction, then a websocket_session, then another transaction

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -371,8 +371,11 @@ fn lint_websocket_session(
     );
     let mut violations = Vec::new();
     for msg in &session.messages {
+        // Frames recorded with their own arrival time replay with it; records
+        // written before the per-frame field existed fall back to the session
+        // timestamp, which is all they ever carried.
         let event = msg.frame_event(
-            session.timestamp,
+            msg.timestamp.unwrap_or(session.timestamp),
             session.id,
             session.id,
             &session.extensions,
@@ -734,6 +737,7 @@ severity = "warn"
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         }
     }
 

--- a/lint-http-proxy/src/proxy/websocket/mod.rs
+++ b/lint-http-proxy/src/proxy/websocket/mod.rs
@@ -12,10 +12,12 @@ use hyper::Request;
 
 use super::hop_by_hop::parse_connection_tokens;
 
-// Wired into the relay by the transparent-relay change; the allow dies there.
+// Wired into the relay by the transparent-relay change; the allows die there.
 #[allow(dead_code)]
 mod frame;
 mod handshake;
+#[allow(dead_code)]
+mod observer;
 mod relay;
 
 pub(super) use handshake::{handle_websocket_upgrade, WsUpgradeRequest};

--- a/lint-http-proxy/src/proxy/websocket/observer.rs
+++ b/lint-http-proxy/src/proxy/websocket/observer.rs
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The passive per-direction observer between the wire and the record.
+//!
+//! Each relay direction owns one: the pump hands it every chunk it forwards,
+//! the observer scans frame boundaries, stamps each completed header with its
+//! arrival time, commits one protocol event per frame (real FIN, RSV, opcode,
+//! MASK bit, and length — as the wire spelled them), and accumulates the
+//! session's rows. No sharing, no locks: a direction's state belongs to its
+//! own task until the relay joins both and merges the outcomes.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::lint::Violation;
+use crate::protocol_event::NegotiatedExtensions;
+use crate::proxy::pipeline::ProtocolEventPipeline;
+use crate::websocket_session::{MessageDirection, WebSocketMessageInfo};
+
+use super::frame::{FrameScanner, ScanItem};
+
+/// Observes one direction of a relayed session.
+pub(super) struct DirectionObserver {
+    direction: MessageDirection,
+    connection_id: Uuid,
+    session_id: Uuid,
+    extensions: NegotiatedExtensions,
+    pipeline: ProtocolEventPipeline,
+    scanner: FrameScanner,
+    frames: Vec<WebSocketMessageInfo>,
+    violations: Vec<Violation>,
+    close_code: Option<u16>,
+}
+
+/// What one direction saw, ready to merge into the session record.
+pub(super) struct DirectionOutcome {
+    pub frames: Vec<WebSocketMessageInfo>,
+    pub violations: Vec<Violation>,
+    /// The status code of this direction's first Close frame, if one arrived
+    /// with a readable code.
+    pub close_code: Option<u16>,
+}
+
+impl DirectionObserver {
+    pub(super) fn new(
+        direction: MessageDirection,
+        connection_id: Uuid,
+        session_id: Uuid,
+        extensions: NegotiatedExtensions,
+        pipeline: ProtocolEventPipeline,
+    ) -> Self {
+        Self {
+            direction,
+            connection_id,
+            session_id,
+            extensions,
+            pipeline,
+            scanner: FrameScanner::new(),
+            frames: Vec::new(),
+            violations: Vec::new(),
+            close_code: None,
+        }
+    }
+
+    /// Observe a chunk the pump is about to forward: scan it, and for every
+    /// frame header it completes, record the row and commit the event through
+    /// lint. Synchronous on purpose — nothing here awaits, so observation
+    /// cannot reorder against the forward write.
+    pub(super) fn observe(&mut self, chunk: &[u8]) {
+        for item in self.scanner.feed(chunk) {
+            match item {
+                ScanItem::Frame(header) => {
+                    let stamp = Utc::now();
+                    let info = WebSocketMessageInfo {
+                        direction: self.direction,
+                        opcode: header.opcode,
+                        payload_length: header.payload_length,
+                        fin: header.fin,
+                        rsv: header.rsv,
+                        masked: Some(header.masked),
+                        timestamp: Some(stamp),
+                    };
+                    let event = info.frame_event(
+                        stamp,
+                        self.connection_id,
+                        self.session_id,
+                        &self.extensions,
+                    );
+                    self.violations.extend(self.pipeline.commit(&event));
+                    self.frames.push(info);
+                }
+                // The status code is the first two octets of a Close payload;
+                // the scanner already unmasked it. First Close wins within a
+                // direction — anything after it is recorded but changes no
+                // conclusion here.
+                // cite(RFC 6455 § 5.5.1): "If there is a body, the first two bytes of the body MUST be a 2-byte unsigned integer (in network byte order) representing a status code with value /code/ defined in Section 7.4."
+                ScanItem::ControlPayload { opcode: 8, payload } => {
+                    if self.close_code.is_none() && payload.len() >= 2 {
+                        self.close_code = Some(u16::from_be_bytes([payload[0], payload[1]]));
+                    }
+                }
+                ScanItem::ControlPayload { .. } => {}
+            }
+        }
+    }
+
+    /// True when this direction's wire ended in the middle of a frame.
+    pub(super) fn mid_frame(&self) -> bool {
+        self.scanner.mid_frame()
+    }
+
+    pub(super) fn into_outcome(self) -> DirectionOutcome {
+        DirectionOutcome {
+            frames: self.frames,
+            violations: self.violations,
+            close_code: self.close_code,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capture::CaptureWriter;
+    use std::sync::Arc;
+
+    async fn test_observer(direction: MessageDirection) -> (DirectionObserver, String) {
+        let tmp = std::env::temp_dir().join(format!("lint_ws_observer_{}.jsonl", Uuid::new_v4()));
+        let path = tmp.to_str().unwrap().to_string();
+        let captures = CaptureWriter::new(path.clone(), false).await.unwrap();
+        let cfg = crate::config::Config::default();
+        let engine = Arc::new(crate::engine::PreparedEngine::new(&cfg).unwrap());
+        let pipeline = ProtocolEventPipeline::new(
+            engine,
+            Arc::new(crate::protocol_event_store::ProtocolEventStore::new(
+                300, 100,
+            )),
+            captures,
+        );
+        (
+            DirectionObserver::new(
+                direction,
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                NegotiatedExtensions::NoneAccepted,
+                pipeline,
+            ),
+            path,
+        )
+    }
+
+    /// The observer records the header bits as the wire spelled them — the
+    /// masked flag is `Some(bit)` now, never the old `None`, and each frame
+    /// carries its own arrival time.
+    #[tokio::test]
+    async fn frames_are_recorded_with_real_header_bits_and_timestamps() {
+        let (mut observer, path) = test_observer(MessageDirection::Client).await;
+
+        // Masked text "hi", then an unmasked fragmented binary start.
+        let key = [1u8, 2, 3, 4];
+        let mut wire = vec![0x81, 0x82, 1, 2, 3, 4];
+        wire.extend(b"hi".iter().enumerate().map(|(i, b)| b ^ key[i % 4]));
+        wire.extend([0x02, 0x03, 9, 9, 9]); // binary, fin=false, unmasked, 3 bytes
+
+        observer.observe(&wire);
+        let outcome = observer.into_outcome();
+
+        assert_eq!(outcome.frames.len(), 2);
+        assert_eq!(outcome.frames[0].masked, Some(true));
+        assert_eq!(outcome.frames[0].opcode, 1);
+        assert!(outcome.frames[0].fin);
+        assert!(outcome.frames[0].timestamp.is_some());
+        assert_eq!(outcome.frames[1].masked, Some(false));
+        assert!(
+            !outcome.frames[1].fin,
+            "the real FIN bit, not a hardcoded true"
+        );
+        assert_eq!(outcome.close_code, None);
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    /// Each direction reads its own close code, from an unmasked payload.
+    #[tokio::test]
+    async fn the_close_code_is_read_from_this_directions_close_frame() {
+        let (mut observer, path) = test_observer(MessageDirection::Client).await;
+
+        let key = [7u8, 7, 7, 7];
+        let payload = [0x03u8, 0xE9]; // 1001
+        let mut wire = vec![0x88, 0x82, 7, 7, 7, 7];
+        wire.extend(payload.iter().enumerate().map(|(i, b)| b ^ key[i % 4]));
+
+        observer.observe(&wire);
+        assert!(!observer.mid_frame());
+        let outcome = observer.into_outcome();
+        assert_eq!(outcome.close_code, Some(1001));
+        assert_eq!(outcome.frames.len(), 1);
+        assert_eq!(outcome.frames[0].opcode, 8);
+
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    /// A truncated direction is visible to the relay for its wind-down log.
+    #[tokio::test]
+    async fn a_wire_cut_mid_frame_reports_as_such() {
+        let (mut observer, path) = test_observer(MessageDirection::Server).await;
+        observer.observe(&[0x81, 0x05, b'h']);
+        assert!(observer.mid_frame());
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+}

--- a/lint-http-proxy/src/proxy/websocket/relay.rs
+++ b/lint-http-proxy/src/proxy/websocket/relay.rs
@@ -212,6 +212,7 @@ fn message_to_info(
         fin,
         rsv,
         masked,
+        timestamp: None,
     }
 }
 

--- a/lint-http-proxy/src/websocket_session.rs
+++ b/lint-http-proxy/src/websocket_session.rs
@@ -43,6 +43,11 @@ pub struct WebSocketMessageInfo {
     /// existed would have become one.
     #[serde(default)]
     pub masked: Option<bool>,
+    /// When the frame's header arrived at the relay. `None` in records
+    /// written before this field existed — replay then falls back to the
+    /// session timestamp, which is all those records ever had.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<DateTime<Utc>>,
 }
 
 fn default_fin() -> bool {
@@ -92,9 +97,18 @@ pub struct WebSocketSession {
     pub timestamp: DateTime<Utc>,
     pub duration_ms: u64,
     pub messages: Vec<WebSocketMessageInfo>,
-    /// Close status code from the first Close frame, if any.
+    /// Close status code from the first Close frame, if any — kept for
+    /// records and readers that predate the per-direction fields below; when
+    /// both sides closed, this holds the earlier of the two.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub close_code: Option<u16>,
+    /// Close status code the client sent, if any. Separate from the server's
+    /// because a close handshake has two frames and they may not agree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_close_code: Option<u16>,
+    /// Close status code the server sent, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_close_code: Option<u16>,
     /// Protocol-level violations detected during the session.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub violations: Vec<crate::lint::Violation>,
@@ -116,6 +130,8 @@ impl WebSocketSession {
             duration_ms: 0,
             messages: Vec::new(),
             close_code: None,
+            client_close_code: None,
+            server_close_code: None,
             violations: Vec::new(),
             extensions: crate::protocol_event::NegotiatedExtensions::Unrecorded,
         }
@@ -178,6 +194,7 @@ mod tests {
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         });
         session.messages.push(WebSocketMessageInfo {
             direction: MessageDirection::Server,
@@ -186,6 +203,7 @@ mod tests {
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         });
         session.messages.push(WebSocketMessageInfo {
             direction: MessageDirection::Client,
@@ -194,6 +212,7 @@ mod tests {
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         });
         session.close_code = Some(1000);
         session.duration_ms = 150;
@@ -207,6 +226,48 @@ mod tests {
         assert_eq!(deserialized.messages[0].direction, MessageDirection::Client);
         assert_eq!(deserialized.messages[0].opcode, 1);
         assert_eq!(deserialized.close_code, Some(1000));
+    }
+
+    /// The per-frame timestamp and per-direction close codes are additive:
+    /// an old record reads back without them, and a new record carries them
+    /// through a roundtrip.
+    #[test]
+    fn additive_fields_default_on_old_records_and_roundtrip_on_new_ones() {
+        let json = serde_json::json!({
+            "id": Uuid::new_v4(),
+            "transaction_id": Uuid::new_v4(),
+            "timestamp": Utc::now(),
+            "duration_ms": 12,
+            "messages": [{
+                "direction": "client",
+                "opcode": 1,
+                "payload_length": 3,
+            }],
+        })
+        .to_string();
+        let old: WebSocketSession = serde_json::from_str(&json).expect("an older session");
+        assert_eq!(old.messages[0].timestamp, None);
+        assert_eq!(old.client_close_code, None);
+        assert_eq!(old.server_close_code, None);
+
+        let mut session = WebSocketSession::new(Uuid::new_v4());
+        let stamp = Utc::now();
+        session.messages.push(WebSocketMessageInfo {
+            direction: MessageDirection::Client,
+            opcode: 8,
+            payload_length: 2,
+            fin: true,
+            rsv: 0,
+            masked: Some(true),
+            timestamp: Some(stamp),
+        });
+        session.client_close_code = Some(1000);
+        session.server_close_code = Some(1001);
+        let round: WebSocketSession =
+            serde_json::from_str(&serde_json::to_string(&session).unwrap()).unwrap();
+        assert_eq!(round.messages[0].timestamp, Some(stamp));
+        assert_eq!(round.client_close_code, Some(1000));
+        assert_eq!(round.server_close_code, Some(1001));
     }
 
     #[test]
@@ -225,6 +286,7 @@ mod tests {
             fin: true,
             rsv: 0,
             masked: None,
+            timestamp: None,
         };
         let v: serde_json::Value = serde_json::to_value(&msg).unwrap();
         assert_eq!(v["direction"].as_str(), Some("server"));

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2264,7 +2264,7 @@ sources:
     - file: lint-http-core/src/protocol_event.rs
       line: 71
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 101
+      line: 103
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 250
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
@@ -2318,7 +2318,7 @@ sources:
     snippet: The request MUST contain a |Connection| header field whose value MUST include the "Upgrade" token.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 39
+      line: 41
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 24
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (2)
@@ -2326,7 +2326,7 @@ sources:
     snippet: The request MUST contain an |Upgrade| header field whose value MUST include the "websocket" keyword.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 38
+      line: 40
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 110
   - label: lint-http-proxy/src/proxy/websocket/mod.rs (3)
@@ -2334,7 +2334,15 @@ sources:
     snippet: Note that like other HTTP header fields, this header field MAY be split or combined across multiple lines.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 70
+      line: 72
+  - label: lint-http-proxy/src/proxy/websocket/observer.rs
+    section: § 5.5.1
+    snippet: If there is a body, the first two bytes of the body MUST be a 2-byte unsigned integer (in network byte order) representing a status code with value /code/ defined in Section 7.4.
+    cited_by:
+    - file: lint-http-proxy/src/proxy/websocket/observer.rs
+      line: 98
+    - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
+      line: 210
   - label: lint-http-proxy/src/proxy/websocket/relay.rs
     section: § 5.2
     snippet: '%x0 denotes a continuation frame * %x1 denotes a text frame * %x2 denotes a binary frame * %x3-7 are reserved for further non-control frames * %x8 denotes a connection close * %x9 denotes a ping * %xA denotes a pong'
@@ -2627,17 +2635,11 @@ sources:
       line: 308
   - label: websocket_frame_opcode_sequence (11)
     section: § 5.5.1
-    snippet: If there is a body, the first two bytes of the body MUST be a 2-byte unsigned integer (in network byte order) representing a status code with value /code/ defined in Section 7.4.
-    cited_by:
-    - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
-      line: 210
-  - label: websocket_frame_opcode_sequence (12)
-    section: § 5.5.1
     snippet: The Close frame MAY contain a body (the "Application data" portion of the frame) that indicates a reason for closing
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 209
-  - label: websocket_frame_opcode_sequence (13)
+  - label: websocket_frame_opcode_sequence (12)
     section: § 5.5.1
     snippet: The Close frame contains an opcode of 0x8.
     cited_by:
@@ -2645,19 +2647,19 @@ sources:
       line: 208
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 270
-  - label: websocket_frame_opcode_sequence (14)
+  - label: websocket_frame_opcode_sequence (13)
     section: § 5.5.1
     snippet: The application MUST NOT send any more data frames after sending a Close frame.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 283
-  - label: websocket_frame_opcode_sequence (15)
+  - label: websocket_frame_opcode_sequence (14)
     section: § 5.6
     snippet: Data frames (e.g., non-control frames) are identified by opcodes where the most significant bit of the opcode is 0.
     cited_by:
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 249
-  - label: websocket_frame_opcode_sequence (16)
+  - label: websocket_frame_opcode_sequence (15)
     section: § 5.8
     snippet: This specification provides opcodes 0x3 through 0x7 and 0xB through 0xF, the "Extension data" field, and the frame-rsv1, frame-rsv2, and frame-rsv3 bits of the frame header for use by extensions.
     cited_by:


### PR DESCRIPTION
DirectionObserver scans the chunks a direction forwards, stamps every completed header with its arrival time, commits one protocol event per frame through lint, and accumulates rows, violations, and that direction's close code with no shared state to lock. The capture model grows the additive fields this needs — an optional per-frame timestamp and per-direction close codes on the session — all serde-defaulted so records written before them read back unchanged, and replay falls back to the session timestamp exactly where an old record has nothing finer. Not yet wired into the relay.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
