### PR TITLE
Each validator and date check is a named question

### DIFF
--- a/lint-http-rules/src/rules/cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/cache_validation_chain.rs
@@ -84,120 +84,83 @@ impl Rule for CacheValidationChain {
             // form — and therefore cannot be matched against a previously observed
             // ETag.  Skip the rule in that case to avoid spurious warnings.
             // cite(RFC 9110 § 13.1.2): "The "If-None-Match" header field makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource, when the field value is "*""
-            if has_inm {
-                for hv in req.headers.get_all("if-none-match").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        for member in crate::helpers::headers::split_commas_respecting_quotes(s) {
-                            if member == "*" {
-                                return None;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Determine the most recent validator seen in history.  Iterate in
-            // newest-first order and stop when we have either a strong ETag or a
-            // Last-Modified value.  A 304 response may include headers that update
-            // the validator; treat it the same as a 200 when present.
-            // History here is already scoped to this (client, resource) pair by the
-            // rule's ByResource query, so the loop needs no URI/client filter: the
-            // newest response carrying any validator is the one a cache would hold.
-            let mut known_etag: Option<String> = None;
-            let mut known_lm: Option<String> = None;
-            for past in history.iter() {
-                if let Some(resp) = &past.response {
-                    let (etag, lm) =
-                        crate::helpers::headers::extract_validators_from_response(&resp.headers);
-                    if etag.is_some() || lm.is_some() {
-                        // Within that response ETag wins over Last-Modified, matching
-                        // the MUST-vs-SHOULD strength §4.3.1 assigns to the two
-                        // validators when a cache builds a conditional request.
-                        // cite(RFC 9111 § 4.3.1): "MUST send the relevant entity tags (using If-Match, If-None-Match, or If-Range) if the entity tags were provided in the stored response(s) being validated."
-                        if etag.is_some() {
-                            known_etag = etag.clone();
-                            known_lm = None;
-                        } else if known_etag.is_none() {
-                            // Last-Modified is the fallback validator (a SHOULD-send).
-                            // cite(RFC 9111 § 4.3.1): "SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value."
-                            known_lm = lm.clone();
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if known_etag.is_none() && known_lm.is_none() {
-                // no validator available to compare against
+            let inm_lines = || crate::helpers::headers::field_lines(&req.headers, "if-none-match");
+            if inm_lines()
+                .flat_map(crate::helpers::headers::split_commas_respecting_quotes)
+                .any(|member| member == "*")
+            {
                 return None;
             }
 
-            // Compare depending on validator type
-            if let Some(etag) = &known_etag {
-                if has_inm {
-                    // Iterate over all If-None-Match header fields; a match in any of
-                    // them is sufficient to satisfy the validator.
-                    let mut any_match = false;
-                    let mut first_inm_val: Option<String> = None;
-                    for value in req.headers.get_all("if-none-match").iter() {
-                        if let Ok(inm_val) = value.to_str() {
-                            if first_inm_val.is_none() {
-                                first_inm_val = Some(inm_val.to_string());
-                            }
-                            if crate::helpers::headers::inm_matches_known(inm_val, etag) {
-                                any_match = true;
-                                break;
-                            }
-                        }
-                    }
-                    if !any_match {
-                        let reported = first_inm_val
-                            .as_deref()
-                            .unwrap_or("<non-UTF8 If-None-Match>");
-                        // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
-                        return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
-                                "Conditional request uses If-None-Match '{}' which does not match most recent validator '{}' from history; cache validation chain may be broken",
-                                reported.trim(),
-                                etag
-                            )));
-                    }
-                }
-            } else if let Some(lm) = &known_lm {
-                if has_ims {
-                    if let Some(ims_val) =
-                        crate::helpers::headers::get_header_str(&req.headers, "if-modified-since")
-                    {
-                        let ims_str = ims_val.trim();
-                        // if the IMS value is not even a valid HTTP-date, let another
-                        // rule handle it rather than flagging a validation mismatch.
-                        if !crate::http_date::is_valid_http_date(ims_str) {
-                            return None;
-                        }
+            // The most recent validator seen in history: the newest response
+            // carrying either one, since a cache holding this resource would
+            // hold that one. A 304 that updates the validator is a response like
+            // any other here. History is already scoped to this (client,
+            // resource) pair by the rule's ByResource query, so no URI or client
+            // filter is needed.
+            let (etag, last_modified) = history
+                .responses()
+                .map(|(_, resp)| {
+                    crate::helpers::headers::extract_validators_from_response(&resp.headers)
+                })
+                .find(|(etag, last_modified)| etag.is_some() || last_modified.is_some())?;
 
-                        let lm_str = lm.trim();
-                        // attempt to parse both sides; the parser is occasionally
-                        // conservative, so we fall back to string equality if parsing
-                        // fails despite validity.
-                        let lm_dt = crate::http_date::parse_http_date_to_datetime(lm_str);
-                        let ims_dt = crate::http_date::parse_http_date_to_datetime(ims_str);
-
-                        let mismatch = match (ims_dt, lm_dt) {
-                            (Ok(i), Ok(l)) => i != l,
-                            _ => ims_str != lm_str,
-                        };
-                        // Same basis as the If-None-Match branch: the cache is expected
-                        // to carry the stored validator into its conditional request, so
-                        // a stale Last-Modified signals a broken chain.
-                        // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
-                        if mismatch {
-                            return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
-                                    "Conditional request uses If-Modified-Since '{}' which does not match most recent Last-Modified '{}' from history; cache validation chain may be broken",
-                                    ims_str,
-                                    lm_str
-                                )));
-                        }
-                    }
+            // Within that response ETag wins over Last-Modified, matching the
+            // MUST-vs-SHOULD strength §4.3.1 assigns to the two validators when a
+            // cache builds a conditional request.
+            // cite(RFC 9111 § 4.3.1): "MUST send the relevant entity tags (using If-Match, If-None-Match, or If-Range) if the entity tags were provided in the stored response(s) being validated."
+            // cite(RFC 9111 § 4.3.1): "SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value."
+            if let Some(known_etag) = etag {
+                if has_inm
+                    && !inm_lines()
+                        .any(|line| crate::helpers::headers::inm_matches_known(line, &known_etag))
+                {
+                    // A field line that is not text matched nothing, and is what
+                    // the finding has to quote when it is all the request sent.
+                    let reported = inm_lines().next().unwrap_or("<non-UTF8 If-None-Match>");
+                    // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
+                    return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
+                            "Conditional request uses If-None-Match '{}' which does not match most recent validator '{}' from history; cache validation chain may be broken",
+                            reported.trim(),
+                            known_etag
+                        )));
                 }
+                return None;
+            }
+
+            let known_last_modified = last_modified?;
+            if !has_ims {
+                return None;
+            }
+            let ims =
+                crate::helpers::headers::get_header_str(&req.headers, "if-modified-since")?.trim();
+            // If the IMS value is not even a valid HTTP-date, let another rule
+            // handle it rather than flagging a validation mismatch.
+            if !crate::http_date::is_valid_http_date(ims) {
+                return None;
+            }
+
+            // Compare as instants where both sides parse, so two spellings of one
+            // time still match; the parser is occasionally conservative, so a
+            // failure on either side falls back to comparing the text.
+            let known_last_modified = known_last_modified.trim();
+            let mismatch = match (
+                crate::http_date::parse_http_date_to_datetime(ims),
+                crate::http_date::parse_http_date_to_datetime(known_last_modified),
+            ) {
+                (Ok(ims_dt), Ok(lm_dt)) => ims_dt != lm_dt,
+                _ => ims != known_last_modified,
+            };
+            // Same basis as the If-None-Match branch: the cache is expected to
+            // carry the stored validator into its conditional request, so a stale
+            // Last-Modified signals a broken chain.
+            // cite(RFC 9111 § 4.3.1): "It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI."
+            if mismatch {
+                return Some(self.cited(&RFC_9111_4_3_1, ctx.severity, format!(
+                        "Conditional request uses If-Modified-Since '{}' which does not match most recent Last-Modified '{}' from history; cache validation chain may be broken",
+                        ims,
+                        known_last_modified
+                    )));
             }
 
             None

--- a/lint-http-rules/src/rules/conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/conditional_request_handling.rs
@@ -54,6 +54,141 @@ const RFC_9110_8_8_2: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "Last-Modified header field",
 };
 
+/// Which preconditions a request carried.
+///
+/// The four fields are asked in three different groupings — the two entity-tag
+/// ones together, the two date ones together, and `If-None-Match` alone, which
+/// § 13.2.2 makes govern whether `If-Modified-Since` is evaluated at all — and
+/// naming the groupings is what keeps a check from testing the wrong pair.
+struct Preconditions {
+    if_none_match: bool,
+    if_match: bool,
+    if_modified_since: bool,
+    if_unmodified_since: bool,
+}
+
+impl Preconditions {
+    fn of(headers: &hyper::HeaderMap) -> Self {
+        Self {
+            if_none_match: headers.contains_key("if-none-match"),
+            if_match: headers.contains_key("if-match"),
+            if_modified_since: headers.contains_key("if-modified-since"),
+            if_unmodified_since: headers.contains_key("if-unmodified-since"),
+        }
+    }
+
+    /// Whether the request is conditional at all.
+    fn any(&self) -> bool {
+        self.if_none_match || self.if_match || self.if_modified_since || self.if_unmodified_since
+    }
+
+    /// Whether a precondition compares against an entity-tag validator.
+    fn entity_tag(&self) -> bool {
+        self.if_none_match || self.if_match
+    }
+
+    /// Whether a precondition compares against a modification date.
+    fn date(&self) -> bool {
+        self.if_modified_since || self.if_unmodified_since
+    }
+}
+
+/// The two methods whose failed precondition is answered with 304 rather than
+/// 412, which is what makes the checks below about a `200` at all.
+// cite(RFC 9110 § 13.1.2): "the 304 (Not Modified) status code if the request method is GET or HEAD"
+fn is_get_or_head(method: &str) -> bool {
+    method.eq_ignore_ascii_case("GET") || method.eq_ignore_ascii_case("HEAD")
+}
+
+impl ConditionalRequestHandling {
+    /// A precondition carries validator metadata from a stored response, so a
+    /// client sending one should have been given that validator.
+    ///
+    /// Requiring the client to have *previously observed* the validator is a
+    /// stateful heuristic with no governing MUST/SHOULD in RFC 9110 (recorded
+    /// §4.1) — `If-None-Match: *` legitimately needs no prior tag — so none of
+    /// these findings carries a cite.
+    fn validator_was_observed(
+        &self,
+        sent: &Preconditions,
+        history: &crate::transaction_history::TransactionHistory,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        let Some(prev) = history.previous() else {
+            return Some(self.violation(severity, "Conditional request sent but no previous response recorded for this resource (no ETag/Last-Modified to validate against)".into()));
+        };
+        let Some(resp) = &prev.response else {
+            return Some(self.violation(
+                severity,
+                "Conditional request sent but previous transaction has no response recorded".into(),
+            ));
+        };
+        if sent.entity_tag() && !resp.headers.contains_key("etag") {
+            return Some(self.violation(severity, "Request contains entity-tag conditional (If-Match/If-None-Match) but previous response did not include an ETag".into()));
+        }
+        if sent.date() && !resp.headers.contains_key("last-modified") {
+            return Some(self.violation(severity, "Request contains time-based conditional (If-Modified-Since/If-Unmodified-Since) but previous response did not include Last-Modified".into()));
+        }
+        None
+    }
+
+    /// A GET or HEAD whose `If-None-Match` condition is false is answered with
+    /// 304, not 200.
+    ///
+    /// The members are compared exactly rather than by the weak comparison
+    /// § 8.8.3.2 mandates: a deliberate narrowing that only ever under-flags,
+    /// since an exact match is also a weak match.
+    // cite(RFC 9110 § 13.1.2): "An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods."
+    fn if_none_match_was_evaluated(
+        &self,
+        tx: &crate::http_transaction::HttpTransaction,
+        sent: &Preconditions,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        if !sent.if_none_match || !is_get_or_head(&tx.request.method) {
+            return None;
+        }
+        let resp = tx.response.as_ref()?;
+        if resp.status != 200 {
+            return None;
+        }
+        let etag = crate::helpers::headers::get_header_str(&resp.headers, "etag")?.trim();
+        let condition_was_false =
+            crate::helpers::headers::field_lines(&tx.request.headers, "if-none-match")
+                .flat_map(crate::helpers::headers::list_members)
+                .any(|member| member == etag || member == "*");
+
+        condition_was_false.then(|| self.violation(severity, "Conditional GET/HEAD: the If-None-Match condition was not met (response ETag matched) but the server returned 200; RFC 9110 §13.1.2 requires a 304 (Not Modified) for GET/HEAD".into()))
+    }
+
+    /// A GET or HEAD whose `If-Modified-Since` condition is false should be
+    /// answered with 304 — a SHOULD here, unlike § 13.1.2's MUST.
+    ///
+    /// Asked only where `If-None-Match` is absent: § 13.2.2 evaluates
+    /// `If-Modified-Since` only then, so with both present the check above
+    /// governs and a 200 may be perfectly legal.
+    // cite(RFC 9110 § 13.1.3): "An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response"
+    // cite(RFC 9110 § 13.2.2): "When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition"
+    fn if_modified_since_was_evaluated(
+        &self,
+        tx: &crate::http_transaction::HttpTransaction,
+        sent: &Preconditions,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        if !sent.if_modified_since || sent.if_none_match || !is_get_or_head(&tx.request.method) {
+            return None;
+        }
+        let resp = tx.response.as_ref()?;
+        if resp.status != 200 {
+            return None;
+        }
+        let since = crate::http_date::header_timestamp(&tx.request.headers, "if-modified-since")?;
+        let last_modified = crate::http_date::header_timestamp(&resp.headers, "last-modified")?;
+
+        (last_modified <= since).then(|| self.violation(severity, "Conditional GET/HEAD used If-Modified-Since but server returned 200 even though Last-Modified indicates the resource was not modified; consider returning 304 Not Modified".into()))
+    }
+}
+
 impl Rule for ConditionalRequestHandling {
     fn id(&self) -> &'static str {
         "conditional_request_handling"
@@ -72,121 +207,13 @@ impl Rule for ConditionalRequestHandling {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // Only applies when request contains one or more conditional headers
-            let req = &tx.request;
-            let has_inm = req.headers.get("if-none-match").is_some();
-            let has_ifm = req.headers.get("if-modified-since").is_some();
-            let has_imatch = req.headers.get("if-match").is_some();
-            let has_iunmod = req.headers.get("if-unmodified-since").is_some();
-
-            if !(has_inm || has_ifm || has_imatch || has_iunmod) {
+            let sent = Preconditions::of(&tx.request.headers);
+            if !sent.any() {
                 return None;
             }
-
-            // If we have no previous transaction recorded for this client+resource,
-            // warn that conditionals were sent without an observed validator.
-            let prev = match history.previous() {
-                Some(p) => p,
-                None => {
-                    return Some(self.violation(ctx.severity, "Conditional request sent but no previous response recorded for this resource (no ETag/Last-Modified to validate against)".into()))
-                }
-            };
-
-            // Previous transaction must include a response with validators when
-            // entity-tag/date conditionals are used.
-            if let Some(resp) = &prev.response {
-                // An entity-tag precondition compares against a validator (an ETag). Requiring the
-                // client to have *previously observed* that validator is a stateful heuristic with
-                // no governing MUST/SHOULD in RFC 9110 (recorded §4.1) — e.g. `If-None-Match: *`
-                // legitimately needs no prior tag — so this construct carries no cite.
-                if (has_inm || has_imatch) && resp.headers.get("etag").is_none() {
-                    return Some(self.violation(ctx.severity, "Request contains entity-tag conditional (If-Match/If-None-Match) but previous response did not include an ETag".into()));
-                }
-
-                // Same shape for a date-based precondition (a Last-Modified validator): the
-                // prior-observation requirement is the same uncited stateful heuristic.
-                if (has_ifm || has_iunmod) && resp.headers.get("last-modified").is_none() {
-                    return Some(self.violation(ctx.severity, "Request contains time-based conditional (If-Modified-Since/If-Unmodified-Since) but previous response did not include Last-Modified".into()));
-                }
-            } else {
-                return Some(self.violation(ctx.severity, "Conditional request sent but previous transaction has no response recorded"
-                            .into()));
-            }
-
-            // Response-side sanity checks for common conditional patterns (GET/HEAD):
-            // - If-None-Match: if the response ETag matches one of the request's tags (or the
-            //   request sent `*` against an existing representation) and the server returned 200
-            //   for GET/HEAD, the If-None-Match condition was false — §13.1.2 requires a 304, not
-            //   a 200. (Exact string match, not the weak comparison §8.8.3.2 mandates: a deliberate
-            //   narrowing that only under-flags — an exact match is also a weak match.)
-            // cite(RFC 9110 § 13.1.2): "An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods."
-            if has_inm
-                && (req.method.eq_ignore_ascii_case("GET")
-                    || req.method.eq_ignore_ascii_case("HEAD"))
-            {
-                if let Some(resp) = &tx.response {
-                    if resp.status == 200 {
-                        if let Some(resp_etag_hv) = resp.headers.get("etag") {
-                            if let Ok(resp_etag) = resp_etag_hv.to_str() {
-                                for hv in req.headers.get_all("if-none-match").iter() {
-                                    if let Ok(inm_raw) = hv.to_str() {
-                                        for member in crate::helpers::headers::list_members(inm_raw)
-                                        {
-                                            if member == resp_etag.trim() || member == "*" {
-                                                return Some(self.violation(ctx.severity, "Conditional GET/HEAD: the If-None-Match condition was not met (response ETag matched) but the server returned 200; RFC 9110 §13.1.2 requires a 304 (Not Modified) for GET/HEAD".into()));
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // - If-Modified-Since: if the response Last-Modified is not more recent than the
-            //   conditional value and the server returned 200 for GET/HEAD, the condition was
-            //   false, so a 304 SHOULD have been sent. (A SHOULD here, unlike §13.1.2's MUST.)
-            //   Guarded by `!has_inm`: per §13.2.2, If-Modified-Since is evaluated only when
-            //   If-None-Match is absent, so if both are present the If-None-Match branch governs
-            //   and a 200 may be legal (INM condition true) — flagging here would be a false
-            //   positive.
-            // cite(RFC 9110 § 13.1.3): "An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response"
-            // cite(RFC 9110 § 13.2.2): "When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition"
-            if has_ifm
-                && !has_inm
-                && (req.method.eq_ignore_ascii_case("GET")
-                    || req.method.eq_ignore_ascii_case("HEAD"))
-            {
-                if let Some(resp) = &tx.response {
-                    if resp.status == 200 {
-                        if let (Some(req_ifms), Some(resp_lm_hv)) = (
-                            crate::helpers::headers::get_header_str(
-                                &req.headers,
-                                "if-modified-since",
-                            ),
-                            resp.headers.get("last-modified"),
-                        ) {
-                            if let Ok(resp_lm) = resp_lm_hv.to_str() {
-                                if crate::http_date::is_valid_http_date(req_ifms)
-                                    && crate::http_date::is_valid_http_date(resp_lm)
-                                {
-                                    if let (Ok(req_dt), Ok(resp_dt)) = (
-                                        crate::http_date::parse_http_date_to_datetime(req_ifms),
-                                        crate::http_date::parse_http_date_to_datetime(resp_lm),
-                                    ) {
-                                        if resp_dt <= req_dt {
-                                            return Some(self.violation(ctx.severity, "Conditional GET/HEAD used If-Modified-Since but server returned 200 even though Last-Modified indicates the resource was not modified; consider returning 304 Not Modified".into()));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            None
+            self.validator_was_observed(&sent, history, ctx.severity)
+                .or_else(|| self.if_none_match_was_evaluated(tx, &sent, ctx.severity))
+                .or_else(|| self.if_modified_since_was_evaluated(tx, &sent, ctx.severity))
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -36,6 +36,182 @@ const RFC_8594_3: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "`Sunset` header semantics",
 };
 
+/// What a field defined as an `HTTP-date` carries.
+///
+/// The three ways a field can fail to state a time are distinct findings here —
+/// nothing was written, what was written is not text, what was written is not a
+/// date — and reading them off a chain of `if let`s is what made one rule spell
+/// the same three readings four times, twice with different wording for the
+/// same defect.
+enum Timestamp<'a> {
+    /// No field line by that name.
+    Absent,
+    /// A field line whose octets are not text, so no value can be read from it.
+    Unreadable,
+    /// Text, but not a timestamp a recipient can parse. The text itself is not
+    /// carried: every reader of this variant either reports the field by name
+    /// or leaves the value to the rule that owns its format.
+    Unparseable,
+    /// A timestamp, and the text it was written as.
+    At(chrono::DateTime<chrono::Utc>, &'a str),
+}
+
+/// Read the first `name` field line as a timestamp.
+///
+/// This is a *recipient* parse: `parse_http_date_to_datetime` owns the § 5.6.7
+/// HTTP-date grammar and the accept-all-three-formats obligation, so
+/// [`Timestamp::Unparseable`] means "no recipient could read this", not "the
+/// sender used the wrong one of the three formats" — that obligation belongs to
+/// the per-field format rules.
+///
+/// Only the first line is read: every field asked here but `Sunset` is a
+/// singleton, and `Sunset` is read line by line below through
+/// [`Timestamp::of`], because no other rule owns its repetition.
+fn timestamp<'a>(headers: &'a hyper::HeaderMap, name: &str) -> Timestamp<'a> {
+    headers.get(name).map_or(Timestamp::Absent, Timestamp::of)
+}
+
+impl<'a> Timestamp<'a> {
+    /// Read one field line. Never [`Timestamp::Absent`] — the line exists.
+    fn of(value: &'a hyper::header::HeaderValue) -> Self {
+        let Ok(text) = value.to_str() else {
+            return Timestamp::Unreadable;
+        };
+        match crate::http_date::parse_http_date_to_datetime(text) {
+            Ok(at) => Timestamp::At(at, text),
+            Err(_) => Timestamp::Unparseable,
+        }
+    }
+}
+
+impl DateAndTimeHeadersConsistent {
+    /// `Date` states a time, or states nothing at all.
+    // cite(RFC 9110 § 6.6.1): "The "Date" header field represents the date and time at which the message was originated"
+    fn date_is_readable(
+        &self,
+        headers: &hyper::HeaderMap,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        match timestamp(headers, "date") {
+            Timestamp::Absent | Timestamp::At(..) => None,
+            Timestamp::Unreadable => Some(self.cited(
+                &RFC_9110_6_6_1,
+                severity,
+                "Date header contains non-UTF8 bytes and is invalid".into(),
+            )),
+            Timestamp::Unparseable => Some(self.cited(
+                &RFC_9110_6_6_1,
+                severity,
+                "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
+            )),
+        }
+    }
+
+    /// A representation cannot have last changed after the message that carries
+    /// it was written.
+    ///
+    /// An unparseable `Last-Modified` is left to the rule that owns that
+    /// field's format, so this one does not report it twice.
+    // cite(RFC 9110 § 8.8.2.1): "An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1)."
+    fn last_modified_not_after_date(
+        &self,
+        headers: &hyper::HeaderMap,
+        date: chrono::DateTime<chrono::Utc>,
+        date_text: &str,
+        skew: chrono::Duration,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        match timestamp(headers, "last-modified") {
+            Timestamp::Absent | Timestamp::Unparseable => None,
+            Timestamp::Unreadable => Some(self.violation(
+                severity,
+                "Last-Modified header contains non-UTF8 bytes and is invalid".into(),
+            )),
+            Timestamp::At(last_modified, text) if last_modified > date + skew => {
+                Some(self.violation(severity, format!(
+                    "Last-Modified '{}' is later than Date '{}'; Last-Modified must not be in the future relative to Date",
+                    text, date_text
+                )))
+            }
+            Timestamp::At(..) => None,
+        }
+    }
+
+    /// `Sunset` announces a shutdown, so it names a time still to come.
+    ///
+    /// One § 3 sentence licenses both halves — the HTTP-date format and the
+    /// future check (the skew only makes the past-check lenient).
+    ///
+    /// Every field line is judged, not just the first: `Sunset` is a singleton
+    /// the repeated-singleton rule does not list, so a second line judged
+    /// nowhere would be a second line judged not at all.
+    // cite(RFC 8594 § 3): "The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future."
+    fn sunset_is_after_date(
+        &self,
+        headers: &hyper::HeaderMap,
+        date: chrono::DateTime<chrono::Utc>,
+        date_text: &str,
+        skew: chrono::Duration,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        headers
+            .get_all("sunset")
+            .iter()
+            .find_map(|line| match Timestamp::of(line) {
+                Timestamp::Unreadable => Some(self.violation(
+                    severity,
+                    "Sunset header contains non-UTF8 bytes and is invalid".into(),
+                )),
+                Timestamp::Unparseable => Some(self.violation(
+                    severity,
+                    "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into(),
+                )),
+                Timestamp::At(sunset, text) if sunset <= date - skew => {
+                    Some(self.cited(&RFC_8594_3, severity, format!(
+                        "Sunset header '{}' is before or equal to Date '{}'; Sunset should indicate a future shutdown date",
+                        text, date_text
+                    )))
+                }
+                Timestamp::At(..) | Timestamp::Absent => None,
+            })
+    }
+
+    /// A conditional request asking for changes since a time later than the
+    /// request itself is nonsense.
+    ///
+    /// No sentence mandates this ordering, so it is a reasonableness heuristic,
+    /// recorded in the ledger rather than cited. The format of
+    /// `If-Modified-Since` is owned by its dedicated rule, so an unparseable
+    /// value is skipped here.
+    fn if_modified_since_not_after_date(
+        &self,
+        headers: &hyper::HeaderMap,
+        skew: chrono::Duration,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        let since = match timestamp(headers, "if-modified-since") {
+            Timestamp::Absent | Timestamp::Unparseable => return None,
+            Timestamp::Unreadable => {
+                return Some(self.violation(
+                    severity,
+                    "If-Modified-Since header contains non-UTF8 bytes and is invalid".into(),
+                ))
+            }
+            Timestamp::At(since, text) => (since, text),
+        };
+        let Timestamp::At(date, date_text) = timestamp(headers, "date") else {
+            return None;
+        };
+        if since.0 > date + skew {
+            return Some(self.violation(severity, format!(
+                "If-Modified-Since '{}' is later than Date '{}'; conditional requests should not use a future date",
+                since.1, date_text
+            )));
+        }
+        None
+    }
+}
+
 impl Rule for DateAndTimeHeadersConsistent {
     fn id(&self) -> &'static str {
         "date_and_time_headers_consistent"
@@ -53,176 +229,50 @@ impl Rule for DateAndTimeHeadersConsistent {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
+        //
+        // Each check below is one sentence about one pair of fields, and each
+        // states its own reading of a field that is absent, unreadable or not a
+        // date — which is why they are named functions rather than a ladder:
+        // the ladder made those three readings look like one.
         let finding = || -> Option<Violation> {
-            use chrono::Duration;
-
             // Tolerate some small clock skew when comparing dates. 60s is a linter
             // heuristic — no spec licenses it; §8.8.2.1's "MUST NOT ... later than ...
             // Date" is strict, so this only makes the rule *more* lenient (recorded in
             // the audit ledger, not cited).
             const ALLOWED_SKEW_SECS: i64 = 60;
-            let skew = Duration::seconds(ALLOWED_SKEW_SECS);
+            let skew = chrono::Duration::seconds(ALLOWED_SKEW_SECS);
+            let severity = ctx.severity;
 
-            // Check Date header (request or response)
-            if let Some(hv) = tx.request.headers.get_all("date").iter().next() {
-                if let Ok(s) = hv.to_str() {
-                    // This is a *recipient* parse: `parse_http_date_to_datetime` owns the
-                    // §5.6.7 HTTP-date grammar and the accept-all-three-formats obligation
-                    // (so those quotes live there, not duplicated here). The failure below
-                    // therefore fires only on an unparseable value — hence "HTTP-date",
-                    // not "IMF-fixdate"; the sender's IMF-fixdate obligation is a separate
-                    // rule's concern. This rule's own claim is only what Date *is*:
-                    // cite(RFC 9110 § 6.6.1): "The "Date" header field represents the date and time at which the message was originated"
-                    if crate::http_date::parse_http_date_to_datetime(s).is_err() {
-                        return Some(self.cited(
-                            &RFC_9110_6_6_1,
-                            ctx.severity,
-                            "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
-                        ));
-                    }
-                } else {
-                    return Some(self.cited(
-                        &RFC_9110_6_6_1,
-                        ctx.severity,
-                        "Date header contains non-UTF8 bytes and is invalid".into(),
-                    ));
-                }
+            if let Some(v) = self.date_is_readable(&tx.request.headers, severity) {
+                return Some(v);
             }
 
             if let Some(resp) = &tx.response {
-                // Response Date check — same recipient parse as the request Date above.
-                // cite(RFC 9110 § 6.6.1): "The "Date" header field represents the date and time at which the message was originated"
-                if let Some(hv) = resp.headers.get_all("date").iter().next() {
-                    if let Ok(s) = hv.to_str() {
-                        if crate::http_date::parse_http_date_to_datetime(s).is_err() {
-                            return Some(self.cited(
-                                &RFC_9110_6_6_1,
-                                ctx.severity,
-                                "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Date header contains non-UTF8 bytes and is invalid".into(),
-                        ));
-                    }
+                if let Some(v) = self.date_is_readable(&resp.headers, severity) {
+                    return Some(v);
                 }
-
-                // If both Date and Last-Modified present and parseable, ensure Last-Modified is not in the future relative to Date
-                if let Some(date_str) =
-                    crate::helpers::headers::get_header_str(&resp.headers, "date")
-                {
-                    if let Ok(date_dt) = crate::http_date::parse_http_date_to_datetime(date_str) {
-                        if let Some(lm_str_raw) =
-                            resp.headers.get_all("last-modified").iter().next()
-                        {
-                            // handle non-utf8
-                            match lm_str_raw.to_str() {
-                                Ok(lm_str) => {
-                                    match crate::http_date::parse_http_date_to_datetime(lm_str) {
-                                        Ok(lm_dt) => {
-                                            // cite(RFC 9110 § 8.8.2.1): "An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1)."
-                                            if lm_dt > date_dt + skew {
-                                                return Some(self.violation(ctx.severity, format!(
-                                                    "Last-Modified '{}' is later than Date '{}'; Last-Modified must not be in the future relative to Date",
-                                                    lm_str, date_str
-                                                )));
-                                            }
-                                        }
-                                        Err(_) => {
-                                            // Let dedicated Last-Modified format rule report invalid date; avoid duplicate
-                                        }
-                                    }
-                                }
-                                Err(_) => {
-                                    return Some(self.violation(ctx.severity, "Last-Modified header contains non-UTF8 bytes and is invalid".into()));
-                                }
-                            }
-                        }
-
-                        // Sunset header: a valid HTTP-date that SHOULD be in the future.
-                        // One §3 sentence licenses both halves — the HTTP-date format and
-                        // the future check below (the skew makes the past-check lenient).
-                        // cite(RFC 8594 § 3): "The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future."
-                        for hv in resp.headers.get_all("sunset").iter() {
-                            match hv.to_str() {
-                                Ok(s) => match crate::http_date::parse_http_date_to_datetime(s) {
-                                    Ok(sunset_dt) => {
-                                        if sunset_dt <= date_dt - skew {
-                                            return Some(self.cited(&RFC_8594_3, ctx.severity, format!(
-                                                    "Sunset header '{}' is before or equal to Date '{}'; Sunset should indicate a future shutdown date",
-                                                    s, date_str
-                                                )));
-                                        }
-                                    }
-                                    Err(_) => {
-                                        return Some(self.violation(ctx.severity, "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into()));
-                                    }
-                                },
-                                Err(_) => {
-                                    return Some(
-                                        self.violation(
-                                            ctx.severity,
-                                            "Sunset header contains non-UTF8 bytes and is invalid"
-                                                .into(),
-                                        ),
-                                    );
-                                }
-                            }
-                        }
+                // The two comparisons below are against Date, so they are asked
+                // only where Date is a timestamp; where it is not, the check
+                // above has already reported it.
+                if let Timestamp::At(date, date_text) = timestamp(&resp.headers, "date") {
+                    if let Some(v) = self.last_modified_not_after_date(
+                        &resp.headers,
+                        date,
+                        date_text,
+                        skew,
+                        severity,
+                    ) {
+                        return Some(v);
+                    }
+                    if let Some(v) =
+                        self.sunset_is_after_date(&resp.headers, date, date_text, skew, severity)
+                    {
+                        return Some(v);
                     }
                 }
             }
 
-            // Request-level If-Modified-Since: if a Date header is present, flag an
-            // If-Modified-Since later than it. No spec sentence mandates this ordering
-            // (a conditional date after the request's own Date is merely nonsensical),
-            // so it is a reasonableness heuristic — uncited, recorded in the ledger. The
-            // format of If-Modified-Since is owned by its dedicated rule (parse errors
-            // are skipped here to avoid duplicate reports).
-            if let Some(ifms_hv) = tx
-                .request
-                .headers
-                .get_all("if-modified-since")
-                .iter()
-                .next()
-            {
-                match ifms_hv.to_str() {
-                    Ok(ifms_str) => match crate::http_date::parse_http_date_to_datetime(ifms_str) {
-                        Ok(ifms_dt) => {
-                            if let Some(date_str) =
-                                crate::helpers::headers::get_header_str(&tx.request.headers, "date")
-                            {
-                                if let Ok(date_dt) =
-                                    crate::http_date::parse_http_date_to_datetime(date_str)
-                                {
-                                    if ifms_dt > date_dt + skew {
-                                        return Some(self.violation(ctx.severity, format!(
-                                                "If-Modified-Since '{}' is later than Date '{}'; conditional requests should not use a future date",
-                                                ifms_str, date_str
-                                            )));
-                                    }
-                                }
-                            }
-                        }
-                        Err(_) => {
-                            // If-Modified-Since format is validated by dedicated rule; avoid duplicate reporting
-                        }
-                    },
-                    Err(_) => {
-                        return Some(
-                            self.violation(
-                                ctx.severity,
-                                "If-Modified-Since header contains non-UTF8 bytes and is invalid"
-                                    .into(),
-                            ),
-                        );
-                    }
-                }
-            }
-
-            None
+            self.if_modified_since_not_after_date(&tx.request.headers, skew, severity)
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -989,11 +989,18 @@ severity = "warn"
     ///
     /// Raise the floor when a batch lands. If this fails downward, a `cited()`
     /// site became a `violation()` one: say why in the commit or put it back.
+    ///
+    /// **Two finding sites merging into one lowers this number without losing a
+    /// citation**, and that is the only reason it has ever moved down: the
+    /// `Date` field's request and response readings were two copies of the same
+    /// two findings and now share one function, which cites what both cited.
+    /// The count of *sites* is not the count of sentences read, so when a
+    /// duplicate disappears, lower the floor and say which one.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce, out
-        /// of 583. The rest are the per-rule reading that has not happened yet.
-        const FLOOR: usize = 173;
+        /// of 579. The rest are the per-rule reading that has not happened yet.
+        const FLOOR: usize = 172;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4272,7 +4272,7 @@ sources:
     snippet: The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future.
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 147
+      line: 148
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
       line: 64
 - label: RFC 8615
@@ -5103,9 +5103,7 @@ sources:
     - file: lint-http-rules/src/rules/cache_coherence.rs
       line: 97
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 75
-    - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 94
+      line: 89
   - label: cache_coherence (3)
     section: § 8.8.2
     snippet: The "Last-Modified" header field in a response provides a timestamp indicating the date and time at which the origin server believes the selected representation was last modified
@@ -5273,19 +5271,25 @@ sources:
     snippet: An origin server that evaluates an If-None-Match condition MUST NOT perform the requested method if the condition evaluates to false; instead, the origin server MUST respond with either a) the 304 (Not Modified) status code if the request method is GET or HEAD or b) the 412 (Precondition Failed) status code for all other request methods.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 122
+      line: 141
   - label: conditional_request_handling (2)
+    section: § 13.1.2
+    snippet: the 304 (Not Modified) status code if the request method is GET or HEAD
+    cited_by:
+    - file: lint-http-rules/src/rules/conditional_request_handling.rs
+      line: 98
+  - label: conditional_request_handling (3)
     section: § 13.1.3
     snippet: An origin server that evaluates an If-Modified-Since condition SHOULD NOT perform the requested method if the condition evaluates to false; instead, the origin server SHOULD generate a 304 (Not Modified) response
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 154
-  - label: conditional_request_handling (3)
+      line: 170
+  - label: conditional_request_handling (4)
     section: § 13.2.2
     snippet: When the method is GET or HEAD, If-None-Match is not present, and If-Modified-Since is present, evaluate the If-Modified-Since precondition
     cited_by:
     - file: lint-http-rules/src/rules/conditional_request_handling.rs
-      line: 155
+      line: 171
   - label: connection_header_tokens_valid
     section: § 7.6.1
     snippet: A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content.  For example, Cache-Control is never appropriate as a connection option (Section 5.2 of [CACHING]).
@@ -5589,7 +5593,7 @@ sources:
     snippet: An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1).
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 125
+      line: 115
   - label: early_data_header_safe_method
     section: § 16.1.1
     snippet: 'HTTP method registrations MUST include the following fields:'
@@ -9028,15 +9032,15 @@ sources:
     snippet: It then updates that request with one or more precondition header fields. These contain validator metadata sourced from a stored response(s) that has the same URI.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 157
+      line: 121
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 191
+      line: 157
   - label: cache_validation_chain (2)
     section: § 4.3.1
     snippet: MUST send the relevant entity tags (using If-Match, If-None-Match, or If-Range) if the entity tags were provided in the stored response(s) being validated.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 116
+      line: 111
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 191
   - label: cache_validation_chain (3)
@@ -9044,7 +9048,7 @@ sources:
     snippet: SHOULD send the Last-Modified value (using If-Modified-Since) if the request is not for a subrange, a single stored response is being validated, and that response contains a Last-Modified value.
     cited_by:
     - file: lint-http-rules/src/rules/cache_validation_chain.rs
-      line: 122
+      line: 112
     - file: lint-http-rules/src/rules/range_request_and_caching.rs
       line: 164
   - label: caching_directive_interaction


### PR DESCRIPTION
`date_and_time_headers_consistent` spelled the same three readings of a timestamp field — nothing written, not text, not a date — four times over, in ladders deep enough that the readings stopped looking distinct: the same defect on the request's Date and the response's Date was worded twice and cited once. `Timestamp` names the four states a field can be in, and the four comparisons are four functions that each say which pair they are about and what a missing half means.

`conditional_request_handling` asked its four precondition fields in three different groupings, one of them the §13.2.2 rule that If-None-Match governs whether If-Modified-Since is evaluated at all; `Preconditions` names the groupings so a check cannot test the wrong pair. `cache_validation_chain` kept a candidate ETag and a candidate Last-Modified as two mutable Options with the precedence between them spread across the loop that filled them.

The citation floor drops by one and no citation was lost: the Date field's two readings were two copies of one finding and now share the function that cites it. The test says so.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
