### PR TITLE
A Set-Cookie line is split once, by the module that owns the grammar

### DIFF
--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -149,6 +149,103 @@ impl Cookie {
     }
 }
 
+/// One `cookie-av`: an attribute name, and the value it carries if any.
+///
+/// `value` distinguishes "no `=` was written" (`None`) from "an `=` with
+/// nothing after it" (`Some("")`), because the two are different defects for
+/// the flag attributes: `Secure` takes no value at all, so `Secure=` is a
+/// sender writing one.
+// cite(RFC 6265 § 4.1.1): "cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av"
+pub struct Attribute<'a> {
+    pub name: &'a str,
+    pub value: Option<&'a str>,
+}
+
+impl Attribute<'_> {
+    /// Whether this is the named attribute, compared case-insensitively.
+    // cite(RFC 6265 § 5.2.1): "If the attribute-name case-insensitively matches the string "Expires", the user agent MUST process the cookie-av as follows."
+    pub fn is(&self, name: &str) -> bool {
+        self.name.eq_ignore_ascii_case(name)
+    }
+
+    /// Whether a value was written after the `=`.
+    pub fn has_value(&self) -> bool {
+        self.value.is_some_and(|v| !v.is_empty())
+    }
+}
+
+/// Split one `Set-Cookie` field line into its cookie-pair and its attributes.
+///
+/// The parser below and the rule that reports attribute defects were each
+/// splitting this line themselves, on the same two characters, and neither
+/// could say what the other did with an empty segment. The pair comes back as
+/// written — judging it is the caller's job — and the attributes come back with
+/// the empty segments a stray `;` produces already dropped.
+// cite(RFC 6265 § 4.1.1): "set-cookie-string = cookie-pair *( ";" SP cookie-av )"
+pub fn split_set_cookie(line: &str) -> (&str, impl Iterator<Item = Attribute<'_>>) {
+    let mut segments = line.split(';').map(str::trim);
+    // `split` always yields at least one segment, so the pair is whatever
+    // stands before the first `;` — possibly empty, which is a defect the
+    // caller names.
+    let pair = segments.next().unwrap_or("");
+    let attributes = segments
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| match segment.split_once('=') {
+            Some((name, value)) => Attribute {
+                name: name.trim(),
+                value: Some(value.trim()),
+            },
+            None => Attribute {
+                name: segment,
+                value: None,
+            },
+        });
+    (pair, attributes)
+}
+
+/// The host the request was sent to, which a cookie with no `Domain` is bound
+/// to.
+// cite(RFC 6265 § 5.3): "Set the cookie's host-only-flag to true."
+fn default_domain(request_uri: &str) -> String {
+    let Some(idx) = request_uri.find("://") else {
+        // An unparseable request-target leaves nothing to bind to, and an empty
+        // domain matches no request later.
+        return String::new();
+    };
+    let authority = request_uri[idx + 3..].split('/').next().unwrap_or("");
+    authority
+        .split(':')
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+}
+
+/// The default-path of a cookie set by a request to `request_uri`.
+///
+/// The branches are § 5.1.4's numbered steps, in its order.
+// cite(RFC 6265 § 5.1.4): "The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:"
+fn default_path(request_uri: &str) -> String {
+    let Some(p) = crate::helpers::uri::extract_path_from_request_target(request_uri) else {
+        return "/".into();
+    };
+    // Step 2. Quoted here only as its tail: the step opens "If the uri-path is
+    // empty or if the first character of the uri-" and the document's line
+    // break lands inside `uri-path`, so the sentence cannot be quoted whole.
+    // cite(RFC 6265 § 5.1.4): "output %x2F ("/") and skip the remaining steps."
+    if !p.starts_with('/') {
+        return "/".into();
+    }
+    // cite(RFC 6265 § 5.1.4): "If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step."
+    if p.matches('/').count() <= 1 {
+        return "/".into();
+    }
+    // cite(RFC 6265 § 5.1.4): "Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/")."
+    match p.rfind('/') {
+        Some(0) | None => "/".into(),
+        Some(pos) => p[..pos].to_string(),
+    }
+}
+
 /// Parse a `Set-Cookie` header value into a `Cookie` struct, using the
 /// request URI and timestamp to derive default domain/path and compute
 /// expiration.  Returns `None` if the value cannot be parsed at all.
