### PR TITLE
The notes describe the documents that are actually read

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -168,6 +168,12 @@ const RFC_9112_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
 generated docs cannot come to name different text. A `debug_assert` in `cited`
 rejects a reference the rule does not declare, and the suite runs in debug.
 
+The `.html` in that URL is not a style preference, and
+`spec_refs_use_the_source_registry` insists on it: it is the document apysource
+fetches and checks every `// cite` quote against. The link a reader clicks and
+the document the quote was verified in are the same string, which is the whole
+reason the gate can be strict about it.
+
 Attachment is per finding site and opt-in. The `// cite` comment beside the
 statement is the oracle: attach the reference that comment names, and leave the
 site un-cited when the answer needs a decision — where the block quotes several

--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -511,12 +511,10 @@ mod tests {
     /// rather than one. A minimal-encoding assumption anywhere in the decoder
     /// would pass every other case here and fail this one.
     ///
-    /// The worked examples live in Appendix A.1, and the cite names it. That was long
-    /// uncitable: a `§` selector compared a *digit* prefix, so the `A. Pseudocode` node
-    /// the parser built could never be selected, and the bare `A.1.` heading was not
-    /// recognised as a heading at all. apysource 0.5.1 fixed both, so the section is
-    /// named here and the quote is checked against the appendix it actually comes from,
-    /// not the whole document.
+    /// The worked examples live in Appendix A.1, and the cite names it — so the
+    /// quote is checked against the appendix it comes from rather than against the
+    /// whole document, which is the difference between catching a vector that moved
+    /// and noticing it is still somewhere in a hundred pages.
     ///
     // cite(RFC 9000 § A.1): "For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025)."
     #[test]

--- a/specs/sources.yaml
+++ b/specs/sources.yaml
@@ -8,11 +8,13 @@
 # cite names an entry here by its `label`; apysource does the rest — claiming the
 # URL for a repo, parsing the format, resolving `§ N` and `#anchor` targeting.
 #
-# RFCs are deliberately absent. `RFC 9110` resolves by pattern to
-# rfc-editor.org/rfc/rfc9110.txt, so this file holds only what a pattern cannot
-# mint: documents with a biography. That is also where the catalogue's
-# rfc-editor / datatracker host mixing ends — an RFC on datatracker is cited as
-# `RFC 6454`, and comes from one place.
+# RFCs are deliberately absent. apysource ships a repository that claims
+# rfc-editor and declares the `RFC NNNN` name family beside it, so `RFC 9110`
+# needs no entry and this file holds only what a name cannot mint: documents with
+# a biography. It is also where the catalogue's rfc-editor / datatracker host
+# mixing ends, and now by construction rather than by convention — both hosts are
+# one repository's, so an RFC cited as `RFC 6454` comes from one place whichever
+# of them you had open.
 #
 # THE URLS HERE ARE CANONICAL, AND CHECKED (2026-07-13). The catalogue they were
 # drawn from was not: of the 40 documents cited by the 185 rules, 22 were stale,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4376,7 +4376,7 @@ sources:
     snippet: For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to the decimal value 151,288,809,941,952,652; the four-byte sequence 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd decodes to 15,293; and the single byte 0x25 decodes to 37 (as does the two-byte sequence 0x4025).
     cited_by:
     - file: lint-http-proxy/src/h3_instrument.rs
-      line: 521
+      line: 519
   - label: quic_transport_parameters_valid
     section: § 18
     snippet: The extension_data field of the quic_transport_parameters extension defined in [QUIC-TLS] contains the QUIC transport parameters


### PR DESCRIPTION
specs/sources.yaml said RFCs resolve by pattern to rfc9110.txt. Neither half is true: they resolve through a repository, and to the HTML. The sentence after it gets stronger rather than replaced — the catalogue's rfc-editor/datatracker host mixing ends here by *construction* now, because both hosts belong to one repository, so an RFC comes from one place whichever of them you had open.

docs/development.md gains the sentence a new contributor needs to understand why the SpecRef gate is strict about `.html`: that URL is the document apysource fetches and checks the `// cite` quote against, so the link a reader clicks and the document the quote was verified in are one string.

h3_instrument.rs carried a paragraph of archaeology about a `§` selector that compared digit prefixes and an apysource release that fixed it. That code path does not exist any more — RFC 9000's appendix is addressed by the anchor the publisher wrote — so what survives is the claim: the quote is checked against the appendix it comes from, not against a hundred pages.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
