### PR TITLE
The complexity gate is set one point above the tallest function

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,10 +4,16 @@
 
 disallowed-methods = []
 
-# Deliberately above clippy's default of 25. The rules crate is dominated by
-# flat RFC parsers (linear byte scans with early-return error branches) whose
-# complexity is inherent — forcing them under 25 would mean threading parser
-# state across artificial helper boundaries, hurting readability. 30 still bites
-# on genuinely tangled functions (mixed parsing + multi-branch policy, god-style
-# entry points) without penalizing honest parsers.
-cognitive-complexity-threshold = 30
+# Below clippy's default of 25, and one point above the highest function in the
+# tree — which is where this has always been set, so the gate bites on the next
+# function to grow rather than on a backlog.
+#
+# It stood at 30 on the reasoning that the rules crate is dominated by flat RFC
+# parsers whose complexity is inherent. That was true of the parsers and false
+# of what was actually at the ceiling: every function that hit 30 was a
+# *duplicated* answer — eleven readings of Cache-Control that disagreed about
+# where a directive ends, eleven fields checked by eleven copies of one dispatch,
+# a startup sequence and its accept loop and its shutdown in one function. None
+# of them needed parser state threaded across an artificial boundary; each had a
+# name it was missing. Lower this again when the ceiling drops again.
+cognitive-complexity-threshold = 19

--- a/lint-http-proxy/src/proxy/exchange.rs
+++ b/lint-http-proxy/src/proxy/exchange.rs
@@ -26,7 +26,7 @@ use crate::state::ClientIdentifier;
 
 use super::hop_by_hop::{format_http_version, is_hop_by_hop_header, parse_connection_tokens};
 use super::tee_body::{self, CapturedBody};
-use super::upstream_h3::H3Failure;
+use super::upstream_h3::{H3Failure, H3Route, H3UpstreamClient};
 use super::{boxed_full, BoxError, ClientBody, ResponseBody, Shared};
 
 /// The request-side facts every transaction record needs: computed once by the
@@ -150,82 +150,7 @@ pub(super) async fn exchange(
             }
         };
 
-    // Choose the upstream transport at this single seam: HTTP/3 when the origin
-    // authority is on the H3 allowlist (capability-driven, opt-in) and not
-    // currently negative-cached, else the hyper H1/H2 client. Both branches
-    // yield a `Response<ResponseBody>` so the tee/commit machinery below is
-    // identical; the H3 branch stamps the response version as HTTP/3, which is
-    // what lands in `tx.response.version` (a fall-back records its real version).
-    let h3_target = uri.authority().and_then(|a| {
-        let authority = a.as_str();
-        let h3 = shared.upstream.h3.as_ref()?;
-        if h3.is_suppressed(authority) {
-            debug!(%authority, "h3 upstream suppressed by negative cache; using H1/H2");
-            return None;
-        }
-        h3.route_for(authority)
-            .map(|route| (h3, authority.to_string(), route))
-    });
-    if h3_target.is_none() {
-        if let Some(a) = uri.authority() {
-            // Only interesting when H3 is configured at all; otherwise this is
-            // the ordinary H1/H2 path and not worth a line per request.
-            if shared.upstream.h3.is_some() {
-                debug!(authority = %a, "no h3 route for origin; using H1/H2");
-            }
-        }
-    }
-    let resp: Result<hyper::Response<ResponseBody>, String> = if let Some((h3, authority, route)) =
-        h3_target
-    {
-        debug!(%authority, "forwarding upstream over HTTP/3");
-        match h3.forward(upstream_req, &route, shared).await {
-            Ok(r) => {
-                h3.record_success(&authority);
-                Ok(r)
-            }
-            Err(H3Failure::Retryable {
-                error,
-                request,
-                pre_request,
-            }) => {
-                // A connect/handshake failure marks the origin as not currently
-                // reachable over H3. Fall back to H1/H2 when it is safe: always
-                // for a pre-request failure (nothing reached the origin), else
-                // only for an idempotent method (RFC 9110 §9.2.2) — a header-sent
-                // failure of a non-idempotent method must not be blindly retried.
-                if pre_request {
-                    h3.record_failure(&authority);
-                }
-                if pre_request || facts.method.is_idempotent() {
-                    warn!(%authority, error = %error, "h3 upstream unavailable; falling back to H1/H2");
-                    forward_via_hyper(shared, *request).await
-                } else {
-                    Err(format!(
-                        "h3 upstream error (non-idempotent, not retried): {error}"
-                    ))
-                }
-            }
-            Err(H3Failure::Consumed { error }) => {
-                // Request bytes were in flight with no response; the streaming
-                // body cannot be replayed, so surface the failure as-is.
-                Err(format!("h3 upstream error: {error}"))
-            }
-            Err(H3Failure::ResponseTimeout { error, replay }) => match replay {
-                // A slow (not unreachable) origin: the request was fully sent but
-                // no head came in time. Retry an idempotent bodyless request on
-                // H1/H2; do *not* negative-cache — the origin is healthy, just
-                // slow, and suppressing H3 would punish it. Anything else 502s.
-                Some(request) => {
-                    warn!(%authority, error = %error, "h3 upstream response-head timeout; retrying idempotent request via H1/H2");
-                    forward_via_hyper(shared, *request).await
-                }
-                None => Err(format!("h3 upstream response timed out: {error}")),
-            },
-        }
-    } else {
-        forward_via_hyper(shared, upstream_req).await
-    };
+    let resp = forward_upstream(shared, &uri, upstream_req, &facts).await;
     let resp = match resp {
         Ok(r) => r,
         Err(e) => {
@@ -263,7 +188,140 @@ pub(super) async fn exchange(
     // (already sent upstream) and the response body (just read by the client) —
     // so each `body_length` reflects the real total and each captured body is a
     // bounded prefix.
-    let shared = shared.clone();
+    spawn_commit(
+        shared.clone(),
+        facts,
+        started,
+        ResponseFacts {
+            status,
+            version: resp_ver,
+            headers: upstream_headers,
+            // Filled in from the tee once the body has finished streaming.
+            body_length: None,
+            trailers: None,
+        },
+        body_done,
+        done_rx,
+    );
+
+    ProxiedResponse {
+        status,
+        headers: out_headers,
+        body: resp_body,
+    }
+}
+
+/// Forward `req` to the origin, over HTTP/3 where that origin is routable and
+/// currently believed reachable, else over the hyper H1/H2 client.
+///
+/// Both arms yield the same `Response<ResponseBody>`, which is what lets the
+/// tee/commit machinery in [`exchange`] be written once.
+async fn forward_upstream(
+    shared: &Arc<Shared>,
+    uri: &Uri,
+    req: Request<ClientBody>,
+    facts: &RequestFacts,
+) -> Result<hyper::Response<ResponseBody>, String> {
+    let Some((h3, authority, route)) = h3_route(shared, uri) else {
+        return forward_via_hyper(shared, req).await;
+    };
+
+    debug!(%authority, "forwarding upstream over HTTP/3");
+    match h3.forward(req, &route, shared).await {
+        Ok(response) => {
+            h3.record_success(&authority);
+            Ok(response)
+        }
+        Err(failure) => recover_from_h3(shared, h3, &authority, facts, failure).await,
+    }
+}
+
+/// The H3 route for this origin, when there is one to use.
+///
+/// `None` covers three different situations — no H3 client configured, the
+/// origin not on the allowlist, and the origin negative-cached after a recent
+/// failure — and only the last two are worth a log line, since the first is the
+/// ordinary H1/H2 path.
+fn h3_route<'a>(
+    shared: &'a Arc<Shared>,
+    uri: &Uri,
+) -> Option<(&'a H3UpstreamClient, String, H3Route)> {
+    let h3 = shared.upstream.h3.as_ref()?;
+    let authority = uri.authority()?.as_str();
+
+    if h3.is_suppressed(authority) {
+        debug!(%authority, "h3 upstream suppressed by negative cache; using H1/H2");
+        return None;
+    }
+    let Some(route) = h3.route_for(authority) else {
+        debug!(%authority, "no h3 route for origin; using H1/H2");
+        return None;
+    };
+    Some((h3, authority.to_string(), route))
+}
+
+/// Decide what an H3 upstream failure becomes: a retry over H1/H2, or an error.
+///
+/// The three failure shapes differ in what reached the origin, and that is what
+/// decides. Nothing reached it (`pre_request`): retry any method, and mark the
+/// origin unreachable. The header section reached it: retry only an idempotent
+/// method (RFC 9110 §9.2.2) — a non-idempotent request must not be blindly
+/// replayed. The request was fully sent and the origin merely slow: retry when
+/// the request can be replayed, and do *not* negative-cache, since the origin is
+/// healthy and suppressing H3 would punish it for being slow.
+async fn recover_from_h3(
+    shared: &Arc<Shared>,
+    h3: &H3UpstreamClient,
+    authority: &str,
+    facts: &RequestFacts,
+    failure: H3Failure,
+) -> Result<hyper::Response<ResponseBody>, String> {
+    match failure {
+        H3Failure::Retryable {
+            error,
+            request,
+            pre_request,
+        } => {
+            if pre_request {
+                h3.record_failure(authority);
+            }
+            if !pre_request && !facts.method.is_idempotent() {
+                return Err(format!(
+                    "h3 upstream error (non-idempotent, not retried): {error}"
+                ));
+            }
+            warn!(%authority, error = %error, "h3 upstream unavailable; falling back to H1/H2");
+            forward_via_hyper(shared, *request).await
+        }
+        // Request bytes were in flight with no response; the streaming body
+        // cannot be replayed, so surface the failure as-is.
+        H3Failure::Consumed { error } => Err(format!("h3 upstream error: {error}")),
+        H3Failure::ResponseTimeout {
+            error,
+            replay: Some(request),
+        } => {
+            warn!(%authority, error = %error, "h3 upstream response-head timeout; retrying idempotent request via H1/H2");
+            forward_via_hyper(shared, *request).await
+        }
+        H3Failure::ResponseTimeout {
+            error,
+            replay: None,
+        } => Err(format!("h3 upstream response timed out: {error}")),
+    }
+}
+
+/// Commit the transaction once both body halves have finished streaming — the
+/// request body (already sent upstream) and the response body (just read by the
+/// client) — so each `body_length` is the real total and each captured body is a
+/// bounded prefix.
+fn spawn_commit(
+    shared: Arc<Shared>,
+    facts: RequestFacts,
+    started: Instant,
+    response: ResponseFacts,
+    body_done: oneshot::Receiver<CapturedBody>,
+    done_rx: oneshot::Receiver<CapturedBody>,
+) {
     tokio::spawn(async move {
         let (req_cap, resp_cap) = tokio::join!(body_done, done_rx);
         let (Ok(req_cap), Ok(resp_cap)) = (req_cap, resp_cap) else {
@@ -279,11 +337,9 @@ pub(super) async fn exchange(
         let mut tx = assemble_transaction(
             &facts,
             ResponseFacts {
-                status,
-                version: resp_ver,
-                headers: upstream_headers,
                 body_length: Some(resp_cap.total),
                 trailers: resp_cap.trailers,
+                ..response
             },
             started.elapsed().as_millis() as u64,
         );
@@ -296,12 +352,6 @@ pub(super) async fn exchange(
 
         shared.pipeline().commit(tx).await;
     });
-
-    ProxiedResponse {
-        status,
-        headers: out_headers,
-        body: resp_body,
-    }
 }
 
 /// Send `req` through the hyper H1/H2 client, boxing its response body into the

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -236,30 +236,15 @@ async fn run_proxy_inner(
     // Load the platform trust store once; the forwarding client and the
     // WebSocket-upgrade path share it.
     let upstream = upstream::Upstream::new(&cfg)?;
-
-    let ca = if cfg.tls.enabled {
-        let cert_path = cfg.tls.ca_cert_path.as_deref().unwrap_or("ca.crt");
-        let key_path = cfg.tls.ca_key_path.as_deref().unwrap_or("ca.key");
-        Some(
-            CertificateAuthority::load_or_generate(
-                std::path::Path::new(cert_path),
-                std::path::Path::new(key_path),
-            )
-            .await?,
-        )
-    } else {
-        None
-    };
+    let ca = load_ca(&cfg).await?;
 
     let ttl = cfg.general.ttl_seconds;
-    let max_history = cfg.general.max_history;
-    let state = Arc::new(crate::state::StateStore::new(ttl, max_history));
+    let state = Arc::new(crate::state::StateStore::new(ttl, cfg.general.max_history));
     let protocol_event_store = Arc::new(crate::protocol_event_store::ProtocolEventStore::new(
         ttl,
         cfg.general.max_protocol_event_history,
     ));
 
-    // Seed state from captures file if enabled
     seed_state_from_captures(&cfg, &state).await;
 
     // Connection bound and drain budget. Read before `cfg` moves into `Shared`.
@@ -267,48 +252,13 @@ async fn run_proxy_inner(
     let shutdown_timeout = Duration::from_secs(cfg.general.shutdown_timeout_seconds);
     let semaphore = Arc::new(Semaphore::new(max_connections));
 
-    // Spawn background cleanup task, cancellable so shutdown can join it.
-    let state_cleanup = state.clone();
-    let pe_store_cleanup = protocol_event_store.clone();
-    let cleanup_shutdown = shutdown.clone();
-    let cleanup_handle = tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(60));
-        loop {
-            tokio::select! {
-                _ = interval.tick() => {
-                    state_cleanup.cleanup_expired();
-                    pe_store_cleanup.cleanup_expired();
-                }
-                _ = cleanup_shutdown.cancelled() => break,
-            }
-        }
-    });
+    let cleanup_handle = spawn_expiry_sweep(state.clone(), protocol_event_store.clone(), &shutdown);
 
-    // Pre-compute QUIC transport parameters and endpoint if HTTP/3 is
-    // configured, so the values can be stored on `Shared` and emitted as
-    // protocol events when connections are established.
-    let (h3_endpoint, quic_transport_params) = if let Some(ref h3_listen) = cfg.general.h3_listen {
-        let h3_addr: SocketAddr = h3_listen.parse()?;
-        let h3_ca = ca
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("h3_listen requires TLS to be enabled"))?
-            .clone();
-        let server_name = cfg
-            .general
-            .h3_server_name
-            .clone()
-            .unwrap_or_else(|| "localhost".to_string());
-        let h3_bind = match listen_h3 {
-            Some(socket) => H3Bind::Bound(socket),
-            None => H3Bind::Addr(h3_addr),
-        };
-        let (endpoint, params) = init_h3_endpoint(h3_bind, &server_name, &h3_ca)?;
-        (Some(endpoint), Some(params))
-    } else {
-        (None, None)
-    };
+    // QUIC parameters are computed before `Shared` because they are stored on
+    // it, to be emitted as protocol events when connections are established.
+    let (h3_endpoint, quic_transport_params) = prepare_h3(&cfg, listen_h3, ca.as_ref())?;
 
-    // Precompute the enabled rule set once; cfg is immutable from here on.
+    // Enabled rule set precomputed once; cfg is immutable from here on.
     let engine = Arc::new(crate::engine::PreparedEngine::new(&cfg)?);
 
     let shared = Arc::new(Shared {
@@ -324,59 +274,161 @@ async fn run_proxy_inner(
         shutdown: shutdown.clone(),
     });
 
-    // Periodically evict idle pooled H3 *upstream* connections. Only spawned when
-    // the H3 upstream client exists; cancelled on shutdown.
-    let pool_sweep_handle = shared.upstream.h3.is_some().then(|| {
-        let shared_sweep = shared.clone();
-        let sweep_shutdown = shutdown.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        if let Some(h3) = shared_sweep.upstream.h3.as_ref() {
-                            h3.sweep_idle();
-                        }
-                    }
-                    _ = sweep_shutdown.cancelled() => break,
-                }
-            }
-        })
-    });
+    let pool_sweep_handle = spawn_h3_pool_sweep(&shared, &shutdown);
 
