### PR TITLE
Cache-Control has one reader at each of its three layers

### DIFF
--- a/lint-http-rules/src/helpers/cache_control.rs
+++ b/lint-http-rules/src/helpers/cache_control.rs
@@ -85,24 +85,88 @@ impl<'a> Directive<'a> {
     }
 }
 
+/// Every list member in the section's `Cache-Control` field lines, in order and
+/// as written — **including the empty ones**.
+///
+/// [`directives`] drops an empty member because a caller asking what the sender
+/// requested has nothing to read in one. A caller reporting on the sender's
+/// syntax has the opposite need: an empty element is precisely its finding, and
+/// before this existed those callers reached past the reader and re-split the
+/// field themselves to see it.
+///
+/// **A field line that is empty contributes no members at all**, and that is
+/// the one exemption every caller of this needs: an entirely empty
+/// `Cache-Control` value is a zero-element list, which `#element` permits,
+/// while an empty element *within* a list is forbidden. Three rules wrote that
+/// distinction out separately — skipping the empty value at the call site and
+/// reporting the empty member in a function two levels down — which is two
+/// places to get one sentence right.
+///
+/// Field lines that are not readable as text are skipped by both readers.
+/// Naming *that* defect belongs to the rule that owns the field and needs the
+/// field line rather than the member, so it asks
+/// [`crate::helpers::headers::has_unreadable_line`].
+// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
+// cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
+// cite(RFC 9110 § 5.6.1): "#element => [ element ] *( OWS "," OWS [ element ] )"
+pub fn members(headers: &HeaderMap) -> impl Iterator<Item = &str> {
+    crate::helpers::headers::field_lines(headers, "cache-control").flat_map(members_of)
+}
+
+/// The list members of one `Cache-Control` field line, as written.
+///
+/// [`members`] over a whole section is this applied to each readable line. A
+/// caller reaches for this one when it reports per line — because the field
+/// line, not the member, is what its finding is about — and the two must agree
+/// about the member boundary, which is why the split lives here once.
+pub fn members_of(line: &str) -> Vec<&str> {
+    if line.trim().is_empty() {
+        return Vec::new();
+    }
+    // `,` is the list separator the grammar prints; `;` is a tolerance for the
+    // malformed `a;b` form some senders write. Accepting it only ever widens
+    // what a directive search finds, never narrows it.
+    split_top_level(line, b",;")
+}
+
 /// Every directive in the section's `Cache-Control` field lines, in order.
 ///
-/// Field lines that are not readable as text are skipped rather than reported:
-/// naming that defect belongs to the rule that owns the field's syntax, and
-/// every caller here is asking what the sender *asked for*, not whether they
-/// wrote it correctly.
-// cite(RFC 9110 § 5.2): "When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma."
+/// Empty members are dropped: every caller here is asking what the sender
+/// *asked for*, not whether they wrote it correctly. Use [`members`] to see
+/// them.
 pub fn directives(headers: &HeaderMap) -> impl Iterator<Item = Directive<'_>> {
-    headers
-        .get_all("cache-control")
-        .iter()
-        .filter_map(|hv| hv.to_str().ok())
-        // `,` is the list separator the grammar prints; `;` is a tolerance for
-        // the malformed `a;b` form some senders write. Accepting it only ever
-        // widens what a directive search finds, never narrows it.
-        .flat_map(|value| split_top_level(value, b",;"))
+    members(headers)
         .filter(|member| !member.is_empty())
         .map(Directive::parse)
+}
+
+/// Read one list member strictly, as a rule reporting on this field's syntax
+/// must: a defect comes back as the sentence that names it.
+///
+/// The three defects below were transcribed twice, once in each of the two
+/// rules that check this field's grammar, down to the wording — which is what
+/// made them worth moving rather than merely sharing a splitter. What the two
+/// rules do *after* the name is read is genuinely different, and stays theirs.
+// cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
+// cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
+pub fn read_member(member: &str) -> Result<Directive<'_>, String> {
+    if member.is_empty() {
+        return Err("Empty directive in Cache-Control header".into());
+    }
+    let directive = Directive::parse(member);
+    if directive.name.is_empty() {
+        return Err(format!(
+            "Empty directive name in Cache-Control member: '{}'",
+            member
+        ));
+    }
+    if let Some(c) = crate::helpers::token::find_invalid_token_char(directive.name) {
+        return Err(format!(
+            "Directive name contains invalid character: '{}'",
+            c
+        ));
+    }
+    Ok(directive)
 }
 
 /// Whether the section carries the named directive at all.
@@ -243,6 +307,49 @@ mod tests {
         let d = directives(&hm).next().unwrap();
         assert_eq!(d.delta_seconds(), Some(-1));
         assert_eq!(delta_seconds(&hm, "max-age"), None);
+    }
+
+    /// The syntax rules see what the question-asking readers filter away.
+    #[test]
+    fn members_keeps_the_empty_elements_directives_drops() {
+        let hm = headers(&["max-age=1, ,public"]);
+        assert_eq!(
+            members(&hm).collect::<Vec<_>>(),
+            ["max-age=1", "", "public"]
+        );
+        assert_eq!(directives(&hm).count(), 2);
+    }
+
+    /// An empty *value* is a zero-element list and contributes no member; an
+    /// empty *element* inside a list is a member, and a defect.
+    #[test]
+    fn an_empty_field_value_is_a_zero_element_list() {
+        assert_eq!(members(&headers(&[""])).count(), 0);
+        assert_eq!(members(&headers(&["   "])).count(), 0);
+        assert_eq!(members(&headers(&[","])).collect::<Vec<_>>(), ["", ""]);
+        assert_eq!(
+            members(&headers(&["", "max-age=1"])).collect::<Vec<_>>(),
+            ["max-age=1"]
+        );
+    }
+
+    #[test]
+    fn read_member_names_each_defect_in_the_directive_name() {
+        assert_eq!(
+            read_member("").unwrap_err(),
+            "Empty directive in Cache-Control header"
+        );
+        assert_eq!(
+            read_member("=1").unwrap_err(),
+            "Empty directive name in Cache-Control member: '=1'"
+        );
+        assert_eq!(
+            read_member("no cache").unwrap_err(),
+            "Directive name contains invalid character: ' '"
+        );
+        let directive = read_member("max-age=60").unwrap();
+        assert_eq!(directive.name, "max-age");
+        assert_eq!(directive.argument, Some("60"));
     }
 
     #[test]

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -172,6 +172,17 @@ pub fn field_lines<'a>(headers: &'a HeaderMap, name: &str) -> impl Iterator<Item
         .filter_map(|hv| hv.to_str().ok())
 }
 
+/// Whether any field line for `name` carries octets that are not text.
+///
+/// The companion to [`field_lines`], and the reason that one can be silent: it
+/// skips such a line, so a rule whose *finding* is that the sender wrote one
+/// has to ask separately. Keeping the two beside each other is what stops the
+/// silent skip from quietly deleting a rule's finding when it adopts the
+/// reader.
+pub fn has_unreadable_line(headers: &HeaderMap, name: &str) -> bool {
+    headers.get_all(name).iter().any(|hv| hv.to_str().is_err())
+}
+
 /// Collect all header values for the given name and concatenate them using
 /// ", " as a separator, trimming each entry.
 ///

