### PR TITLE
The venv is built from the same pin CI installs

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,6 +34,16 @@ lint:
 test:
     cargo test --workspace --all-features
 
+# Build .venv from the pinned citation toolchain. The pin lives in
+# specs/requirements.txt because the bytes of specs/specs_generated.yaml depend
+# on it; a .venv built by hand is how a local `extract` and CI's disagree about a
+# file neither of them edited.
+install-citations:
+    python3 -m venv .venv
+    .venv/bin/pip install --quiet --upgrade pip
+    .venv/bin/pip install --quiet -r specs/requirements.txt
+    @.venv/bin/apycite --help >/dev/null && echo "✓ citation toolchain installed from specs/requirements.txt"
+
 # Citations file is current and the ratchet holds — offline, from the .venv.
 citations:
     #!/usr/bin/env bash


### PR DESCRIPTION
specs/requirements.txt already decides what CI installs. A developer's .venv was built by hand, which is how a local `apycite extract` and CI's come to disagree about a file neither of them edited — and the disagreement surfaces as a --frozen diff on somebody else's pull request.

`just install-citations` builds it from that one file, which also writes down what was previously recorded nowhere tracked: the toolchain versions the committed citations file was generated by.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