-    // Start HTTP/3 (QUIC) accept loop if an endpoint was created. It shares the
-    // same connection semaphore as TCP, so `max_connections` bounds both
-    // transports and the drain barrier below waits for live H3 connections too.
+    // The H3 accept loop shares the connection semaphore with TCP, so
+    // `max_connections` bounds both transports and the drain below waits for
+    // live H3 connections too.
     let h3_handle = h3_endpoint.map(|endpoint| {
-        let shared_h3 = shared.clone();
-        let shutdown_h3 = shutdown.clone();
-        let semaphore_h3 = semaphore.clone();
-        tokio::spawn(async move {
-            run_h3_accept_loop(endpoint, shared_h3, shutdown_h3, semaphore_h3).await;
-        })
+        let shared = shared.clone();
+        let shutdown = shutdown.clone();
+        let semaphore = semaphore.clone();
+        tokio::spawn(async move { run_h3_accept_loop(endpoint, shared, shutdown, semaphore).await })
     });
 
-    // Use a manual TcpListener accept loop to preserve the remote address and
-    // avoid relying on the removed `make_service_fn` helper in hyper v1.
+    // A manual accept loop preserves the remote address, which hyper v1 gives
+    // no other way to reach.
     let listener = listen_tcp.into_listener().await?;
     // Read the address back off the socket rather than echoing the request: with
     // `:0` the requested port is 0 and the bound one is what a client needs.
+    //
+    // Bound before it is logged: a tracing field expression is evaluated only
+    // when the level is enabled, so inlining this call would skip both it and
+    // its error propagation whenever INFO is off.
     let listen = listener.local_addr()?;
     info!(%listen, "listening");
+    accept_until_shutdown(listener, &shared, &semaphore, &shutdown, accept_limit).await?;
 
-    let executor = TokioExecutor::new();
-    let server_builder = AutoConnBuilder::new(executor);
+    // Graceful shutdown: stop accepting (done), cancel handlers, then drain.
+    shutdown.cancel();
+    drain_connections(&semaphore, max_connections, shutdown_timeout).await;
 
-    // Accept loop, bounded by the connection semaphore and interruptible by
-    // shutdown. Each accepted connection holds an owned permit for its lifetime,
-    // so the semaphore doubles as the drain barrier below.
-    let mut remaining = accept_limit;
-    loop {
-        if let Some(0) = remaining {
-            break;
+    let _ = cleanup_handle.await;
+    for handle in [h3_handle, pool_sweep_handle].into_iter().flatten() {
+        let _ = handle.await;
+    }
+
+    // Flush, fsync, and join the capture writer last, after all handlers that
+    // could write to it have drained, so no capture line is lost or truncated.
+    if let Err(e) = shared.captures.shutdown().await {
+        warn!(error = %e, "failed to shut down capture writer");
+    }
+
+    Ok(())
+}
+
+/// Load or generate the CA the TLS interception path signs with, when TLS is
+/// enabled at all.
+async fn load_ca(cfg: &Config) -> anyhow::Result<Option<Arc<CertificateAuthority>>> {
+    if !cfg.tls.enabled {
+        return Ok(None);
+    }
+    let cert_path = cfg.tls.ca_cert_path.as_deref().unwrap_or("ca.crt");
+    let key_path = cfg.tls.ca_key_path.as_deref().unwrap_or("ca.key");
+    Ok(Some(
+        CertificateAuthority::load_or_generate(
+            std::path::Path::new(cert_path),
+            std::path::Path::new(key_path),
+        )
+        .await?,
+    ))
+}
+
+/// Build the QUIC endpoint and its transport parameters, when HTTP/3 is
+/// configured. Both are `None` together, and `h3_listen` without TLS is a
+/// configuration error rather than a silent downgrade: the endpoint has no
+/// certificate to present.
+fn prepare_h3(
+    cfg: &Config,
+    listen_h3: Option<std::net::UdpSocket>,
+    ca: Option<&Arc<CertificateAuthority>>,
+) -> anyhow::Result<(
+    Option<quinn::Endpoint>,
+    Option<crate::protocol_event::QuicTransportParameters>,
+)> {
+    let Some(h3_listen) = cfg.general.h3_listen.as_ref() else {
+        return Ok((None, None));
+    };
+    let ca = ca
+        .ok_or_else(|| anyhow::anyhow!("h3_listen requires TLS to be enabled"))?
+        .clone();
+    let server_name = cfg
+        .general
+        .h3_server_name
+        .clone()
+        .unwrap_or_else(|| "localhost".to_string());
+    let bind = match listen_h3 {
+        Some(socket) => H3Bind::Bound(socket),
+        None => H3Bind::Addr(h3_listen.parse()?),
+    };
+    let (endpoint, params) = init_h3_endpoint(bind, &server_name, &ca)?;
+    Ok((Some(endpoint), Some(params)))
+}
+
+/// Spawn the periodic eviction of expired transactions and protocol events,
+/// cancellable so shutdown can join it.
+fn spawn_expiry_sweep(
+    state: Arc<crate::state::StateStore>,
+    protocol_events: Arc<crate::protocol_event_store::ProtocolEventStore>,
+    shutdown: &CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    let shutdown = shutdown.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    state.cleanup_expired();
+                    protocol_events.cleanup_expired();
+                }
+                _ = shutdown.cancelled() => break,
+            }
         }
+    })
+}
 
-        // Reserve a slot first, so we never accept beyond `max_connections`.
+/// Spawn the periodic eviction of idle pooled H3 *upstream* connections. Only
+/// spawned when the H3 upstream client exists.
+fn spawn_h3_pool_sweep(
+    shared: &Arc<Shared>,
+    shutdown: &CancellationToken,
+) -> Option<tokio::task::JoinHandle<()>> {
+    shared.upstream.h3.as_ref()?;
+    let shared = shared.clone();
+    let shutdown = shutdown.clone();
+    Some(tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    if let Some(h3) = shared.upstream.h3.as_ref() {
+                        h3.sweep_idle();
+                    }
+                }
+                _ = shutdown.cancelled() => break,
+            }
+        }
+    }))
+}
+
+/// Accept connections until shutdown is cancelled, or until `accept_limit`
+/// connections have been accepted (which is how the tests bound a run).
+///
+/// The loop is bounded by the connection semaphore: a permit is reserved
+/// *before* accepting, so the count can never exceed `max_connections`, and
+/// each accepted connection holds an owned permit for its lifetime — which is
+/// what makes the semaphore double as the drain barrier.
+async fn accept_until_shutdown(
+    listener: tokio::net::TcpListener,
+    shared: &Arc<Shared>,
+    semaphore: &Arc<Semaphore>,
+    shutdown: &CancellationToken,
+    accept_limit: Option<usize>,
+) -> anyhow::Result<()> {
+    let server_builder = AutoConnBuilder::new(TokioExecutor::new());
+    let mut remaining = accept_limit;
+
+    while remaining != Some(0) {
         let permit = tokio::select! {
             biased;
             _ = shutdown.cancelled() => break,
@@ -396,20 +448,25 @@ async fn run_proxy_inner(
         }
 
         let shared = shared.clone();
-        let builder_clone = server_builder.clone();
-        let shutdown_conn = shutdown.clone();
+        let builder = server_builder.clone();
+        let shutdown = shutdown.clone();
         tokio::spawn(async move {
             // Released when this task ends; the drain waits on all permits.
             let _permit = permit;
-            serve_connection(stream, remote_addr, shared, builder_clone, shutdown_conn).await;
+            serve_connection(stream, remote_addr, shared, builder, shutdown).await;
         });
     }
 
-    // Graceful shutdown: stop accepting (done), cancel handlers, then drain.
-    shutdown.cancel();
+    Ok(())
+}
 
-    // Wait until every connection task has released its permit (acquiring the
-    // full set proves the count is back to zero), bounded by the timeout.
+/// Wait until every connection task has released its permit — acquiring the
+/// full set proves the count is back to zero — bounded by the timeout.
+async fn drain_connections(
+    semaphore: &Arc<Semaphore>,
+    max_connections: usize,
+    shutdown_timeout: Duration,
+) {
     let drain = semaphore.acquire_many(max_connections.min(u32::MAX as usize) as u32);
     if timeout(shutdown_timeout, drain).await.is_err() {
         warn!(
@@ -417,22 +474,6 @@ async fn run_proxy_inner(
             "shutdown drain timed out; some connections did not finish"
         );
     }
-
-    let _ = cleanup_handle.await;
-    if let Some(handle) = h3_handle {
-        let _ = handle.await;
-    }
-    if let Some(handle) = pool_sweep_handle {
-        let _ = handle.await;
-    }
-
-    // Flush, fsync, and join the capture writer last, after all handlers that
-    // could write to it have drained, so no capture line is lost or truncated.
-    if let Err(e) = shared.captures.shutdown().await {
-        warn!(error = %e, "failed to shut down capture writer");
-    }
-
-    Ok(())
 }
 
 /// Seed in-memory state from the captures file when `captures_seed` is enabled.

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -2658,84 +2658,99 @@ mod tests {
         );
     }
 
+    /// Each row is a weight and whether the `qvalue` production admits it. A
+    /// table rather than a run of `assert!` lines, so a failure names the value.
     #[test]
     fn test_valid_qvalue() {
-        assert!(valid_qvalue("1"));
-        assert!(valid_qvalue("1.0"));
-        assert!(valid_qvalue("1.00"));
-        assert!(valid_qvalue("1.000"));
-        assert!(valid_qvalue("0"));
-        assert!(valid_qvalue("0.5"));
-        assert!(valid_qvalue("0.123"));
-        assert!(valid_qvalue("0.000"));
-        // `0*3DIGIT` and `0*3("0")` are satisfied by no digits at all, so a
-        // point with nothing after it conforms. The enumeration this replaced
-        // reported both as malformed.
-        assert!(valid_qvalue("0."));
-        assert!(valid_qvalue("1."));
-        assert!(!valid_qvalue("1.0000"));
-        assert!(!valid_qvalue("0.1234"));
-        // Only zeroes may follow a leading 1: the weight is capped at 1.
-        assert!(!valid_qvalue("1.1"));
-        assert!(!valid_qvalue("1.001"));
-        assert!(!valid_qvalue("abc"));
-        assert!(!valid_qvalue(""));
-        assert!(!valid_qvalue("2"));
-        assert!(!valid_qvalue("-1"));
-        assert!(!valid_qvalue("0.5.5"));
-        assert!(!valid_qvalue("00"));
-        assert!(!valid_qvalue("0.a"));
+        const CASES: &[(&str, bool)] = &[
+            ("1", true),
+            ("1.0", true),
+            ("1.00", true),
+            ("1.000", true),
+            ("0", true),
+            ("0.5", true),
+            ("0.123", true),
+            ("0.000", true),
+            // `0*3DIGIT` and `0*3("0")` are satisfied by no digits at all, so a
+            // point with nothing after it conforms. The enumeration this replaced
+            // reported both as malformed.
+            ("0.", true),
+            ("1.", true),
+            ("1.0000", false),
+            ("0.1234", false),
+            // Only zeroes may follow a leading 1: the weight is capped at 1.
+            ("1.1", false),
+            ("1.001", false),
+            ("abc", false),
+            ("", false),
+            ("2", false),
+            ("-1", false),
+            ("0.5.5", false),
+            ("00", false),
+            ("0.a", false),
+        ];
+
+        for (value, is_qvalue) in CASES {
+            assert_eq!(valid_qvalue(value), *is_qvalue, "for {value:?}");
+        }
     }
 
+    /// Each row is a value and whether it is a serialized origin. The list is
+    /// a table rather than thirty `assert!` lines so that a failure names the
+    /// value that failed, and so the reasons — grouped below — stay attached to
+    /// the values they explain.
     #[test]
     fn test_is_valid_serialized_origin() {
-        assert!(is_valid_serialized_origin("https://example.com"));
-        assert!(is_valid_serialized_origin("http://example.com:8080"));
-        assert!(is_valid_serialized_origin("https://localhost"));
-        assert!(is_valid_serialized_origin("https://[::1]:8080"));
-        assert!(is_valid_serialized_origin("https://[::1]"));
+        const CASES: &[(&str, bool)] = &[
+            ("https://example.com", true),
+            ("http://example.com:8080", true),
+            ("https://localhost", true),
+            ("https://[::1]:8080", true),
+            ("https://[::1]", true),
+            // Port range & formatting.
+            ("http://example.com:1", true),
+            ("http://example.com:65535", true),
+            ("http://example.com:080", true), // leading zero allowed -> 80
+            // `0` is a 16-bit unsigned integer and RFC 6335 §6 calls it a value
+            // *inside* the namespace, reserved rather than invalid. This asserted
+            // the opposite until the port reading was shared with the two rules
+            // that had already audited the bound.
+            ("http://example.com:0", true),
+            ("http://example.com:65536", false), // out of range
+            ("http://example.com:999999999999", false), // too large
+            // The grammar has no path component, and a browser compares the value
+            // byte-for-byte against a serialized origin, which never carries one.
+            ("https://example.com/", false),
+            ("https://example.com/path", false),
+            ("https://example.com:8080/", false),
+            ("https://[::1]/path", false),
+            // § 3.2 ends the authority at three characters and the slash is one of
+            // them. The other two were accepted here until the terminator sentence
+            // stopped being enumerated by hand — and only in the shape below,
+            // because a port or a bracketed literal put the trailing junk in front
+            // of a reader that was already strict about it.
+            ("https://example.com?x=1", false),
+            ("https://example.com#frag", false),
+            ("https://example.com?", false),
+            ("https://example.com#", false),
+            ("https://example.com:8080?x=1", false),
+            ("https://[::1]#frag", false),
+            ("example.com", false),
+            ("https:///foo", false),
+            ("https://", false),
+            ("http://host:notaport", false),
+            ("https://user@example.com", false),
+            ("https://[::1", false),
+            ("", false),
+        ];
 
-        // Port range & formatting checks
-        assert!(is_valid_serialized_origin("http://example.com:1"));
-        assert!(is_valid_serialized_origin("http://example.com:65535"));
-        assert!(is_valid_serialized_origin("http://example.com:080")); // leading zero allowed -> 80
-                                                                       // `0` is a 16-bit unsigned integer and RFC 6335 §6 calls it a value
-                                                                       // *inside* the namespace, reserved rather than invalid. This asserted
-                                                                       // the opposite until the port reading was shared with the two rules
-                                                                       // that had already audited the bound.
-        assert!(is_valid_serialized_origin("http://example.com:0"));
-
-        assert!(!is_valid_serialized_origin("http://example.com:65536")); // out of range
-        assert!(!is_valid_serialized_origin(
-            "http://example.com:999999999999"
-        )); // too large
-
-        // The grammar has no path component, and a browser compares the value
-        // byte-for-byte against a serialized origin, which never carries one.
-        assert!(!is_valid_serialized_origin("https://example.com/"));
-        assert!(!is_valid_serialized_origin("https://example.com/path"));
-        assert!(!is_valid_serialized_origin("https://example.com:8080/"));
-        assert!(!is_valid_serialized_origin("https://[::1]/path"));
-
-        // § 3.2 ends the authority at three characters and the slash is one of
-        // them. The other two were accepted here until the terminator sentence
-        // stopped being enumerated by hand — and only in the shape below,
-        // because a port or a bracketed literal put the trailing junk in front
-        // of a reader that was already strict about it.
-        assert!(!is_valid_serialized_origin("https://example.com?x=1"));
-        assert!(!is_valid_serialized_origin("https://example.com#frag"));
-        assert!(!is_valid_serialized_origin("https://example.com?"));
-        assert!(!is_valid_serialized_origin("https://example.com#"));
-        assert!(!is_valid_serialized_origin("https://example.com:8080?x=1"));
-        assert!(!is_valid_serialized_origin("https://[::1]#frag"));
-
-        assert!(!is_valid_serialized_origin("example.com"));
-        assert!(!is_valid_serialized_origin("https:///foo"));
-        assert!(!is_valid_serialized_origin("https://"));
-        assert!(!is_valid_serialized_origin("http://host:notaport"));
-        assert!(!is_valid_serialized_origin("https://user@example.com"));
-        assert!(!is_valid_serialized_origin("https://[::1"));
-        assert!(!is_valid_serialized_origin(""));
+        for (value, is_origin) in CASES {
+            assert_eq!(
+                is_valid_serialized_origin(value),
+                *is_origin,
+                "for {value:?}"
+            );
+        }
     }
 
     /// **The authority's contents, which this predicate measured nothing of.**

--- a/lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
+++ b/lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
@@ -30,6 +30,166 @@ const MDN_X_FRAME_OPTIONS: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "`X-Frame-Options` — legacy header with values `DENY`, `SAMEORIGIN`, and the obsolete `ALLOW-FROM`. Note: `ALLOW-FROM` is deprecated and not supported by most modern browsers — prefer using CSP's `frame-ancestors` for origin-specific framing policies",
 };
 