@@ -157,12 +254,11 @@ pub fn parse_set_cookie(
     request_uri: &str,
     timestamp: chrono::DateTime<chrono::Utc>,
 ) -> Option<Cookie> {
-    let parts: Vec<&str> = header_value.split(';').map(|p| p.trim()).collect();
-    if parts.is_empty() || parts[0].is_empty() {
+    let (pair, attributes) = split_set_cookie(header_value);
+    if pair.is_empty() {
         return None;
     }
 
-    let pair = parts[0];
     let mut kv = pair.splitn(2, '=');
     let name = kv.next()?.trim().to_string();
     let value = kv.next().unwrap_or("").trim().to_string();
@@ -174,14 +270,9 @@ pub fn parse_set_cookie(
     let mut expires_attr: Option<chrono::DateTime<chrono::Utc>> = None;
     let mut same_site = SameSite::Unspecified;
 
-    for attr in parts.iter().skip(1) {
-        if attr.is_empty() {
-            continue;
-        }
-        let mut av = attr.splitn(2, '=');
-        let key = av.next().unwrap().trim().to_ascii_lowercase();
-        let val_opt = av.next().map(|v| v.trim());
-        match key.as_str() {
+    for attr in attributes {
+        let val_opt = attr.value;
+        match attr.name.to_ascii_lowercase().as_str() {
             "domain" => {
                 if let Some(v) = val_opt {
                     // cookie domains ignore leading dot per modern spec
@@ -232,59 +323,12 @@ pub fn parse_set_cookie(
         }
     }
 
-    // Determine default domain from request URI (host portion)
-    let default_domain = if let Some(idx) = request_uri.find("://") {
-        let after = &request_uri[idx + 3..];
-        let hostport = after.split('/').next().unwrap_or("");
-        hostport
-            .split(':')
-            .next()
-            .unwrap_or("")
-            .to_ascii_lowercase()
-    } else {
-        // if we can't parse the URI, fall back to empty so rule later will
-        // not match anything
-        "".to_string()
-    };
-
     // No Domain attribute → host-only cookie bound to the request-host.
     // cite(RFC 6265 § 5.3): "Set the cookie's host-only-flag to true."
     let host_only = domain_attr.is_none();
-    let domain = domain_attr.unwrap_or(default_domain);
+    let domain = domain_attr.unwrap_or_else(|| default_domain(request_uri));
 
-    // The branches below are § 5.1.4's numbered steps, in its order.
-    // cite(RFC 6265 § 5.1.4): "The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:"
-    let default_path =
-        if let Some(p) = crate::helpers::uri::extract_path_from_request_target(request_uri) {
-            // Step 2. Quoted here only as its tail: the step opens "If the uri-path is
-            // empty or if the first character of the uri-" and the document's line
-            // break lands inside `uri-path`, so the sentence cannot be quoted whole.
-            // cite(RFC 6265 § 5.1.4): "output %x2F ("/") and skip the remaining steps."
-            if !p.starts_with('/') {
-                "/".into()
-            } else {
-                // cite(RFC 6265 § 5.1.4): "If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step."
-                let slash_count = p.matches('/').count();
-                if slash_count <= 1 {
-                    "/".into()
-                } else {
-                    // cite(RFC 6265 § 5.1.4): "Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/")."
-                    if let Some(pos) = p.rfind('/') {
-                        if pos == 0 {
-                            "/".into()
-                        } else {
-                            p[..pos].to_string()
-                        }
-                    } else {
-                        "/".into()
-                    }
-                }
-            }
-        } else {
-            "/".into()
-        };
-
-    let path = path_attr.unwrap_or(default_path);
+    let path = path_attr.unwrap_or_else(|| default_path(request_uri));
 
     // compute expiration time from Max-Age or Expires
     let expiration = if let Some(n) = max_age {

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -42,6 +42,200 @@ const RFC_9110_5_6_7: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "HTTP-date (IMF-fixdate) — used for the `Expires` attribute",
 };
 
+impl CookieAttributeConsistent {
+    /// The first defect in one `Set-Cookie` field line, if it has one.
+    ///
+    /// The line is a cookie-pair and then attributes, and those are two
+    /// different grammars: the pair is judged here, each attribute by
+    /// [`Self::attribute_defect`], and the one question that needs both — a
+    /// `SameSite=None` cookie that is not `Secure` — after the walk.
+    fn set_cookie_defect(&self, line: &str, severity: crate::lint::Severity) -> Option<Violation> {
+        let (pair, attributes) = crate::helpers::cookie::split_set_cookie(line);
+        if pair.is_empty() {
+            return Some(self.violation(severity, "Set-Cookie header missing cookie-pair".into()));
+        }
+
+        let name = pair.split('=').next().unwrap_or("").trim();
+        if name.is_empty() {
+            return Some(self.violation(severity, "Set-Cookie cookie name is empty".into()));
+        }
+        // cite(RFC 6265 § 4.1.1): "cookie-pair       = cookie-name "=" cookie-value cookie-name       = token"
+        if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
+            return Some(self.cited(
+                &RFC_6265_4_1_1,
+                severity,
+                format!("Set-Cookie cookie-name contains invalid character: '{}'", c),
+            ));
+        }
+
+        let mut secure_present = false;
+        let mut same_site: Option<String> = None;
+        for attribute in attributes {
+            if let Some(defect) = self.attribute_defect(&attribute, severity) {
+                return Some(defect);
+            }
+            // Past the defect check the values are known good, so what is
+            // recorded here is what the sender successfully asked for.
+            if attribute.is("secure") {
+                secure_present = true;
+            } else if attribute.is("samesite") {
+                same_site = attribute.value.map(|v| v.to_ascii_lowercase());
+            }
+        }
+
+        // `SameSite=None` without `Secure` is not a cookie with a weaker policy — it is
+        // a cookie the user agent throws away. That is why this is a violation and not
+        // a suggestion.
+        // cite(draft-ietf-httpbis-rfc6265bis § 5.7): "If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true."
+        if same_site.as_deref() == Some("none") && !secure_present {
+            return Some(self.violation(
+                severity,
+                "Set-Cookie with 'SameSite=None' must also set 'Secure'".into(),
+            ));
+        }
+        None
+    }
+
+    /// What is wrong with one `cookie-av`, if anything.
+    ///
+    /// An attribute this rule does not know is not a defect: the grammar ends
+    /// in `extension-av`, and a user agent ignores what it does not recognise.
+    // cite(RFC 6265 § 4.1.1): "extension-av      = <any CHAR except CTLs or ";">"
+    fn attribute_defect(
+        &self,
+        attribute: &crate::helpers::cookie::Attribute<'_>,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        // The two flag attributes: the grammar admits no "=", so the attribute
+        // is its own presence and a value written after it is a defect.
+        // cite(RFC 6265 § 4.1.1): "secure-av         = "Secure""
+        // cite(RFC 6265 § 4.1.1): "httponly-av       = "HttpOnly""
+        for flag in ["Secure", "HttpOnly"] {
+            if attribute.is(flag) {
+                return attribute.has_value().then(|| {
+                    self.cited(
+                        &RFC_6265_4_1_1,
+                        severity,
+                        format!("Set-Cookie attribute '{}' must not have a value", flag),
+                    )
+                });
+            }
+        }
+
+        if attribute.is("SameSite") {
+            let Some(value) = attribute.value else {
+                return Some(self.violation(
+                    severity,
+                    "Set-Cookie attribute 'SameSite' requires a value".into(),
+                ));
+            };
+            // cite(draft-ietf-httpbis-rfc6265bis § 4.1.1): "samesite-value = "Strict" / "Lax" / "None""
+            let known = ["strict", "lax", "none"]
+                .iter()
+                .any(|known| value.eq_ignore_ascii_case(known));
+            return (!known).then(|| {
+                self.violation(
+                    severity,
+                    format!(
+                        "Set-Cookie attribute 'SameSite' has invalid value: '{}'",
+                        value
+                    ),
+                )
+            });
+        }
+
+        if attribute.is("Max-Age") {
+            let Some(value) = attribute.value else {
+                return Some(self.violation(
+                    severity,
+                    "Set-Cookie attribute 'Max-Age' requires a numeric value".into(),
+                ));
+            };
+            // A leading "-" is accepted on purpose: the ABNF says non-zero-digit
+            // *DIGIT, but the parsing algorithm the ABNF is a summary of admits a
+            // sign, and a negative Max-Age is how a cookie is deleted.
+            // `parse::<i64>` enforces both of §5.2.2's processing gates: a
+            // valid first character *and* an all-DIGIT remainder.
+            // cite(RFC 6265 § 5.2.2): "If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av."
+            // cite(RFC 6265 § 5.2.2): "If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av."
+            return value.parse::<i64>().is_err().then(|| {
+                self.cited(
+                    &RFC_6265_5_2_2,
+                    severity,
+                    format!(
+                        "Set-Cookie attribute 'Max-Age' is not a valid integer: '{}'",
+                        value
+                    ),
+                )
+            });
+        }
+
+        if attribute.is("Expires") {
+            let Some(value) = attribute.value else {
+                return Some(self.violation(
+                    severity,
+                    "Set-Cookie attribute 'Expires' requires a HTTP-date value".into(),
+                ));
+            };
+            // cite(RFC 6265 § 4.1.1): "expires-av        = "Expires=" sane-cookie-date"
+            return (!crate::http_date::is_valid_http_date(value)).then(|| {
+                self.cited(
+                    &RFC_6265_4_1_1,
+                    severity,
+                    format!(
+                        "Set-Cookie attribute 'Expires' is not a valid HTTP-date: '{}'",
+                        value
+                    ),
+                )
+            });
+        }
+
+        if attribute.is("Path") {
+            let Some(value) = attribute.value else {
+                return Some(self.violation(
+                    severity,
+                    "Set-Cookie attribute 'Path' requires a value".into(),
+                ));
+            };
+            return (!value.starts_with('/')).then(|| {
+                self.violation(
+                    severity,
+                    format!(
+                        "Set-Cookie attribute 'Path' should start with '/': '{}'",
+                        value
+                    ),
+                )
+            });
+        }
+
+        if attribute.is("Domain") {
+            let Some(value) = attribute.value else {
+                return Some(self.violation(
+                    severity,
+                    "Set-Cookie attribute 'Domain' requires a value".into(),
+                ));
+            };
+            if value.is_empty() {
+                return Some(self.violation(
+                    severity,
+                    "Set-Cookie attribute 'Domain' must not be empty".into(),
+                ));
+            }
+            return value.contains(' ').then(|| {
+                self.violation(
+                    severity,
+                    format!(
+                        "Set-Cookie attribute 'Domain' must not contain spaces: '{}'",
+                        value
+                    ),
+                )
+            });
+        }
+
+        None
+    }
+}
+
 impl Rule for CookieAttributeConsistent {
     fn id(&self) -> &'static str {
         "cookie_attribute_consistent"
@@ -59,243 +253,19 @@ impl Rule for CookieAttributeConsistent {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
-        let finding =
-            || -> Option<Violation> {
-                let resp = tx.response.as_ref()?;
-
-                for hv in resp.headers.get_all("set-cookie").iter() {
-                    let s = match hv.to_str() {
-                        Ok(v) => v,
-                        Err(_) => {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Set-Cookie header value is not valid UTF-8".into(),
-                            ))
-                        }
-                    };
-
-                    // Split into cookie-pair and attribute segments
-                    let parts = s.split(';').map(|p| p.trim()).collect::<Vec<_>>();
-                    if parts.is_empty() || parts[0].is_empty() {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Set-Cookie header missing cookie-pair".into(),
-                        ));
-                    }
-
-                    // Validate cookie-name token
-                    let pair = parts[0];
-                    let mut split = pair.splitn(2, '=');
-                    let name = split.next().unwrap_or("").trim();
-                    if name.is_empty() {
-                        return Some(
-                            self.violation(ctx.severity, "Set-Cookie cookie name is empty".into()),
-                        );
-                    }
-
-                    // cite(RFC 6265 § 4.1.1): "cookie-pair       = cookie-name "=" cookie-value cookie-name       = token"
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-                        return Some(self.cited(
-                            &RFC_6265_4_1_1,
-                            ctx.severity,
-                            format!("Set-Cookie cookie-name contains invalid character: '{}'", c),
-                        ));
-                    }
-
-                    // Track attributes
-                    let mut secure_present = false;
-                    let mut samesite_value: Option<String> = None;
-
-                    for attr in parts.iter().skip(1) {
-                        if attr.is_empty() {
-                            // trailing semicolons or accidental empty attributes
-                            continue;
-                        }
-
-                        // Attribute may be key or key=value
-                        let mut av = attr.splitn(2, '=');
-                        let key = av.next().unwrap().trim();
-                        let val_opt = av.next().map(|v| v.trim());
-
-                        if key.eq_ignore_ascii_case("secure") {
-                            // Secure must be a flag (no '=') per RFC; consider 'Secure=...' invalid.
-                            // The grammar admits no "=" — the attribute is its own presence.
-                            // cite(RFC 6265 § 4.1.1): "secure-av         = "Secure""
-                            if val_opt.is_some() && !val_opt.unwrap().is_empty() {
-                                return Some(self.cited(
-                                    &RFC_6265_4_1_1,
-                                    ctx.severity,
-                                    "Set-Cookie attribute 'Secure' must not have a value".into(),
-                                ));
-                            }
-                            secure_present = true;
-                            continue;
-                        }
-
-                        if key.eq_ignore_ascii_case("httponly") {
-                            // cite(RFC 6265 § 4.1.1): "httponly-av       = "HttpOnly""
-                            if val_opt.is_some() && !val_opt.unwrap().is_empty() {
-                                return Some(self.cited(
-                                    &RFC_6265_4_1_1,
-                                    ctx.severity,
-                                    "Set-Cookie attribute 'HttpOnly' must not have a value".into(),
-                                ));
-                            }
-                            continue;
-                        }
-
-                        if key.eq_ignore_ascii_case("samesite") {
-                            let v = match val_opt {
-                                Some(v) => v,
-                                None => {
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        "Set-Cookie attribute 'SameSite' requires a value".into(),
-                                    ))
-                                }
-                            };
-                            // Accept Strict, Lax, None (case-insensitive)
-                            // cite(draft-ietf-httpbis-rfc6265bis § 4.1.1): "samesite-value = "Strict" / "Lax" / "None""
-                            let vnorm = v.trim().to_ascii_lowercase();
-                            if vnorm != "strict" && vnorm != "lax" && vnorm != "none" {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!(
-                                        "Set-Cookie attribute 'SameSite' has invalid value: '{}'",
-                                        v
-                                    ),
-                                ));
-                            }
-                            samesite_value = Some(vnorm);
-                            continue;
-                        }
-
-                        if key.eq_ignore_ascii_case("max-age") {
-                            let v = match val_opt {
-                                Some(v) => v,
-                                None => return Some(
-                                    self.violation(
-                                        ctx.severity,
-                                        "Set-Cookie attribute 'Max-Age' requires a numeric value"
-                                            .into(),
-                                    ),
-                                ),
-                            };
-                            // A leading "-" is accepted on purpose: the ABNF says non-zero-digit
-                            // *DIGIT, but the parsing algorithm the ABNF is a summary of admits a
-                            // sign, and a negative Max-Age is how a cookie is deleted.
-                            // `parse::<i64>` enforces both of §5.2.2's processing gates: a
-                            // valid first character *and* an all-DIGIT remainder.
-                            // cite(RFC 6265 § 5.2.2): "If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av."
-                            // cite(RFC 6265 § 5.2.2): "If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av."
-                            if v.parse::<i64>().is_err() {
-                                return Some(self.cited(
-                                    &RFC_6265_5_2_2,
-                                    ctx.severity,
-                                    format!(
-                                    "Set-Cookie attribute 'Max-Age' is not a valid integer: '{}'",
-                                    v
-                                ),
-                                ));
-                            }
-                            continue;
-                        }
-
-                        if key.eq_ignore_ascii_case("expires") {
-                            let v = match val_opt {
-                                Some(v) => v,
-                                None => return Some(
-                                    self.violation(
-                                        ctx.severity,
-                                        "Set-Cookie attribute 'Expires' requires a HTTP-date value"
-                                            .into(),
-                                    ),
-                                ),
-                            };
-                            // cite(RFC 6265 § 4.1.1): "expires-av        = "Expires=" sane-cookie-date"
-                            if !crate::http_date::is_valid_http_date(v) {
-                                return Some(self.cited(
-                                    &RFC_6265_4_1_1,
-                                    ctx.severity,
-                                    format!(
-                                    "Set-Cookie attribute 'Expires' is not a valid HTTP-date: '{}'",
-                                    v
-                                ),
-                                ));
-                            }
-                            continue;
-                        }
-
-                        if key.eq_ignore_ascii_case("path") {
-                            let v = match val_opt {
-                                Some(v) => v,
-                                None => {
-                                    // path with no value is acceptable? flag it
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        "Set-Cookie attribute 'Path' requires a value".into(),
-                                    ));
-                                }
-                            };
-                            if !v.starts_with('/') {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!(
-                                        "Set-Cookie attribute 'Path' should start with '/': '{}'",
-                                        v
-                                    ),
-                                ));
-                            }
-                            continue;
-                        }
-
-                        if key.eq_ignore_ascii_case("domain") {
-                            let v = match val_opt {
-                                Some(v) => v,
-                                None => {
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        "Set-Cookie attribute 'Domain' requires a value".into(),
-                                    ))
-                                }
-                            };
-                            if v.is_empty() {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    "Set-Cookie attribute 'Domain' must not be empty".into(),
-                                ));
-                            }
-                            if v.contains(' ') {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!(
-                                    "Set-Cookie attribute 'Domain' must not contain spaces: '{}'",
-                                    v
-                                ),
-                                ));
-                            }
-                            continue;
-                        }
-
-                        // Unknown attribute: don't flag by default
-                    }
-
-                    // `SameSite=None` without `Secure` is not a cookie with a weaker policy — it is
-                    // a cookie the user agent throws away. That is why this is a violation and not
-                    // a suggestion.
-                    // cite(draft-ietf-httpbis-rfc6265bis § 5.7): "If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true."
-                    if let Some(sv) = samesite_value {
-                        if sv == "none" && !secure_present {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Set-Cookie with 'SameSite=None' must also set 'Secure'".into(),
-                            ));
-                        }
-                    }
-                }
-
-                None
-            };
+        let finding = || -> Option<Violation> {
+            let resp = tx.response.as_ref()?;
+            resp.headers
+                .get_all("set-cookie")
+                .iter()
+                .find_map(|line| match line.to_str() {
+                    Err(_) => Some(self.violation(
+                        ctx.severity,
+                        "Set-Cookie header value is not valid UTF-8".into(),
+                    )),
+                    Ok(line) => self.set_cookie_defect(line, ctx.severity),
+                })
+        };
         Vec::from_iter(finding())
     }
 

