### PR TITLE
The extension negotiation passes through a relay that no longer reads…

### DIFF
--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -22,8 +22,8 @@ use crate::proxy::exchange::{
 use crate::proxy::hop_by_hop::format_http_version;
 use crate::proxy::{boxed_full, BoxError, ResponseBody, Shared};
 
+use super::accepted_extensions;
 use super::relay::relay_websocket;
-use super::{accepted_extensions, without_extension_negotiation};
 
 /// Everything the transport front half hands the WebSocket upgrade path.
 pub(in crate::proxy) struct WsUpgradeRequest {
@@ -87,15 +87,13 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
     // Build the upstream handshake request. Preserve hop-by-hop headers: the
     // WebSocket upgrade depends on `Connection`/`Upgrade` reaching the origin
     // (the request-side analog of the 101 carve-out in
-    // `filter_response_headers`). The one field removed is the extension
-    // negotiation, which stops at the relay — the frames of an accepted
-    // extension would be unreadable in the middle, and a session tungstenite
-    // cannot read is a session it kills. The capture records `facts.headers`
-    // as received, offer included; see
-    // `websocket::without_extension_negotiation`.
-    let upstream_headers = without_extension_negotiation(&facts.headers);
+    // `filter_response_headers`). The extension negotiation travels with them:
+    // the relay forwards bytes without decoding frames, so the frames of an
+    // accepted extension pass through it as readily as any others, and an
+    // intermediary that can carry an extension's frames has no business
+    // silencing its negotiation.
     let upstream_req =
-        match upstream_request_builder(&facts.method, &uri, &upstream_headers, &shared, false)
+        match upstream_request_builder(&facts.method, &uri, &facts.headers, &shared, false)
             .body(Full::new(body_bytes.clone()))
         {
             Ok(r) => r,
@@ -185,13 +183,13 @@ pub(in crate::proxy) async fn handle_websocket_upgrade(
         let server_upgraded = hyper::upgrade::on(&mut upstream_resp);
 
         // Build the 101 response to send back to the client.
-        // Forward ALL headers including upgrade-related ones (Connection, Upgrade,
-        // Sec-WebSocket-Accept) — do NOT strip hop-by-hop headers for 101. The one
-        // exception is the extension negotiation, which stops at the relay:
-        // see `without_extension_negotiation`. The capture above already
-        // recorded the 101 as received.
+        // Forward ALL headers including upgrade-related ones (Connection,
+        // Upgrade, Sec-WebSocket-Accept) — do NOT strip hop-by-hop headers for
+        // 101, and let the accepted extension negotiation through with them:
+        // the transparent relay carries an extension's frames, so the client
+        // must see what the origin accepted.
         let mut resp_builder = Response::builder().status(101);
-        for (name, value) in without_extension_negotiation(&headers).iter() {
+        for (name, value) in headers.iter() {
             resp_builder = resp_builder.header(name, value);
         }
         let resp = resp_builder

--- a/lint-http-proxy/src/proxy/websocket/mod.rs
+++ b/lint-http-proxy/src/proxy/websocket/mod.rs
@@ -48,33 +48,6 @@ pub(super) fn is_websocket_upgrade<B>(req: &Request<B>) -> bool {
     has_upgrade && is_websocket
 }
 
-/// The message minus its `Sec-WebSocket-Extensions` field: the extension
-/// negotiation stops at the relay, in both directions.
-///
-/// **The relay is a WebSocket endpoint on each leg, not a tunnel.** Every frame
-/// passes through tungstenite, which implements no extension and returns
-/// `ProtocolError::NonZeroReservedBits` for any frame that sets one — so a
-/// negotiation relayed end-to-end authorises frames the middle cannot read.
-/// That was live: the client's `permessage-deflate` offer reached the origin,
-/// the origin's acceptance reached the client, and the first compressed frame
-/// killed the session (RULECITES P48). An intermediary that cannot read an
-/// extension's frames must not relay its negotiation, so the offer is removed
-/// from the upstream handshake request and the acceptance — which a conforming
-/// origin then never sends, but a broken one still might — from the `101`
-/// forwarded to the client.
-///
-/// **Captures are untouched.** Both the request and the `101` are recorded as
-/// received, offer and acceptance included, before this runs — the rules read
-/// what each party wrote, not what the relay could live with.
-// cite(RFC 6455 § 9.1): "Note that like other HTTP header fields, this header field MAY be split or combined across multiple lines."
-pub(super) fn without_extension_negotiation(headers: &hyper::HeaderMap) -> hyper::HeaderMap {
-    let mut out = headers.clone();
-    // `HeaderMap::remove` takes every value of the name, so a field split
-    // across lines — which § 9.1 permits in as many words — leaves nothing.
-    out.remove("sec-websocket-extensions");
-    out
-}
-
 /// What a `101` settled about extensions, read from the response and not from
 /// the offer.
 ///
@@ -115,35 +88,6 @@ mod tests {
     use bytes::Bytes;
     use http_body_util::{BodyExt, Full};
     use rstest::rstest;
-
-    /// The negotiation stops at the relay: the field is removed however many
-    /// lines carried it, and nothing else moves. The frames of an accepted
-    /// extension would be unreadable to tungstenite in the middle, so relaying
-    /// the offer or the acceptance authorised sessions the relay then killed
-    /// (RULECITES P48).
-    #[test]
-    fn extension_negotiation_is_stripped_and_nothing_else_is() {
-        use hyper::header::{HeaderName, HeaderValue};
-        let name = HeaderName::from_static("sec-websocket-extensions");
-
-        let mut headers = hyper::HeaderMap::new();
-        headers.insert(
-            hyper::header::UPGRADE,
-            HeaderValue::from_static("websocket"),
-        );
-        headers.insert(
-            HeaderName::from_static("sec-websocket-key"),
-            HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
-        );
-        headers.append(name.clone(), HeaderValue::from_static("permessage-deflate"));
-        headers.append(name.clone(), HeaderValue::from_static("bbf-usp-protocol"));
-
-        let out = without_extension_negotiation(&headers);
-        assert!(!out.contains_key(&name), "both field lines are gone");
-        assert_eq!(out.len(), 2, "everything else survives");
-        assert!(out.contains_key(hyper::header::UPGRADE));
-        assert!(out.contains_key("sec-websocket-key"));
-    }
 
     /// The one line that turns a `101` into the fact a frame rule reads.
     ///

--- a/lint-http-proxy/tests/proxy_websocket_relay.rs
+++ b/lint-http-proxy/tests/proxy_websocket_relay.rs
@@ -667,3 +667,164 @@ async fn defective_frames_produce_live_findings() -> anyhow::Result<()> {
     let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
+
+/// Extension negotiation passes through end to end: the client's offer
+/// reaches the origin, the origin's acceptance reaches the client inside the
+/// 101, an RSV1 frame (what a permessage-deflate origin sends) survives the
+/// relay — and the RSV rule, enabled, stands down because the handshake it
+/// can now see accepted an extension.
+#[tokio::test]
+async fn extension_negotiation_flows_end_to_end() -> anyhow::Result<()> {
+    // A raw origin that requires the offer, accepts it in the 101, then sends
+    // one RSV1 "compressed" text frame (no real deflate needed — the relay
+    // never reads payloads) and reads until EOF.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let origin_addr = listener.local_addr()?;
+    tokio::spawn(async move {
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let mut buf = [0u8; 4096];
+            let mut req = Vec::new();
+            loop {
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                if n == 0 {
+                    return;
+                }
+                req.extend_from_slice(&buf[..n]);
+                if req.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let req_str = String::from_utf8_lossy(&req).to_string();
+            assert!(
+                req_str.to_ascii_lowercase().contains("permessage-deflate"),
+                "the client's extension offer must reach the origin: {req_str}"
+            );
+            let key = req_str
+                .lines()
+                .find_map(|l| {
+                    l.to_ascii_lowercase()
+                        .starts_with("sec-websocket-key:")
+                        .then(|| l.split(':').nth(1).unwrap().trim().to_string())
+                })
+                .unwrap_or_default();
+            let accept = {
+                use base64::Engine;
+                use sha1::{Digest, Sha1};
+                let mut h = Sha1::new();
+                h.update(key.as_bytes());
+                h.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+                base64::engine::general_purpose::STANDARD.encode(h.finalize())
+            };
+            let mut reply = format!(
+                "HTTP/1.1 101 Switching Protocols\r\n\
+                 Upgrade: websocket\r\n\
+                 Connection: Upgrade\r\n\
+                 Sec-WebSocket-Accept: {accept}\r\n\
+                 Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n"
+            )
+            .into_bytes();
+            // RSV1 set, text, unmasked (server side), 2 bytes.
+            reply.extend([0xC1, 0x02, 0xAB, 0xCD]);
+            let _ = sock.write_all(&reply).await;
+            while sock.read(&mut buf).await.unwrap_or(0) > 0 {}
+        }
+    });
+
+    let cfg = Config {
+        lint: lint_http_core::test_helpers::make_test_config_with_enabled_rules(&[
+            "websocket_frame_rsv_bits",
+        ]),
+        ..Default::default()
+    };
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+
+    let mut tcp = tokio::net::TcpStream::connect(proxy_addr).await?;
+    let ws_key = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        uuid::Uuid::new_v4().as_bytes(),
+    );
+    tcp.write_all(
+        format!(
+            "GET http://{origin}/ws HTTP/1.1\r\n\
+             Host: {origin}\r\n\
+             Connection: Upgrade\r\n\
+             Upgrade: websocket\r\n\
+             Sec-WebSocket-Version: 13\r\n\
+             Sec-WebSocket-Key: {ws_key}\r\n\
+             Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n",
+            origin = origin_addr,
+        )
+        .as_bytes(),
+    )
+    .await?;
+
+    // The 101 reaching the client carries the origin's acceptance, and the
+    // RSV1 frame follows it through the relay.
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    let frame_bytes = loop {
+        let n = tcp.read(&mut tmp).await?;
+        anyhow::ensure!(n > 0, "proxy closed before delivering the frame");
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(head_end) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            let body = &buf[head_end + 4..];
+            if body.len() >= 4 {
+                break body.to_vec();
+            }
+        }
+    };
+    let head = String::from_utf8_lossy(&buf).to_ascii_lowercase();
+    assert!(head.contains("101"));
+    assert!(
+        head.contains("sec-websocket-extensions: permessage-deflate"),
+        "the origin's acceptance must reach the client: {head}"
+    );
+    assert_eq!(&frame_bytes[..4], &[0xC1, 0x02, 0xAB, 0xCD][..]);
+    drop(tcp);
+
+    // The session records the acceptance and the RSV1 frame — and the enabled
+    // RSV rule stands down, because the handshake licensed the bit.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let session = loop {
+        let content = tokio::fs::read_to_string(&captures_path)
+            .await
+            .unwrap_or_default();
+        let session = content.lines().find_map(|l| {
+            serde_json::from_str::<serde_json::Value>(l)
+                .ok()
+                .filter(|v| v["type"] == "websocket_session")
+        });
+        if session.is_some() || std::time::Instant::now() > deadline {
+            break session;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    .expect("a websocket session in the capture");
+
+    assert!(
+        session["extensions"]
+            .to_string()
+            .contains("permessage-deflate"),
+        "the session records what the 101 accepted: {}",
+        session["extensions"]
+    );
+    let rsv_frame = session["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["rsv"].as_u64() == Some(0b100))
+        .expect("the RSV1 frame is recorded");
+    assert_eq!(rsv_frame["direction"].as_str(), Some("server"));
+    let violations = session["violations"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        violations.is_empty(),
+        "an accepted extension stands the RSV finding down: {violations:?}"
+    );
+
+    handle.abort();
+    let _ = tokio::fs::remove_file(&captures_path).await;
+    Ok(())
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2264,7 +2264,7 @@ sources:
     - file: lint-http-core/src/protocol_event.rs
       line: 71
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 100
+      line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs
       line: 250
   - label: lint-http-proxy/src/proxy/websocket/frame.rs
@@ -2329,12 +2329,6 @@ sources:
       line: 37
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 110
-  - label: lint-http-proxy/src/proxy/websocket/mod.rs (3)
-    section: § 9.1
-    snippet: Note that like other HTTP header fields, this header field MAY be split or combined across multiple lines.
-    cited_by:
-    - file: lint-http-proxy/src/proxy/websocket/mod.rs
-      line: 69
   - label: lint-http-proxy/src/proxy/websocket/observer.rs
     section: § 5.5.1
     snippet: If there is a body, the first two bytes of the body MUST be a 2-byte unsigned integer (in network byte order) representing a status code with value /code/ defined in Section 7.4.
@@ -6237,7 +6231,7 @@ sources:
     snippet: A 1xx response is terminated by the end of the header section; it cannot contain content or trailers.
     cited_by:
     - file: lint-http-proxy/src/proxy/websocket/handshake.rs
-      line: 169
+      line: 167
     - file: lint-http-rules/src/rules/http3_status_code_valid.rs
       line: 83
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs


### PR DESCRIPTION
… payloads

Both Sec-WebSocket-Extensions strips are gone — the client's offer reaches the origin and the origin's acceptance reaches the client inside the 101 — because the hazard that justified them died with the decoding relay: frame boundaries are extension-independent, so the byte pump carries compressed frames as readily as plain ones. NegotiatedExtensions::Accepted is now reachable live for the first time, and the end-to-end test proves the whole chain: the offer arrives at the origin, the acceptance arrives at the client, an RSV1 frame survives the relay, and the enabled RSV rule stands down because the handshake it can finally see licensed the bit.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