+/// What a `frame-ancestors` directive permits, across every enforced policy in
+/// the response.
+#[derive(Default)]
+struct FrameAncestors {
+    /// `'none'` was listed: nothing may frame the resource.
+    none: bool,
+    /// `'self'` was listed: the resource's own origin may frame it.
+    own_origin: bool,
+    /// The serialized origins listed, each without its trailing slash.
+    origins: Vec<String>,
+}
+
+impl FrameAncestors {
+    /// Read the directive from the response, or `None` where no enforced policy
+    /// names it.
+    ///
+    /// Report-only policies are not read: they change no framing decision, so a
+    /// disagreement with one is not a disagreement about what happens.
+    // cite(CSP3 § 6.4.2): "The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed."
+    fn of(headers: &hyper::HeaderMap) -> Option<Self> {
+        let mut policy = Self::default();
+        let mut named = false;
+
+        for directive in crate::helpers::headers::field_lines(headers, "content-security-policy")
+            .flat_map(crate::helpers::headers::parse_semicolon_list)
+        {
+            let mut parts = directive.split_whitespace();
+            if !parts
+                .next()
+                .is_some_and(|name| name.eq_ignore_ascii_case("frame-ancestors"))
+            {
+                continue;
+            }
+            // The directive is named even when it lists nothing, and a
+            // `frame-ancestors` with no source expression permits no framing at
+            // all — which is a finding for the rule that owns the grammar, not a
+            // reason to read the header as absent here.
+            named = true;
+
+            for member in parts {
+                // Keyword sources are written in single quotes; a serialized
+                // origin is not. An unbalanced quote is left as written, since
+                // it matches no keyword either way.
+                let source = member
+                    .strip_prefix('\'')
+                    .and_then(|rest| rest.strip_suffix('\''))
+                    .unwrap_or(member);
+                if source.eq_ignore_ascii_case("none") {
+                    policy.none = true;
+                } else if source.eq_ignore_ascii_case("self") {
+                    policy.own_origin = true;
+                } else {
+                    policy
+                        .origins
+                        .push(source.strip_suffix('/').unwrap_or(source).to_string());
+                }
+            }
+        }
+
+        named.then_some(policy)
+    }
+
+    /// Whether the policy permits framing by anyone at all.
+    fn permits_framing(&self) -> bool {
+        self.own_origin || !self.origins.is_empty()
+    }
+
+    /// Whether the policy lists this serialized origin.
+    fn lists(&self, origin: &str) -> bool {
+        self.origins.iter().any(|o| o.eq_ignore_ascii_case(origin))
+    }
+}
+
+/// The framing policy an `X-Frame-Options` field value states.
+// cite(HTML Speculative Loading § 7.7): "The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable."
+enum FrameOptions<'a> {
+    /// `DENY`.
+    Deny,
+    /// `SAMEORIGIN`.
+    SameOrigin,
+    /// `ALLOW-FROM <origin>`, carrying the origin exactly as written — which is
+    /// what a finding quotes back, while the comparison uses it without its
+    /// trailing slash.
+    AllowFrom(&'a str),
+    /// Anything else, including an `ALLOW-FROM` naming no origin.
+    Unrecognized,
+}
+
+impl<'a> FrameOptions<'a> {
+    fn of(value: &'a str) -> Self {
+        if value.eq_ignore_ascii_case("DENY") {
+            return Self::Deny;
+        }
+        if value.eq_ignore_ascii_case("SAMEORIGIN") {
+            return Self::SameOrigin;
+        }
+        let Some(rest) = value
+            .get(..10)
+            .filter(|head| head.eq_ignore_ascii_case("ALLOW-FROM"))
+            .map(|_| value[10..].trim_start())
+        else {
+            return Self::Unrecognized;
+        };
+        if rest.is_empty() {
+            return Self::Unrecognized;
+        }
+        Self::AllowFrom(rest)
+    }
+}
+
+impl ContentSecurityPolicyAndFrameOptionsConsistent {
+    /// Whether the one origin `ALLOW-FROM` permits is an origin the policy
+    /// permits too.
+    fn allow_from_defect(
+        &self,
+        csp: &FrameAncestors,
+        as_written: &str,
+        request_uri: &str,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        let allowed = as_written.strip_suffix('/').unwrap_or(as_written);
+
+        if csp.none {
+            return Some(self.violation(severity, format!(
+                "X-Frame-Options: ALLOW-FROM {} permits framing but Content-Security-Policy frame-ancestors is 'none'",
+                as_written
+            )));
+        }
+
+        // A listed origin agrees; `'self'` agrees when the request's own origin
+        // is the one allowed, since that is the origin `'self'` stands for.
+        let own_origin = || {
+            csp.own_origin
+                && extract_origin_from_uri(request_uri)
+                    .is_some_and(|origin| origin.eq_ignore_ascii_case(allowed))
+        };
+
+        if !csp.origins.is_empty() {
+            return (!csp.lists(allowed) && !own_origin()).then(|| {
+                self.violation(severity, format!(
+                    "X-Frame-Options: ALLOW-FROM {} is not included in Content-Security-Policy frame-ancestors",
+                    as_written
+                ))
+            });
+        }
+
+        if csp.own_origin {
+            let origin = extract_origin_from_uri(request_uri)?;
+            return (!origin.eq_ignore_ascii_case(allowed)).then(|| {
+                self.violation(severity, format!(
+                    "X-Frame-Options: ALLOW-FROM {} does not match Content-Security-Policy frame-ancestors 'self' (origin {})",
+                    as_written, origin
+                ))
+            });
+        }
+
+        None
+    }
+}
+
 impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
     fn id(&self) -> &'static str {
         "content_security_policy_and_frame_options_consistent"
@@ -48,177 +208,47 @@ impl Rule for ContentSecurityPolicyAndFrameOptionsConsistent {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // Only check responses
             let resp = tx.response.as_ref()?;
 
-            // Collect CSP frame-ancestors info across header fields
-            let mut csp_found = false;
-            let mut csp_none = false;
-            let mut csp_self = false;
-            let mut csp_origins: Vec<String> = Vec::new();
+            // With no frame-ancestors directive there is nothing to compare
+            // X-Frame-Options against.
+            let csp = FrameAncestors::of(&resp.headers)?;
 
-            for hv in resp.headers.get_all("content-security-policy").iter() {
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => continue, // other rule flags non-utf8
-                };
-
-                for dir in crate::helpers::headers::parse_semicolon_list(s) {
-                    let mut parts = dir.split_whitespace();
-                    let name = match parts.next() {
-                        Some(n) => n,
-                        None => continue,
-                    };
-                    if !name.eq_ignore_ascii_case("frame-ancestors") {
-                        continue;
-                    }
-
-                    csp_found = true;
-
-                    // parse members
-                    let mut had_member = false;
-                    for member in parts {
-                        let m = member.trim();
-                        if m.is_empty() {
-                            continue;
-                        }
-                        had_member = true;
-                        // strip single quotes if present
-                        let token = if m.len() >= 2 && m.starts_with('\'') && m.ends_with('\'') {
-                            &m[1..m.len() - 1]
-                        } else {
-                            m
-                        };
-                        if token.eq_ignore_ascii_case("none") {
-                            csp_none = true;
-                        } else if token.eq_ignore_ascii_case("self") {
-                            csp_self = true;
-                        } else {
-                            // treat as origin candidate (store normalized without trailing slash)
-                            let mut o = token.to_string();
-                            if o.ends_with('/') {
-                                o.pop();
-                            }
-                            csp_origins.push(o);
-                        }
-                    }
-
-                    // If directive had no members (e.g., 'frame-ancestors'), treat as malformed; skip
-                    if !had_member {
-                        continue;
-                    }
-                }
-            }
-
-            // If no CSP frame-ancestors, nothing to compare
-            if !csp_found {
-                return None;
-            }
-
-            // Get X-Frame-Options header. The two headers answer the same question, and a
-            // browser that honours `frame-ancestors` ignores `X-Frame-Options` — so when they
-            // disagree, one of them is a statement of intent that nothing enforces. That
-            // precedence (and why only enforced CSP counts, so report-only is skipped above)
-            // is §6.4.2.2's; the two purpose cites give each header's own scope.
+            // The two headers answer the same question, and a browser that honours
+            // `frame-ancestors` ignores `X-Frame-Options` — so when they disagree, one of
+            // them is a statement of intent that nothing enforces. That precedence (and
+            // why only enforced CSP counts, so report-only is skipped above) is
+            // §6.4.2.2's; the two purpose cites give each header's own scope.
             // cite(CSP3 § 6.4.2.2): "the frame-ancestors directive overrides the ``X-Frame-Options`` header."
             // cite(CSP3 § 6.4.2): "The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed."
             // cite(HTML Speculative Loading § 7.7): "The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable."