--- a/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
+++ b/lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
@@ -41,32 +41,21 @@ impl Rule for CacheControlAndPragmaConsistent {
             // read by two generations of cache and had better say the same thing to each.
             // cite(RFC 9111 § 5.4): "The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request"
             for hv in tx.request.headers.get_all("pragma").iter() {
-                let s = match hv.to_str() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        // Ignore non-UTF8 header values here and let dedicated
-                        // syntax/token rules (e.g., `pragma_token_valid`) handle encoding errors.
-                        continue;
-                    }
+                let Ok(s) = hv.to_str() else {
+                    // Ignore non-UTF8 header values here and let dedicated
+                    // syntax/token rules (e.g., `pragma_token_valid`) handle encoding errors.
+                    continue;
                 };
                 for m in crate::helpers::headers::list_members(s) {
                     if m.eq_ignore_ascii_case("no-cache") {
                         // if request also contains Cache-Control: only-if-cached, that's contradictory
-                        for cc in tx.request.headers.get_all("cache-control").iter() {
-                            if let Ok(ccv) = cc.to_str() {
-                                for part in
-                                    crate::helpers::headers::split_commas_respecting_quotes(ccv)
-                                {
-                                    let name = part.split('=').next().unwrap().trim();
-                                    if name.eq_ignore_ascii_case("only-if-cached") {
-                                        // No sentence says this combination is illegal; it is a
-                                        // heuristic — Pragma: no-cache asks a cache to revalidate,
-                                        // only-if-cached asks it to serve from cache or fail. Recorded
-                                        // in the tracker.
-                                        return Some(self.violation(ctx.severity, "Request contains 'Pragma: no-cache' and 'Cache-Control: only-if-cached' which are contradictory (RFC 9111 §5.4)".to_string()));
-                                    }
-                                }
-                            }
+                        // No sentence says this combination is illegal; it is a
+                        // heuristic — Pragma: no-cache asks a cache to revalidate,
+                        // only-if-cached asks it to serve from cache or fail. Recorded
+                        // in the tracker.
+                        if crate::helpers::cache_control::has(&tx.request.headers, "only-if-cached")
+                        {
+                            return Some(self.violation(ctx.severity, "Request contains 'Pragma: no-cache' and 'Cache-Control: only-if-cached' which are contradictory (RFC 9111 §5.4)".to_string()));
                         }
                     }
                 }

--- a/lint-http-rules/src/rules/cache_control_directive_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_directive_valid.rs
@@ -17,6 +17,40 @@ const RFC_9111_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "Cache-Control directives and general directive syntax",
 };
 
+impl CacheControlDirectiveValid {
+    /// The first defect in one message's `Cache-Control` field, if it has one.
+    ///
+    /// Read line by line rather than over the whole section, because an
+    /// unreadable line is one of the findings and the field line is what that
+    /// finding is about. Where the members come from, and which of them the
+    /// grammar's `#element` even admits, is
+    /// [`crate::helpers::cache_control`]'s answer.
+    fn defect(
+        &self,
+        headers: &hyper::HeaderMap,
+        side: &str,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        for line in headers.get_all("cache-control").iter() {
+            let Ok(line) = line.to_str() else {
+                return Some(self.violation(
+                    severity,
+                    "Cache-Control header contains non-UTF8 value".into(),
+                ));
+            };
+            for member in crate::helpers::cache_control::members_of(line) {
+                if let Some(message) = member_defect(member) {
+                    return Some(self.violation(
+                        severity,
+                        format!("Invalid Cache-Control header in {}: {}", side, message),
+                    ));
+                }
+            }
+        }
+        None
+    }
+}
+
 impl Rule for CacheControlDirectiveValid {
     fn id(&self) -> &'static str {
         "cache_control_directive_valid"
@@ -34,56 +68,16 @@ impl Rule for CacheControlDirectiveValid {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
+        //
+        // Both sides of the exchange carry this field and are read the same way;
+        // only the word in the finding differs.
+        // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
         let finding = || -> Option<Violation> {
-            // Apply to both request and response messages
-            // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
-            for header_val in tx.request.headers.get_all("cache-control").iter() {
-                if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
-                    // An entirely empty Cache-Control value is a zero-element list, which is legal
-                    // (`#element => [ 1#element ]`); that is distinct from an empty *element*
-                    // within a list, which check_cache_control_directives flags. Skip it.
-                    if v.is_empty() {
-                        continue;
-                    }
-                    if let Some(msg) = check_cache_control_directives(v) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!("Invalid Cache-Control header in request: {}", msg),
-                        ));
-                    }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Cache-Control header contains non-UTF8 value".into(),
-                    ));
-                }
-            }
-
-            if let Some(resp) = &tx.response {
-                for header_val in resp.headers.get_all("cache-control").iter() {
-                    if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
-                        // An entirely empty Cache-Control value is a zero-element list, which is legal
-                        // (`#element => [ 1#element ]`); that is distinct from an empty *element*
-                        // within a list, which check_cache_control_directives flags. Skip it.
-                        if v.is_empty() {
-                            continue;
-                        }
-                        if let Some(msg) = check_cache_control_directives(v) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!("Invalid Cache-Control header in response: {}", msg),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Cache-Control header contains non-UTF8 value".into(),
-                        ));
-                    }
-                }
-            }
-
-            None
+            self.defect(&tx.request.headers, "request", ctx.severity)
+                .or_else(|| {
+                    let resp = tx.response.as_ref()?;
+                    self.defect(&resp.headers, "response", ctx.severity)
+                })
         };
         Vec::from_iter(finding())
     }
@@ -113,129 +107,97 @@ impl Rule for CacheControlDirectiveValid {
     }
 }
 
