### PR TITLE
tokio-tungstenite is a test dependency

### DIFF
--- a/lint-http-proxy/Cargo.toml
+++ b/lint-http-proxy/Cargo.toml
@@ -60,11 +60,11 @@ h3-quinn = { workspace = true }
 rcgen = { workspace = true }
 pem = { workspace = true }
 http-body-util = { workspace = true }
-tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
 rustls-native-certs = { workspace = true }
 
 [dev-dependencies]
+tokio-tungstenite = { workspace = true }
 lint-http-core = { workspace = true, features = ["test-utils"] }
 wiremock = { workspace = true }
 rstest = { workspace = true }

--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -40,8 +40,8 @@ pub(in crate::proxy) struct WsUpgradeRequest {
     pub client_on_upgrade: hyper::upgrade::OnUpgrade,
 }
 
-/// Handle a WebSocket upgrade request: connect directly to upstream, relay
-/// frames via tokio-tungstenite, and capture the session.
+/// Handle a WebSocket upgrade request: connect directly to upstream, hand
+/// both completed upgrades to the transparent relay, and capture the session.
 pub(in crate::proxy) async fn handle_websocket_upgrade(
     req: WsUpgradeRequest,
     shared: Arc<Shared>,


### PR DESCRIPTION
After the transparent relay, no production code decodes WebSocket traffic through tungstenite; the tests keep it as a genuine peer implementation on the far ends of the relay, which is the role a validating endpoint library is actually right for.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