-            let xfo_count = resp.headers.get_all("x-frame-options").iter().count();
-            if xfo_count == 0 {
+            //
+            // A repeated X-Frame-Options is the duplicate-header rule's finding, and
+            // an unreadable one belongs to the rule that owns the field: either way
+            // there is no single policy here to compare.
+            if resp.headers.get_all("x-frame-options").iter().count() != 1 {
                 return None;
             }
-            if xfo_count > 1 {
-                // Other rule will report duplicate header; avoid duplicate diagnostics here
-                return None;
-            }
-
-            // Absent or non-utf8 -> let the dedicated rule report it.
-            let xfo_val =
+            let xfo =
                 crate::helpers::headers::get_header_str(&resp.headers, "x-frame-options")?.trim();
 
-            // Recognize canonical forms
-            if xfo_val.eq_ignore_ascii_case("DENY") {
-                // DENY forbids framing; contradiction if CSP permits any framing
-                if csp_none {
-                    // Both deny -> ok
-                    return None;
+            match FrameOptions::of(xfo) {
+                // DENY forbids framing, so it contradicts a policy that permits any.
+                FrameOptions::Deny => (!csp.none && csp.permits_framing()).then(|| {
+                    self.violation(ctx.severity, "X-Frame-Options: DENY contradicts Content-Security-Policy frame-ancestors which permits framing".into())
+                }),
+                // SAMEORIGIN permits same-origin framing, so only an outright
+                // 'none' contradicts it.
+                FrameOptions::SameOrigin => csp.none.then(|| {
+                    self.violation(ctx.severity, "Content-Security-Policy frame-ancestors: 'none' forbids framing while X-Frame-Options: SAMEORIGIN permits same-origin frames".into())
+                }),
+                FrameOptions::AllowFrom(as_written) => {
+                    self.allow_from_defect(&csp, as_written, &tx.request.uri, ctx.severity)
                 }
-                // CSP permits framing if it had any non-'none' member
-                if csp_self || !csp_origins.is_empty() {
-                    return Some(self.violation(ctx.severity, "X-Frame-Options: DENY contradicts Content-Security-Policy frame-ancestors which permits framing".into()));
-                }
-                return None;
+                // A form no user agent implements says nothing to contradict;
+                // reporting it belongs to the rule that owns the field.
+                FrameOptions::Unrecognized => None,
             }
-
-            if xfo_val.eq_ignore_ascii_case("SAMEORIGIN") {
-                // SAMEORIGIN permits same-origin; contradiction only if CSP explicitly forbids all
-                if csp_none {
-                    return Some(self.violation(ctx.severity, "Content-Security-Policy frame-ancestors: 'none' forbids framing while X-Frame-Options: SAMEORIGIN permits same-origin frames".into()));
-                }
-                // otherwise compatible (both allow some framing)
-                return None;
-            }
-
-            // ALLOW-FROM
-            if xfo_val.len() >= 10 && xfo_val[..10].eq_ignore_ascii_case("ALLOW-FROM") {
-                let rest = xfo_val[10..].trim_start();
-                if rest.is_empty() {
-                    return None; // malformed XFO, other rule will report
-                }
-                let allow_origin = if let Some(stripped) = rest.strip_suffix('/') {
-                    stripped
-                } else {
-                    rest
-                };
-
-                // If CSP forbids all -> contradiction
-                if csp_none {
-                    return Some(self.violation(ctx.severity, format!("X-Frame-Options: ALLOW-FROM {} permits framing but Content-Security-Policy frame-ancestors is 'none'", rest)));
-                }
-
-                // If CSP has explicit origins, require the ALLOW-FROM origin to be present
-                if !csp_origins.is_empty() {
-                    let mut matched = false;
-                    for o in &csp_origins {
-                        if o.eq_ignore_ascii_case(allow_origin) {
-                            matched = true;
-                            break;
-                        }
-                    }
-                    if !matched {
-                        // Maybe CSP used 'self' and that matches server origin; compare to request origin
-                        if csp_self {
-                            // derive request origin
-                            let req_origin = extract_origin_from_uri(&tx.request.uri);
-                            if let Some(rorig) = req_origin {
-                                if rorig.eq_ignore_ascii_case(allow_origin) {
-                                    return None; // matches self
-                                }
-                            }
-                        }
-
-                        return Some(self.violation(ctx.severity, format!("X-Frame-Options: ALLOW-FROM {} is not included in Content-Security-Policy frame-ancestors", rest)));
-                    }
-                }
-
-                // if CSP only had 'self', check if ALLOW-FROM equals request origin
-                if csp_self && csp_origins.is_empty() {
-                    let req_origin = extract_origin_from_uri(&tx.request.uri);
-                    if let Some(rorig) = req_origin {
-                        if rorig.eq_ignore_ascii_case(allow_origin) {
-                            return None;
-                        } else {
-                            return Some(self.violation(ctx.severity, format!("X-Frame-Options: ALLOW-FROM {} does not match Content-Security-Policy frame-ancestors 'self' (origin {})", rest, rorig)));
-                        }
-                    }
-                }
-
-                // Otherwise compatible
-                return None;
-            }
-
-            // Unsupported XFO form -> ignore (other rule flags)
-            None
         };
         Vec::from_iter(finding())
     }

--- a/lint-http-rules/src/rules/content_security_policy_valid.rs
+++ b/lint-http-rules/src/rules/content_security_policy_valid.rs
@@ -29,6 +29,158 @@ const MDN_CONTENT_SECURITY_POLICY: crate::rules::SpecRef = crate::rules::SpecRef
     note: "Mozilla MDN overview and directive examples",
 };
 
+/// The three hash algorithms a `hash-source` may name. They were written out
+/// three times, in two places each, with a message per algorithm — which is why
+/// they are one list now: the check does not vary by algorithm, only the
+/// example in the wording does.
+// cite(CSP3 § 2.3): "hash-algorithm = "sha256" / "sha384" / "sha512""
+const HASH_PREFIXES: [&str; 3] = ["sha256-", "sha384-", "sha512-"];
+
+impl ContentSecurityPolicyValid {
+    /// One `;`-separated directive: its name, then each of its source
+    /// expressions.
+    fn directive_defect(
+        &self,
+        directive: &str,
+        position: usize,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        if directive.is_empty() {
+            // A trailing or doubled semicolon.
+            return Some(self.violation(
+                severity,
+                format!(
+                    "Content-Security-Policy contains empty directive at position {}",
+                    position
+                ),
+            ));
+        }
+
+        let mut parts = directive.split_whitespace();
+        let name = parts
+            .next()
+            .expect("split_whitespace yields at least one item since the directive is not empty");
+
+        // A CSP directive-name is narrower than the HTTP `token`: only
+        // letters, digits and `-`. Enforcing `token` here let typos like
+        // `default_src` (underscore is a legal tchar) pass unflagged.
+        // cite(CSP3 § 2.3): "directive-name = 1*( ALPHA / DIGIT / "-" )"
+        if let Some(c) = name
+            .chars()
+            .find(|c| !(c.is_ascii_alphanumeric() || *c == '-'))
+        {
+            return Some(self.violation(
+                severity,
+                format!(
+                    "Invalid character '{}' in CSP directive-name '{}', at position {}",
+                    c, name, position
+                ),
+            ));
+        }
+
+        parts.find_map(|source| self.source_expression_defect(source, name, severity))
+    }
+
+    /// One source expression, quoted or not.
+    ///
+    /// The quoted forms are checked for being closed and non-empty, and for a
+    /// nonce or hash that names no value. The unquoted ones are checked for
+    /// being a nonce or hash at all: those two *must* be quoted, so an unquoted
+    /// one is not a source expression the policy will enforce.
+    ///
+    /// This is deliberately not a full source-expression grammar — the rule
+    /// catches the common, obvious mistakes and says so in its description.
+    fn source_expression_defect(
+        &self,
+        source: &str,
+        directive: &str,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        if source.starts_with('\'') {
+            if !source.ends_with('\'') || source.len() < 2 {
+                return Some(self.violation(
+                    severity,
+                    format!(
+                    "Unterminated or empty single-quoted source expression '{}' in directive '{}'",
+                    source, directive
+                ),
+                ));
+            }
+            let inner = &source[1..source.len() - 1];
+            if inner.is_empty() {
+                return Some(self.violation(
+                    severity,
+                    format!(
+                        "Empty single-quoted source expression '{}' in directive '{}'",
+                        source, directive
+                    ),
+                ));
+            }
+
+            if let Some(nonce) = inner.strip_prefix("nonce-") {
+                if nonce.is_empty() {
+                    return Some(self.violation(
+                        severity,
+                        format!("Empty nonce value in directive '{}'", directive),
+                    ));
+                }
+                if nonce.chars().any(char::is_whitespace) {
+                    return Some(self.violation(
+                        severity,
+                        format!(
+                            "Invalid nonce value containing whitespace in directive '{}'",
+                            directive
+                        ),
+                    ));
+                }
+            }
+
+            if HASH_PREFIXES
+                .iter()
+                .any(|prefix| inner.strip_prefix(prefix) == Some(""))
+            {
+                return Some(self.violation(
+                    severity,
+                    format!("Empty hash value in directive '{}'", directive),
+                ));
+            }
+
+            // Nothing below applies to a value that opens with a quote.
+            return None;
+        }
+
+        if let Some(nonce) = source.strip_prefix("nonce-") {
+            if nonce.is_empty() {
+                return Some(self.violation(
+                    severity,
+                    format!("Empty nonce value in directive '{}'", directive),
+                ));
+            }
+            return Some(self.violation(
+                severity,
+                "Nonce source expressions MUST be single-quoted (e.g., 'nonce-...')".into(),
+            ));
+        }
+
+        let prefix = HASH_PREFIXES
+            .iter()
+            .find(|prefix| source.starts_with(**prefix))?;
+        if source.len() == prefix.len() {
+            return Some(self.violation(
+                severity,
+                format!("Empty hash value in directive '{}'", directive),
+            ));
+        }
+        Some(self.violation(
+            severity,
+            format!(
+                "Hash source expressions MUST be single-quoted (e.g., '{}...')",
+                prefix
+            ),
+        ))
+    }
+}
+
 impl Rule for ContentSecurityPolicyValid {
     fn id(&self) -> &'static str {
         "content_security_policy_valid"
@@ -47,158 +199,28 @@ impl Rule for ContentSecurityPolicyValid {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            // Only check responses
             let resp = tx.response.as_ref()?;
 
-            for hv in resp.headers.get_all("content-security-policy").iter() {
-                // UTF-8
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Content-Security-Policy header value is not valid UTF-8".into(),
-                        ));
-                    }
+            for line in resp.headers.get_all("content-security-policy").iter() {
+                let Ok(policy) = line.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Content-Security-Policy header value is not valid UTF-8".into(),
+                    ));
                 };
 
-                let s_trim = s.trim();
-                if s_trim.is_empty() {
+                if policy.trim().is_empty() {
                     return Some(self.violation(
                         ctx.severity,
                         "Content-Security-Policy header MUST not be empty".into(),
                     ));
                 }
 
-                // Split directives on ';'
-                for (i, raw_dir) in s.split(';').enumerate() {
-                    let dir = raw_dir.trim();
-                    if dir.is_empty() {
-                        // Empty directive (e.g., trailing or consecutive semicolons)
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Content-Security-Policy contains empty directive at position {}",
-                                i
-                            ),
-                        ));
-                    }
-
-                    // Directive name is the first token up to whitespace
-                    let mut parts = dir.split_whitespace();
-                    let name = parts
-                        .next()
-                        .expect("split_whitespace yields at least one item since dir is not empty");
-
-                    // A CSP directive-name is narrower than the HTTP `token`: only
-                    // letters, digits and `-`. Enforcing `token` here let typos like
-                    // `default_src` (underscore is a legal tchar) pass unflagged.
-                    // cite(CSP3 § 2.3): "directive-name = 1*( ALPHA / DIGIT / "-" )"
-                    if let Some(c) = name
-                        .chars()
-                        .find(|c| !(c.is_ascii_alphanumeric() || *c == '-'))
+                for (position, directive) in policy.split(';').enumerate() {
+                    if let Some(defect) =
+                        self.directive_defect(directive.trim(), position, ctx.severity)
                     {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Invalid character '{}' in CSP directive-name '{}', at position {}",
-                                c, name, i
-                            ),
-                        ));
-                    }
-
-                    // Basic checks for values: ensure single-quoted keywords are closed and non-empty
-                    for val in parts {
-                        if val.starts_with('\'') {
-                            // Single-quoted token expected (e.g., 'self' or 'nonce-...')
-                            if !val.ends_with('\'') || val.len() < 2 {
-                                return Some(self.violation(ctx.severity, format!("Unterminated or empty single-quoted source expression '{}' in directive '{}'", val, name)));
-                            }
-                            let inner = &val[1..val.len() - 1];
-                            if inner.is_empty() {
-                                return Some(self.violation(ctx.severity, format!(
-                                        "Empty single-quoted source expression '{}' in directive '{}'",
-                                        val, name
-                                    )));
-                            }
-
-                            // Validate nonce/hash when present inside quoted source expression
-                            if let Some(rest) = inner.strip_prefix("nonce-") {
-                                if rest.is_empty() {
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        format!("Empty nonce value in directive '{}'", name),
-                                    ));
-                                }
-                                if rest.chars().any(|c: char| c.is_whitespace()) {
-                                    return Some(self.violation(ctx.severity, format!("Invalid nonce value containing whitespace in directive '{}'", name)));
-                                }
-                            }
-
-                            if let Some(rest) = inner.strip_prefix("sha256-") {
-                                if rest.is_empty() {
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        format!("Empty hash value in directive '{}'", name),
-                                    ));
-                                }
-                            } else if let Some(rest) = inner.strip_prefix("sha384-") {
-                                if rest.is_empty() {
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        format!("Empty hash value in directive '{}'", name),
-                                    ));
-                                }
-                            } else if let Some(rest) = inner.strip_prefix("sha512-") {
-                                if rest.is_empty() {
-                                    return Some(self.violation(
-                                        ctx.severity,
-                                        format!("Empty hash value in directive '{}'", name),
-                                    ));
-                                }
-                            }
-                        }
-
-                        // Basic nonce/hash forms: allow 'nonce-<token>' and 'sha256-...'
-                        if let Some(rest) = val.strip_prefix("nonce-") {
-                            if rest.is_empty() {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!("Empty nonce value in directive '{}'", name),
-                                ));
-                            }
-                            return Some(self.violation(ctx.severity, "Nonce source expressions MUST be single-quoted (e.g., 'nonce-...')"
-                                        .into()));
-                        }
-
-                        if let Some(rest) = val.strip_prefix("sha256-") {
-                            if rest.is_empty() {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!("Empty hash value in directive '{}'", name),
-                                ));
-                            }
-                            return Some(self.violation(ctx.severity, "Hash source expressions MUST be single-quoted (e.g., 'sha256-...')"
-                                        .into()));
-                        } else if let Some(rest) = val.strip_prefix("sha384-") {
-                            if rest.is_empty() {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!("Empty hash value in directive '{}'", name),
-                                ));
-                            }
-                            return Some(self.violation(ctx.severity, "Hash source expressions MUST be single-quoted (e.g., 'sha384-...')"
-                                        .into()));
-                        } else if let Some(rest) = val.strip_prefix("sha512-") {
-                            if rest.is_empty() {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!("Empty hash value in directive '{}'", name),
-                                ));
-                            }
-                            return Some(self.violation(ctx.severity, "Hash source expressions MUST be single-quoted (e.g., 'sha512-...')"
-                                        .into()));
-                        }
+                        return Some(defect);
                     }
                 }
             }