-fn check_cache_control_directives(s: &str) -> Option<String> {
-    for member in crate::helpers::headers::split_commas_respecting_quotes(s) {
-        // An empty element *within* the list is forbidden, unlike the empty whole
-        // value the callers skip as a zero-element list.
-        // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
-        if member.is_empty() {
-            return Some("Empty directive in Cache-Control header".into());
-        }
+/// What is wrong with one `cache-directive`, if anything.
+///
+/// The name is read by the shared strict reader, which owns the three defects
+/// the two Cache-Control syntax rules report identically. What this rule adds is
+/// the part that is its own: what each *named* directive's argument may say.
+// cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
+fn member_defect(member: &str) -> Option<String> {
+    let directive = match crate::helpers::cache_control::read_member(member) {
+        Ok(directive) => directive,
+        Err(message) => return Some(message),
+    };
+    let name = directive.name;
+    // An empty argument is accepted for directives that take one; the `=` with
+    // nothing after it is the leniency recorded in the token rule beside this.
+    let argument = directive.argument.filter(|a| !a.is_empty())?;
 
-        // The name/value split below transcribes the cache-directive grammar; the
-        // `token` and `quoted-string` rules themselves stay helper-owned.
-        // cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
-        let mut kv = member.splitn(2, '=');
-        let name = kv.next().unwrap().trim();
-        if name.is_empty() {
-            return Some(format!(
-                "Empty directive name in Cache-Control member: '{}'",
-                member
-            ));
-        }
-
-        if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-            return Some(format!(
-                "Directive name contains invalid character: '{}'",
-                c
-            ));
-        }
-
-        if let Some(vpart) = kv.next() {
-            let vpart = vpart.trim();
-            if vpart.is_empty() {
-                // empty value allowed for directives that accept an empty value
-                continue;
+    match name.to_ascii_lowercase().as_str() {
+        "max-age" | "s-maxage" => {
+            // Both take a delta-seconds argument, which is why a sign, a
+            // decimal point or any non-digit is rejected here.
+            // cite(RFC 9111 § 1.2.2): "The delta-seconds rule specifies a non-negative integer, representing time in seconds."
+            if let Some(c) = crate::helpers::token::find_invalid_token_char(argument) {
+                // If it contains non-token chars it's invalid (no quotes allowed here)
+                return Some(format!(
+                    "{} value contains invalid character: '{}'",
+                    name, c
+                ));
             }
-
-            // Specific directive checks
-            let lname = name.to_ascii_lowercase();
-            match lname.as_str() {
-                "max-age" | "s-maxage" => {
-                    // Both take a delta-seconds argument, which is why a sign, a
-                    // decimal point or any non-digit is rejected here.
-                    // cite(RFC 9111 § 1.2.2): "The delta-seconds rule specifies a non-negative integer, representing time in seconds."
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(vpart) {
-                        // If it contains non-token chars it's invalid (no quotes allowed here)
-                        return Some(format!(
-                            "{} value contains invalid character: '{}'",
-                            name, c
-                        ));
-                    }
-                    if vpart.chars().any(|ch| !ch.is_ascii_digit()) {
-                        return Some(format!("{} must be a non-negative integer", name));
-                    }
-                    // A digit run too large for any particular integer type is still
-                    // syntactically valid `1*DIGIT`, and the spec says what to do about
-                    // it — clamp, not reject — so there is nothing here to report. The
-                    // value's magnitude is the recipient's problem, not the sender's.
-                    // cite(RFC 9111 § 1.2.2): "If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648"
-                    // cite(RFC 9111 § 1.2.2): "or the greatest positive integer it can conveniently represent."
-                }
-                "private" | "no-cache" => {
-                    // Both take the same optional argument: a `#field-name` list, which
-                    // is what this branch validates (as a quoted-string or, leniently,
-                    // as a bare comma-separated list). The sentence below is stated for
-                    // private; no-cache's qualified form (§5.2.2.4) has the same shape.
-                    // cite(RFC 9111 § 5.2.2.7): "If a qualified private response directive is present, with an argument that lists one or more field names"
-                    if vpart.starts_with('"') {
-                        match crate::helpers::headers::unescape_quoted_string(vpart) {
-                            Ok(inner) => {
-                                for field in inner.split(',') {
-                                    let f = field.trim();
-                                    if f.is_empty() {
-                                        return Some(format!("Empty field-name in {} value", name));
-                                    }
-                                    if let Some(c) =
-                                        crate::helpers::token::find_invalid_token_char(f)
-                                    {
-                                        return Some(format!(
-                                            "{} includes invalid field-name character: '{}'",
-                                            name, c
-                                        ));
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                return Some(format!(
-                                    "Invalid quoted-string in {} value: {}",
-                                    name, e
-                                ))
-                            }
-                        }
-                    } else {
-                        // unquoted: allow single token or comma-separated tokens
-                        for part in vpart.split(',') {
-                            let p = part.trim();
-                            if p.is_empty() {
-                                return Some(format!("Empty field-name in {} value", name));
-                            }
-                            if let Some(c) = crate::helpers::token::find_invalid_token_char(p) {
-                                return Some(format!(
-                                    "{} includes invalid field-name character: '{}'",
-                                    name, c
-                                ));
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    // For other directives, accept token or quoted-string and ensure token syntax if unquoted
-                    if vpart.starts_with('"') {
-                        if let Err(e) = crate::helpers::headers::validate_quoted_string(vpart) {
-                            return Some(format!(
-                                "Invalid quoted-string in directive {} value: {}",
-                                name, e
-                            ));
-                        }
-                    } else if let Some(c) = crate::helpers::token::find_invalid_token_char(vpart) {
-                        return Some(format!(
-                            "Directive {} value contains invalid character: '{}'",
-                            name, c
-                        ));
-                    }
-                }
+            if argument.chars().any(|ch| !ch.is_ascii_digit()) {
+                return Some(format!("{} must be a non-negative integer", name));
             }
+            // A digit run too large for any particular integer type is still
+            // syntactically valid `1*DIGIT`, and the spec says what to do about
+            // it — clamp, not reject — so there is nothing here to report. The
+            // value's magnitude is the recipient's problem, not the sender's.
+            // cite(RFC 9111 § 1.2.2): "If a cache receives a delta-seconds value greater than the greatest integer it can represent, or if any of its subsequent calculations overflows, the cache MUST consider the value to be 2147483648"
+            // cite(RFC 9111 § 1.2.2): "or the greatest positive integer it can conveniently represent."
+            None
+        }
+        // Both take the same optional argument: a `#field-name` list, which is
+        // what this branch validates (as a quoted-string or, leniently, as a
+        // bare comma-separated list). The sentence below is stated for private;
+        // no-cache's qualified form (§5.2.2.4) has the same shape.
+        // cite(RFC 9111 § 5.2.2.7): "If a qualified private response directive is present, with an argument that lists one or more field names"
+        "private" | "no-cache" => field_name_list_defect(name, argument),
+        _ => {
+            // For other directives, accept token or quoted-string and ensure token syntax if unquoted
+            if argument.starts_with('"') {
+                if let Err(e) = crate::helpers::headers::validate_quoted_string(argument) {
+                    return Some(format!(
+                        "Invalid quoted-string in directive {} value: {}",
+                        name, e
+                    ));
+                }
+                return None;
+            }
+            crate::helpers::token::find_invalid_token_char(argument).map(|c| {
+                format!(
+                    "Directive {} value contains invalid character: '{}'",
+                    name, c
+                )
+            })
+        }
+    }
+}
+
+/// The `#field-name` argument `private` and `no-cache` share, quoted or bare.
+///
+/// The two spellings ask the same question of each name, which is why the walk
+/// below is written once over whichever list the argument turned out to be.
+fn field_name_list_defect(name: &str, argument: &str) -> Option<String> {
+    let list = if argument.starts_with('"') {
+        match crate::helpers::headers::unescape_quoted_string(argument) {
+            Ok(inner) => inner,
+            Err(e) => return Some(format!("Invalid quoted-string in {} value: {}", name, e)),
+        }
+    } else {
+        // unquoted: allow single token or comma-separated tokens
+        argument.to_string()
+    };
+
+    for field in list.split(',') {
+        let field = field.trim();
+        if field.is_empty() {
+            return Some(format!("Empty field-name in {} value", name));
+        }
+        if let Some(c) = crate::helpers::token::find_invalid_token_char(field) {
+            return Some(format!(
+                "{} includes invalid field-name character: '{}'",
+                name, c
+            ));
         }
     }
     None

--- a/lint-http-rules/src/rules/cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -17,6 +17,40 @@ const RFC_9111_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     note: "Cache-Control directives and general directive syntax",
 };
 
+impl CacheControlTokenValid {
+    /// The first defect in one message's `Cache-Control` field, if it has one.
+    ///
+    /// Read line by line rather than over the whole section, because an
+    /// unreadable line is one of the findings and the field line is what that
+    /// finding is about. Where the members come from, and which of them the
+    /// grammar's `#element` even admits, is
+    /// [`crate::helpers::cache_control`]'s answer.
+    fn defect(
+        &self,
+        headers: &hyper::HeaderMap,
+        side: &str,
+        severity: crate::lint::Severity,
+    ) -> Option<Violation> {
+        for line in headers.get_all("cache-control").iter() {
+            let Ok(line) = line.to_str() else {
+                return Some(self.violation(
+                    severity,
+                    "Cache-Control header contains non-UTF8 value".into(),
+                ));
+            };
+            for member in crate::helpers::cache_control::members_of(line) {
+                if let Some(message) = member_defect(member) {
+                    return Some(self.violation(
+                        severity,
+                        format!("Invalid Cache-Control header in {}: {}", side, message),
+                    ));
+                }
+            }
+        }
+        None
+    }
+}
+
 impl Rule for CacheControlTokenValid {
     fn id(&self) -> &'static str {
         "cache_control_token_valid"
@@ -34,56 +68,16 @@ impl Rule for CacheControlTokenValid {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
+        //
+        // Both sides of the exchange carry this field and are read the same way;
+        // only the word in the finding differs.
+        // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
         let finding = || -> Option<Violation> {
-            // Apply to both request and response messages
-            // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
-            for header_val in tx.request.headers.get_all("cache-control").iter() {
-                if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
-                    // An entirely empty Cache-Control value is a zero-element list, which is legal
-                    // (`#element => [ 1#element ]`); that is distinct from an empty *element*
-                    // within a list, which check_cache_control_value flags. Skip it.
-                    if v.is_empty() {
-                        continue;
-                    }
-                    if let Some(msg) = check_cache_control_value(v) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!("Invalid Cache-Control header in request: {}", msg),
-                        ));
-                    }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Cache-Control header contains non-UTF8 value".into(),
-                    ));
-                }
-            }
-
-            if let Some(resp) = &tx.response {
-                for header_val in resp.headers.get_all("cache-control").iter() {
-                    if let Some(v) = header_val.to_str().ok().map(|s| s.trim()) {
-                        // An entirely empty Cache-Control value is a zero-element list, which is legal
-                        // (`#element => [ 1#element ]`); that is distinct from an empty *element*
-                        // within a list, which check_cache_control_value flags. Skip it.
-                        if v.is_empty() {
-                            continue;
-                        }
-                        if let Some(msg) = check_cache_control_value(v) {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!("Invalid Cache-Control header in response: {}", msg),
-                            ));
-                        }
-                    } else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Cache-Control header contains non-UTF8 value".into(),
-                        ));
-                    }
-                }
-            }
-
-            None
+            self.defect(&tx.request.headers, "request", ctx.severity)
+                .or_else(|| {
+                    let resp = tx.response.as_ref()?;
+                    self.defect(&resp.headers, "response", ctx.severity)
+                })
         };
         Vec::from_iter(finding())
     }