--- a/lint-http-rules/src/rules/cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/cookie_lifecycle.rs
@@ -36,6 +36,118 @@ const RFC_6265_5_1_4: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "Path matching",
 };
 
+/// The request a cookie is being sent on, in the three terms a cookie is
+/// matched against.
+struct RequestScope {
+    scheme: String,
+    host: String,
+    path: String,
+}
+
+impl RequestScope {
+    fn of(request_uri: &str) -> Self {
+        Self {
+            scheme: if request_uri.to_ascii_lowercase().starts_with("https://") {
+                "https".into()
+            } else {
+                "http".into()
+            },
+            host: crate::helpers::uri::extract_host_from_request_target(request_uri)
+                .unwrap_or_default(),
+            path: crate::helpers::uri::extract_path_from_request_target(request_uri)
+                .unwrap_or_else(|| "/".into()),
+        }
+    }
+
+    /// Whether a stored cookie would be sent on this request.
+    // cite(RFC 6265 § 5.4): "The user agent MUST use an algorithm equivalent to the following algorithm to compute the "cookie-string" from a cookie store and a request-uri:"
+    fn applies(&self, cookie: &crate::helpers::cookie::Cookie) -> bool {
+        cookie.domain_matches(&self.host)
+            && cookie.path_matches(&self.path)
+            && (!cookie.secure || self.scheme == "https")
+    }
+}
+
+/// Whether a cookie the client sent was ever set, and how closely.
+enum PreviouslySet {
+    /// Never seen set for this request's host — it may predate the capture.
+    Never,
+    /// Seen set for the host, but never for a path this request matches.
+    ForAnotherPath,
+    /// Seen set for host and path, so it was applicable once and is not now.
+    AndApplicable,
+}
+
+/// Search the history for a `Set-Cookie` that would have put `name` in the
+/// store for this request.
+///
+/// The history is walked in whatever order it comes in: `AndApplicable` ends
+/// the walk wherever it is found, and `ForAnotherPath` is true of the whole
+/// history or of none of it, so neither answer depends on the order.
+fn previously_set(
+    history: &crate::transaction_history::TransactionHistory,
+    name: &str,
+    request: &RequestScope,
+) -> PreviouslySet {
+    let mut for_another_path = false;
+    for (past, resp) in history.responses() {
+        for line in crate::helpers::headers::field_lines(&resp.headers, "set-cookie") {
+            let Some(cookie) =
+                crate::helpers::cookie::parse_set_cookie(line, &past.request.uri, past.timestamp)
+            else {
+                continue;
+            };
+            if cookie.name != name || !cookie.domain_matches(&request.host) {
+                continue;
+            }
+            if cookie.path_matches(&request.path) {
+                return PreviouslySet::AndApplicable;
+            }
+            for_another_path = true;
+        }
+    }
+    if for_another_path {
+        PreviouslySet::ForAnotherPath
+    } else {
+        PreviouslySet::Never
+    }
+}
+
+impl CookieLifecycle {
+    /// A cookie marked `Secure` is not sent over an insecure channel.
+    ///
+    /// The stored cookie is matched on name *and value*, not name alone: the
+    /// `Cookie` header omits domain and path, so a name-only match would flag a
+    /// legitimate non-secure cookie whenever a secure one shares its name. The
+    /// stale-value check that follows catches the mismatches this misses.
+    // cite(RFC 6265 § 4.1.2.5): "The Secure attribute limits the scope of the cookie to "secure" channels"
+    fn secure_cookie_stayed_on_https(
+        &self,
+        live: &[crate::helpers::cookie::Cookie],
+        request: &RequestScope,
+        name: &str,
+        value: &str,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        if request.scheme == "https" {
+            return None;
+        }
+        let sent_a_secure_cookie = live.iter().any(|c| {
+            c.name == name
+                && c.value == value
+                && c.secure
+                && c.domain_matches(&request.host)
+                && c.path_matches(&request.path)
+        });
+        sent_a_secure_cookie.then(|| {
+            self.violation(
+                severity,
+                format!("Secure cookie '{}' sent over insecure transport", name),
+            )
+        })
+    }
+}
+
 impl Rule for CookieLifecycle {
     fn id(&self) -> &'static str {
         "cookie_lifecycle"
@@ -56,171 +168,73 @@ impl Rule for CookieLifecycle {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // only care about outgoing requests that carry Cookie headers
-            let cookie_headers: Vec<_> = tx.request.headers.get_all("cookie").iter().collect();
-            if cookie_headers.is_empty() {
+            // Only requests that carry cookies say anything about the store.
+            let sent: Vec<(String, String)> =
+                crate::helpers::headers::field_lines(&tx.request.headers, "cookie")
+                    .flat_map(crate::helpers::cookie::parse_cookie_header)
+                    .collect();
+            if sent.is_empty() {
                 return None;
             }
 
-            // parse request host, path, and scheme for matching
-            let req_uri = &tx.request.uri;
-            let scheme = if req_uri.to_ascii_lowercase().starts_with("https://") {
-                "https"
-            } else {
-                "http"
-            };
+            let request = RequestScope::of(&tx.request.uri);
+            // Already filtered to what is unexpired at this request's time.
+            let live = crate::helpers::cookie::build_cookie_store(history, tx.timestamp);
 
-            // extract host portion (without port) using shared helper
-            let req_host =
-                crate::helpers::uri::extract_host_from_request_target(req_uri).unwrap_or_default();
-
-            let req_path = crate::helpers::uri::extract_path_from_request_target(req_uri)
-                .unwrap_or_else(|| "/".into());
-
-            // Grab a flat slice of history once so we don't re-allocate every
-            // time we need to walk it.  `TransactionHistory::iter()` yields
-            // &HttpTransaction in oldest-first order, so reversing it gives
-            // newest-first which we later want when scanning for domain/path
-            // reasons.
-            let history_items: Vec<_> = history.iter().collect();
-
-            // Build live cookie store using helper; it already filters out
-            // expired entries up to the current request timestamp.
-            let live_cookies = crate::helpers::cookie::build_cookie_store(history, tx.timestamp);
-
-            // Parse cookie header(s) into name/value pairs.  Multiple header
-            // fields are concatenated per RFC 6265 §4.2.
-            let mut sent_pairs: Vec<(String, String)> = Vec::new();
-            for hv in cookie_headers.iter() {
-                if let Ok(s) = hv.to_str() {
-                    sent_pairs.extend(crate::helpers::cookie::parse_cookie_header(s));
+            for (name, value) in sent {
+                if let Some(v) =
+                    self.secure_cookie_stayed_on_https(&live, &request, &name, &value, ctx.severity)
+                {
+                    return Some(v);
                 }
-            }
 
-            // examine each sent cookie for violations
-            for (name, value) in sent_pairs {
-                // search for the *best* applicable live cookie.  RFC 6265
-                // specifies that user agents should include the cookie with the
-                // most specific path (longest) when multiple match.  Domain
-                // specificity is approximated by longer domain string (more
-                // labels); history order is already taken into account when the
-                // store was built.  Choose the candidate with the highest "score".
-                // §5.4's cookie-string ordering lists the most specific cookie
-                // first; we borrow that ordering here to decide which stored cookie
-                // a bare `name=value` pair (the Cookie header carries no path or
-                // domain) is meant to be — the longest-path, then longest-domain,
-                // candidate is the authoritative value.
+                // The Cookie header carries no domain or path, so which stored
+                // cookie a bare `name=value` pair *is* has to be decided: §5.4's
+                // cookie-string ordering lists the most specific first, and that
+                // ordering is borrowed here to pick the authoritative value —
+                // longest path, then longest domain.
                 // cite(RFC 6265 § 5.4): "Cookies with longer paths are listed before cookies with shorter paths."
-                let mut matching_live: Option<&crate::helpers::cookie::Cookie> = None;
-                for c in &live_cookies {
-                    if c.name == name
-                        && c.domain_matches(&req_host)
-                        && c.path_matches(&req_path)
-                        && (!c.secure || scheme == "https")
-                    {
-                        let better = if let Some(existing) = matching_live {
-                            let existing_score = (existing.path.len(), existing.domain.len());
-                            let this_score = (c.path.len(), c.domain.len());
-                            this_score > existing_score
-                        } else {
-                            true
-                        };
-                        if better {
-                            matching_live = Some(c);
-                        }
-                    }
-                }
+                let applicable = live
+                    .iter()
+                    .filter(|c| request.applies(c) && c.name == name)
+                    // `min_by_key` on the reversed key keeps the *first* of
+                    // equally specific candidates, which is the order the store
+                    // was built in.
+                    .min_by_key(|c| std::cmp::Reverse((c.path.len(), c.domain.len())));
 
-                // check for secure-over-http violation first.  Rather than just
-                // looking for any stored secure cookie with the same name we
-                // also compare the value, because the Cookie header omits
-                // domain/path attributes.  Without the value check a more
-                // specific non-secure cookie could be sent without warning, yet
-                // the rule would still flag because a different secure cookie of
-                // the same name exists.  Matching on (name,value) reduces false
-                // positives; the following stale-value check will catch other
-                // mismatches.
-                if scheme != "https" {
-                    // only flag if the client actually sent the exact same
-                    // name/value pair we know was marked secure and applicable to
-                    // this request.
-                    if live_cookies.iter().any(|c| {
-                        c.name == name
-                            && c.value == value
-                            && c.secure
-                            && c.domain_matches(&req_host)
-                            && c.path_matches(&req_path)
-                    }) {
-                        // cite(RFC 6265 § 4.1.2.5): "The Secure attribute limits the scope of the cookie to "secure" channels"
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!("Secure cookie '{}' sent over insecure transport", name),
-                        ));
-                    }
-                }
-
-                if let Some(c) = matching_live {
-                    // live cookie exists; ensure value matches
-                    if c.value != value {
+                if let Some(applicable) = applicable {
+                    if applicable.value != value {
                         return Some(self.violation(ctx.severity, format!(
                                 "Cookie '{}' value '{}' does not match stored value '{}', likely stale",
-                                name, value, c.value
+                                name, value, applicable.value
                             )));
                     }
-                } else {
-                    // no live cookie.  inspect history to see why it isn't live:
-                    // * expired/removed (domain+path match), or
-                    // * path restriction prevented it while domain still matches.
-                    let mut seen_domain = false;
-                    let mut seen_path = false;
-                    for prev in history_items.iter().rev() {
-                        if let Some(resp) = &prev.response {
-                            for hv in resp.headers.get_all("set-cookie").iter() {
-                                if let Ok(s) = hv.to_str() {
-                                    if let Some(cookie) = crate::helpers::cookie::parse_set_cookie(
-                                        s,
-                                        &prev.request.uri,
-                                        prev.timestamp,
-                                    ) {
-                                        if cookie.name == name && cookie.domain_matches(&req_host) {
-                                            seen_domain = true;
-                                            if cookie.path_matches(&req_path) {
-                                                seen_path = true;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if seen_path {
-                            break;
-                        }
-                    }
-                    if seen_path {
-                        // there was a matching cookie in the past but it is no longer
-                        // live (either expired, deleted, or replaced by another). A client
-                        // still sending it has a store the user agent was required to have
-                        // emptied.
-                        // cite(RFC 6265 § 5.3): "The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store."
+                    continue;
+                }
+
+                // Nothing live by that name. Why not?
+                match previously_set(history, &name, &request) {
+                    // It was live once and is not now, so the client is holding
+                    // a store the user agent was required to have emptied.
+                    // cite(RFC 6265 § 5.3): "The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store."
+                    PreviouslySet::AndApplicable => {
                         return Some(self.cited(&RFC_6265_5_3, ctx.severity, format!(
                                 "Cookie '{}' was previously set but is expired or removed and should not be sent",
                                 name
-                            )));
+                            )))
                     }
-                    if seen_domain {
-                        // a cookie existed for the domain but path did not match
+                    PreviouslySet::ForAnotherPath => {
                         return Some(self.violation(
                             ctx.severity,
                             format!(
                                 "Cookie '{}' is not valid for path '{}' and should not be sent",
-                                name, req_path
+                                name, request.path
                             ),
-                        ));
+                        ))
                     }
+                    // The cookie may predate the capture; assume it is legitimate.
+                    PreviouslySet::Never => {}
                 }
-                // otherwise, the cookie may predate our history; assume it's
-                // legitimate and do not flag.
             }
 
             None

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -991,16 +991,18 @@ severity = "warn"
     /// site became a `violation()` one: say why in the commit or put it back.
     ///
     /// **Two finding sites merging into one lowers this number without losing a
-    /// citation**, and that is the only reason it has ever moved down: the
-    /// `Date` field's request and response readings were two copies of the same
-    /// two findings and now share one function, which cites what both cited.
-    /// The count of *sites* is not the count of sentences read, so when a
-    /// duplicate disappears, lower the floor and say which one.
+    /// citation**, and that is the only reason it has ever moved down. Twice so
+    /// far: the `Date` field's request and response readings were two copies of
+    /// the same two findings and now share one function, and `Secure` and
+    /// `HttpOnly` — one sentence each, the same defect, the same wording — are
+    /// now one site over both names. Each still cites what it cited; the count
+    /// of *sites* is not the count of sentences read, so when a duplicate
+    /// disappears, lower the floor and say which one.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce, out
-        /// of 579. The rest are the per-rule reading that has not happened yet.
-        const FLOOR: usize = 172;
+        /// of 578. The rest are the per-rule reading that has not happened yet.
+        const FLOOR: usize = 171;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -707,13 +707,13 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 158
+      line: 132
   - label: cookie_attribute_consistent (2)
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 286
+      line: 89
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
@@ -1989,37 +1989,43 @@ sources:
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 96
+      line: 62
   - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 215
+      line: 180
   - label: cookie_attribute_consistent (3)
+    section: § 4.1.1
+    snippet: extension-av      = <any CHAR except CTLs or ";">
+    cited_by:
+    - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
+      line: 103
+  - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 136
-  - label: cookie_attribute_consistent (4)
+      line: 112
+  - label: cookie_attribute_consistent (5)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 123
-  - label: cookie_attribute_consistent (5)
+      line: 111
+  - label: cookie_attribute_consistent (6)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 189
-  - label: cookie_attribute_consistent (6)
+      line: 159
+  - label: cookie_attribute_consistent (7)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 190
+      line: 160
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
@@ -2049,25 +2055,43 @@ sources:
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 154
+      line: 123
   - label: cookie_lifecycle (2)
     section: § 5.3
     snippet: The user agent MUST evict all expired cookies from the cookie store if, at any time, an expired cookie exists in the cookie store.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 205
+      line: 219
   - label: cookie_lifecycle (3)
     section: § 5.4
     snippet: Cookies with longer paths are listed before cookies with shorter paths.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
-      line: 113
+      line: 196
+  - label: cookie_lifecycle (4)
+    section: § 5.4
+    snippet: 'The user agent MUST use an algorithm equivalent to the following algorithm to compute the "cookie-string" from a cookie store and a request-uri:'
+    cited_by:
+    - file: lint-http-rules/src/rules/cookie_lifecycle.rs
+      line: 63
   - label: lint-http-rules/src/helpers/cookie.rs
     section: § 4.1.1
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 39
+  - label: lint-http-rules/src/helpers/cookie.rs (2)
+    section: § 4.1.1
+    snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 158
+  - label: lint-http-rules/src/helpers/cookie.rs (3)
+    section: § 4.1.1
+    snippet: set-cookie-string = cookie-pair *( ";" SP cookie-av )
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 184
   - label: cookie domain-match
     section: § 5.1.3
     snippet: A string domain-matches a given domain string if at least one of the following conditions hold
@@ -2080,45 +2104,53 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 129
-  - label: lint-http-rules/src/helpers/cookie.rs (2)
+  - label: lint-http-rules/src/helpers/cookie.rs (4)
     section: § 5.1.4
     snippet: If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 266
-  - label: lint-http-rules/src/helpers/cookie.rs (3)
+      line: 238
+  - label: lint-http-rules/src/helpers/cookie.rs (5)
     section: § 5.1.4
     snippet: Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 271
-  - label: lint-http-rules/src/helpers/cookie.rs (4)
+      line: 242
+  - label: lint-http-rules/src/helpers/cookie.rs (6)
     section: § 5.1.4
     snippet: 'The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 256
-  - label: lint-http-rules/src/helpers/cookie.rs (5)
+      line: 226
+  - label: lint-http-rules/src/helpers/cookie.rs (7)
     section: § 5.1.4
     snippet: output %x2F ("/") and skip the remaining steps.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 262
+      line: 234
+  - label: lint-http-rules/src/helpers/cookie.rs (8)
+    section: § 5.2.1
+    snippet: If the attribute-name case-insensitively matches the string "Expires", the user agent MUST process the cookie-av as follows.
+    cited_by:
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 166
   - label: cookie Path attribute
     section: § 5.2.4
     snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 197
+      line: 288
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
       line: 79
-  - label: lint-http-rules/src/helpers/cookie.rs (6)
+  - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 251
-  - label: lint-http-rules/src/helpers/cookie.rs (7)
+      line: 208
+    - file: lint-http-rules/src/helpers/cookie.rs
+      line: 327
+  - label: lint-http-rules/src/helpers/cookie.rs (10)
     section: § 5.4
     snippet: The cookie's host-only-flag is true and the canonicalized request-host is identical to the cookie's domain.
     cited_by:


### PR DESCRIPTION
The parser and the rule that reports attribute defects were each splitting the field line themselves, on the same two characters, and neither could say what the other did with an empty segment or with an `=` carrying nothing after it. `split_set_cookie` returns the cookie-pair as written and the attributes with the stray-semicolon segments already dropped, and `Attribute` is where the flag attributes' question — was a value written at all — is asked once instead of three times.

The default-domain and default-path derivations move out of the parser and under their own names; §5.1.4's numbered steps stay in the parser's order, because the correspondence to the document is the point of them.

`cookie_lifecycle` grows the two models it was doing without: `RequestScope` for the three terms a stored cookie is matched against, and `PreviouslySet` for the question it asks when nothing live matches — was this cookie ever set for this host, and was it ever set for a path this request matches. The history walk that answered it was reversed by hand, on a comment about the ordering that the container contradicts; neither answer depends on the order, and the code now says which.

The citation floor drops by one for the same reason as the last: `Secure` and `HttpOnly` are one sentence each, the same defect and the same wording, and are now one site over both names.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