--- a/lint-http-rules/src/rules/digest_header_syntax.rs
+++ b/lint-http-rules/src/rules/digest_header_syntax.rs
@@ -43,6 +43,395 @@ const RFC_7231_APPENDIX_B: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "Where `Content-MD5` was removed from HTTP — RFC 9530 does not mention the field at all",
 };
 
+/// Which side of the exchange a field is read on.
+#[derive(Clone, Copy)]
+enum Side {
+    Request,
+    Response,
+}
+
+impl std::fmt::Display for Side {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Side::Request => "request",
+            Side::Response => "response",
+        })
+    }
+}
+
+/// The four grammars the fields in [`FIELDS`] follow.
+#[derive(Clone, Copy)]
+enum Syntax {
+    /// RFC 3230's `Digest`: `alg=base64`, and the algorithm is an ordinary
+    /// case-insensitive token rather than a structured-field key.
+    LegacyDigest,
+    /// RFC 3230's `Want-Digest`: a list of algorithm tokens.
+    LegacyWantDigest,
+    /// RFC 9530's `Content-Digest` / `Repr-Digest`: a Dictionary of
+    /// algorithm key to Byte Sequence. The two fields differ only in *what* is
+    /// hashed — message content versus representation data — not in syntax, so
+    /// one reading serves both.
+    // cite(RFC 9530 § 2): "It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:"
+    StructuredDigest,
+    /// RFC 9530's `Want-Content-Digest` / `Want-Repr-Digest`: a Dictionary of
+    /// algorithm key to weight.
+    // cite(RFC 9530 § 4): "Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:"
+    WantPreference,
+    /// No grammar at all: the field's presence is the whole finding, so
+    /// whatever it says is read and not judged.
+    Anything,
+}
+
+impl Syntax {
+    /// What is wrong with this field value, if anything.
+    fn defect(self, value: &str) -> Option<String> {
+        match self {
+            Syntax::LegacyDigest => legacy_digest_defect(value),
+            Syntax::LegacyWantDigest => token_list(
+                value,
+                "Want-Digest header contains empty member",
+                "Want-Digest algorithm contains invalid character: '{}'",
+            )
+            .err(),
+            Syntax::StructuredDigest => structured_digest_defect(value),
+            Syntax::WantPreference => want_preference_defect(value),
+            Syntax::Anything => None,
+        }
+    }
+}
+
+/// One field this rule reads.
+struct Field {
+    /// The field name as a lookup key.
+    name: &'static str,
+    /// The field name as a finding spells it.
+    display: &'static str,
+    side: Side,
+    syntax: Syntax,
+    /// What a defect finding names as its authority, in parentheses.
+    reference: &'static str,
+    /// Set for a field that no longer exists: the finding a well-formed value
+    /// still earns.
+    // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
+    obsolete: Option<&'static str>,
+}
+
+const OBSOLETE_DIGEST: &str =
+    "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest";
+const OBSOLETE_WANT_DIGEST: &str =
+    "Want-Digest header is obsoleted by RFC 9530; prefer Want-Content-Digest or Want-Repr-Digest";
+/// Content-MD5 is obsolete, but RFC 9530 is not what obsoleted it — that
+/// document never mentions the field. It was removed from HTTP by RFC 7231,
+/// years earlier, and the sentence in the citation below is the whole
+/// provenance. RFC 9530 is named only as what to use instead.
+// cite(RFC 7231): "The Content-MD5 header field has been removed because it was inconsistently implemented with respect to partial responses."
+const OBSOLETE_CONTENT_MD5: &str =
+    "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead";
+
+/// Every field this rule reads, in the order it reads them — which is the order
+/// findings are reported in, so it is the order the rule's tests pin.
+const FIELDS: &[Field] = &[
+    Field {
+        name: "digest",
+        display: "Digest",
+        side: Side::Request,
+        syntax: Syntax::LegacyDigest,
+        reference: "obsoleted by RFC 9530",
+        obsolete: Some(OBSOLETE_DIGEST),
+    },
+    Field {
+        name: "want-digest",
+        display: "Want-Digest",
+        side: Side::Request,
+        syntax: Syntax::LegacyWantDigest,
+        reference: "obsoleted by RFC 9530",
+        obsolete: Some(OBSOLETE_WANT_DIGEST),
+    },
+    Field {
+        name: "digest",
+        display: "Digest",
+        side: Side::Response,
+        syntax: Syntax::LegacyDigest,
+        reference: "obsoleted by RFC 9530",
+        obsolete: Some(OBSOLETE_DIGEST),
+    },
+    Field {
+        name: "content-digest",
+        display: "Content-Digest",
+        side: Side::Request,
+        syntax: Syntax::StructuredDigest,
+        reference: "RFC 9530 §2",
+        obsolete: None,
+    },
+    Field {
+        name: "repr-digest",
+        display: "Repr-Digest",
+        side: Side::Request,
+        syntax: Syntax::StructuredDigest,
+        reference: "RFC 9530 §3",
+        obsolete: None,
+    },
+    Field {
+        name: "want-content-digest",
+        display: "Want-Content-Digest",
+        side: Side::Request,
+        syntax: Syntax::WantPreference,
+        reference: "RFC 9530 §4",
+        obsolete: None,
+    },
+    Field {
+        name: "want-repr-digest",
+        display: "Want-Repr-Digest",
+        side: Side::Request,
+        syntax: Syntax::WantPreference,
+        reference: "RFC 9530 §4",
+        obsolete: None,
+    },
+    Field {
+        name: "content-digest",
+        display: "Content-Digest",
+        side: Side::Response,
+        syntax: Syntax::StructuredDigest,
+        reference: "RFC 9530 §2",
+        obsolete: None,
+    },
+    Field {
+        name: "repr-digest",
+        display: "Repr-Digest",
+        side: Side::Response,
+        syntax: Syntax::StructuredDigest,
+        reference: "RFC 9530 §3",
+        obsolete: None,
+    },
+    Field {
+        name: "want-content-digest",
+        display: "Want-Content-Digest",
+        side: Side::Response,
+        syntax: Syntax::WantPreference,
+        reference: "RFC 9530 §4",
+        obsolete: None,
+    },
+    Field {
+        name: "want-repr-digest",
+        display: "Want-Repr-Digest",
+        side: Side::Response,
+        syntax: Syntax::WantPreference,
+        reference: "RFC 9530 §4",
+        obsolete: None,
+    },
+    // Content-MD5 has no syntax to be wrong: its presence is the finding, so
+    // the reading below accepts anything the value says.
+    Field {
+        name: "content-md5",
+        display: "Content-MD5",
+        side: Side::Request,
+        syntax: Syntax::Anything,
+        reference: "removed by RFC 7231",
+        obsolete: Some(OBSOLETE_CONTENT_MD5),
+    },
+    Field {
+        name: "content-md5",
+        display: "Content-MD5",
+        side: Side::Response,
+        syntax: Syntax::Anything,
+        reference: "removed by RFC 7231",
+        obsolete: Some(OBSOLETE_CONTENT_MD5),
+    },
+];
+
+/// Split a comma-separated list of `key=value` members.
+///
+/// Splitting on a bare comma is safe for every field routed through here: the
+/// Dictionary values are Byte Sequences and Integers, neither of which can
+/// contain a comma, and the legacy `Digest` value is base64, which has no comma
+/// in its alphabet either. A quote-aware split would find nothing extra.
+/// (Dictionary *parameters*, which could complicate this, are not defined for
+/// any of these fields.)
+fn key_value_members(
+    value: &str,
+    empty_member: &str,
+    missing_eq: &str,
+    empty_algorithm: &str,
+) -> Result<Vec<(String, String)>, String> {
+    let mut members = Vec::new();
+    for member in value.split(',') {
+        let member = member.trim();
+        if member.is_empty() {
+            return Err(empty_member.to_string());
+        }
+        let Some(eq) = member.find('=') else {
+            return Err(missing_eq.replace("{}", member));
+        };
+        let algorithm = member[..eq].trim();
+        if algorithm.is_empty() {
+            return Err(empty_algorithm.replace("{}", member));
+        }
+        members.push((algorithm.to_string(), member[eq + 1..].trim().to_string()));
+    }
+    Ok(members)
+}
+
+/// Split a comma-separated list of bare tokens.
+fn token_list(value: &str, empty_member: &str, invalid_token: &str) -> Result<Vec<String>, String> {
+    let mut members = Vec::new();
+    for member in value.split(',') {
+        let member = member.trim();
+        if member.is_empty() {
+            return Err(empty_member.to_string());
+        }
+        if let Some(c) = crate::helpers::token::find_invalid_token_char(member) {
+            return Err(invalid_token.replace("{}", &c.to_string()));
+        }
+        members.push(member.to_string());
+    }
+    Ok(members)
+}
+
+/// The RFC 3230 shape: an ordinary token and bare base64, with no `:`
+/// delimiters and no structured field anywhere in it.
+fn legacy_digest_defect(value: &str) -> Option<String> {
+    let members = match key_value_members(
+        value,
+        "Digest header contains empty member",
+        "Digest member '{}' missing '=' separator",
+        "Digest member '{}' has empty algorithm",
+    ) {
+        Err(defect) => return Some(defect),
+        Ok(members) => members,
+    };
+
+    for (algorithm, encoded) in members {
+        if encoded.is_empty() {
+            return Some(format!("Digest member '{}' has empty value", algorithm));
+        }
+
+        // The algorithm is a token. RFC 3230 also makes it case-insensitive,
+        // which is why no lowercase rule is applied on this legacy path — the
+        // opposite of the structured fields below.
+        // cite(RFC 3230 § 4.1.1): "digest-algorithm = token"
+        // cite(RFC 3230 § 4.1.1): "All digest-algorithm values are case-insensitive."
+        if let Some(c) = crate::helpers::token::find_invalid_token_char(&algorithm) {
+            return Some(format!(
+                "Digest algorithm contains invalid character: '{}'",
+                c
+            ));
+        }
+
+        if base64::engine::general_purpose::STANDARD
+            .decode(&encoded)
+            .is_err()
+        {
+            return Some(format!(
+                "Digest value for algorithm '{}' is not valid base64",
+                algorithm
+            ));
+        }
+    }
+    None
+}
+
+/// The RFC 9530 shape: a Dictionary key and a Byte Sequence.
+fn structured_digest_defect(value: &str) -> Option<String> {
+    let members = match key_value_members(
+        value,
+        "Digest field contains empty member",
+        "Digest member '{}' missing '=' separator",
+        "Digest member '{}' has empty algorithm",
+    ) {
+        Err(defect) => return Some(defect),
+        Ok(members) => members,
+    };
+
+    for (algorithm, encoded) in members {
+        // These are Dictionary *keys*, not RFC 3230 tokens: an SF key may not
+        // contain uppercase. The distinction matters most on exactly the path a
+        // deployment is likely to take — RFC 3230's `digest-algorithm = token`
+        // is case-insensitive and its registry spells the algorithms `SHA-256`,
+        // `MD5`, so carrying that spelling across to Content-Digest produces a
+        // field no structured-field parser will accept. The `key` grammar
+        // itself is owned by the structured-fields helper.
+        // cite(RFC 9530 § 2): "key conveys the hashing algorithm (see Section 5) used to compute the digest;"
+        if !crate::helpers::structured_fields::is_valid_sf_key(&algorithm) {
+            return Some(format!(
+                "Digest algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
+                algorithm,
+                algorithm.to_ascii_lowercase()
+            ));
+        }
+
+        // The `:`-delimited base64 form, whose grammar the structured-fields
+        // helper owns (hand-rolling it here was a second transcription of the
+        // same rule).
+        // cite(RFC 9530 § 2): "value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation."
+        if !crate::helpers::structured_fields::is_byte_sequence(&encoded) {
+            return Some(format!(
+                "Digest member '{}={}' value must be a byte sequence like ':b64:'",
+                algorithm, encoded
+            ));
+        }
+
+        // Two deliberate strictnesses beyond the grammar, neither of which the
+        // spec states, so neither is cited. (1) `::` is a well-formed Byte
+        // Sequence carrying zero bytes, but a digest of nothing identifies no
+        // content, so it is reported. (2) the decode below demands canonical
+        // padding, while a structured-field parser synthesizes padding when it
+        // is missing — so an unpadded-but-decodable value is reported here and
+        // accepted there.
+        let inner = &encoded[1..encoded.len() - 1];
+        if inner.is_empty() {
+            return Some(format!(
+                "Digest member '{}' has empty byte sequence",
+                algorithm
+            ));
+        }
+        if base64::engine::general_purpose::STANDARD
+            .decode(inner)
+            .is_err()
+        {
+            return Some(format!(
+                "Digest value for algorithm '{}' is not valid base64",
+                algorithm
+            ));
+        }
+    }
+    None
+}
+
+/// The RFC 9530 preference shape: a Dictionary key and a weight.
+fn want_preference_defect(value: &str) -> Option<String> {
+    let members = match key_value_members(
+        value,
+        "Want-* header contains empty member",
+        "Want member '{}' missing '=' separator",
+        "Want member '{}' has empty algorithm",
+    ) {
+        Err(defect) => return Some(defect),
+        Ok(members) => members,
+    };
+
+    for (algorithm, weight) in members {
+        // Same Dictionary-key rule as the digest fields above.
+        if !crate::helpers::structured_fields::is_valid_sf_key(&algorithm) {
+            return Some(format!(
+                "Want-* algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
+                algorithm,
+                algorithm.to_ascii_lowercase()
+            ));
+        }
+
+        // The bound is the spec's own, not a chosen tolerance, and the type is
+        // Integer, so no decimal point.
+        // cite(RFC 9530 § 4): "value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive."
+        let Ok(n) = weight.parse::<i64>() else {
+            return Some(format!("Want-* weight '{}' is not an integer", weight));
+        };
+        if !(0..=10).contains(&n) {
+            return Some(format!("Want-* weight '{}' out of range 0..=10", weight));
+        }
+    }
+    None
+}
+
 impl Rule for DigestHeaderSyntax {
     fn id(&self) -> &'static str {
         "digest_header_syntax"
@@ -60,478 +449,44 @@ impl Rule for DigestHeaderSyntax {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
+        //
+        // Eleven fields, one loop. Each was written out as its own block —
+        // read the lines, report the unreadable one, validate, report the
+        // defect — and the eleven copies differed only in the field's name, the
+        // side it is read on, and which of four syntaxes it follows. Those are
+        // the three columns of [`FIELDS`].
         let finding = || -> Option<Violation> {
-            // Shared parser for comma-separated key=value members
-            let parse_key_value_members = |value: &str,
-                                           empty_member_msg: &str,
-                                           missing_eq_fmt: &str,
-                                           empty_alg_fmt: &str|
-             -> Result<Vec<(String, String)>, String> {
-                let mut members = Vec::new();
-                // Splitting on a bare comma is safe for every field routed through here:
-                // the Dictionary values are Byte Sequences and Integers, neither of which
-                // can contain a comma, and the legacy `Digest` value is base64, which has
-                // no comma in its alphabet either. A quote-aware split would find nothing
-                // extra. (Dictionary *parameters*, which could complicate this, are not
-                // defined for any of these fields.)
-                for member in value.split(',') {
-                    let m = member.trim();
-                    if m.is_empty() {
-                        return Err(empty_member_msg.to_string());
-                    }
-                    match m.find('=') {
-                        None => return Err(missing_eq_fmt.replace("{}", m)),
-                        Some(eq) => {
-                            let alg = m[..eq].trim();
-                            let val = m[eq + 1..].trim();
-                            if alg.is_empty() {
-                                return Err(empty_alg_fmt.replace("{}", m));
-                            }
-                            members.push((alg.to_string(), val.to_string()));
-                        }
-                    }
-                }
-                Ok(members)
-            };
-
-            // Shared parser for comma-separated token-only members (e.g., Want-Digest)
-            let parse_token_list = |value: &str,
-                                    empty_member_msg: &str,
-                                    invalid_token_fmt: &str|
-             -> Result<Vec<String>, String> {
-                let mut members = Vec::new();
-                for member in value.split(',') {
-                    let m = member.trim();
-                    if m.is_empty() {
-                        return Err(empty_member_msg.to_string());
-                    }
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(m) {
-                        return Err(invalid_token_fmt.replace("{}", &c.to_string()));
-                    }
-                    members.push(m.to_string());
-                }
-                Ok(members)
-            };
-
-            // Helper to validate legacy `Digest` header member value (alg=base64).
-            // This is the RFC 3230 shape, not a structured field: the algorithm is an
-            // ordinary token and the value is bare base64 with no `:` delimiters.
-            let validate_legacy_digest = |value: &str| -> Option<String> {
-                let members = match parse_key_value_members(
-                    value,
-                    "Digest header contains empty member",
-                    "Digest member '{}' missing '=' separator",
-                    "Digest member '{}' has empty algorithm",
-                ) {
-                    Err(e) => return Some(e),
-                    Ok(m) => m,
+            for field in FIELDS {
+                let headers = match field.side {
+                    Side::Request => &tx.request.headers,
+                    Side::Response => match tx.response.as_ref() {
+                        Some(resp) => &resp.headers,
+                        None => continue,
+                    },
                 };
 
-                for (alg, val) in members {
-                    if val.is_empty() {
-                        return Some(format!("Digest member '{}' has empty value", alg));
-                    }
-
-                    // Algorithm must be a token. RFC 3230 also makes it case-insensitive,
-                    // which is why no lowercase rule is applied on this legacy path — the
-                    // opposite of the structured fields below.
-                    // cite(RFC 3230 § 4.1.1): "digest-algorithm = token"
-                    // cite(RFC 3230 § 4.1.1): "All digest-algorithm values are case-insensitive."
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(&alg) {
-                        return Some(format!(
-                            "Digest algorithm contains invalid character: '{}'",
-                            c
+                for line in headers.get_all(field.name).iter() {
+                    let Ok(value) = line.to_str() else {
+                        return Some(self.violation(
+                            ctx.severity,
+                            format!("{} header value is not valid UTF-8", field.display),
                         ));
-                    }
+                    };
 
-                    // Value must be valid base64
-                    let decoded = base64::engine::general_purpose::STANDARD.decode(&val);
-                    if decoded.is_err() {
-                        return Some(format!(
-                            "Digest value for algorithm '{}' is not valid base64",
-                            alg
-                        ));
-                    }
-                }
-                None
-            };
-
-            // Helper to validate new RFC 9530 fields (Content-Digest / Repr-Digest).
-            // Both are Dictionaries of algorithm-key to digest-value, which is what the
-            // member loop below checks; the two fields differ only in *what* is hashed
-            // (message content vs representation data), not in syntax, so one validator
-            // serves both.
-            // cite(RFC 9530 § 2): "It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:"
-            let validate_structured_digest = |value: &str| -> Option<String> {
-                let members = match parse_key_value_members(
-                    value,
-                    "Digest field contains empty member",
-                    "Digest member '{}' missing '=' separator",
-                    "Digest member '{}' has empty algorithm",
-                ) {
-                    Err(e) => return Some(e),
-                    Ok(m) => m,
-                };
-
-                for (alg, val) in members {
-                    // These are Dictionary *keys*, not RFC 3230 tokens: an SF key may not
-                    // contain uppercase. The distinction matters most on exactly the path a
-                    // deployment is likely to take — RFC 3230's `digest-algorithm = token`
-                    // is case-insensitive and its registry spells the algorithms `SHA-256`,
-                    // `MD5`, so carrying that spelling across to Content-Digest produces a
-                    // field no structured-field parser will accept. The `key` grammar
-                    // itself is owned by the structured-fields helper.
-                    // cite(RFC 9530 § 2): "key conveys the hashing algorithm (see Section 5) used to compute the digest;"
-                    if !crate::helpers::structured_fields::is_valid_sf_key(&alg) {
-                        return Some(format!(
-                            "Digest algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
-                            alg,
-                            alg.to_ascii_lowercase()
-                        ));
-                    }
-
-                    // Value must be a Byte Sequence — the `:`-delimited base64 form, whose
-                    // grammar the structured-fields helper owns (hand-rolling it here was a
-                    // second transcription of the same rule).
-                    // cite(RFC 9530 § 2): "value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation."
-                    if !crate::helpers::structured_fields::is_byte_sequence(&val) {
-                        return Some(format!(
-                            "Digest member '{}={}' value must be a byte sequence like ':b64:'",
-                            alg, val
-                        ));
-                    }
-                    let inner = &val[1..val.len() - 1];
-                    // Two deliberate strictnesses beyond the grammar, neither of which the
-                    // spec states, so neither is cited. (1) `::` is a well-formed Byte
-                    // Sequence carrying zero bytes, but a digest of nothing identifies no
-                    // content, so it is reported. (2) the decode below demands canonical
-                    // padding, while a structured-field parser synthesizes padding when it
-                    // is missing — so an unpadded-but-decodable value is reported here and
-                    // accepted there.
-                    if inner.is_empty() {
-                        return Some(format!("Digest member '{}' has empty byte sequence", alg));
-                    }
-                    let decoded = base64::engine::general_purpose::STANDARD.decode(inner);
-                    if decoded.is_err() {
-                        return Some(format!(
-                            "Digest value for algorithm '{}' is not valid base64",
-                            alg
-                        ));
-                    }
-                }
-                None
-            };
-
-            // Helper to validate Want-Content-Digest / Want-Repr-Digest dictionaries.
-            // Syntax: alg=weight[, alg2=weight]
-            // cite(RFC 9530 § 4): "Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:"
-            let validate_want_field = |value: &str| -> Option<String> {
-                let members = match parse_key_value_members(
-                    value,
-                    "Want-* header contains empty member",
-                    "Want member '{}' missing '=' separator",
-                    "Want member '{}' has empty algorithm",
-                ) {
-                    Err(e) => return Some(e),
-                    Ok(m) => m,
-                };
-
-                for (alg, val) in members {
-                    // Same Dictionary-key rule as the digest fields above.
-                    if !crate::helpers::structured_fields::is_valid_sf_key(&alg) {
-                        return Some(format!(
-                            "Want-* algorithm key '{}' is not a valid structured-field key (keys are lowercase: try '{}')",
-                            alg,
-                            alg.to_ascii_lowercase()
-                        ));
-                    }
-
-                    // Weight must be integer 0..=10 — the bound is the spec's own, not a
-                    // chosen tolerance, and the type is Integer (so no decimal point).
-                    // cite(RFC 9530 § 4): "value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive."
-                    match val.parse::<i64>() {
-                        Ok(n) => {
-                            if !(0..=10).contains(&n) {
-                                return Some(format!(
-                                    "Want-* weight '{}' out of range 0..=10",
-                                    val
-                                ));
-                            }
-                        }
-                        Err(_) => {
-                            return Some(format!("Want-* weight '{}' is not an integer", val))
-                        }
-                    }
-                }
-                None
-            };
-
-            // Helper to validate legacy Want-Digest header (comma-separated token list)
-            let validate_want_digest = |value: &str| -> Option<String> {
-                parse_token_list(
-                    value,
-                    "Want-Digest header contains empty member",
-                    "Want-Digest algorithm contains invalid character: '{}'",
-                )
-                .err()
-            };
-
-            // Check deprecated legacy headers and validate them (requests)
-            if let Some(hv) = tx.request.headers.get_all("digest").iter().next() {
-                if let Ok(s) = hv.to_str() {
-                    // First validate legacy syntax
-                    if let Some(msg) = validate_legacy_digest(s) {
+                    if let Some(defect) = field.syntax.defect(value) {
                         return Some(self.violation(
                             ctx.severity,
                             format!(
-                                "Invalid Digest header in request: {} (obsoleted by RFC 9530)",
-                                msg
+                                "Invalid {} header in {}: {} ({})",
+                                field.display, field.side, defect, field.reference
                             ),
                         ));
                     }
 
-                    // If syntax ok, report obsolescence — the field itself is gone, not
-                    // merely discouraged.
-                    // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
-                    return Some(self.violation(ctx.severity, "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest".into()));
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Digest header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            // Check deprecated legacy Want-Digest header in requests
-            if let Some(hv) = tx.request.headers.get_all("want-digest").iter().next() {
-                if let Ok(s) = hv.to_str() {
-                    // Validate token list
-                    if let Some(msg) = validate_want_digest(s) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Invalid Want-Digest header in request: {} (obsoleted by RFC 9530)",
-                                msg
-                            ),
-                        ));
-                    }
-
-                    // If syntax ok, report obsolescence — the field itself is gone, not
-                    // merely discouraged.
-                    // cite(RFC 9530): "This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields."
-                    return Some(self.violation(ctx.severity, "Want-Digest header is obsoleted by RFC 9530; prefer Want-Content-Digest or Want-Repr-Digest".into()));
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Want-Digest header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            // Responses: check deprecated legacy 'Digest' header
-            if let Some(resp) = &tx.response {
-                if let Some(hv) = resp.headers.get_all("digest").iter().next() {
-                    if let Ok(s) = hv.to_str() {
-                        if let Some(msg) = validate_legacy_digest(s) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!(
-                                    "Invalid Digest header in response: {} (obsoleted by RFC 9530)",
-                                    msg
-                                ),
-                            ));
-                        }
-
-                        return Some(self.violation(ctx.severity, "Digest header is obsoleted by RFC 9530; prefer Content-Digest or Repr-Digest".into()));
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Digest header value is not valid UTF-8".into(),
-                        ));
-                    }
-                }
-            }
-
-            // Validate new RFC 9530 integrity fields in requests
-            for hv in tx.request.headers.get_all("content-digest").iter() {
-                if let Ok(s) = hv.to_str() {
-                    if let Some(msg) = validate_structured_digest(s) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Invalid Content-Digest header in request: {} (RFC 9530 §2)",
-                                msg
-                            ),
-                        ));
-                    }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Content-Digest header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            for hv in tx.request.headers.get_all("repr-digest").iter() {
-                if let Ok(s) = hv.to_str() {
-                    if let Some(msg) = validate_structured_digest(s) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Invalid Repr-Digest header in request: {} (RFC 9530 §3)",
-                                msg
-                            ),
-                        ));
-                    }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Repr-Digest header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            // Validate integrity preference fields (Want-Content-Digest / Want-Repr-Digest)
-            for hv in tx.request.headers.get_all("want-content-digest").iter() {
-                if let Ok(s) = hv.to_str() {
-                    if let Some(msg) = validate_want_field(s) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Invalid Want-Content-Digest header in request: {} (RFC 9530 §4)",
-                                msg
-                            ),
-                        ));
-                    }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Want-Content-Digest header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            for hv in tx.request.headers.get_all("want-repr-digest").iter() {
-                if let Ok(s) = hv.to_str() {
-                    if let Some(msg) = validate_want_field(s) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!(
-                                "Invalid Want-Repr-Digest header in request: {} (RFC 9530 §4)",
-                                msg
-                            ),
-                        ));
-                    }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Want-Repr-Digest header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            // Validate new RFC 9530 integrity fields in responses
-            if let Some(resp) = &tx.response {
-                for hv in resp.headers.get_all("content-digest").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        if let Some(msg) = validate_structured_digest(s) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!(
-                                    "Invalid Content-Digest header in response: {} (RFC 9530 §2)",
-                                    msg
-                                ),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Content-Digest header value is not valid UTF-8".into(),
-                        ));
-                    }
-                }
-
-                for hv in resp.headers.get_all("repr-digest").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        if let Some(msg) = validate_structured_digest(s) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!(
-                                    "Invalid Repr-Digest header in response: {} (RFC 9530 §3)",
-                                    msg
-                                ),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Repr-Digest header value is not valid UTF-8".into(),
-                        ));
-                    }
-                }
-
-                for hv in resp.headers.get_all("want-content-digest").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        if let Some(msg) = validate_want_field(s) {
-                            return Some(self.violation(ctx.severity, format!(
-                                    "Invalid Want-Content-Digest header in response: {} (RFC 9530 §4)",
-                                    msg
-                                )));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Want-Content-Digest header value is not valid UTF-8".into(),
-                        ));
-                    }
-                }
-
-                for hv in resp.headers.get_all("want-repr-digest").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        if let Some(msg) = validate_want_field(s) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!(
-                                    "Invalid Want-Repr-Digest header in response: {} (RFC 9530 §4)",
-                                    msg
-                                ),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Want-Repr-Digest header value is not valid UTF-8".into(),
-                        ));
-                    }
-                }
-            }
-
-            // Content-MD5 is obsolete, but RFC 9530 is not what obsoleted it — that
-            // document never mentions the field. It was removed from HTTP by RFC 7231,
-            // years earlier, and the sentence below is the whole provenance. RFC 9530 is
-            // named only as what to use instead.
-            // cite(RFC 7231): "The Content-MD5 header field has been removed because it was inconsistently implemented with respect to partial responses."
-            if let Some(hv) = tx.request.headers.get_all("content-md5").iter().next() {
-                if hv.to_str().is_ok() {
-                    return Some(self.violation(ctx.severity, "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead"
-                                .into()));
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Content-MD5 header value is not valid UTF-8".into(),
-                    ));
-                }
-            }
-
-            if let Some(resp) = &tx.response {
-                if let Some(hv) = resp.headers.get_all("content-md5").iter().next() {
-                    if hv.to_str().is_ok() {
-                        return Some(self.violation(ctx.severity, "Content-MD5 was removed from HTTP by RFC 7231; use Content-Digest (RFC 9530) instead".into()));
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Content-MD5 header value is not valid UTF-8".into(),
-                        ));
+                    // A well-formed obsolete field is still a finding: the field
+                    // itself is gone, not merely discouraged.
+                    if let Some(obsolete) = field.obsolete {
+                        return Some(self.violation(ctx.severity, obsolete.into()));
                     }
                 }
             }