@@ -113,64 +107,39 @@ impl Rule for CacheControlTokenValid {
     }
 }
 
-fn check_cache_control_value(s: &str) -> Option<String> {
-    // Split by top-level commas but ignore commas inside quoted-strings
-    for member in crate::helpers::headers::split_commas_respecting_quotes(s) {
-        // An empty element *within* the list is forbidden, unlike the empty whole
-        // value the callers skip as a zero-element list.
-        // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
-        if member.is_empty() {
-            return Some("Empty directive in Cache-Control header".into());
-        }
+/// What is wrong with one `cache-directive`, if anything.
+///
+/// The name is read by the shared strict reader; what stays here is this rule's
+/// own question, which is about the value's *shape* rather than about what any
+/// particular directive means by it.
+// cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
+fn member_defect(member: &str) -> Option<String> {
+    let directive = match crate::helpers::cache_control::read_member(member) {
+        Ok(directive) => directive,
+        Err(message) => return Some(message),
+    };
+    let argument = directive.argument?;
 
-        // The name/value split transcribes the cache-directive grammar. The two
-        // value shapes it names, `token` (§5.6.2) and `quoted-string` (§5.6.4),
-        // stay owned by the helpers this function calls below.
-        // cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
-        let mut kv = member.splitn(2, '=');
-        let name = kv.next().unwrap().trim();
-        if name.is_empty() {
-            return Some(format!(
-                "Empty directive name in Cache-Control member: '{}'",
-                member
-            ));
+    // The `( token / quoted-string )` alternation is read by the shared helper
+    // that owns it; what stays here is what this field says about each answer.
+    match crate::helpers::headers::token_or_quoted_string(argument) {
+        Ok(_) => None,
+        // Leniency, recorded rather than changed: `foo=` does not match the
+        // grammar above — once "=" is present the optional group requires a
+        // token (`1*tchar`) or a quoted-string, neither of which can be empty.
+        // The rule accepts it anyway, so it under-reports this one shape. That
+        // is the safe direction for a linter, and tightening it would be a
+        // behavior change. (`foo=""` is genuinely valid: quoted-string permits
+        // empty content.)
+        Err(crate::helpers::headers::WordDefect::Empty) => None,
+        Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
+            Some(format!("Invalid quoted-string in directive value: {}", e))
         }
-
-        if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-            return Some(format!(
-                "Directive name contains invalid character: '{}'",
-                c
-            ));
-        }
-
-        if let Some(vpart) = kv.next() {
-            let vpart = vpart.trim();
-            // The `( token / quoted-string )` alternation is read by the shared
-            // helper that owns it; what stays here is what this field says about
-            // each answer.
-            match crate::helpers::headers::token_or_quoted_string(vpart) {
-                Ok(_) => {}
-                // Leniency, recorded rather than changed: `foo=` does not match the
-                // grammar above — once "=" is present the optional group requires a
-                // token (`1*tchar`) or a quoted-string, neither of which can be empty.
-                // The rule accepts it anyway, so it under-reports this one shape. That
-                // is the safe direction for a linter, and tightening it would be a
-                // behavior change. (`foo=""` is genuinely valid: quoted-string permits
-                // empty content.)
-                Err(crate::helpers::headers::WordDefect::Empty) => continue,
-                Err(crate::helpers::headers::WordDefect::NotQuotedString(e)) => {
-                    return Some(format!("Invalid quoted-string in directive value: {}", e));
-                }
-                Err(crate::helpers::headers::WordDefect::NotToken(c)) => {
-                    return Some(format!(
-                        "Directive value contains invalid character: '{}'",
-                        c
-                    ));
-                }
-            }
-        }
+        Err(crate::helpers::headers::WordDefect::NotToken(c)) => Some(format!(
+            "Directive value contains invalid character: '{}'",
+            c
+        )),
     }
-    None
 }
 
 /// Registers this rule into the engine's auto-collected catalogue.

--- a/lint-http-rules/src/rules/caching_directive_interaction.rs
+++ b/lint-http-rules/src/rules/caching_directive_interaction.rs
@@ -56,57 +56,40 @@ impl Rule for CachingDirectiveInteraction {
         let finding = || -> Option<Violation> {
             // Helper to check a single HeaderMap for contradictions
             let check_headers = |hdrs: &hyper::HeaderMap| -> Option<Violation> {
-                use crate::helpers::headers::split_commas_respecting_quotes;
-
-                // Collect directives across possibly multiple header fields
-                let mut directives: Vec<(String, Option<String>)> = Vec::new();
-
-                for hv in hdrs.get_all("cache-control").iter() {
-                    let s = match hv.to_str() {
-                        Ok(s) => s,
-                        Err(_) => {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Cache-Control header contains non-UTF8 value".into(),
-                            ))
-                        }
-                    };
-
-                    // An entirely empty Cache-Control value is a zero-element list, which is legal
-                    // (`#element => [ 1#element ]`); that is distinct from an empty *element*
-                    // within a list, which the check below flags. Skip the empty-list case.
-                    if s.trim().is_empty() {
-                        continue;
-                    }
-
-                    for member in split_commas_respecting_quotes(s) {
-                        let m = member;
-                        if m.is_empty() {
-                            // Cache-Control is a `#cache-directive` list, and the sender (client on a
-                            // request, server on a response) must not emit empty list elements.
-                            // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
-                            return Some(self.violation(
-                                ctx.severity,
-                                "Cache-Control header contains empty member".into(),
-                            ));
-                        }
-
-                        let mut kv = m.splitn(2, '=');
-                        let name = kv.next().unwrap().trim().to_ascii_lowercase();
-                        let value = kv.next().map(|v| v.trim().to_string());
-
-                        directives.push((name, value));
-                    }
+                // The shared reader skips a field line it cannot read as text;
+                // reporting that is this rule's, so it is asked for separately.
+                if crate::helpers::headers::has_unreadable_line(hdrs, "cache-control") {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Cache-Control header contains non-UTF8 value".into(),
+                    ));
                 }
 
-                if directives.is_empty() {
-                    return None;
+                // An empty *element* within the list is forbidden — as distinct
+                // from an entirely empty field value, which is a legal
+                // zero-element list and which `members` already exempts.
+                // `directives` would have dropped the empty member; this is
+                // what the raw reader is for.
+                // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
+                if crate::helpers::cache_control::members(hdrs).any(str::is_empty) {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Cache-Control header contains empty member".into(),
+                    ));
                 }
 
