### PR TITLE
The cache rules read Cache-Control through the shared reader

### DIFF
--- a/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
+++ b/lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
@@ -48,67 +48,40 @@ impl Rule for ExpiresAndCacheControlConsistent {
         let finding = || -> Option<Violation> {
             let resp = tx.response.as_ref()?;
 
-            // If either header is missing, nothing to check
-            let mut has_expires = false;
-            let mut expires_dt: Option<DateTime<Utc>> = None;
-            // Expires is an HTTP-date; parse it with the recipient parser (the HTTP-date grammar
-            // itself, §5.6.7, is owned by the http_date helper).
+            // Expires is an HTTP-date; the recipient parser owns the grammar.
             // cite(RFC 9111 § 5.3): "The Expires field value is an HTTP-date timestamp, as defined in Section 5.6.7 of [HTTP]."
             // An unparseable Expires is not missing information: §5.3 assigns it a meaning,
             // so it is retained here (as already-expired) rather than returning early.
             // Reporting the *invalidity* itself still belongs to other rules; what this rule
             // does with it is compare the meaning against Cache-Control.
-            let mut expires_raw = String::new();
-            if let Some(hv) = resp.headers.get_all("expires").iter().next() {
-                if let Ok(s) = hv.to_str() {
-                    has_expires = true;
-                    expires_raw = s.trim().to_string();
-                    if let Ok(dt) = crate::http_date::parse_http_date_to_datetime(s.trim()) {
-                        expires_dt = Some(dt);
-                    }
-                }
-            }
+            let expires_raw =
+                crate::helpers::headers::get_header_str(&resp.headers, "expires")?.trim();
+            let expires_dt: Option<DateTime<Utc>> =
+                crate::http_date::header_timestamp(&resp.headers, "expires");
 
+            // The Cache-Control directives this rule compares against Expires.
+            // `max-age` is read directly rather than through
+            // `get_cache_control_max_age`, which answers None when no-cache or
+            // no-store is present alongside — right for a caller asking what
+            // freshness was advertised, wrong for one asking what the two fields
+            // *said*, which is the contradiction below.
             let mut cc_present = false;
-            // Collect the Cache-Control response directives of interest. `no-cache`/`no-store`
-            // and `max-age` are parsed inline here; `s-maxage` uses a shared helper below.
-            // (NOTE: `get_cache_control_max_age` exists but is intentionally *not* used — it
-            // returns None when no-cache/no-store is also present, whereas the contradiction
-            // checks need the raw max-age even then. This divergence is recorded in the tracker.)
             let mut cc_no_cache = false;
             let mut cc_no_store = false;
             let mut cc_max_age: Option<i64> = None;
-
-            for hv in resp.headers.get_all("cache-control").iter() {
-                if let Ok(s) = hv.to_str() {
-                    cc_present = true;
-                    for part in s.split(',') {
-                        let p = part.trim();
-                        if p.is_empty() {
-                            continue;
-                        }
-                        let mut it = p.splitn(2, '=');
-                        let name = it.next().unwrap().trim().to_ascii_lowercase();
-                        match name.as_str() {
-                            "no-cache" => cc_no_cache = true,
-                            "no-store" => cc_no_store = true,
-                            "max-age" => {
-                                if let Some(val) = it.next() {
-                                    if let Ok(n) = val.trim().parse::<i64>() {
-                                        cc_max_age = Some(n);
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
+            for directive in crate::helpers::cache_control::directives(&resp.headers) {
+                cc_present = true;
+                if directive.is("no-cache") {
+                    cc_no_cache = true;
+                } else if directive.is("no-store") {
+                    cc_no_store = true;
+                } else if directive.is("max-age") {
+                    cc_max_age = directive.delta_seconds().or(cc_max_age);
                 }
             }
-            // Parse s-maxage via a shared helper after the loop so that s-maxage
-            // parsing is consistent with other uses in the codebase.
             let cc_s_maxage = crate::helpers::headers::get_cache_control_s_maxage(&resp.headers);
 
-            if !has_expires || !cc_present {
+            if !cc_present {
                 return None;
             }
 
@@ -122,7 +95,7 @@ impl Rule for ExpiresAndCacheControlConsistent {
             // framing as the dated checks below; needs no reference time, since "already
             // expired" is true against any.
             // cite(RFC 9111 § 5.3): "A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired")."
-            if expires_dt.is_none() {
+            let Some(expires) = expires_dt else {
                 if cc_max_age.unwrap_or(-1) > 0 || cc_s_maxage.unwrap_or(-1) > 0 {
                     return Some(self.cited(&RFC_9111_5_3, ctx.severity, format!(
                             "Expires '{}' is not a valid HTTP-date, so a cache MUST read it as already expired, but Cache-Control max-age/s-maxage says the response is still fresh — values are contradictory (RFC 9111 §5.3)",
@@ -130,24 +103,12 @@ impl Rule for ExpiresAndCacheControlConsistent {
                         )));
                 }
                 return None;
-            }
-
-            let expires = expires_dt.unwrap();
-
-            // Determine reference time: Date header if present, otherwise fall back to the transaction timestamp
-            let date_ref = if let Some(hv) = resp.headers.get_all("date").iter().next() {
-                if let Ok(s) = hv.to_str() {
-                    if let Ok(dt) = crate::http_date::parse_http_date_to_datetime(s.trim()) {
-                        dt
-                    } else {
-                        tx.timestamp
-                    }
-                } else {
-                    tx.timestamp
-                }
-            } else {
-                tx.timestamp
             };
+
+            // The reference time is the origin's clock where it stated one, and
+            // the time we saw the message where it did not.
+            let date_ref =
+                crate::http_date::header_timestamp(&resp.headers, "date").unwrap_or(tx.timestamp);
 
             // Expires and the Cache-Control freshness directives can disagree. The spec resolves
             // that by *precedence*, not by calling it an error — so flagging the disagreement is

--- a/lint-http-rules/src/rules/immutable_cache_never_stale.rs
+++ b/lint-http-rules/src/rules/immutable_cache_never_stale.rs
@@ -65,53 +65,25 @@ impl Rule for ImmutableCacheNeverStale {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // locate the most recent prior response with an immutable
-            // directive that isn't simultaneously forbidding caching.
-            let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
-            for past in history.iter() {
-                if let Some(resp) = &past.response {
-                    if header_has_immutable(&resp.headers) {
-                        candidate = Some(past);
-                        break;
-                    }
-                }
-            }
-
-            let prev_tx = candidate?;
+            // The most recent prior response with an immutable directive that
+            // isn't simultaneously forbidding caching.
+            let (prev_tx, prev_resp) =
+                history.latest_response(|resp| header_has_immutable(&resp.headers))?;
 
             // Advertised freshness lifetime. The max-age/Expires calculation
             // (RFC 9111 §4.2.1) is owned by the helper, which carries the cite.
             let freshness_lifetime = crate::helpers::headers::compute_freshness_lifetime(
-                &prev_tx.response.as_ref().unwrap().headers,
+                &prev_resp.headers,
                 prev_tx.timestamp,
             );
 
-            // Seed the age from the response's Age field. A non-negative delta-seconds
-            // is the only meaningful value, so a negative or unparseable one is dropped.
-            // cite(RFC 9111 § 5.1): "The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server"
-            let mut age_val: i64 = 0;
-            if let Some(resp) = &prev_tx.response {
-                if let Some(hv) = resp.headers.get("age") {
-                    if let Ok(s) = hv.to_str() {
-                        if let Ok(n) = s.trim().parse::<i64>() {
-                            if n >= 0 {
-                                age_val = n;
-                            }
-                        }
-                    }
-                }
-            }
-            // current_age ≈ Age + time observed in our own history. This is a
-            // deliberate simplification of §4.2.3's full age computation (which adds
-            // response_delay and resident_time from request/response timing we do not
-            // record); the elapsed clamp to ≥ 0 absorbs clock skew the same way §4.2.3
-            // does by flooring. It is an estimate, adequate for a best-effort warning.
-            let elapsed = tx
-                .timestamp
-                .signed_duration_since(prev_tx.timestamp)
-                .num_seconds();
-            let elapsed = if elapsed < 0 { 0 } else { elapsed };
-            let current_age = age_val.saturating_add(elapsed);
+            // Age stated by the response plus the time it has since spent in our
+            // record; the helper owns that estimate and what it leaves out.
+            let current_age = crate::helpers::headers::estimated_age(
+                &prev_resp.headers,
+                prev_tx.timestamp,
+                tx.timestamp,
+            );
 
             // Only the two revalidation preconditions count as "revalidation" here:
             // If-None-Match and If-Modified-Since are what a cache sends to revalidate.
@@ -183,29 +155,11 @@ fn header_has_immutable(headers: &hyper::HeaderMap) -> bool {
     // best-effort warning.)
     // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request"
     // cite(RFC 9111 § 5.2.2.4): "the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response"
-    for hv in headers.get_all("cache-control").iter() {
-        if let Ok(s) = hv.to_str() {
-            let l = s.to_ascii_lowercase();
-            if l.contains("no-store") || l.contains("no-cache") {
-                return false;
-            }
-        }
+    if crate::helpers::cache_control::forbids_storage_or_reuse(headers) {
+        return false;
     }
-    // Search for the immutable directive (RFC 8246 §2) across fields. The name is
-    // a case-insensitive directive token; the `;` in the split is a tolerance —
-    // Cache-Control separates directives with `,`, not `;`, but accepting both
-    // only widens detection of a malformed header, never narrows it.
-    // cite(RFC 9111 § 5.2): "Cache directives are identified by a token, to be compared case-insensitively"
-    for hv in headers.get_all("cache-control").iter() {
-        if let Ok(s) = hv.to_str() {
-            for directive in s.split(|c| [',', ';'].contains(&c)) {
-                if directive.trim().eq_ignore_ascii_case("immutable") {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    // The immutable directive (RFC 8246 §2) takes no argument.
+    crate::helpers::cache_control::has_unqualified(headers, "immutable")
 }
 
 /// Registers this rule into the engine's auto-collected catalogue.

--- a/lint-http-rules/src/rules/must_revalidate_enforced.rs
+++ b/lint-http-rules/src/rules/must_revalidate_enforced.rs
@@ -80,49 +80,25 @@ impl Rule for MustRevalidateEnforced {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // find the most recent past response that contained must-revalidate
-            let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
-            for past in history.iter() {
-                if let Some(resp) = &past.response {
-                    if header_has_must_revalidate(&resp.headers) {
-                        candidate = Some(past);
-                        break;
-                    }
-                }
-            }
-
-            let prev_tx = candidate?;
+            // The most recent past response that contained must-revalidate.
+            let (prev_tx, prev_resp) =
+                history.latest_response(|resp| header_has_must_revalidate(&resp.headers))?;
 
             // Freshness lifetime advertised by the response. The helper owns the §4.2.1
             // derivation (max-age wins, else Expires − Date), returning zero when no explicit
             // lifetime is available.
             let freshness_lifetime = crate::helpers::headers::compute_freshness_lifetime(
-                &prev_tx.response.as_ref().unwrap().headers,
+                &prev_resp.headers,
                 prev_tx.timestamp,
             );
 
-            // Estimate current age as the Age header (if numeric) plus elapsed seconds. This is a
-            // simplification of §4.2.3's full algorithm (it omits response_delay and the Date-based
-            // apparent_age term); adequate for staleness detection. A non-numeric or absurd Age is
-            // treated as zero.
-            let mut age_val: i64 = 0;
-            if let Some(resp) = &prev_tx.response {
-                if let Some(hv) = resp.headers.get("age") {
-                    if let Ok(s) = hv.to_str() {
-                        if let Ok(n) = s.trim().parse::<i64>() {
-                            if n >= 0 {
-                                age_val = n;
-                            }
-                        }
-                    }
-                }
-            }
-            let elapsed = tx
-                .timestamp
-                .signed_duration_since(prev_tx.timestamp)
-                .num_seconds();
-            let elapsed = if elapsed < 0 { 0 } else { elapsed };
-            let current_age = age_val.saturating_add(elapsed);
+            // Age stated by the response plus the time it has since spent in our
+            // record; the helper owns that estimate and what it leaves out.
+            let current_age = crate::helpers::headers::estimated_age(
+                &prev_resp.headers,
+                prev_tx.timestamp,
+                tx.timestamp,
+            );
 
             // A conditional request (carrying a precondition header field) is how a client
             // revalidates — the "successfully validated by the origin" that §5.2.2.2 requires.
@@ -137,9 +113,8 @@ impl Rule for MustRevalidateEnforced {
             // cite(RFC 9111 § 4.2): "A "fresh" response is one whose age has not yet exceeded its freshness lifetime. Conversely, a "stale" response is one where it has."
             if current_age >= freshness_lifetime && !has_conditional {
                 // warn only if there was a validator on the original response
-                let resp = prev_tx.response.as_ref().unwrap();
-                let has_validator =
-                    resp.headers.contains_key("etag") || resp.headers.contains_key("last-modified");
+                let has_validator = prev_resp.headers.contains_key("etag")
+                    || prev_resp.headers.contains_key("last-modified");
                 // cite(RFC 9111 § 5.2.2.2): "The must-revalidate response directive indicates that once the response has become stale, a cache MUST NOT reuse that response to satisfy another request until it has been successfully validated by the origin, as defined by Section 4.3."
                 if has_validator {
                     return Some(self.cited(&RFC_9111_5_2_2_2, ctx.severity, format!(
@@ -194,24 +169,9 @@ impl Rule for MustRevalidateEnforced {
 }
 
 /// Helper to detect presence of a must-revalidate directive in Cache-Control
-/// headers.  We match each directive name case-insensitively, splitting on comma
-/// (the grammar separator) and — as a tolerance — semicolon, which some
-/// implementations wrongly use.
+/// headers. The directive takes no argument, so the bare form is the only form.
 fn header_has_must_revalidate(headers: &hyper::HeaderMap) -> bool {
-    for hv in headers.get_all("cache-control").iter() {
-        if let Ok(s) = hv.to_str() {
-            // Cache-Control is a comma-separated list of directives; the semicolon split is a
-            // tolerance for the malformed `a;b` form (the grammar only allows `,`).
-            for directive in s.split(|c| [',', ';'].contains(&c)) {
-                // Directive names are case-insensitive.
-                // cite(RFC 9111 § 5.2): "Cache directives are identified by a token, to be compared case-insensitively"
-                if directive.trim().eq_ignore_ascii_case("must-revalidate") {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    crate::helpers::cache_control::has_unqualified(headers, "must-revalidate")
 }
 
 /// Registers this rule into the engine's auto-collected catalogue.

--- a/lint-http-rules/src/rules/no_cache_revalidation.rs
+++ b/lint-http-rules/src/rules/no_cache_revalidation.rs
@@ -71,25 +71,15 @@ impl Rule for NoCacheRevalidation {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // locate the most recent past response with a no-cache directive.
-            let mut candidate: Option<&crate::http_transaction::HttpTransaction> = None;
-            for past in history.iter() {
-                if let Some(resp) = &past.response {
-                    if header_has_no_cache(&resp.headers) {
-                        candidate = Some(past);
-                        break;
-                    }
-                }
-            }
-
-            let prev_tx = candidate?;
+            // The most recent past response with a no-cache directive.
+            let (_, prev_resp) =
+                history.latest_response(|resp| header_has_no_cache(&resp.headers))?;
 
             // only warn if the original response supplied a validator; without one
             // there is no way to perform a conditional revalidation, so an
             // unconditional request may still be legitimate.
-            let resp = prev_tx.response.as_ref().unwrap();
-            let has_validator =
-                resp.headers.contains_key("etag") || resp.headers.contains_key("last-modified");
+            let has_validator = prev_resp.headers.contains_key("etag")
+                || prev_resp.headers.contains_key("last-modified");
             if !has_validator {
                 return None;
             }
@@ -144,31 +134,14 @@ impl Rule for NoCacheRevalidation {
     }
 }
 
-/// Look for a `no-cache` directive in any Cache-Control header field.
+/// Look for an unqualified `no-cache` directive in any Cache-Control field line.
+///
+/// Only the bare form forbids reuse without revalidation; the qualified form
+/// lets a cache reuse the response, revalidating or excluding only the listed
+/// fields, so it is not what this rule enforces.
+// cite(RFC 9111 § 5.2.2.4): "The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request"
 fn header_has_no_cache(headers: &hyper::HeaderMap) -> bool {
-    for hv in headers.get_all("cache-control").iter() {
-        if let Ok(s) = hv.to_str() {
-            for directive in s.split(|c| [',', ';'].contains(&c)) {
-                let directive = directive.trim();
-                if directive.is_empty() {
-                    continue;
-                }
-                // Only the *unqualified* no-cache (no argument) forbids reuse without
-                // revalidation; the qualified form lets a cache reuse the response, revalidating
-                // or excluding only the listed fields.
-                // cite(RFC 9111 § 5.2.2.4): "The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request"
-                let mut parts = directive.splitn(2, '=');
-                // Directive names are case-insensitive.
-                // cite(RFC 9111 § 5.2): "Cache directives are identified by a token, to be compared case-insensitively"
-                let name = parts.next().map(str::trim).unwrap_or("");
-                let has_argument = parts.next().map(|a| !a.trim().is_empty()).unwrap_or(false);
-                if name.eq_ignore_ascii_case("no-cache") && !has_argument {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    crate::helpers::cache_control::has_unqualified(headers, "no-cache")
 }
 
 /// Registers this rule into the engine's auto-collected catalogue.

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -66,94 +66,47 @@ impl Rule for NoStoreEnforced {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // Build maps of validators to a boolean indicating whether the most
-            // recent occurrence of that validator came from a no-store response.
+            // Which validators came from a no-store response, and which did not.
             //
-            // The `TransactionHistory` type is documented to yield entries "newest
-            // first" (see its own docs).  Our algorithm depends on that ordering
-            // so that the first time we see a given validator value we record the
-            // state that should win.  To make the assumption explicit and guard
-            // against future changes in history construction we sort the entries
-            // ourselves by timestamp.  That way the rule behaves correctly even if
-            // the caller accidentally supplies an unsorted vector.
-            use std::collections::HashSet;
+            // The history yields entries newest first — the container asserts
+            // that invariant where it is built — so the *first* appearance of a
+            // validator is its most recent one, and that is the appearance that
+            // decides. The `seen` sets below are what make later (older)
+            // entries unable to overwrite it; the earlier reading of this rule
+            // also removed from the no-store sets on a non-no-store entry, which
+            // could never fire — nothing is inserted for a validator that was
+            // already seen — and said the same decision twice.
+            use std::collections::{HashMap, HashSet};
 
-            // We'll keep normalized ETag values (weak prefix stripped) for
-            // comparison, but retain the original header text in violation
-            // messages.  `seen_etags` tracks normalized values we've already
-            // encountered so that later entries win.
+            // ETags compare with the weak prefix stripped; the raw text is kept
+            // for the finding message.
             let mut no_store_etags: HashSet<String> = HashSet::new();
+            // Last-Modified is compared both as written and as a timestamp, so
+            // the parse is done once here rather than per candidate below.
+            let mut no_store_lastmod: HashMap<String, chrono::DateTime<chrono::Utc>> =
+                HashMap::new();
             let mut seen_etags: HashSet<String> = HashSet::new();
-
-            // For Last-Modified we need both the raw string (for direct
-            // comparisons) and a parsed `DateTime` to avoid reparsing the same
-            // history value on every request.  Store the parsed time in the map
-            // keyed by the raw string so we can easily remove entries when a
-            // later non-no-store response overrides them.
-            let mut no_store_lastmod: std::collections::HashMap<
-                String,
-                chrono::DateTime<chrono::Utc>,
-            > = std::collections::HashMap::new();
             let mut seen_lastmod: HashSet<String> = HashSet::new();
 
-            // Collect the entries and ensure newest-first ordering by timestamp.
-            // This is a small extra cost, but the history is typically short.
-            let mut entries: Vec<&crate::http_transaction::HttpTransaction> =
-                history.iter().collect();
-            entries.sort_by_key(|tx| std::cmp::Reverse(tx.timestamp));
+            for (_, resp) in history.responses() {
+                let is_no_store = header_has_no_store(&resp.headers);
 
-            // debug-time sanity check: timestamps should now be non-increasing.
-            #[cfg(debug_assertions)]
-            {
-                for pair in entries.windows(2) {
-                    if let [first, second] = pair {
-                        debug_assert!(
-                            first.timestamp >= second.timestamp,
-                            "history entries must be newest-first"
-                        );
+                if let Some(etag) = crate::helpers::headers::get_header_str(&resp.headers, "etag") {
+                    let normalized = crate::helpers::headers::normalize_etag(etag);
+                    if seen_etags.insert(normalized.clone()) && is_no_store {
+                        no_store_etags.insert(normalized);
                     }
                 }
-            }
 
-            for past in entries {
-                if let Some(resp) = &past.response {
-                    let is_no_store = header_has_no_store(&resp.headers);
-
-                    if let Some(hv) = resp.headers.get("etag") {
-                        if let Ok(s) = hv.to_str() {
-                            let val = s.trim().to_string();
-                            let normalized = crate::helpers::headers::normalize_etag(&val);
-                            if !seen_etags.contains(&normalized) {
-                                seen_etags.insert(normalized.clone());
-                                if is_no_store {
-                                    no_store_etags.insert(normalized.clone());
-                                } else {
-                                    no_store_etags.remove(&normalized);
-                                }
-                            }
-                        }
-                    }
-
-                    if let Some(hv) = resp.headers.get("last-modified") {
-                        if let Ok(s) = hv.to_str() {
-                            let val = s.trim().to_string();
-                            if !seen_lastmod.contains(&val) {
-                                seen_lastmod.insert(val.clone());
-                                if is_no_store {
-                                    // parse once and store if successful
-                                    if let Ok(dt) =
-                                        crate::http_date::parse_http_date_to_datetime(&val)
-                                    {
-                                        no_store_lastmod.insert(val.clone(), dt);
-                                    } else {
-                                        // unparsable dates can't match later, so
-                                        // ensure they're not in the map
-                                        no_store_lastmod.remove(&val);
-                                    }
-                                } else {
-                                    no_store_lastmod.remove(&val);
-                                }
-                            }
+                if let Some(lastmod) =
+                    crate::helpers::headers::get_header_str(&resp.headers, "last-modified")
+                {
+                    let val = lastmod.trim().to_string();
+                    // An unparseable date matches no candidate later, so it is
+                    // recorded as seen and nothing more.
+                    if seen_lastmod.insert(val.clone()) && is_no_store {
+                        if let Ok(dt) = crate::http_date::parse_http_date_to_datetime(&val) {
+                            no_store_lastmod.insert(val, dt);
                         }
                     }
                 }
@@ -255,22 +208,11 @@ impl Rule for NoStoreEnforced {
 }
 
 /// Look for a `no-store` directive in any Cache-Control header field.
+///
+/// `no-store` is defined with no argument, so the bare form is the only form,
+/// and asking for it excludes a member that merely starts with the name.
 fn header_has_no_store(headers: &hyper::HeaderMap) -> bool {
-    for hv in headers.get_all("cache-control").iter() {
-        if let Ok(s) = hv.to_str() {
-            // Split on comma (the grammar separator) and, as a tolerance, semicolon, which some
-            // implementations wrongly use. no-store takes no argument, so an exact directive-name
-            // match is correct (no qualified form to distinguish, unlike no-cache).
-            for directive in s.split(|c| [',', ';'].contains(&c)) {
-                // Directive names are case-insensitive.
-                // cite(RFC 9111 § 5.2): "Cache directives are identified by a token, to be compared case-insensitively"
-                if directive.trim().eq_ignore_ascii_case("no-store") {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+    crate::helpers::cache_control::has_unqualified(headers, "no-store")
 }
 
 /// Registers this rule into the engine's auto-collected catalogue.

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -55,96 +55,86 @@ impl Rule for PrivateCacheVisibility {
                 return None;
             }
 
-            // Detect an *unqualified* private directive: the exact-name match excludes the qualified
-            // `private="field"` form, which lets a shared cache store the rest — matching the cite's
-            // "unqualified" wording.
-            fn header_has_private(headers: &hyper::HeaderMap) -> bool {
-                for hv in headers.get_all("cache-control").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        for directive in s.split(|c| [',', ';'].contains(&c)) {
-                            // Directive names are case-insensitive.
-                            // cite(RFC 9111 § 5.2): "Cache directives are identified by a token, to be compared case-insensitively"
-                            if directive.trim().eq_ignore_ascii_case("private") {
-                                return true;
-                            }
-                        }
-                    }
+            // The validators other clients were handed under an *unqualified*
+            // `private` — the exact-name match excludes the qualified
+            // `private="field"` form, which lets a shared cache store the rest,
+            // matching the cite's "unqualified" wording.
+            //
+            // Collecting them up front is what makes each validator the request
+            // presents one comparison below, rather than a walk of the history
+            // nested inside a walk of the members inside a walk of the field
+            // lines.
+            let private_responses = || {
+                history
+                    .responses()
+                    .filter(|(past, _)| past.client != tx.client)
+                    .filter(|(_, resp)| {
+                        crate::helpers::cache_control::has_unqualified(&resp.headers, "private")
+                    })
+            };
+            let private_etags: Vec<String> = private_responses()
+                .filter_map(|(_, resp)| {
+                    crate::helpers::headers::get_header_str(&resp.headers, "etag")
+                })
+                .map(crate::helpers::headers::normalize_etag)
+                .collect();
+            let private_last_modified: Vec<chrono::DateTime<chrono::Utc>> = private_responses()
+                .filter_map(|(_, resp)| {
+                    crate::http_date::header_timestamp(&resp.headers, "last-modified")
+                })
+                .collect();
+
+            // Heuristic: a validator from a `private` response turning up in a
+            // *different* client's request suggests a shared cache stored what only
+            // one user was to hold. The cite grounds *why that is forbidden*; the
+            // inference is the linter's — an ETag identifies a representation, not a
+            // user, so two clients that fetched the same private representation
+            // directly from the origin share it legitimately.
+            // cite(RFC 9111 § 5.2.2.7): "The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user)."
+            for member in tx
+                .request
+                .headers
+                .get_all("if-none-match")
+                .iter()
+                .filter_map(|hv| hv.to_str().ok())
+                .flat_map(crate::helpers::headers::list_members)
+            {
+                if private_etags.contains(&crate::helpers::headers::normalize_etag(member)) {
+                    return Some(self.cited(
+                        &RFC_9111_5_2_2_7,
+                        ctx.severity,
+                        format!(
+                            "Validator '{}' from a private response seen by a different client",
+                            member
+                        ),
+                    ));
                 }
-                false
             }
 
-            // check If-None-Match members
-            for hv in tx.request.headers.get_all("if-none-match").iter() {
-                if let Ok(s) = hv.to_str() {
-                    for member in crate::helpers::headers::list_members(s) {
-                        let normalized = crate::helpers::headers::normalize_etag(member);
-
-                        for past in history.iter() {
-                            if past.client == tx.client {
-                                continue;
-                            }
-                            if let Some(resp) = &past.response {
-                                if header_has_private(&resp.headers) {
-                                    if let Some(hv2) = resp.headers.get("etag") {
-                                        if let Ok(val) = hv2.to_str() {
-                                            let val_norm =
-                                                crate::helpers::headers::normalize_etag(val);
-                                            // Heuristic: a validator from a `private` response turning
-                                            // up in a *different* client's request suggests a shared
-                                            // cache stored what only one user was to hold. The cite
-                                            // grounds *why that is forbidden*; the inference is the
-                                            // linter's — an ETag identifies a representation, not a
-                                            // user, so two clients that fetched the same private
-                                            // representation directly from the origin share it legitimately.
-                                            // cite(RFC 9111 § 5.2.2.7): "The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user)."
-                                            if val_norm == normalized {
-                                                return Some(self.cited(&RFC_9111_5_2_2_7, ctx.severity, format!(
-                                                        "Validator '{}' from a private response seen by a different client",
-                                                        member
-                                                    )));
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // check If-Modified-Since headers
-            for hv in tx.request.headers.get_all("if-modified-since").iter() {
-                if let Ok(s) = hv.to_str() {
-                    let candidate = s.trim();
-                    if let Ok(candidate_dt) =
-                        crate::http_date::parse_http_date_to_datetime(candidate)
-                    {
-                        for past in history.iter() {
-                            if past.client == tx.client {
-                                continue;
-                            }
-                            if let Some(resp) = &past.response {
-                                if header_has_private(&resp.headers) {
-                                    if let Some(hv2) = resp.headers.get("last-modified") {
-                                        if let Ok(val) = hv2.to_str() {
-                                            if let Ok(val_dt) =
-                                                crate::http_date::parse_http_date_to_datetime(val)
-                                            {
-                                                // Same heuristic + cite as the ETag branch above.
-                                                // cite(RFC 9111 § 5.2.2.7): "The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user)."
-                                                if val_dt == candidate_dt {
-                                                    return Some(self.cited(&RFC_9111_5_2_2_7, ctx.severity, format!(
-                                                            "Validator '{}' from a private response seen by a different client",
-                                                            candidate
-                                                        )));
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+            // Same heuristic and cite as the ETag branch above, compared as
+            // timestamps so two spellings of one instant still match.
+            // cite(RFC 9111 § 5.2.2.7): "The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user)."
+            for candidate in tx
+                .request
+                .headers
+                .get_all("if-modified-since")
+                .iter()
+                .filter_map(|hv| hv.to_str().ok())
+                .map(str::trim)
+            {
+                let Ok(candidate_dt) = crate::http_date::parse_http_date_to_datetime(candidate)
+                else {
+                    continue;
+                };
+                if private_last_modified.contains(&candidate_dt) {
+                    return Some(self.cited(
+                        &RFC_9111_5_2_2_7,
+                        ctx.severity,
+                        format!(
+                            "Validator '{}' from a private response seen by a different client",
+                            candidate
+                        ),
+                    ));
                 }
             }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3887,7 +3887,7 @@ sources:
     snippet: Clients SHOULD NOT issue a conditional request during the response's freshness lifetime (e.g., upon a reload) unless explicitly overridden by the user (e.g., a force reload).
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 125
+      line: 97
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
       line: 122
   - label: immutable_cache_never_stale (2)
@@ -3895,7 +3895,7 @@ sources:
     snippet: The immutable extension only applies during the freshness lifetime of the stored response.
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 126
+      line: 98
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
       line: 121
 - label: RFC 8259
@@ -9060,9 +9060,9 @@ sources:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 120
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 99
+      line: 93
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 134
+      line: 116
   - label: caching_directive_interaction (3)
     section: § 5.2.2.9
     snippet: The public response directive indicates that a cache MAY store the response even if it would otherwise be prohibited, subject to the constraints defined in Section 3.
@@ -9074,39 +9074,39 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 160
+      line: 121
   - label: expires_and_cache_control_consistent (2)
     section: § 5.3
     snippet: A cache recipient MUST interpret invalid date formats, especially the value "0", as representing a time in the past (i.e., "already expired").
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 124
+      line: 97
   - label: expires_and_cache_control_consistent (3)
     section: § 5.3
     snippet: If a response includes a Cache-Control header field with the max-age directive (Section 5.2.2.1), a recipient MUST ignore the Expires header field.
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 159
+      line: 120
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 173
+      line: 134
   - label: expires_and_cache_control_consistent (4)
     section: § 5.3
     snippet: The Expires field value is an HTTP-date timestamp, as defined in Section 5.6.7 of [HTTP].
     cited_by:
     - file: lint-http-rules/src/rules/expires_and_cache_control_consistent.rs
-      line: 56
+      line: 52
   - label: immutable_cache_never_stale
     section: § 5.2.2.4
     snippet: the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 185
+      line: 157
   - label: immutable_cache_never_stale (2)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request
     cited_by:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 184
+      line: 156
   - label: delta-seconds
     section: § 1.2.2
     snippet: delta-seconds  = 1*DIGIT
@@ -9127,16 +9127,6 @@ sources:
       line: 27
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 62
-    - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 198
-    - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 207
-    - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 162
-    - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 266
-    - file: lint-http-rules/src/rules/private_cache_visibility.rs
-      line: 66
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 5.2
     snippet: cache-directive  = token [ "=" ( token / quoted-string ) ]
@@ -9150,7 +9140,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 147
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 103
+      line: 93
   - label: lint-http-rules/src/helpers/cache_control.rs (4)
     section: § 5.2.2.4
     snippet: The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request
@@ -9160,7 +9150,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 148
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 159
+      line: 142
   - label: lint-http-rules/src/helpers/cache_control.rs (5)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
@@ -9170,9 +9160,9 @@ sources:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 135
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 171
+      line: 124
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 198
+      line: 151
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 4.1
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
@@ -9209,8 +9199,6 @@ sources:
       line: 711
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 27
-    - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
-      line: 91
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
       line: 95
   - label: max_age_directive_valid
@@ -9244,15 +9232,15 @@ sources:
     snippet: A "fresh" response is one whose age has not yet exceeded its freshness lifetime. Conversely, a "stale" response is one where it has.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 137
+      line: 113
   - label: must_revalidate_enforced (2)
     section: § 4.3.1
     snippet: It then updates that request with one or more precondition header fields.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 129
+      line: 105
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
-      line: 99
+      line: 89
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
       line: 51
     - file: lint-http-rules/src/rules/s_max_age_enforced.rs
@@ -9264,7 +9252,7 @@ sources:
     snippet: The must-revalidate response directive indicates that once the response has become stale, a cache MUST NOT reuse that response to satisfy another request until it has been successfully validated by the origin, as defined by Section 4.3.
     cited_by:
     - file: lint-http-rules/src/rules/must_revalidate_enforced.rs
-      line: 143
+      line: 118
   - label: pragma_token_valid
     section: § 5.4
     snippet: As a result, this specification deprecates Pragma.


### PR DESCRIPTION
Five rules carried a private `header_has_<directive>` that was the same twelve lines with a different name in the comparison, and each had its own answer for the qualified form: `no_cache_revalidation` excluded `no-cache="field"` because §5.2.2.4 says the qualified form licenses reuse, while the other four compared the whole member and would have missed `no-store=` for the opposite reason. They are one call each now, and the qualified/unqualified question is asked by name.

Three of them also hand-rolled "the newest prior response satisfying P", then re-opened the Option they had just closed with `.response.as_ref().unwrap()`; `latest_response` hands the pair over once. `no_store_enforced` additionally sorted the history it was given and debug-asserted the order afterwards, duplicating an invariant the container already asserts where it is built, and removed validators from a set that could not contain them.

`private_cache_visibility` was a walk of the history nested inside a walk of the members inside a walk of the field lines; collecting the private validators first makes each validator the request presents one comparison.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
