### PR TITLE
The nightly says which cited documents are no longer in force

### DIFF
--- a/.github/workflows/citations.yml
+++ b/.github/workflows/citations.yml
@@ -80,5 +80,20 @@ jobs:
       # --strict-redirects turns a moved source into a failure. The catalogue this
       # replaced had 14 MDN URLs that a plain fetcher followed a 301 to and passed
       # green; that silence is the thing being bought out here.
+      #
+      # There is no --strict-supersession, and its absence is a decision rather
+      # than an oversight. This job reports six RFCs whose publisher has replaced
+      # them — 2068, 2616, 2617, 3230, 7231, 7234 — and the run stays green,
+      # because for five of them the successor *deleted* the thing being linted:
+      # RFC 9111 removed the Warning header field, RFC 2616 removed Keep-Alive,
+      # RFC 9110 does not repeat 7231's account of why Content-MD5 went, and
+      # RFC 6455 points normatively at 2616's #rule ABNF. A rule enforcing those
+      # has nowhere current to cite. Only 3230 -> 9530 is worth a look.
+      #
+      # So the warnings are the feature: what they are for is the *next* one, the
+      # day an RFC this project cites as current stops being so. Until a cite can
+      # record "knowingly historical, because the successor removed this", the
+      # six standing warnings are the price, and turning them into failures would
+      # only mean deleting the check.
       - name: Verify every quote against its source
         run: apycite verify --refresh --strict-redirects

--- a/specs/requirements.txt
+++ b/specs/requirements.txt
@@ -21,6 +21,14 @@
 # which is exactly the review the unpinned form skipped. APYCITE.md's A10 is the
 # precedent: 0.8.0 fixed one extraction defect and shipped another in the same
 # tag, so for one release the tool lost section labels it had just gained.
+#
+# 0.10.0/0.6.0 regenerates nothing, and that is worth stating because the
+# paragraph above leads you to expect otherwise: this pair adds a check rather
+# than changing what extraction writes down, so specs_generated.yaml is
+# byte-identical and `extract --frozen` passes across the bump. What it adds is
+# the nightly job's `Document supersession` row — whether each cited document is
+# still the one in force. Six of ours are not; see .github/workflows/citations.yml
+# for why that is a warning and not a failure.
 
-apycite==0.5.0
-apysource==0.9.0
+apycite==0.6.0
+apysource==0.10.0


### PR DESCRIPTION
apysource 0.10.0 and apycite 0.6.0 add a `Document supersession` check: whether each cited document is still the one that governs, as distinct from whether it still says what was quoted. A citation can be perfectly verifiable and quote a specification its publisher replaced years ago, and nothing here could see that.

This pin bump regenerates nothing, which is worth saying because the argument already in specs/requirements.txt leads you to expect otherwise — every previous move of these pins rewrote specs_generated.yaml, because the reader decides each source's URL and media type. This pair adds a check and changes nothing about what extraction writes down, so the file is byte-identical and `extract --frozen` passes across the bump.

Six of our 57 cited RFCs have been replaced: 2068, 2616, 2617, 3230, 7231, 7234. The run stays green, and that is deliberate rather than a default nobody revisited. For five of them the successor *deleted* the thing being linted — RFC 9111 removed the Warning header field, RFC 2616 removed Keep-Alive, RFC 9110 does not repeat 7231's account of why Content-MD5 went, and RFC 6455 points normatively at 2616's `#rule` ABNF. keep_alive_header_valid.rs has said so in prose for a while: "no document in force names it". Only 3230 -> 9530 is worth a look.

So the warnings are not a backlog. What they are for is the *next* one — the day an RFC this project cites as current stops being so, on a nightly run that fetches nothing new from us. Turning them into failures today would only mean deleting the check, and `--strict-supersession` exists for a project whose cites can all point at documents in force. Ours cannot, until a cite can record that it is knowingly historical and why.

Verified by rebuilding .venv from PyPI with the exact CI command and running both jobs: `extract --frozen` and `ratchet` clean, and `verify --refresh --strict-redirects` at 1542/1542 fragments, 61/61 repo documents, 51/57 documents in force, exit 0.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