+                // Directive names are compared case-insensitively, so the map is
+                // keyed by the folded name; the argument is kept as written.
                 use std::collections::HashMap;
                 let mut seen: HashMap<String, Vec<Option<String>>> = HashMap::new();
-                for (n, v) in directives {
-                    seen.entry(n).or_default().push(v);
+                for directive in crate::helpers::cache_control::directives(hdrs) {
+                    seen.entry(directive.name.to_ascii_lowercase())
+                        .or_default()
+                        .push(directive.argument.map(str::to_string));
+                }
+
+                if seen.is_empty() {
+                    return None;
                 }
 
                 // public vs private contradiction. Only *unqualified* private (no `=field-name`

--- a/lint-http-rules/src/rules/immutable_requires_freshness.rs
+++ b/lint-http-rules/src/rules/immutable_requires_freshness.rs
@@ -65,52 +65,43 @@ impl Rule for ImmutableRequiresFreshness {
             let mut found_immutable = false;
             let mut conflicting: Option<String> = None;
 
-            for hv in resp.headers.get_all("cache-control").iter() {
-                let s = match hv.to_str() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Cache-Control header contains non-UTF8 value".into(),
-                        ))
+            // The shared reader skips a field line it cannot read as text;
+            // reporting that is this rule's, so it is asked for separately.
+            if crate::helpers::headers::has_unreadable_line(&resp.headers, "cache-control") {
+                return Some(self.violation(
+                    ctx.severity,
+                    "Cache-Control header contains non-UTF8 value".into(),
+                ));
+            }
+
+            for directive in crate::helpers::cache_control::directives(&resp.headers) {
+                let lname = directive.name.to_ascii_lowercase();
+                let value = directive.argument;
+
+                // `immutable` is the RFC 8246 §2 Cache-Control extension: it tells clients the
+                // origin will not update the representation during the response's freshness
+                // lifetime. (Its defining sentence resists machine extraction from the RFC HTML,
+                // so the two §2 cites on the violation below — its freshness-window behaviour —
+                // carry the spec reference for this rule.)
+                if lname == "immutable" {
+                    found_immutable = true;
+                    continue;
+                }
+
+                let normalized = match (lname.as_str(), value) {
+                    // A zero lifetime is a zero lifetime however it is spelled.
+                    ("max-age" | "s-maxage", Some(v)) if v.parse::<u64>() == Ok(0) => {
+                        format!("{}=0", lname)
                     }
+                    ("no-store" | "no-cache", None) => lname.clone(),
+                    // A qualified `no-cache="field"` restricts reuse of the listed fields
+                    // only; the response still has a freshness lifetime, so `immutable`
+                    // still has a window to apply to.
+                    _ => continue,
                 };
 
-                for member in crate::helpers::headers::split_commas_respecting_quotes(s) {
-                    if member.is_empty() {
-                        continue;
-                    }
-                    let (name, value) = match member.split_once('=') {
-                        Some((n, v)) => (n.trim(), Some(v.trim())),
-                        None => (member, None),
-                    };
-                    let lname = name.to_ascii_lowercase();
-
-                    // `immutable` is the RFC 8246 §2 Cache-Control extension: it tells clients the
-                    // origin will not update the representation during the response's freshness
-                    // lifetime. (Its defining sentence resists machine extraction from the RFC HTML,
-                    // so the two §2 cites on the violation below — its freshness-window behaviour —
-                    // carry the spec reference for this rule.)
-                    if lname == "immutable" {
-                        found_immutable = true;
-                        continue;
-                    }
-
-                    let normalized = match (lname.as_str(), value) {
-                        // A zero lifetime is a zero lifetime however it is spelled.
-                        ("max-age" | "s-maxage", Some(v)) if v.parse::<u64>() == Ok(0) => {
-                            format!("{}=0", lname)
-                        }
-                        ("no-store" | "no-cache", None) => lname.clone(),
-                        // A qualified `no-cache="field"` restricts reuse of the listed fields
-                        // only; the response still has a freshness lifetime, so `immutable`
-                        // still has a window to apply to.
-                        _ => continue,
-                    };
-
-                    if NEVER_FRESH.contains(&normalized.as_str()) && conflicting.is_none() {
-                        conflicting = Some(normalized);
-                    }
+                if NEVER_FRESH.contains(&normalized.as_str()) && conflicting.is_none() {
+                    conflicting = Some(normalized);
                 }
             }
 

--- a/lint-http-rules/src/rules/status_and_caching_semantics.rs
+++ b/lint-http-rules/src/rules/status_and_caching_semantics.rs
@@ -59,32 +59,17 @@ impl Rule for StatusAndCachingSemantics {
             }
 
             // Helper: check Cache-Control directives for explicit freshness (max-age or s-maxage)
-            for hv in resp.headers.get_all("cache-control").iter() {
-                if let Ok(s) = hv.to_str() {
-                    for part in s.split(',') {
-                        let p = part.trim();
-                        if p.is_empty() {
-                            continue;
-                        }
-                        // split on '=' to check for max-age / s-maxage. Directive names are
-                        // case-insensitive; a present max-age or s-maxage is explicit freshness that
-                        // makes the response storable (RFC 9111 §3), so no violation.
-                        // cite(RFC 9111 § 5.2.2.1): "The max-age response directive indicates that the response is to be considered stale after its age is greater than the specified number of seconds."
-                        // cite(RFC 9111 § 5.2.2.10): "The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires"
-                        let mut it = p.splitn(2, '=');
-                        let name = it.next().unwrap().trim().to_ascii_lowercase();
-                        if name == "max-age" || name == "s-maxage" {
-                            if let Some(val) = it.next() {
-                                // Accept non-negative integer delta-seconds (allow whitespace)
-                                if let Ok(n) = val.trim().parse::<i64>() {
-                                    if n >= 0 {
-                                        return None; // explicit freshness present
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            // A present max-age or s-maxage is explicit freshness that makes the
+            // response storable (RFC 9111 §3), so there is nothing to report. The
+            // helper answers with the first non-negative delta-seconds given for
+            // the directive, which is exactly this question.
+            // cite(RFC 9111 § 5.2.2.1): "The max-age response directive indicates that the response is to be considered stale after its age is greater than the specified number of seconds."
+            // cite(RFC 9111 § 5.2.2.10): "The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires"
+            let advertises_freshness = ["max-age", "s-maxage"].iter().any(|directive| {
+                crate::helpers::cache_control::delta_seconds(&resp.headers, directive).is_some()
+            });
+            if advertises_freshness {
+                return None;
             }
 
             // A present, well-formed Expires is explicit freshness. Note this is stricter than

--- a/lint-http-rules/src/rules/vary_and_cache_consistent.rs
+++ b/lint-http-rules/src/rules/vary_and_cache_consistent.rs
@@ -68,36 +68,17 @@ impl Rule for VaryAndCacheConsistent {
             // If Vary: * is present, an explicit cacheability directive is likely ineffective (the
             // response can never be selected). No sentence says this pairing is illegal, so this is
             // a misconfiguration heuristic, recorded in the tracker.
-            for hv in resp.headers.get_all("cache-control").iter() {
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => continue,
-                };
-
-                for member in crate::helpers::headers::split_commas_respecting_quotes(s) {
-                    let m = member;
-                    if m.is_empty() {
-                        continue;
-                    }
-                    // directive = token [ '=' ... ]
-                    let name = m
-                        .split('=')
-                        .next()
-                        .expect("split always yields at least one item")
-                        .trim()
-                        .to_ascii_lowercase();
-                    match name.as_str() {
-                        // Only directives that *advertise reuse* are flagged. `no-cache` is
-                        // deliberately excluded: it promises no reuse benefit (it requires
-                        // revalidation), so pairing it with Vary: * is not a misconfiguration signal.
-                        "max-age" | "s-maxage" | "public" => {
-                            return Some(self.violation(ctx.severity, format!(
-                                    "Response includes Vary: '*' and Cache-Control directive '{}'; Vary: '*' prevents caches from selecting stored responses, making cache directives like '{}' ineffective (see RFC 9111 §4.1)",
-                                    name, name
-                                )));
-                        }
-                        _ => {}
-                    }
+            // Only directives that *advertise reuse* are flagged. `no-cache` is
+            // deliberately excluded: it promises no reuse benefit (it requires
+            // revalidation), so pairing it with Vary: * is not a misconfiguration signal.
+            const ADVERTISES_REUSE: [&str; 3] = ["max-age", "s-maxage", "public"];
+            for directive in crate::helpers::cache_control::directives(&resp.headers) {
+                if ADVERTISES_REUSE.iter().any(|name| directive.is(name)) {
+                    let name = directive.name.to_ascii_lowercase();
+                    return Some(self.violation(ctx.severity, format!(
+                            "Response includes Vary: '*' and Cache-Control directive '{}'; Vary: '*' prevents caches from selecting stored responses, making cache directives like '{}' ineffective (see RFC 9111 §4.1)",
+                            name, name
+                        )));
                 }
             }
 

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -42,19 +42,19 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2387
+      line: 2398
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2382
+      line: 2393
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2381
+      line: 2392
   - label: origin_matching_for_cors
     section: § 4.10
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
@@ -342,7 +342,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2447
+      line: 2458
   - label: refresh_header_syntax
     section: § 1.1
     snippet: A code point is found that is not a URL unit.
@@ -1128,7 +1128,7 @@ sources:
     snippet: authority   = [ userinfo "@" ] host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2429
+      line: 2440
     - file: lint-http-rules/src/helpers/uri.rs
       line: 170
   - label: lint-http-rules/src/helpers/ipv6.rs
@@ -2252,7 +2252,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2383
+      line: 2394
     - file: lint-http-rules/src/helpers/uri.rs
       line: 320
   - label: lint-http-rules/src/helpers/uri.rs
@@ -3902,25 +3902,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1906
+      line: 1917
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1847
+      line: 1858
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1885
+      line: 1896
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1878
+      line: 1889
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.html
   fragments:
@@ -3931,7 +3931,7 @@ sources:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
       line: 97
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 122
+      line: 113
   - label: immutable_cache_never_stale (2)
     section: § 2
     snippet: The immutable extension only applies during the freshness lifetime of the stored response.
@@ -3939,7 +3939,7 @@ sources:
     - file: lint-http-rules/src/rules/immutable_cache_never_stale.rs
       line: 98
     - file: lint-http-rules/src/rules/immutable_requires_freshness.rs
-      line: 121
+      line: 112
 - label: RFC 8259
   url: https://www.rfc-editor.org/rfc/rfc8259.html
   fragments:
@@ -4301,7 +4301,7 @@ sources:
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 972
+      line: 983
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 162
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -6211,7 +6211,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 22
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1004
+      line: 1015
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 40
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -6223,7 +6223,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 125
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1039
+      line: 1050
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 108
   - label: lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -6291,7 +6291,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 97
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 569
+      line: 580
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 84
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -6359,9 +6359,9 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 60
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1174
+      line: 1185
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1203
+      line: 1214
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 75
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -6377,11 +6377,11 @@ sources:
     snippet: When a field name is repeated within a section, its combined field value consists of the list of corresponding field line values within that section, concatenated in order, with each field line value separated by a comma.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 94
+      line: 109
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 228
+      line: 239
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1613
+      line: 1624
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 54
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -6398,6 +6398,70 @@ sources:
       line: 21
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 25
+  - label: lint-http-rules/src/helpers/cache_control.rs (2)
+    section: § 5.6.1
+    snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
+    cited_by:
+    - file: lint-http-rules/src/helpers/cache_control.rs
+      line: 111
+  - label: lint-http-rules/src/helpers/cache_control.rs (3)
+    section: § 5.6.1.1
+    snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
+    cited_by:
+    - file: lint-http-rules/src/helpers/cache_control.rs
+      line: 110
+    - file: lint-http-rules/src/helpers/cache_control.rs
+      line: 151
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 582
+    - file: lint-http-rules/src/helpers/headers.rs
+      line: 618
+    - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
+      line: 86
+    - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
+      line: 325
+    - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
+      line: 86
+    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
+      line: 511
+    - file: lint-http-rules/src/rules/caching_directive_interaction.rs
+      line: 73
+    - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
+      line: 64
+    - file: lint-http-rules/src/rules/expect_header_valid.rs
+      line: 139
+    - file: lint-http-rules/src/rules/forwarded_header_valid.rs
+      line: 223
+    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
+      line: 99
+    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+      line: 100
+    - file: lint-http-rules/src/rules/link_header_valid.rs
+      line: 515
+    - file: lint-http-rules/src/rules/pragma_token_valid.rs
+      line: 140
+    - file: lint-http-rules/src/rules/prefer_header_valid.rs
+      line: 212
+    - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
+      line: 197
+    - file: lint-http-rules/src/rules/range_header_syntax.rs
+      line: 260
+    - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
+      line: 365
+    - file: lint-http-rules/src/rules/te_header_valid.rs
+      line: 67
+    - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
+      line: 99
+    - file: lint-http-rules/src/rules/trailer_header_valid.rs
+      line: 67
+    - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
+      line: 151
+    - file: lint-http-rules/src/rules/vary_header_valid.rs
+      line: 71
+    - file: lint-http-rules/src/rules/via_header_syntax.rs
+      line: 265
+    - file: lint-http-rules/src/rules/warning_header_syntax.rs
+      line: 339
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -6525,19 +6589,19 @@ sources:
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 988
+      line: 999
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 11.7.3
     snippet: Proxy-Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 989
+      line: 1000
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1815
+      line: 1826
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 179
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -6547,7 +6611,7 @@ sources:
     snippet: 'Vary = #( "*" / field-name )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1104
+      line: 1115
     - file: lint-http-rules/src/rules/vary_header_valid.rs
       line: 49
   - label: If-None-Match weak comparison
@@ -6555,19 +6619,19 @@ sources:
     snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 446
+      line: 457
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 16.3.2
     snippet: If the field is allowable in trailers; by default, it will not be (see Section 6.5.1).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 909
+      line: 920
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5
     snippet: Fields are sent and received within the header and trailer sections of messages
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 359
+      line: 370
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 52
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
@@ -6577,15 +6641,15 @@ sources:
     snippet: Field names are case-insensitive
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1037
+      line: 1048
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1105
+      line: 1116
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1106
+      line: 1117
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 110
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6599,7 +6663,7 @@ sources:
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).  For consistency, use comma SP.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 197
+      line: 208
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 145
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6611,13 +6675,13 @@ sources:
     snippet: Since it cannot be combined into a single field value, recipients ought to handle "Set-Cookie" as a special case while processing fields.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 198
+      line: 209
   - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.3
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1614
+      line: 1625
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -6657,7 +6721,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2085
+      line: 2096
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 209
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
@@ -6689,9 +6753,9 @@ sources:
     snippet: A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 229
+      line: 240
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 264
+      line: 275
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 226
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
@@ -6717,7 +6781,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1611
+      line: 1622
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 159
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -6727,7 +6791,7 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1612
+      line: 1623
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 253
   - label: lint-http-rules/src/helpers/headers.rs (14)
@@ -6735,71 +6799,13 @@ sources:
     snippet: field-content  = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 265
+      line: 276
   - label: lint-http-rules/src/helpers/headers.rs (15)
-    section: § 5.6.1.1
-    snippet: In any production that uses the list construct, a sender MUST NOT generate empty list elements.
-    cited_by:
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 571
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 607
-    - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
-      line: 86
-    - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
-      line: 325
-    - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 86
-    - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 511
-    - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 120
-    - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 121
-    - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 87
-    - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 64
-    - file: lint-http-rules/src/rules/expect_header_valid.rs
-      line: 139
-    - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 223
-    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 99
-    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 100
-    - file: lint-http-rules/src/rules/link_header_valid.rs
-      line: 515
-    - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 140
-    - file: lint-http-rules/src/rules/prefer_header_valid.rs
-      line: 212
-    - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
-      line: 197
-    - file: lint-http-rules/src/rules/range_header_syntax.rs
-      line: 260
-    - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 365
-    - file: lint-http-rules/src/rules/te_header_valid.rs
-      line: 67
-    - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
-      line: 99
-    - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 67
-    - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
-      line: 151
-    - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 71
-    - file: lint-http-rules/src/rules/via_header_syntax.rs
-      line: 265
-    - file: lint-http-rules/src/rules/warning_header_syntax.rs
-      line: 339
-  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 568
+      line: 579
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 78
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -6810,36 +6816,36 @@ sources:
       line: 485
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 507
-  - label: lint-http-rules/src/helpers/headers.rs (17)
+  - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.1.2
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 570
+      line: 581
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 606
+      line: 617
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 189
-  - label: lint-http-rules/src/helpers/headers.rs (18)
+  - label: lint-http-rules/src/helpers/headers.rs (17)
     section: § 5.6.2
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 605
+      line: 616
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1676
+      line: 1687
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 76
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 90
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 46
-  - label: lint-http-rules/src/helpers/headers.rs (19)
+  - label: lint-http-rules/src/helpers/headers.rs (18)
     section: § 5.6.2
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1677
+      line: 1688
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6863,19 +6869,19 @@ sources:
     snippet: OWS            = *( SP / HTAB )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 418
+      line: 429
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 572
+      line: 583
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 608
+      line: 619
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1175
+      line: 1186
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1204
+      line: 1215
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1228
+      line: 1239
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2014
+      line: 2025
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 101
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -6904,66 +6910,66 @@ sources:
       line: 98
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 66
-  - label: lint-http-rules/src/helpers/headers.rs (20)
+  - label: lint-http-rules/src/helpers/headers.rs (19)
     section: § 5.6.3
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1737
-  - label: lint-http-rules/src/helpers/headers.rs (21)
+      line: 1748
+  - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 417
-  - label: lint-http-rules/src/helpers/headers.rs (22)
+      line: 428
+  - label: lint-http-rules/src/helpers/headers.rs (21)
     section: § 5.6.4
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1452
-  - label: lint-http-rules/src/helpers/headers.rs (23)
+      line: 1463
+  - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1450
+      line: 1461
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 33
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 353
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 537
-  - label: lint-http-rules/src/helpers/headers.rs (24)
+  - label: lint-http-rules/src/helpers/headers.rs (23)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1291
+      line: 1302
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1319
+      line: 1330
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1451
+      line: 1462
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 418
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 586
-  - label: lint-http-rules/src/helpers/headers.rs (25)
+  - label: lint-http-rules/src/helpers/headers.rs (24)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1176
+      line: 1187
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1227
+      line: 1238
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1318
+      line: 1329
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1356
+      line: 1367
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1449
+      line: 1460
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1678
+      line: 1689
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 115
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6976,38 +6982,38 @@ sources:
       line: 352
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 61
-  - label: lint-http-rules/src/helpers/headers.rs (26)
+  - label: lint-http-rules/src/helpers/headers.rs (25)
     section: § 5.6.6
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2304
+      line: 2315
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 198
     - file: lint-http-rules/src/rules/charset_registered.rs
       line: 113
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 225
-  - label: lint-http-rules/src/helpers/headers.rs (27)
+  - label: lint-http-rules/src/helpers/headers.rs (26)
     section: § 5.6.6
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2012
+      line: 2023
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2039
+      line: 2050
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 390
-  - label: lint-http-rules/src/helpers/headers.rs (28)
+  - label: lint-http-rules/src/helpers/headers.rs (27)
     section: § 5.6.6
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2013
+      line: 2024
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2040
+      line: 2051
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2221
+      line: 2232
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 263
     - file: lint-http-rules/src/rules/expect_header_valid.rs
@@ -7017,7 +7023,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2235
+      line: 2246
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 305
     - file: lint-http-rules/src/rules/charset_registered.rs
@@ -7028,27 +7034,27 @@ sources:
       line: 231
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
-  - label: lint-http-rules/src/helpers/headers.rs (29)
+  - label: lint-http-rules/src/helpers/headers.rs (28)
     section: § 5.6.6
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2011
+      line: 2022
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2084
+      line: 2095
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 100
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 389
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
       line: 215
-  - label: lint-http-rules/src/helpers/headers.rs (30)
+  - label: lint-http-rules/src/helpers/headers.rs (29)
     section: § 6.4
     snippet: For example, an HTTP/1.1 message body (Section 6 of [HTTP/1.1]) might consist of a stream of data encoded with the chunked transfer coding -- a sequence of data chunks, one zero-length chunk, and a trailer section -- whereas the content of that same message includes only the data stream after the transfer coding has been decoded; it does not include the chunk lengths, chunked framing syntax, nor the trailer fields (Section 6.5).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 120
-  - label: lint-http-rules/src/helpers/headers.rs (31)
+  - label: lint-http-rules/src/helpers/headers.rs (30)
     section: § 6.4
     snippet: 'HTTP messages often transfer a complete or partial representation as the message "content": a stream of octets sent after the header section, as delineated by the message framing.'
     cited_by:
@@ -7056,24 +7062,24 @@ sources:
       line: 119
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 86
-  - label: lint-http-rules/src/helpers/headers.rs (32)
+  - label: lint-http-rules/src/helpers/headers.rs (31)
     section: § 6.5
     snippet: Fields (Section 5) that are located within a "trailer section" are referred to as "trailer fields"
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 310
+      line: 321
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 360
+      line: 371
     - file: lint-http-rules/src/rules/extension_headers_registered.rs
       line: 93
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 69
-  - label: lint-http-rules/src/helpers/headers.rs (33)
+  - label: lint-http-rules/src/helpers/headers.rs (32)
     section: § 6.5.1
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 908
+      line: 919
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 44
     - file: lint-http-rules/src/rules/post_creates_resource.rs
@@ -7096,18 +7102,18 @@ sources:
       line: 70
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
       line: 74
-  - label: lint-http-rules/src/helpers/headers.rs (34)
+  - label: lint-http-rules/src/helpers/headers.rs (33)
     section: § 6.5.1
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 907
-  - label: lint-http-rules/src/helpers/headers.rs (35)
+      line: 918
+  - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2166
+      line: 2177
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 246
     - file: lint-http-rules/src/rules/charset_present.rs
@@ -7128,12 +7134,12 @@ sources:
       line: 122
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 73
-  - label: lint-http-rules/src/helpers/headers.rs (36)
+  - label: lint-http-rules/src/helpers/headers.rs (35)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2185
+      line: 2196
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -7141,35 +7147,35 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2100
+      line: 2111
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 99
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 98
-  - label: lint-http-rules/src/helpers/headers.rs (37)
+  - label: lint-http-rules/src/helpers/headers.rs (36)
     section: § 8.3.1
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2165
+      line: 2176
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 53
-  - label: lint-http-rules/src/helpers/headers.rs (38)
+  - label: lint-http-rules/src/helpers/headers.rs (37)
     section: § 8.6
     snippet: When transferring a representation as content, Content-Length refers specifically to the amount of data enclosed so that it can be used to delimit framing
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 140
-  - label: lint-http-rules/src/helpers/headers.rs (39)
+  - label: lint-http-rules/src/helpers/headers.rs (38)
     section: § 8.8.3
     snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1935
+      line: 1946
     - file: lint-http-rules/src/rules/etag_syntax.rs
       line: 74
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -7181,13 +7187,13 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1937
-  - label: lint-http-rules/src/helpers/headers.rs (40)
+      line: 1948
+  - label: lint-http-rules/src/helpers/headers.rs (39)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 671
+      line: 682
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 10.1.2
     snippet: mailbox = <mailbox, see [RFC5322], Section 3.4>
@@ -8988,7 +8994,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 305
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 172
+      line: 145
   - label: age_header_numeric (2)
     section: § 1.2.2
     snippet: or the greatest positive integer it can conveniently represent.
@@ -8998,7 +9004,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 306
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 173
+      line: 146
   - label: age_header_numeric (3)
     section: § 5.1
     snippet: Although it is defined as a singleton header field, a cache encountering a message with a list-based Age field value SHOULD use the first member of the field value, discarding subsequent ones.
@@ -9020,7 +9026,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 294
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 157
+      line: 130
   - label: cache_coherence
     section: § 4.2.4
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server
@@ -9032,7 +9038,7 @@ sources:
     snippet: However, support for Cache-Control is now widespread.  As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
-      line: 79
+      line: 68
   - label: cache_control_and_pragma_consistent (2)
     section: § 5.4
     snippet: The "Pragma" request header field was defined for HTTP/1.0 caches, so that clients could specify a "no-cache" request
@@ -9046,23 +9052,15 @@ sources:
     snippet: The "Cache-Control" header field is used to list directives for caches along the request/response chain.
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 39
+      line: 74
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 39
+      line: 74
   - label: cache_control_directive_valid (2)
-    section: § 5.2
-    snippet: cache-directive = token [ "=" ( token / quoted-string ) ]
-    cited_by:
-    - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 127
-    - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 129
-  - label: cache_control_directive_valid (3)
     section: § 5.2.2.7
     snippet: If a qualified private response directive is present, with an argument that lists one or more field names
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 180
+      line: 153
   - label: cache_control_present
     section: § 4.2.2
     snippet: Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time.
@@ -9098,13 +9096,13 @@ sources:
     snippet: 'When there is more than one value present for a given directive (e.g., two Expires header field lines or multiple Cache-Control: max-age directives), either the first occurrence should be used or the response should be considered stale.'
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 145
+      line: 128
   - label: caching_directive_interaction (2)
     section: § 5.2.2.7
     snippet: The unqualified private response directive indicates that a shared cache MUST NOT store the response (i.e., the response is intended for a single user).
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 120
+      line: 103
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
       line: 93
     - file: lint-http-rules/src/rules/private_cache_visibility.rs
@@ -9114,7 +9112,7 @@ sources:
     snippet: The public response directive indicates that a cache MAY store the response even if it would otherwise be prohibited, subject to the constraints defined in Section 3.
     cited_by:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 119
+      line: 102
   - label: expires_and_cache_control_consistent
     section: § 4.2.1
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field
@@ -9180,31 +9178,41 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 28
   - label: lint-http-rules/src/helpers/cache_control.rs (3)
+    section: § 5.2
+    snippet: cache-directive = token [ "=" ( token / quoted-string ) ]
+    cited_by:
+    - file: lint-http-rules/src/helpers/cache_control.rs
+      line: 150
+    - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
+      line: 115
+    - file: lint-http-rules/src/rules/cache_control_token_valid.rs
+      line: 115
+  - label: lint-http-rules/src/helpers/cache_control.rs (4)
     section: § 5.2.2.4
     snippet: The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 147
+      line: 211
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 93
-  - label: lint-http-rules/src/helpers/cache_control.rs (4)
+  - label: lint-http-rules/src/helpers/cache_control.rs (5)
     section: § 5.2.2.4
     snippet: The qualified form of the no-cache response directive, with an argument that lists one or more field names, indicates that a cache MAY use the response to satisfy a subsequent request
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 71
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 148
+      line: 212
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 142
-  - label: lint-http-rules/src/helpers/cache_control.rs (5)
+  - label: lint-http-rules/src/helpers/cache_control.rs (6)
     section: § 5.2.2.5
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 146
+      line: 210
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
-      line: 135
+      line: 118
     - file: lint-http-rules/src/rules/no_store_enforced.rs
       line: 124
     - file: lint-http-rules/src/rules/no_store_enforced.rs
@@ -9214,7 +9222,7 @@ sources:
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1107
+      line: 1118
     - file: lint-http-rules/src/rules/vary_and_cache_consistent.rs
       line: 63
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -9224,25 +9232,25 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 747
+      line: 758
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 757
+      line: 768
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 4.2.3
     snippet: corrected_initial_age = max(apparent_age, corrected_age_value)
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 712
+      line: 723
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 711
+      line: 722
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 27
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -9272,7 +9280,7 @@ sources:
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
       line: 125
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 72
+      line: 66
   - label: must_revalidate_enforced
     section: § 4.2
     snippet: A "fresh" response is one whose age has not yet exceeded its freshness lifetime. Conversely, a "stale" response is one where it has.
@@ -9354,19 +9362,19 @@ sources:
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 46
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 93
+      line: 78
   - label: status_and_caching_semantics
     section: § 3
     snippet: A cache MUST NOT store a response to a request unless
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 104
+      line: 89
   - label: status_and_caching_semantics (2)
     section: § 5.2.2.10
     snippet: The s-maxage response directive indicates that, for a shared cache, the maximum age specified by this directive overrides the maximum age specified by either the max-age directive or the Expires
     cited_by:
     - file: lint-http-rules/src/rules/status_and_caching_semantics.rs
-      line: 73
+      line: 67
   - label: vary_header_cache_valid
     section: § 4.1
     snippet: the cache MUST NOT use that stored response without revalidation unless all the presented request header fields nominated by that Vary field value match those fields in the original request
@@ -10130,7 +10138,7 @@ sources:
     snippet: This includes the Connection header field and those listed as having connection-specific semantics in Section 7.6.1 of [HTTP] (that is, Proxy-Connection, Keep-Alive, Transfer-Encoding, and Upgrade).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 962
+      line: 973
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 39
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs


### PR DESCRIPTION
The reader landed with a claim it had not finished earning: seven rules were still deriving the directive list themselves, in the same five spellings the module documents as the reason it exists. They are converted here, and the two layers they needed but did not have are the reason they could not be before.

`members` is the list as written, empty elements included, for the rules whose *finding* is an empty element — `directives` drops those, because a caller asking what the sender requested has nothing to read in one. The distinction between an empty element and an entirely empty field value — one forbidden, one a legal zero-element list — was written out in three rules, half at the call site and half two functions down; it is now the reader's, once.

`read_member` is the strict reading the two syntax rules share. They transcribed the same three name defects with the same wording, and what they do *after* the name is genuinely different, which is what makes the prefix worth moving and the rest worth leaving. Their entry points were also the same request-then-response block written twice per rule, four copies of one shape, now one `defect` per rule called for each side.

`has_unreadable_line` is the companion `field_lines` needed: the reader skips a line it cannot read as text, so a rule whose finding is that the sender wrote one has to ask separately. Two rules did, and would have lost that finding silently.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