--- a/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
+++ b/lint-http-rules/src/rules/permissions_policy_directives_valid.rs
@@ -207,234 +207,265 @@ fn validate_permissions_policy(s: &str) -> Vec<String> {
         ];
     }
 
-    let mut out: Vec<String> = Vec::new();
+    let mut ignored: Vec<String> = Vec::new();
     let mut seen_keys = std::collections::HashSet::new();
-    let members = split_commas_outside_quotes(s);
-    for m in members {
-        let m = m.trim();
-        if m.is_empty() {
-            return vec!["empty directive/member".into()];
-        }
-
-        // A member with no `=` is not malformed and this used to say it was.
-        // § 4.2.2 reads a bare key as the Boolean true, which parses -- so the
-        // field survives and this one directive does not: a Boolean is a Member
-        // Value of "any other form", and § 5.2 drops the member for it. The same
-        // finding as the explicit `?1` below, reached by leaving the value out.
-        // cite(RFC 9651 § 4.2.2): "Let value be Boolean true."
-        let eq = match find_char_outside_quotes(m, '=') {
-            Some(eq) => eq,
-            None => {
-                out.push(format!(
-                    "member '{}' has no value, which is the Boolean true and not an allowlist: \
-                     § 5.2 permits a string, the token '*', the token 'self', or an inner list \
-                     of those",
-                    m
-                ));
-                continue;
-            }
-        };
-        let (left, right) = m.split_at(eq);
-        let mut feature_part = left.trim();
-        let value_part = right[1..].trim(); // drop '='
-
-        // feature_part may contain params (e.g., key;param=1). Keep only the key name
-        if let Some(semipos) = find_char_outside_quotes(feature_part, ';') {
-            feature_part = feature_part[..semipos].trim();
-        }
-
-        if !is_valid_feature_identifier(feature_part) {
-            return vec![format!(
-                "invalid feature identifier '{}': a Dictionary member name is an SF key \
-                 (lowercase, starting with a letter or '*'), and a key that is not one fails \
-                 parsing -- which discards every directive in the field, not just this one",
-                feature_part
-            )];
-        }
-
-        // A repeated key is not a parse failure and not an error: the parser
-        // keeps the last one and the earlier directive simply stops existing.
-        // That is precisely this rule's subject -- something the server wrote
-        // that will not be enforced -- and it is invisible without being told,
-        // since the header still looks like it says both things. Keys are
-        // compared character for character, which § 4.2.2 says outright and
-        // which the key grammar makes moot anyway.
-        // cite(RFC 9651 § 4.2.2): "Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored."
-        if !seen_keys.insert(feature_part.to_string()) {
-            out.push(format!(
-                "feature '{}' is given more than once; all but the last are ignored, so the \
-                 earlier allowlist has no effect",
-                feature_part
-            ));
-            continue;
-        }
-
-        // value_part may contain parameters separated by ';' outside quotes
-        let parts = split_semicolons_outside_quotes(value_part);
-        let item = parts.first().map(|s| s.trim()).unwrap_or("");
-        // Nothing after the `=` fails § 4.2.2's parse of a Dictionary member
-        // value, so this is the whole field rather than the one directive.
-        if item.is_empty() {
-            return vec![format!("member '{}' has empty value", feature_part)];
-        }
-
-        // Disallow bare booleans, numbers, and byte-sequences as member values
-        // Each of these parses and is then dropped for its form, so each costs
-        // its own directive and the scan carries on to the next one.
-        if item.starts_with('?') {
-            out.push(format!(
-                "member '{}' has boolean value not allowed",
-                feature_part
-            ));
-            continue;
-        }
-        if is_number(item) {
-            out.push(format!(
-                "member '{}' has numeric value not allowed",
-                feature_part
-            ));
-            continue;
-        }
-        if is_byte_sequence(item) {
-            out.push(format!(
-                "member '{}' has byte-sequence value not allowed",
-                feature_part
-            ));
-            continue;
-        }
-
-        // Allowed item forms: inner list '(...)', quoted-string '"..."', token '*' or 'self', or token-like
-        if item.starts_with('(') {
-            if !item.ends_with(')') {
-                return vec![format!(
-                    "member '{}' has unterminated inner-list",
-                    feature_part
-                )];
-            }
-            // inner-list contents are permissively accepted; ensure there are no empty members like '(,)'
-            let inner = &item[1..item.len() - 1];
-            if inner.trim() == "" {
-                // empty inner list is acceptable: ()
-            } else {
-                // ensure no empty inner members after space-splitting outside quotes
-                let members = split_spaces_outside_quotes(inner);
-                for im in members {
-                    if im.trim().is_empty() {
-                        return vec![format!(
-                            "member '{}' has empty inner-list member",
-                            feature_part
-                        )];
-                    }
-                }
-            }
-        } else if item.starts_with('"') {
-            if !is_quoted_string(item) {
-                return vec![format!(
-                    "member '{}' has invalid quoted-string",
-                    feature_part
-                )];
-            }
-        } else if item == "*" || item == "self" {
-            // § 5.2 names two permitted Tokens, and a Token keeps its case:
-            // RFC 9651 § 4.2.6 consumes each character and appends it to the
-            // output unchanged, and nothing anywhere folds a Token. Compare
-            // § 3.2, which says outright that member *keys* cannot contain
-            // uppercase -- the specification distinguishes the two cases, so
-            // this code should not have folded them together.
-            //
-            // `SELF` is therefore a different Token from `self`, which makes it
-            // a Member Value of "any other form", and § 5.2 says what becomes
-            // of those: the directive is dropped. `eq_ignore_ascii_case` here
-            // called that conforming.
-            // cite(Permissions Policy § 5.2): "The Member Values represent allowlists, and must be one of:"
-            // cite(Permissions Policy § 5.2): "Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps."
-            // cite(RFC 9651 § 3.2): "Member keys cannot contain uppercase characters."
-        } else {
-            // Everything else. § 5.2's list of permitted Member Values is
-            // closed -- a String, the Token `*`, the Token `self`, or an Inner
-            // List of those -- so a bare Token that is neither `*` nor `self`
-            // is not a narrower kind of allowlist, it is not an allowlist at
-            // all. This branch used to accept any syntactically well-formed
-            // token, which let `geolocation=camera` and `geolocation=SELF`
-            // through as conforming when a browser drops both.
-            //
-            // Note the asymmetry with Inner List contents just above, which
-            // stay permissive on purpose: § 5.2 says unknown items *inside* a
-            // list are ignored and the Member Value is processed without them,
-            // so an odd entry there costs one origin. An odd value out here
-            // costs the whole directive.
-            // cite(Permissions Policy § 5.2): "Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present."
-            let shape = if is_valid_token_like(item) {
-                "token"
-            } else {
-                "value"
-            };
-            out.push(format!(
-                "member '{}' has {} '{}', which is not an allowlist: § 5.2 permits a string, \
-                 the token '*', the token 'self', or an inner list of those",
-                feature_part, shape, item
-            ));
-            continue;
-        }
-
-        // Validate parameters (if any): only 'report-to' is checked to be a quoted-string when present.
-        for p in parts.iter().skip(1) {
-            let p = p.trim();
-            if p.is_empty() {
-                return vec![format!("empty parameter for feature '{}'", feature_part)];
-            }
-            if let Some(eqpos) = find_char_outside_quotes(p, '=') {
-                let (pn, pv) = p.split_at(eqpos);
-                let pn = pn.trim();
-                let pv = pv[1..].trim();
-                // Checked before the name is compared to anything, and for
-                // every parameter rather than for all but one. A key cannot
-                // hold an uppercase letter, so `Report-To` is not a differently
-                // spelled `report-to`; it is a member the whole field dies on.
-                // cite(RFC 9651 § 4.2.3.3): "If the first character of input_string is not lcalpha or "*", fail parsing."
-                if !is_valid_sf_key(pn) {
-                    return vec![format!(
-                        "invalid parameter '{}' for feature '{}'",
-                        pn, feature_part
-                    )];
-                }
-                if pn == "report-to" {
-                    // The one per-directive failure among the parameters: the
-                    // value parses as a Structured Field and is refused by this
-                    // field's own definition, not by § 4.2.
-                    if !is_quoted_string(pv) {
-                        out.push(format!(
-                            "parameter 'report-to' for '{}' must be a quoted-string",
-                            feature_part
-                        ));
-                        continue;
-                    }
-                } else {
-                    // Any bare Item, not the three that used to be listed here.
-                    // A byte sequence, a Boolean, a Date and a Display String
-                    // are all parameter values, and § 5.2 says nothing about
-                    // parameters other than `report-to` -- so the only question
-                    // left at this site is the Structured Fields one.
-                    // cite(RFC 9651 § 4.2.3.2): "Let param_value be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string."
-                    if !is_bare_item(pv) {
-                        return vec![format!(
-                            "invalid parameter '{}' for feature '{}'",
-                            pn, feature_part
-                        )];
-                    }
-                }
-            } else {
-                // bare parameter name
-                if !is_valid_sf_key(p) {
-                    return vec![format!(
-                        "invalid bare parameter '{}' for '{}'",
-                        p, feature_part
-                    )];
-                }
-            }
+    for member in split_commas_outside_quotes(s) {
+        match judge_member(member.trim(), &mut seen_keys) {
+            // The whole field is gone, so there are no surviving directives to
+            // describe and no reason to keep reading.
+            Verdict::FieldDiscarded(message) => return vec![message],
+            Verdict::DirectiveIgnored(message) => ignored.push(message),
+            Verdict::Enforced => {}
         }
     }
-    out
+    ignored
+}
+
+/// What becomes of one Dictionary member.
+///
+/// The distinction is the whole subject of this rule, and it is the
+/// specification's own: a Structured Fields *parse* failure discards the entire
+/// field, so it is one message and the only one; a member that parses and is
+/// then dropped for its form costs one directive, so those accumulate.
+enum Verdict {
+    /// The field fails to parse: every directive in it is discarded.
+    FieldDiscarded(String),
+    /// This directive parses and is then ignored by the processing steps.
+    DirectiveIgnored(String),
+    /// The directive is enforced as written.
+    Enforced,
+}
+
+/// Judge one Dictionary member: its name, its allowlist, and its parameters.
+fn judge_member(member: &str, seen_keys: &mut std::collections::HashSet<String>) -> Verdict {
+    if member.is_empty() {
+        return Verdict::FieldDiscarded("empty directive/member".into());
+    }
+
+    // A member with no `=` is not malformed and this used to say it was.
+    // § 4.2.2 reads a bare key as the Boolean true, which parses -- so the
+    // field survives and this one directive does not: a Boolean is a Member
+    // Value of "any other form", and § 5.2 drops the member for it. The same
+    // finding as the explicit `?1` below, reached by leaving the value out.
+    // cite(RFC 9651 § 4.2.2): "Let value be Boolean true."
+    let Some(eq) = find_char_outside_quotes(member, '=') else {
+        return Verdict::DirectiveIgnored(format!(
+            "member '{}' has no value, which is the Boolean true and not an allowlist: \
+             § 5.2 permits a string, the token '*', the token 'self', or an inner list \
+             of those",
+            member
+        ));
+    };
+    let (left, right) = member.split_at(eq);
+    let value_part = right[1..].trim(); // drop '='
+
+    // The name may carry parameters (`key;param=1`); only the key names the feature.
+    let mut feature = left.trim();
+    if let Some(semicolon) = find_char_outside_quotes(feature, ';') {
+        feature = feature[..semicolon].trim();
+    }
+
+    if !is_valid_feature_identifier(feature) {
+        return Verdict::FieldDiscarded(format!(
+            "invalid feature identifier '{}': a Dictionary member name is an SF key \
+             (lowercase, starting with a letter or '*'), and a key that is not one fails \
+             parsing -- which discards every directive in the field, not just this one",
+            feature
+        ));
+    }
+
+    // A repeated key is not a parse failure and not an error: the parser
+    // keeps the last one and the earlier directive simply stops existing.
+    // That is precisely this rule's subject -- something the server wrote
+    // that will not be enforced -- and it is invisible without being told,
+    // since the header still looks like it says both things. Keys are
+    // compared character for character, which § 4.2.2 says outright and
+    // which the key grammar makes moot anyway.
+    // cite(RFC 9651 § 4.2.2): "Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored."
+    if !seen_keys.insert(feature.to_string()) {
+        return Verdict::DirectiveIgnored(format!(
+            "feature '{}' is given more than once; all but the last are ignored, so the \
+             earlier allowlist has no effect",
+            feature
+        ));
+    }
+
+    let parts = split_semicolons_outside_quotes(value_part);
+    let item = parts.first().map(|s| s.trim()).unwrap_or("");
+    // Nothing after the `=` fails § 4.2.2's parse of a Dictionary member
+    // value, so this is the whole field rather than the one directive.
+    if item.is_empty() {
+        return Verdict::FieldDiscarded(format!("member '{}' has empty value", feature));
+    }
+
+    match judge_allowlist(item, feature) {
+        Verdict::Enforced => judge_parameters(&parts, feature),
+        verdict => verdict,
+    }
+}
+
+/// Judge the Member Value: is it one of the forms § 5.2 permits?
+// cite(Permissions Policy § 5.2): "The Member Values represent allowlists, and must be one of:"
+// cite(Permissions Policy § 5.2): "Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps."
+fn judge_allowlist(item: &str, feature: &str) -> Verdict {
+    // A Boolean, a Number and a Byte Sequence each parse and are then dropped
+    // for their form, so each costs its own directive and the scan carries on.
+    let dropped_for_its_form = if item.starts_with('?') {
+        Some("boolean")
+    } else if is_number(item) {
+        Some("numeric")
+    } else if is_byte_sequence(item) {
+        Some("byte-sequence")
+    } else {
+        None
+    };
+    if let Some(form) = dropped_for_its_form {
+        return Verdict::DirectiveIgnored(format!(
+            "member '{}' has {} value not allowed",
+            feature, form
+        ));
+    }
+
+    if let Some(inner) = item.strip_prefix('(') {
+        let Some(inner) = inner.strip_suffix(')') else {
+            return Verdict::FieldDiscarded(format!(
+                "member '{}' has unterminated inner-list",
+                feature
+            ));
+        };
+        // Inner-list contents are permissively accepted — see the asymmetry
+        // noted below — but an empty member is a parse failure.
+        if !inner.trim().is_empty()
+            && split_spaces_outside_quotes(inner)
+                .iter()
+                .any(|m| m.trim().is_empty())
+        {
+            return Verdict::FieldDiscarded(format!(
+                "member '{}' has empty inner-list member",
+                feature
+            ));
+        }
+        return Verdict::Enforced;
+    }
+
+    if item.starts_with('"') {
+        return if is_quoted_string(item) {
+            Verdict::Enforced
+        } else {
+            Verdict::FieldDiscarded(format!("member '{}' has invalid quoted-string", feature))
+        };
+    }
+
+    // § 5.2 names two permitted Tokens, and a Token keeps its case:
+    // RFC 9651 § 4.2.6 consumes each character and appends it to the
+    // output unchanged, and nothing anywhere folds a Token. Compare
+    // § 3.2, which says outright that member *keys* cannot contain
+    // uppercase -- the specification distinguishes the two cases, so
+    // this code should not have folded them together.
+    //
+    // `SELF` is therefore a different Token from `self`, which makes it
+    // a Member Value of "any other form", and § 5.2 says what becomes
+    // of those: the directive is dropped. `eq_ignore_ascii_case` here
+    // called that conforming.
+    // cite(RFC 9651 § 3.2): "Member keys cannot contain uppercase characters."
+    if item == "*" || item == "self" {
+        return Verdict::Enforced;
+    }
+
+    // Everything else. § 5.2's list of permitted Member Values is
+    // closed -- a String, the Token `*`, the Token `self`, or an Inner
+    // List of those -- so a bare Token that is neither `*` nor `self`
+    // is not a narrower kind of allowlist, it is not an allowlist at
+    // all. This branch used to accept any syntactically well-formed
+    // token, which let `geolocation=camera` and `geolocation=SELF`
+    // through as conforming when a browser drops both.
+    //
+    // Note the asymmetry with Inner List contents above, which stay
+    // permissive on purpose: § 5.2 says unknown items *inside* a list are
+    // ignored and the Member Value is processed without them, so an odd entry
+    // there costs one origin. An odd value out here costs the whole directive.
+    // cite(Permissions Policy § 5.2): "Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present."
+    let shape = if is_valid_token_like(item) {
+        "token"
+    } else {
+        "value"
+    };
+    Verdict::DirectiveIgnored(format!(
+        "member '{}' has {} '{}', which is not an allowlist: § 5.2 permits a string, \
+         the token '*', the token 'self', or an inner list of those",
+        feature, shape, item
+    ))
+}
+
+/// Judge the parameters after the Member Value. Only `report-to` has a shape
+/// this field's own definition constrains; the rest are judged as Structured
+/// Fields and nothing more.
+///
+/// The scan runs to the end even once a `report-to` has been found wanting,
+/// because a parse failure in a *later* parameter discards the whole field and
+/// outranks it. A second bad `report-to` on the same directive adds nothing:
+/// one directive that will not be enforced is one finding.
+fn judge_parameters(parts: &[&str], feature: &str) -> Verdict {
+    let mut ignored: Option<String> = None;
+    for parameter in parts.iter().skip(1) {
+        let parameter = parameter.trim();
+        if parameter.is_empty() {
+            return Verdict::FieldDiscarded(format!("empty parameter for feature '{}'", feature));
+        }
+
+        let Some(eq) = find_char_outside_quotes(parameter, '=') else {
+            // A bare parameter name, which is the Boolean true — a value this
+            // field says nothing about, so only the key grammar is asked.
+            if !is_valid_sf_key(parameter) {
+                return Verdict::FieldDiscarded(format!(
+                    "invalid bare parameter '{}' for '{}'",
+                    parameter, feature
+                ));
+            }
+            continue;
+        };
+        let (name, value) = parameter.split_at(eq);
+        let name = name.trim();
+        let value = value[1..].trim();
+
+        // Checked before the name is compared to anything, and for
+        // every parameter rather than for all but one. A key cannot
+        // hold an uppercase letter, so `Report-To` is not a differently
+        // spelled `report-to`; it is a member the whole field dies on.
+        // cite(RFC 9651 § 4.2.3.3): "If the first character of input_string is not lcalpha or "*", fail parsing."
+        if !is_valid_sf_key(name) {
+            return Verdict::FieldDiscarded(format!(
+                "invalid parameter '{}' for feature '{}'",
+                name, feature
+            ));
+        }
+
+        if name == "report-to" {
+            // The one per-directive failure among the parameters: the value
+            // parses as a Structured Field and is refused by this field's own
+            // definition, not by § 4.2.
+            if !is_quoted_string(value) {
+                ignored.get_or_insert_with(|| {
+                    format!(
+                        "parameter 'report-to' for '{}' must be a quoted-string",
+                        feature
+                    )
+                });
+            }
+        } else if !is_bare_item(value) {
+            // Any bare Item, not the three that used to be listed here.
+            // A byte sequence, a Boolean, a Date and a Display String
+            // are all parameter values, and § 5.2 says nothing about
+            // parameters other than `report-to` -- so the only question
+            // left at this site is the Structured Fields one.
+            // cite(RFC 9651 § 4.2.3.2): "Let param_value be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string."
+            return Verdict::FieldDiscarded(format!(
+                "invalid parameter '{}' for feature '{}'",
+                name, feature
+            ));
+        }
+    }
+    ignored.map_or(Verdict::Enforced, Verdict::DirectiveIgnored)
 }
 
 // Shared parsing helpers (splitting, quoted-string, byte-seq, key/token-like)

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -168,7 +168,9 @@ sources:
     snippet: The `X-Frame-Options` HTTP response header is a way of controlling whether and how a Document may be loaded inside of a child navigable.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 125
+      line: 107
+    - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
+      line: 224
   - label: refresh_header_syntax
     section: § 7.8
     snippet: It takes the same value and works largely the same.
@@ -402,19 +404,27 @@ sources:
     snippet: The frame-ancestors directive restricts the URLs which can embed the resource using frame, iframe, object, or embed.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 124
+      line: 51
+    - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
+      line: 223
   - label: content_security_policy_and_frame_options_consistent (2)
     section: § 6.4.2.2
     snippet: the frame-ancestors directive overrides the ``X-Frame-Options`` header.
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_and_frame_options_consistent.rs
-      line: 123
+      line: 222
   - label: content_security_policy_valid
     section: § 2.3
     snippet: directive-name = 1*( ALPHA / DIGIT / "-" )
     cited_by:
     - file: lint-http-rules/src/rules/content_security_policy_valid.rs
-      line: 96
+      line: 67
+  - label: content_security_policy_valid (2)
+    section: § 2.3
+    snippet: hash-algorithm = "sha256" / "sha384" / "sha512"
+    cited_by:
+    - file: lint-http-rules/src/rules/content_security_policy_valid.rs
+      line: 36
 - label: Clear-Site-Data
   url: https://www.w3.org/TR/clear-site-data/
   type: text/html
@@ -671,7 +681,7 @@ sources:
     snippet: Any other items inside of an Inner List will be ignored by the processing steps, and the Member Value will be processed as if they were not present.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 366
+      line: 387
   - label: permissions_policy_directives_valid (2)
     section: § 5.2
     snippet: Member Values of any other form will cause the entire Dictionary Member to be ignored by the processing steps.
@@ -679,19 +689,19 @@ sources:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 117
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 350
+      line: 309
   - label: permissions_policy_directives_valid (3)
     section: § 5.2
     snippet: The Member Names must be Tokens.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 463
+      line: 494
   - label: permissions_policy_directives_valid (4)
     section: § 5.2
     snippet: 'The Member Values represent allowlists, and must be one of:'
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 349
+      line: 308
   - label: permissions_policy_directives_valid (5)
     section: § 6.1
     snippet: The `Permissions-Policy` HTTP header field can be used in the response (server to client) to communicate the permissions policy that should be enforced by the client.
@@ -1077,13 +1087,13 @@ sources:
     snippet: All digest-algorithm values are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 139
+      line: 312
   - label: digest_header_syntax (2)
     section: § 4.1.1
     snippet: digest-algorithm = token
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 138
+      line: 311
 - label: RFC 3986
   url: https://www.rfc-editor.org/rfc/rfc3986.html
   fragments:
@@ -3020,7 +3030,7 @@ sources:
     - file: lint-http-rules/src/rules/content_md5_vs_digest_preference.rs
       line: 71
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 513
+      line: 127
 - label: RFC 7234
   url: https://www.rfc-editor.org/rfc/rfc7234.html
   fragments:
@@ -6151,7 +6161,7 @@ sources:
     snippet: The 101 (Switching Protocols) status code indicates that the server understands and is willing to comply with the client's request, via the Upgrade header field
     cited_by:
     - file: lint-http-proxy/src/proxy/exchange.rs
-      line: 386
+      line: 436
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs
     section: § 11.7.1
     snippet: Unlike WWW-Authenticate, the Proxy-Authenticate header field applies only to the next outbound client on the response chain.
@@ -10674,39 +10684,37 @@ sources:
     snippet: This document obsoletes RFC 3230 and the Digest and Want-Digest HTTP fields.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 295
-    - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 321
+      line: 115
   - label: digest_header_syntax (2)
     section: § 2
     snippet: 'It is a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]), where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 164
+      line: 74
   - label: digest_header_syntax (3)
     section: § 2
     snippet: key conveys the hashing algorithm (see Section 5) used to compute the digest;
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 184
+      line: 353
   - label: digest_header_syntax (4)
     section: § 2
     snippet: value is a Byte Sequence (Section 3.3.5 of [STRUCTURED-FIELDS]) that conveys an encoded version of the byte output produced by the digest calculation.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 196
+      line: 365
   - label: digest_header_syntax (5)
     section: § 4
     snippet: 'Want-Content-Digest and Want-Repr-Digest are of type Dictionary where each:'
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 227
+      line: 78
   - label: digest_header_syntax (6)
     section: § 4
     snippet: value is an Integer (Section 3.3.1 of [STRUCTURED-FIELDS]) that conveys an ascending, relative, weighted preference. It must be in the range 0 to 10 inclusive.
     cited_by:
     - file: lint-http-rules/src/rules/digest_header_syntax.rs
-      line: 251
+      line: 424
 - label: RFC 9651
   url: https://www.rfc-editor.org/rfc/rfc9651.html
   fragments:
@@ -10875,7 +10883,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 481
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 224
+      line: 250
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 343
   - label: lint-http-rules/src/helpers/structured_fields.rs (26)
@@ -10931,7 +10939,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 619
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 418
+      line: 461
   - label: lint-http-rules/src/helpers/structured_fields.rs (34)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not lcalpha or "*", fail parsing.
@@ -10939,7 +10947,7 @@ sources:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 225
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 394
+      line: 435
   - label: lint-http-rules/src/helpers/structured_fields.rs (35)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not one of lcalpha, DIGIT, "_", "-", ".", or "*", return output_string.
@@ -11091,9 +11099,9 @@ sources:
     snippet: Member keys cannot contain uppercase characters.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 351
+      line: 370
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 464
+      line: 495
   - label: permissions_policy_directives_valid (3)
     section: § 4.2
     snippet: If parsing fails, either the entire field value MUST be ignored (i.e., treated as if the field were not present in the section), or alternatively the complete HTTP message MUST be treated as malformed.
@@ -11119,7 +11127,7 @@ sources:
     snippet: Note that when duplicate Dictionary keys are encountered, all but the last instance are ignored.
     cited_by:
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
-      line: 262
+      line: 284
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 289
   - label: priority_header_syntax


### PR DESCRIPTION
The threshold stood at 30 on the reasoning that the rules crate is dominated by flat RFC parsers whose complexity is inherent. That was true of the parsers and false of what was actually at the ceiling. Every function at 29 was a duplicated answer with a name missing: `run_proxy_inner` was a startup sequence, an accept loop and a shutdown drain in one function; `digest_header_syntax` checked eleven fields with eleven copies of one dispatch, differing only in the field's name, the side it is read on, and which of four syntaxes it follows; `exchange` carried the whole H3-failure retry matrix inline; `permissions_policy` decided "the field is discarded" and "this directive is ignored" by which of two statements it reached; the two CSP rules each grew a model — what a frame-ancestors policy permits, what an X-Frame-Options value states — and the comparison became a match over it. None needed parser state threaded across an artificial boundary.

Two of the tallest functions were tests: a run of thirty `assert!` lines is a run of thirty branches, and as a table each failure now names the value that failed.

`FrameOptions::of` reads its first ten bytes with `get(..10)`, which is also a panic the old slicing would have taken on a value with a multi-byte character across that boundary.

Nothing is above 18, so the gate is set at 19 — one point of headroom, as it has always been, so it bites on the next function to grow rather than on a backlog.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
