### PR TITLE
One spelling per question, across the readers that already existed

### DIFF
--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -383,18 +383,16 @@ pub fn build_cookie_store(
 
     for prev in history_items.iter().rev() {
         if let Some(resp) = &prev.response {
-            for hv in resp.headers.get_all("set-cookie").iter() {
-                if let Ok(s) = hv.to_str() {
-                    if let Some(cookie) = parse_set_cookie(s, &prev.request.uri, prev.timestamp) {
-                        live_cookies.retain(|c| {
-                            !(c.name == cookie.name
-                                && c.domain == cookie.domain
-                                && c.path == cookie.path)
-                        });
+            for s in crate::helpers::headers::field_lines(&resp.headers, "set-cookie") {
+                if let Some(cookie) = parse_set_cookie(s, &prev.request.uri, prev.timestamp) {
+                    live_cookies.retain(|c| {
+                        !(c.name == cookie.name
+                            && c.domain == cookie.domain
+                            && c.path == cookie.path)
+                    });
 
-                        if !cookie.is_expired_at(prev.timestamp) {
-                            live_cookies.push(cookie);
-                        }
+                    if !cookie.is_expired_at(prev.timestamp) {
+                        live_cookies.push(cookie);
                     }
                 }
             }

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -490,19 +490,15 @@ pub fn inm_matches_known(inm: &str, known: &str) -> bool {
 ///
 /// See [`cache_validation_chain`] for an example consumer.
 pub fn extract_validators_from_response(headers: &HeaderMap) -> (Option<String>, Option<String>) {
-    let etag = headers
-        .get("etag")
-        .and_then(|hv| hv.to_str().ok())
-        .map(str::trim)
-        .map(ToString::to_string);
+    (
+        validator(headers, "etag"),
+        validator(headers, "last-modified"),
+    )
+}
 
-    let last_modified = headers
-        .get("last-modified")
-        .and_then(|hv| hv.to_str().ok())
-        .map(str::trim)
-        .map(ToString::to_string);
-
-    (etag, last_modified)
+/// One validator field, trimmed, if the response carries a readable one.
+fn validator(headers: &HeaderMap, name: &str) -> Option<String> {
+    get_header_str(headers, name).map(|value| value.trim().to_string())
 }
 
 /// Extract **strong** validators from a response's headers.
@@ -515,21 +511,12 @@ pub fn extract_validators_from_response(headers: &HeaderMap) -> (Option<String>,
 pub fn extract_strong_validators_from_response(
     headers: &HeaderMap,
 ) -> (Option<String>, Option<String>) {
-    // ETag: pick first header, ensure UTF-8 and strong
-    let etag = headers
-        .get("etag")
-        .and_then(|hv| hv.to_str().ok())
-        .map(str::trim)
-        .filter(|s| !s.starts_with("W/"))
-        .map(ToString::to_string);
-
-    let last_modified = headers
-        .get("last-modified")
-        .and_then(|hv| hv.to_str().ok())
-        .map(str::trim)
-        .map(ToString::to_string);
-
-    (etag, last_modified)
+    // Exactly the pair above with the weak ETags dropped, which is what the
+    // paragraphs on both functions say the difference is. `Last-Modified` is
+    // not filtered here: whether a timestamp is a strong validator depends on
+    // the origin's clock resolution, not on anything visible in the field.
+    let (etag, last_modified) = extract_validators_from_response(headers);
+    (etag.filter(|etag| !etag.starts_with("W/")), last_modified)
 }
 
 /// Every member of a `#element` list, `OWS`-trimmed, with the empty ones dropped.

--- a/lint-http-rules/src/helpers/structured_fields.rs
+++ b/lint-http-rules/src/helpers/structured_fields.rs
@@ -69,7 +69,23 @@ impl QuoteScan {
     }
 }
 
-pub(crate) fn split_commas_outside_quotes(s: &str) -> Vec<&str> {
+/// Split at every `delimiter` that is at the top level: outside a
+/// quoted-string, and outside an Inner List.
+///
+/// **The parenthesis depth is the reason this is not the splitter in
+/// [`crate::helpers::headers`].** That one reads an HTTP `#rule`, where the
+/// only thing that can hide a comma is a quoted-string; here an Inner List can
+/// hold delimiters too, and the `\` that escapes inside an HTTP
+/// `quoted-string` is not an escape in a Structured Fields String either —
+/// [`QuoteScan`] owns that difference. Two grammars, two walks, and each says
+/// which grammar it is walking.
+///
+/// The comma and the semicolon were separate copies of the walk below,
+/// identical but for the byte compared — the shape that lets a fix to one be a
+/// silent non-fix in the other. [`split_spaces_outside_quotes`] stays its own
+/// function: it collapses runs of its delimiter and has its own rule for a
+/// value ending in one, so it is not this function with a different byte.
+fn split_top_level(s: &str, delimiter: u8) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut start = 0usize;
     let mut paren_depth = 0i32;
@@ -81,7 +97,7 @@ pub(crate) fn split_commas_outside_quotes(s: &str) -> Vec<&str> {
         match b {
             b'(' => paren_depth += 1,
             b')' if paren_depth > 0 => paren_depth -= 1,
-            b',' if paren_depth == 0 => {
+            _ if b == delimiter && paren_depth == 0 => {
                 parts.push(s[start..i].trim());
                 start = i + 1;
             }
@@ -92,27 +108,15 @@ pub(crate) fn split_commas_outside_quotes(s: &str) -> Vec<&str> {
     parts
 }
 
+/// The members of a Structured Fields List or Dictionary.
+// cite(RFC 9651 § 4.2.1): "Given an ASCII string as input_string, return an array of (item_or_inner_list, parameters) tuples."
+pub(crate) fn split_commas_outside_quotes(s: &str) -> Vec<&str> {
+    split_top_level(s, b',')
+}
+
+/// The parameters hanging off a Structured Fields Item or Inner List.
 pub(crate) fn split_semicolons_outside_quotes(s: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut start = 0usize;
-    let mut paren_depth = 0i32;
-    let mut scan = QuoteScan::default();
-    for (i, &b) in s.as_bytes().iter().enumerate() {
-        if !scan.outside(b as char) {
-            continue;
-        }
-        match b {
-            b'(' => paren_depth += 1,
-            b')' if paren_depth > 0 => paren_depth -= 1,
-            b';' if paren_depth == 0 => {
-                parts.push(s[start..i].trim());
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    parts.push(s[start..].trim());
-    parts
+    split_top_level(s, b';')
 }
 
 pub(crate) fn split_spaces_outside_quotes(s: &str) -> Vec<&str> {

--- a/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
+++ b/lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
@@ -67,126 +67,7 @@ impl Rule for AcceptEncodingParameterValid {
             // cite(RFC 9110 § 12.4.2): "weight = OWS ";" OWS "q=" qvalue"
             let check_all = |headers: &hyper::HeaderMap| -> Option<Violation> {
                 for hv in headers.get_all("accept-encoding").iter() {
-                    if let Ok(val) = hv.to_str() {
-                        // A comma split with no regard for quoting, which is
-                        // correct here rather than merely tolerable: nothing in
-                        // this field's grammar is a quoted-string, so there is no
-                        // quoted comma for a quote-aware splitter to protect. An
-                        // empty field value yields no members and no finding, which
-                        // is right — §12.5.3 gives that value a meaning of its own.
-                        // cite(RFC 9110 § 12.5.3): "An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response."
-                        // cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
-                        for part in crate::helpers::headers::list_members(val) {
-                            // Split into token and optional params
-                            let mut iter =
-                                crate::helpers::headers::split_semicolons_respecting_quotes(part)
-                                    .into_iter();
-                            if let Some(primary) = iter.next() {
-                                // `codings` is a content-coding, the literal "identity",
-                                // or the literal "*", and the first two of those are
-                                // tokens. A token is one or more characters, which a
-                                // scan for an invalid character cannot tell you: an
-                                // empty string has no invalid character in it, so
-                                // `;q=0.5` — a member that is all weight and no coding —
-                                // passed on exactly that reasoning.
-                                //
-                                // The asterisk is exempted from the token check
-                                // because it is one of the three alternatives, not a
-                                // coding name; "identity" needs no exemption, being
-                                // a token like any other.
-                                // cite(RFC 9110 § 8.4.1): "content-coding   = token"
-                                // cite(RFC 9110 § 12.5.3): "The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field."
-                                // cite(RFC 9110 § 12.5.3): "An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred."
-                                if primary != "*" {
-                                    if primary.is_empty() {
-                                        return Some(self.violation(ctx.severity, format!(
-                                                "Empty content-coding in Accept-Encoding member '{}'",
-                                                part
-                                            )));
-                                    }
-                                    if let Some(c) =
-                                        crate::helpers::token::find_invalid_token_char(primary)
-                                    {
-                                        return Some(self.violation(
-                                            ctx.severity,
-                                            format!(
-                                                "Invalid token '{}' in Accept-Encoding header",
-                                                c
-                                            ),
-                                        ));
-                                    }
-                                }
-
-                                // Everything after the coding must be a weight. There is
-                                // no parameter list here to be well formed — the whole
-                                // member is `codings [ weight ]`, and `weight` is the
-                                // fixed shape `OWS ";" OWS "q=" qvalue`. Validating
-                                // arbitrary `name=value` pairs answered a question this
-                                // field does not ask, and answered it in the direction
-                                // that matters: `gzip;charset=utf-8` was called well
-                                // formed, when nothing in the grammar produces it.
-                                //
-                                // The weight is a MAY, so its absence is never a
-                                // finding; what is a finding is anything else in
-                                // its place, or two of it.
-                                // cite(RFC 9110 § 12.5.3): "Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2."
-                                let mut weight_seen = false;
-                                for param in iter {
-                                    let param = param.trim();
-                                    // Not skipped as an empty parameter slot, because
-                                    // there are no parameter slots. `weight` brackets
-                                    // nothing, so a `;` with nothing after it is a
-                                    // separator introducing a weight that is not there
-                                    // — whether it sits at the end of the member or
-                                    // between two others.
-                                    if param.is_empty() {
-                                        return Some(self.violation(ctx.severity, format!(
-                                            "Accept-Encoding member '{}' has a ';' with no weight after it",
-                                            part
-                                        )));
-                                    }
-
-                                    // The name is matched without regard to case
-                                    // because §12.4.2 defines the parameter that
-                                    // way, and this is the only name the field
-                                    // admits.
-                                    // cite(RFC 9110 § 12.4.2): "The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content."
-                                    let mut nv = param.splitn(2, '=').map(|s| s.trim());
-                                    let name = nv.next().unwrap();
-                                    let val = nv.next();
-
-                                    if !name.eq_ignore_ascii_case("q") {
-                                        return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
-                                            "'{}' is not a weight, and a weight is the only thing an Accept-Encoding coding may carry (member '{}')",
-                                            param, part
-                                        )));
-                                    }
-                                    if weight_seen {
-                                        return Some(self.violation(ctx.severity, format!(
-                                                "More than one weight in Accept-Encoding member '{}'",
-                                                part
-                                            )));
-                                    }
-                                    weight_seen = true;
-
-                                    let Some(v) = val else {
-                                        return Some(self.violation(ctx.severity, format!(
-                                            "Missing parameter value for '{}' in Accept-Encoding member '{}'",
-                                            name, part
-                                        )));
-                                    };
-
-                                    // cite(RFC 9110 § 12.4.2): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"
-                                    if !crate::helpers::headers::valid_qvalue(v) {
-                                        return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
-                                                "Invalid qvalue '{}' in Accept-Encoding member '{}'",
-                                                v, part
-                                            )));
-                                    }
-                                }
-                            }
-                        }
-                    } else {
+                    let Ok(val) = hv.to_str() else {
                         // Reported rather than skipped, and this field is the reason.
                         // The rules audited alongside this one decode such a value
                         // instead, because `obs-text` is legal inside a quoted-string
@@ -197,6 +78,131 @@ impl Rule for AcceptEncodingParameterValid {
                         // of this field whatever else the value contains.
                         return Some(self.violation(ctx.severity, "Accept-Encoding contains an octet no part of this field's grammar admits"
                                 .into()));
+                    };
+                    // A comma split with no regard for quoting, which is
+                    // correct here rather than merely tolerable: nothing in
+                    // this field's grammar is a quoted-string, so there is no
+                    // quoted comma for a quote-aware splitter to protect. An
+                    // empty field value yields no members and no finding, which
+                    // is right — §12.5.3 gives that value a meaning of its own.
+                    // cite(RFC 9110 § 12.5.3): "An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response."
+                    // cite(RFC 9110 § 5.6.1.2): "#element => [ element ] *( OWS "," OWS [ element ] )"
+                    for part in crate::helpers::headers::list_members(val) {
+                        // Split into token and optional params
+                        let mut iter =
+                            crate::helpers::headers::split_semicolons_respecting_quotes(part)
+                                .into_iter();
+                        if let Some(primary) = iter.next() {
+                            // `codings` is a content-coding, the literal "identity",
+                            // or the literal "*", and the first two of those are
+                            // tokens. A token is one or more characters, which a
+                            // scan for an invalid character cannot tell you: an
+                            // empty string has no invalid character in it, so
+                            // `;q=0.5` — a member that is all weight and no coding —
+                            // passed on exactly that reasoning.
+                            //
+                            // The asterisk is exempted from the token check
+                            // because it is one of the three alternatives, not a
+                            // coding name; "identity" needs no exemption, being
+                            // a token like any other.
+                            // cite(RFC 9110 § 8.4.1): "content-coding   = token"
+                            // cite(RFC 9110 § 12.5.3): "The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field."
+                            // cite(RFC 9110 § 12.5.3): "An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred."
+                            if primary != "*" {
+                                if primary.is_empty() {
+                                    return Some(self.violation(
+                                        ctx.severity,
+                                        format!(
+                                            "Empty content-coding in Accept-Encoding member '{}'",
+                                            part
+                                        ),
+                                    ));
+                                }
+                                if let Some(c) =
+                                    crate::helpers::token::find_invalid_token_char(primary)
+                                {
+                                    return Some(self.violation(
+                                        ctx.severity,
+                                        format!("Invalid token '{}' in Accept-Encoding header", c),
+                                    ));
+                                }
+                            }
+
+                            // Everything after the coding must be a weight. There is
+                            // no parameter list here to be well formed — the whole
+                            // member is `codings [ weight ]`, and `weight` is the
+                            // fixed shape `OWS ";" OWS "q=" qvalue`. Validating
+                            // arbitrary `name=value` pairs answered a question this
+                            // field does not ask, and answered it in the direction
+                            // that matters: `gzip;charset=utf-8` was called well
+                            // formed, when nothing in the grammar produces it.
+                            //
+                            // The weight is a MAY, so its absence is never a
+                            // finding; what is a finding is anything else in
+                            // its place, or two of it.
+                            // cite(RFC 9110 § 12.5.3): "Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2."
+                            let mut weight_seen = false;
+                            for param in iter {
+                                let param = param.trim();
+                                // Not skipped as an empty parameter slot, because
+                                // there are no parameter slots. `weight` brackets
+                                // nothing, so a `;` with nothing after it is a
+                                // separator introducing a weight that is not there
+                                // — whether it sits at the end of the member or
+                                // between two others.
+                                if param.is_empty() {
+                                    return Some(self.violation(ctx.severity, format!(
+                                        "Accept-Encoding member '{}' has a ';' with no weight after it",
+                                        part
+                                    )));
+                                }
+
+                                // The name is matched without regard to case
+                                // because §12.4.2 defines the parameter that
+                                // way, and this is the only name the field
+                                // admits.
+                                // cite(RFC 9110 § 12.4.2): "The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content."
+                                let mut nv = param.splitn(2, '=').map(|s| s.trim());
+                                let name = nv.next().unwrap();
+                                let val = nv.next();
+
+                                if !name.eq_ignore_ascii_case("q") {
+                                    return Some(self.cited(&RFC_9110_12_4_2, ctx.severity, format!(
+                                        "'{}' is not a weight, and a weight is the only thing an Accept-Encoding coding may carry (member '{}')",
+                                        param, part
+                                    )));
+                                }
+                                if weight_seen {
+                                    return Some(self.violation(
+                                        ctx.severity,
+                                        format!(
+                                            "More than one weight in Accept-Encoding member '{}'",
+                                            part
+                                        ),
+                                    ));
+                                }
+                                weight_seen = true;
+
+                                let Some(v) = val else {
+                                    return Some(self.violation(ctx.severity, format!(
+                                        "Missing parameter value for '{}' in Accept-Encoding member '{}'",
+                                        name, part
+                                    )));
+                                };
+
+                                // cite(RFC 9110 § 12.4.2): "qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )"
+                                if !crate::helpers::headers::valid_qvalue(v) {
+                                    return Some(self.cited(
+                                        &RFC_9110_12_4_2,
+                                        ctx.severity,
+                                        format!(
+                                            "Invalid qvalue '{}' in Accept-Encoding member '{}'",
+                                            v, part
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
                     }
                 }
                 None

--- a/lint-http-rules/src/rules/accept_language_weight_valid.rs
+++ b/lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -156,13 +156,12 @@ impl Rule for AcceptLanguageWeightValid {
 
             // Request
             for hv in tx.request.headers.get_all("accept-language").iter() {
-                if let Ok(val) = hv.to_str() {
-                    if let Some(v) = validate_value(val) {
-                        return Some(v);
-                    }
-                } else {
+                let Ok(val) = hv.to_str() else {
                     return Some(self.violation(ctx.severity, "Accept-Language contains an octet no part of this field's grammar admits"
                                 .into()));
+                };
+                if let Some(v) = validate_value(val) {
+                    return Some(v);
                 }
             }
 
@@ -173,13 +172,12 @@ impl Rule for AcceptLanguageWeightValid {
             // what the field would mean here.
             if let Some(resp) = &tx.response {
                 for hv in resp.headers.get_all("accept-language").iter() {
-                    if let Ok(val) = hv.to_str() {
-                        if let Some(v) = validate_value(val) {
-                            return Some(v);
-                        }
-                    } else {
+                    let Ok(val) = hv.to_str() else {
                         return Some(self.violation(ctx.severity, "Accept-Language contains an octet no part of this field's grammar admits"
                                     .into()));
+                    };
+                    if let Some(v) = validate_value(val) {
+                        return Some(v);
                     }
                 }
             }

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -64,75 +64,78 @@ impl Rule for AuthSchemeRegistered {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
-        let finding = || -> Option<Violation> {
-            let config: &crate::helpers::rule_config::AllowedList = ctx.state();
-            // Helper to check a single scheme token against allowed list
-            let check_scheme =
-                |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {
-                    // An auth-scheme is a token; the tchar set is helper-owned.
-                    // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
-                    if let Some(c) = crate::helpers::token::find_invalid_token_char(scheme) {
-                        return Some(AuthSchemeRegistered.violation(
-                            ctx.severity,
-                            format!("Invalid character '{}' in {} auth-scheme", c, hdr_name),
-                        ));
-                    }
-                    // The guidance the allowlist stands for: schemes ought to be registered.
-                    // The comparison is lowercase because the scheme token is case-insensitive
-                    // (§11.1). Note this is checked against an operator-configured `allowed`
-                    // list, not the live IANA registry — the allowlist is the operator's chosen
-                    // subset of acceptable (typically registered) schemes, and §16.4.1 is where
-                    // registered ones live.
-                    // cite(RFC 9110 § 11.1): "New and existing authentication schemes are specified independently and ought to be registered"
-                    // cite(RFC 9110 § 16.4.1): "The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials."
-                    if !allowed.contains(&scheme.to_ascii_lowercase()) {
-                        return Some(AuthSchemeRegistered.violation(
-                            ctx.severity,
-                            format!("Unrecognized auth-scheme '{}' in {}", scheme, hdr_name),
-                        ));
-                    }
-                    None
-                };
+        let finding =
+            || -> Option<Violation> {
+                let config: &crate::helpers::rule_config::AllowedList = ctx.state();
+                // Helper to check a single scheme token against allowed list
+                let check_scheme =
+                    |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {
+                        // An auth-scheme is a token; the tchar set is helper-owned.
+                        // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
+                        if let Some(c) = crate::helpers::token::find_invalid_token_char(scheme) {
+                            return Some(AuthSchemeRegistered.violation(
+                                ctx.severity,
+                                format!("Invalid character '{}' in {} auth-scheme", c, hdr_name),
+                            ));
+                        }
+                        // The guidance the allowlist stands for: schemes ought to be registered.
+                        // The comparison is lowercase because the scheme token is case-insensitive
+                        // (§11.1). Note this is checked against an operator-configured `allowed`
+                        // list, not the live IANA registry — the allowlist is the operator's chosen
+                        // subset of acceptable (typically registered) schemes, and §16.4.1 is where
+                        // registered ones live.
+                        // cite(RFC 9110 § 11.1): "New and existing authentication schemes are specified independently and ought to be registered"
+                        // cite(RFC 9110 § 16.4.1): "The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials."
+                        if !allowed.contains(&scheme.to_ascii_lowercase()) {
+                            return Some(AuthSchemeRegistered.violation(
+                                ctx.severity,
+                                format!("Unrecognized auth-scheme '{}' in {}", scheme, hdr_name),
+                            ));
+                        }
+                        None
+                    };
 
-            // Check WWW-Authenticate challenges in responses
-            if let Some(resp) = &tx.response {
-                for hv in resp.headers.get_all("www-authenticate").iter() {
-                    let s = match hv.to_str() {
-                        Ok(v) => v,
-                        Err(_) => {
+                // Check WWW-Authenticate challenges in responses
+                if let Some(resp) = &tx.response {
+                    for hv in resp.headers.get_all("www-authenticate").iter() {
+                        let Ok(s) = hv.to_str() else {
                             return Some(self.violation(
                                 ctx.severity,
                                 "WWW-Authenticate header contains non-UTF8 value".into(),
-                            ))
-                        }
-                    };
+                            ));
+                        };
 
-                    // split into assembled challenges
-                    match crate::helpers::auth::split_and_group_challenges(s) {
-                        Ok(challenges) => {
-                            for challenge in challenges {
-                                let scheme =
-                                    challenge.split(char::is_whitespace).next().unwrap().trim();
-                                if let Some(v) =
-                                    check_scheme("WWW-Authenticate", scheme, &config.allowed)
-                                {
-                                    return Some(v);
+                        // split into assembled challenges
+                        match crate::helpers::auth::split_and_group_challenges(s) {
+                            Ok(challenges) => {
+                                for challenge in challenges {
+                                    let scheme =
+                                        challenge.split(char::is_whitespace).next().unwrap().trim();
+                                    if let Some(v) =
+                                        check_scheme("WWW-Authenticate", scheme, &config.allowed)
+                                    {
+                                        return Some(v);
+                                    }
                                 }
                             }
-                        }
-                        Err(e) => {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!("Invalid WWW-Authenticate header: {}", e),
-                            ))
+                            Err(e) => {
+                                return Some(self.violation(
+                                    ctx.severity,
+                                    format!("Invalid WWW-Authenticate header: {}", e),
+                                ))
+                            }
                         }
                     }
                 }
-            }
 
-            // Check Authorization header in requests
-            if let Some(hv) = tx.request.headers.get_all("authorization").iter().next() {
-                if let Ok(v) = hv.to_str() {
+                // Check Authorization header in requests
+                if let Some(hv) = tx.request.headers.get_all("authorization").iter().next() {
+                    let Ok(v) = hv.to_str() else {
+                        return Some(self.violation(
+                            ctx.severity,
+                            "Authorization header contains non-UTF8 value".into(),
+                        ));
+                    };
                     // validate basic syntax first
                     if let Err(e) = crate::helpers::auth::validate_authorization_syntax(v) {
                         return Some(self.violation(
@@ -145,16 +148,10 @@ impl Rule for AuthSchemeRegistered {
                     if let Some(vv) = check_scheme("Authorization", scheme, &config.allowed) {
                         return Some(vv);
                     }
-                } else {
-                    return Some(self.violation(
-                        ctx.severity,
-                        "Authorization header contains non-UTF8 value".into(),
-                    ));
                 }
-            }
 
-            None
-        };
+                None
+            };
         Vec::from_iter(finding())
     }
 

--- a/lint-http-rules/src/rules/authentication_challenge_valid.rs
+++ b/lint-http-rules/src/rules/authentication_challenge_valid.rs
@@ -47,53 +47,51 @@ impl Rule for AuthenticationChallengeValid {
             // Map of normalized_realm -> set of auth-schemes that advertise it
             let mut realms: HashMap<String, HashSet<String>> = HashMap::new();
 
-            for hv in resp.headers.get_all("www-authenticate").iter() {
-                if let Ok(s) = hv.to_str() {
-                    // split assembled challenges
-                    let challenges = match crate::helpers::auth::split_and_group_challenges(s) {
-                        Ok(c) => c,
-                        Err(_) => continue,
-                    };
+            for s in crate::helpers::headers::field_lines(&resp.headers, "www-authenticate") {
+                // split assembled challenges
+                let challenges = match crate::helpers::auth::split_and_group_challenges(s) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
 
-                    for ch in challenges.iter() {
-                        let ch = ch.trim();
-                        if ch.is_empty() {
-                            continue;
-                        }
-                        // extract scheme (first token before whitespace)
-                        let mut parts = ch.splitn(2, char::is_whitespace);
-                        let scheme = parts.next().unwrap_or("").trim().to_ascii_lowercase();
+                for ch in challenges.iter() {
+                    let ch = ch.trim();
+                    if ch.is_empty() {
+                        continue;
+                    }
+                    // extract scheme (first token before whitespace)
+                    let mut parts = ch.splitn(2, char::is_whitespace);
+                    let scheme = parts.next().unwrap_or("").trim().to_ascii_lowercase();
 
-                        let mut realm_opt: Option<String> = None;
-                        if let Some(rest) = parts.next() {
-                            let rest = rest.trim();
-                            if rest.contains('=') {
-                                if let Ok(params) = crate::helpers::auth::parse_auth_params(rest) {
-                                    if let Some(r) = params.get("realm") {
-                                        // Normalize quoted and unquoted realm to the same
-                                        // string before comparing: a sender must quote it, but
-                                        // recipients accept both forms, so `realm="a"` and
-                                        // `realm=a` denote the same protection space. (quoted-
-                                        // string unescaping is helper-owned.)
-                                        // cite(RFC 9110 § 11.5): "Recipients might have to support both token and quoted-string syntax for maximum interoperability with existing clients that have been accepting both notations for a long time."
-                                        if r.starts_with('"') {
-                                            if let Ok(unq) =
-                                                crate::helpers::headers::unescape_quoted_string(r)
-                                            {
-                                                realm_opt = Some(unq);
-                                            }
-                                        } else {
-                                            realm_opt = Some(r.trim().to_string());
+                    let mut realm_opt: Option<String> = None;
+                    if let Some(rest) = parts.next() {
+                        let rest = rest.trim();
+                        if rest.contains('=') {
+                            if let Ok(params) = crate::helpers::auth::parse_auth_params(rest) {
+                                if let Some(r) = params.get("realm") {
+                                    // Normalize quoted and unquoted realm to the same
+                                    // string before comparing: a sender must quote it, but
+                                    // recipients accept both forms, so `realm="a"` and
+                                    // `realm=a` denote the same protection space. (quoted-
+                                    // string unescaping is helper-owned.)
+                                    // cite(RFC 9110 § 11.5): "Recipients might have to support both token and quoted-string syntax for maximum interoperability with existing clients that have been accepting both notations for a long time."
+                                    if r.starts_with('"') {
+                                        if let Ok(unq) =
+                                            crate::helpers::headers::unescape_quoted_string(r)
+                                        {
+                                            realm_opt = Some(unq);
                                         }
+                                    } else {
+                                        realm_opt = Some(r.trim().to_string());
                                     }
                                 }
                             }
                         }
+                    }
 
-                        if let Some(realm) = realm_opt {
-                            let entry = realms.entry(realm).or_default();
-                            entry.insert(scheme);
-                        }
+                    if let Some(realm) = realm_opt {
+                        let entry = realms.entry(realm).or_default();
+                        entry.insert(scheme);
                     }
                 }
             }

--- a/lint-http-rules/src/rules/bearer_token_syntax.rs
+++ b/lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -42,14 +42,11 @@ impl Rule for BearerTokenSyntax {
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
             for hv in tx.request.headers.get_all("authorization").iter() {
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Authorization header contains non-UTF8 value".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Authorization header contains non-UTF8 value".into(),
+                    ));
                 };
 
                 // Split scheme and credentials. Auth-scheme names match case-insensitively.

--- a/lint-http-rules/src/rules/conditional_headers_consistent.rs
+++ b/lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -89,24 +89,23 @@ impl Rule for ConditionalHeadersConsistent {
                 // Validate If-Range content: if it's an entity-tag, it MUST NOT be weak.
                 // (A weak marker is the `W/` prefix; a bare quoted-string is a strong tag and
                 // fine, and a date is left to date-validity rules.)
-                if let Ok(s) = hv.to_str() {
-                    let trimmed = s.trim();
-                    // cite(RFC 9110 § 13.1.5): "A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak."
-                    if trimmed.starts_with("W/") {
-                        return Some(self.cited(
-                            &RFC_9110_13_1_5,
-                            ctx.severity,
-                            "If-Range MUST not contain a weak entity-tag (W/...)".into(),
-                        ));
-                    }
-                    // If it starts with a quoted-string, it's a strong ETag and fine; if it's a date, we'll not flag here
-                    // (date validity is checked by other rules)
-                } else {
+                let Ok(s) = hv.to_str() else {
                     return Some(self.violation(
                         ctx.severity,
                         "If-Range header contains non-UTF8 value".into(),
                     ));
+                };
+                let trimmed = s.trim();
+                // cite(RFC 9110 § 13.1.5): "A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak."
+                if trimmed.starts_with("W/") {
+                    return Some(self.cited(
+                        &RFC_9110_13_1_5,
+                        ctx.severity,
+                        "If-Range MUST not contain a weak entity-tag (W/...)".into(),
+                    ));
                 }
+                // If it starts with a quoted-string, it's a strong ETag and fine; if it's a date, we'll not flag here
+                // (date validity is checked by other rules)
             }
 
             // Neither date conditional is a list, so a second field line is a sender

--- a/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
+++ b/lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
@@ -91,15 +91,14 @@ impl Rule for ContentEncodingAndTypeConsistent {
             {
                 let mut seen = std::collections::HashSet::new();
                 for hv in tx.request.headers.get_all("content-encoding").iter() {
-                    if let Ok(val) = hv.to_str() {
-                        if let Some(v) = check_encoding_header("Content-Encoding", val, &mut seen) {
-                            return Some(v);
-                        }
-                    } else {
+                    let Ok(val) = hv.to_str() else {
                         return Some(self.violation(
                             ctx.severity,
                             "Content-Encoding header value is not valid UTF-8".into(),
                         ));
+                    };
+                    if let Some(v) = check_encoding_header("Content-Encoding", val, &mut seen) {
+                        return Some(v);
                     }
                 }
             }
@@ -137,15 +136,14 @@ impl Rule for ContentEncodingAndTypeConsistent {
 
                 let mut seen = std::collections::HashSet::new();
                 for hv in resp.headers.get_all("content-encoding").iter() {
-                    if let Ok(val) = hv.to_str() {
-                        if let Some(v) = check_encoding_header("Content-Encoding", val, &mut seen) {
-                            return Some(v);
-                        }
-                    } else {
+                    let Ok(val) = hv.to_str() else {
                         return Some(self.violation(
                             ctx.severity,
                             "Content-Encoding header value is not valid UTF-8".into(),
                         ));
+                    };
+                    if let Some(v) = check_encoding_header("Content-Encoding", val, &mut seen) {
+                        return Some(v);
                     }
                 }
             }

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -44,14 +44,11 @@ impl Rule for CookieDomainValid {
             let resp = tx.response.as_ref()?;
 
             for hv in resp.headers.get_all("set-cookie").iter() {
-                let s = match hv.to_str() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Set-Cookie header value is not valid UTF-8".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Set-Cookie header value is not valid UTF-8".into(),
+                    ));
                 };
 
                 // split into cookie-pair and attributes

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -50,14 +50,11 @@ impl Rule for CookiePathValid {
             let resp = tx.response.as_ref()?;
 
             for hv in resp.headers.get_all("set-cookie").iter() {
-                let s = match hv.to_str() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Set-Cookie header value is not valid UTF-8".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Set-Cookie header value is not valid UTF-8".into(),
+                    ));
                 };
 
                 // Split into cookie-pair and attribute segments

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -53,14 +53,10 @@ impl Rule for EtagSyntax {
             let mut count = 0usize;
             for hv in resp.headers.get_all("etag").iter() {
                 count += 1;
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "ETag header value is not valid UTF-8".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(
+                        self.violation(ctx.severity, "ETag header value is not valid UTF-8".into()),
+                    );
                 };
 
                 let t = s.trim();

--- a/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_modified_since_date_syntax.rs
@@ -39,14 +39,11 @@ impl Rule for IfModifiedSinceDateSyntax {
         let finding = || -> Option<Violation> {
             // Only applies to requests
             for hv in tx.request.headers.get_all("if-modified-since").iter() {
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "If-Modified-Since header contains non-UTF8 value".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "If-Modified-Since header contains non-UTF8 value".into(),
+                    ));
                 };
 
                 // `OWS` here too, so this branch and the one below agree about what

--- a/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
+++ b/lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
@@ -39,14 +39,11 @@ impl Rule for IfUnmodifiedSinceDateSyntax {
         let finding = || -> Option<Violation> {
             // Applies to requests only
             for hv in tx.request.headers.get_all("if-unmodified-since").iter() {
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "If-Unmodified-Since header contains non-UTF8 value".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "If-Unmodified-Since header contains non-UTF8 value".into(),
+                    ));
                 };
 
                 // `OWS` here too, so this branch and the one below agree about what

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -171,6 +171,54 @@ impl std::fmt::Display for SpecRef {
     }
 }
 
+/// The three bodies [`Rule`] and [`ProtocolRule`] provide identically.
+///
+/// The two traits describe different subjects — a transaction and a protocol
+/// event — but they build findings the same way, because a `Violation` names
+/// the rule by its id whichever trait produced it. That was written down twice,
+/// with a comment on the second copy saying it was the same as the first; a
+/// reader who has to be told two functions agree is reading one function too
+/// many.
+fn resolve_shared_table(cfg: &crate::config::Config, id: &str) -> anyhow::Result<ResolvedRule> {
+    validate_rule_table(cfg, id)?;
+    Ok(ResolvedRule {
+        severity: get_rule_severity_required(cfg, id)?,
+        state: Box::new(()),
+    })
+}
+
+/// Build a finding attributed to `id`.
+fn finding_of(id: &str, severity: crate::lint::Severity, message: String) -> Violation {
+    Violation {
+        rule: id.into(),
+        severity,
+        message,
+        cite: None,
+    }
+}
+
+/// Build a finding attributed to `id`, carrying the sentence it enforces.
+///
+/// `declared` is the rule's own reference list, and the assertion is the whole
+/// reason this takes it: a finding may only cite a reference its rule declares.
+fn cited_finding_of(
+    id: &str,
+    declared: &[SpecRef],
+    spec: &SpecRef,
+    severity: crate::lint::Severity,
+    message: String,
+) -> Violation {
+    debug_assert!(
+        declared.contains(spec),
+        "{}: a finding may only cite a spec the rule declares",
+        id
+    );
+    Violation {
+        cite: Some(spec.citation()),
+        ..finding_of(id, severity, message)
+    }
+}
+
 pub trait Rule: Send + Sync {
     fn id(&self) -> &'static str;
 
@@ -186,11 +234,7 @@ pub trait Rule: Send + Sync {
     /// forward); a rule with a custom config section overrides this to parse
     /// it into its own `state`.
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<ResolvedRule> {
-        validate_rule_table(cfg, self.id())?;
-        Ok(ResolvedRule {
-            severity: get_rule_severity_required(cfg, self.id())?,
-            state: Box::new(()),
-        })
+        resolve_shared_table(cfg, self.id())
     }
 
     /// The scope where the rule should be executed. Default is `Both`;
@@ -229,12 +273,7 @@ pub trait Rule: Send + Sync {
     /// which is why `structured_headers_valid`'s private finding
     /// builder is named for its failure rather than for what it returns.
     fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-            cite: None,
-        }
+        finding_of(self.id(), severity, message)
     }
 
     /// Build one of this rule's findings, carrying the specification text it
@@ -248,15 +287,7 @@ pub trait Rule: Send + Sync {
     /// citation is worse than none. The `// cite` comment beside the call is
     /// the reviewer's oracle that the right one was named.
     fn cited(&self, spec: &SpecRef, severity: crate::lint::Severity, message: String) -> Violation {
-        debug_assert!(
-            self.specifications().contains(spec),
-            "{}: a finding may only cite a spec the rule declares",
-            self.id()
-        );
-        Violation {
-            cite: Some(spec.citation()),
-            ..self.violation(severity, message)
-        }
+        cited_finding_of(self.id(), self.specifications(), spec, severity, message)
     }
 
     /// Every finding this rule has about the transaction; empty means clean.
@@ -480,23 +511,14 @@ pub trait ProtocolRule: Send + Sync {
     /// Resolve this rule's configuration once, when the engine is built. See
     /// [`Rule::prepare`] for the contract.
     fn prepare(&self, cfg: &crate::config::Config) -> anyhow::Result<ResolvedRule> {
-        validate_rule_table(cfg, self.id())?;
-        Ok(ResolvedRule {
-            severity: get_rule_severity_required(cfg, self.id())?,
-            state: Box::new(()),
-        })
+        resolve_shared_table(cfg, self.id())
     }
 
     /// Build one of this rule's findings. See [`Rule::violation`] for the
     /// contract; the body is the same because `Violation.rule` is the id
     /// whichever trait the rule implements.
     fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
-        Violation {
-            rule: self.id().into(),
-            severity,
-            message,
-            cite: None,
-        }
+        finding_of(self.id(), severity, message)
     }
 
     /// Build one of this rule's findings, carrying the specification text it
@@ -510,15 +532,7 @@ pub trait ProtocolRule: Send + Sync {
     /// citation is worse than none. The `// cite` comment beside the call is
     /// the reviewer's oracle that the right one was named.
     fn cited(&self, spec: &SpecRef, severity: crate::lint::Severity, message: String) -> Violation {
-        debug_assert!(
-            self.specifications().contains(spec),
-            "{}: a finding may only cite a spec the rule declares",
-            self.id()
-        );
-        Violation {
-            cite: Some(spec.citation()),
-            ..self.violation(severity, message)
-        }
+        cited_finding_of(self.id(), self.specifications(), spec, severity, message)
     }
 
     /// Every finding this rule has about the event; empty means clean. See

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -115,23 +115,21 @@ impl Rule for NoStoreEnforced {
             // helper to check If-None-Match header members against bad etags.  RFC
             // dictates that multiple header fields are concatenated with commas, and
             // HeaderMap.get_all() returns all values in order.
-            for hv in tx.request.headers.get_all("if-none-match").iter() {
-                if let Ok(s) = hv.to_str() {
-                    for member in crate::helpers::headers::list_members(s) {
-                        let normalized = crate::helpers::headers::normalize_etag(member);
-                        // A validator echoed back from a no-store response is proof the client
-                        // stored the thing it was told not to store.
-                        // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."
-                        if no_store_etags.contains(&normalized) {
-                            return Some(self.cited(
-                                &RFC_9111_5_2_2_5,
-                                ctx.severity,
-                                format!(
-                                    "Conditional request uses ETag '{}' from a no-store response",
-                                    member
-                                ),
-                            ));
-                        }
+            for s in crate::helpers::headers::field_lines(&tx.request.headers, "if-none-match") {
+                for member in crate::helpers::headers::list_members(s) {
+                    let normalized = crate::helpers::headers::normalize_etag(member);
+                    // A validator echoed back from a no-store response is proof the client
+                    // stored the thing it was told not to store.
+                    // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."
+                    if no_store_etags.contains(&normalized) {
+                        return Some(self.cited(
+                            &RFC_9111_5_2_2_5,
+                            ctx.severity,
+                            format!(
+                                "Conditional request uses ETag '{}' from a no-store response",
+                                member
+                            ),
+                        ));
                     }
                 }
             }
@@ -140,26 +138,28 @@ impl Rule for NoStoreEnforced {
             // syntax is a single HTTP-date per field.  To avoid reparsing the same
             // candidate over and over we parse it once before iterating through the
             // historical values.
-            for hv in tx.request.headers.get_all("if-modified-since").iter() {
-                if let Ok(s) = hv.to_str() {
-                    let candidate = s.trim();
-                    let candidate_dt =
-                        crate::http_date::parse_http_date_to_datetime(candidate).ok();
+            for s in crate::helpers::headers::field_lines(&tx.request.headers, "if-modified-since")
+            {
+                let candidate = s.trim();
+                let candidate_dt = crate::http_date::parse_http_date_to_datetime(candidate).ok();
 
-                    // A Last-Modified validator echoed back from a no-store response is the same
-                    // evidence of forbidden storage as the ETag case above.
-                    // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."
-                    if no_store_lastmod.contains_key(candidate)
-                        || (candidate_dt.is_some()
-                            && no_store_lastmod
-                                .values()
-                                .any(|lm_dt| lm_dt == &candidate_dt.unwrap()))
-                    {
-                        return Some(self.cited(&RFC_9111_5_2_2_5, ctx.severity, format!(
-                                "Conditional request uses Last-Modified '{}' from a no-store response",
-                                candidate
-                            )));
-                    }
+                // A Last-Modified validator echoed back from a no-store response is the same
+                // evidence of forbidden storage as the ETag case above.
+                // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."
+                if no_store_lastmod.contains_key(candidate)
+                    || (candidate_dt.is_some()
+                        && no_store_lastmod
+                            .values()
+                            .any(|lm_dt| lm_dt == &candidate_dt.unwrap()))
+                {
+                    return Some(self.cited(
+                        &RFC_9111_5_2_2_5,
+                        ctx.severity,
+                        format!(
+                            "Conditional request uses Last-Modified '{}' from a no-store response",
+                            candidate
+                        ),
+                    ));
                 }
             }
 

--- a/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
+++ b/lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
@@ -53,13 +53,11 @@ impl Rule for PriorityAndCacheabilityConsistent {
             // first non-empty ASCII field line is taken; a Priority header that is
             // empty or non-ASCII on every line is treated as absent and skipped.
             let mut priority_val: Option<&str> = None;
-            for hv in resp.headers.get_all("priority").iter() {
-                if let Ok(s) = hv.to_str() {
-                    let s = s.trim();
-                    if !s.is_empty() {
-                        priority_val = Some(s);
-                        break;
-                    }
+            for s in crate::helpers::headers::field_lines(&resp.headers, "priority") {
+                let s = s.trim();
+                if !s.is_empty() {
+                    priority_val = Some(s);
+                    break;
                 }
             }
             let priority = priority_val?;

--- a/lint-http-rules/src/rules/vary_header_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_valid.rs
@@ -48,15 +48,12 @@ impl Rule for VaryHeaderValid {
             // are each "*" or a field-name.
             // cite(RFC 9110 § 12.5.5): "Vary = #( "*" / field-name )"
             for hv in resp.headers.get_all("vary").iter() {
-                let s = match hv.to_str() {
-                    Ok(s) => s,
-                    Err(_) => {
-                        return Some(self.cited(
-                            &RFC_9110_12_5_5,
-                            ctx.severity,
-                            "Vary header contains non-UTF8 value".into(),
-                        ))
-                    }
+                let Ok(s) = hv.to_str() else {
+                    return Some(self.cited(
+                        &RFC_9110_12_5_5,
+                        ctx.severity,
+                        "Vary header contains non-UTF8 value".into(),
+                    ));
                 };
 
                 // Vary is a `#`-list, so an entirely empty value is a legal zero-element

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -45,25 +45,22 @@ impl Rule for WwwAuthenticateChallengeSyntax {
         let finding = || -> Option<Violation> {
             // Only check response headers; ignore non-UTF8 header values
             if let Some(resp) = &tx.response {
-                for hv in resp.headers.get_all("www-authenticate").iter() {
-                    if let Ok(s) = hv.to_str() {
-                        // Group members into assembled challenges using the helper so we can
-                        // test the grouping logic independently and exercise more branches.
-                        // cite(RFC 9110 § 11.6.1): "The "WWW-Authenticate" response header field indicates the authentication scheme(s) and parameters applicable to the target resource."
-                        let challenges = match crate::helpers::auth::split_and_group_challenges(s) {
-                            Ok(c) => c,
-                            Err(msg) => {
-                                return Some(self.cited(&RFC_9110_11_6_1, ctx.severity, msg));
-                            }
-                        };
+                for s in crate::helpers::headers::field_lines(&resp.headers, "www-authenticate") {
+                    // Group members into assembled challenges using the helper so we can
+                    // test the grouping logic independently and exercise more branches.
+                    // cite(RFC 9110 § 11.6.1): "The "WWW-Authenticate" response header field indicates the authentication scheme(s) and parameters applicable to the target resource."
+                    let challenges = match crate::helpers::auth::split_and_group_challenges(s) {
+                        Ok(c) => c,
+                        Err(msg) => {
+                            return Some(self.cited(&RFC_9110_11_6_1, ctx.severity, msg));
+                        }
+                    };
 
-                        // Now validate each assembled challenge using helper to make it unit-testable
-                        for challenge in challenges.iter() {
-                            if let Err(msg) =
-                                crate::helpers::auth::validate_challenge_syntax(challenge)
-                            {
-                                return Some(self.violation(ctx.severity, msg));
-                            }
+                    // Now validate each assembled challenge using helper to make it unit-testable
+                    for challenge in challenges.iter() {
+                        if let Err(msg) = crate::helpers::auth::validate_challenge_syntax(challenge)
+                        {
+                            return Some(self.violation(ctx.severity, msg));
                         }
                     }
                 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -42,19 +42,19 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2398
+      line: 2385
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2393
+      line: 2380
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2392
+      line: 2379
   - label: origin_matching_for_cors
     section: § 4.10
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
@@ -342,7 +342,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2458
+      line: 2445
   - label: refresh_header_syntax
     section: § 1.1
     snippet: A code point is found that is not a URL unit.
@@ -1128,7 +1128,7 @@ sources:
     snippet: authority   = [ userinfo "@" ] host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2440
+      line: 2427
     - file: lint-http-rules/src/helpers/uri.rs
       line: 170
   - label: lint-http-rules/src/helpers/ipv6.rs
@@ -2053,13 +2053,13 @@ sources:
     snippet: If the attribute-value is empty, the behavior is undefined.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 67
+      line: 64
   - label: cookie_domain_valid (2)
     section: § 5.2.3
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 82
+      line: 79
   - label: cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
@@ -2151,7 +2151,7 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 288
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 79
+      line: 76
   - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.
@@ -2252,7 +2252,7 @@ sources:
     snippet: serialized-origin = scheme "://" host [ ":" port ]
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2394
+      line: 2381
     - file: lint-http-rules/src/helpers/uri.rs
       line: 320
   - label: lint-http-rules/src/helpers/uri.rs
@@ -2912,7 +2912,7 @@ sources:
     snippet: credentials = "Bearer" 1*SP b64token
     cited_by:
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 63
+      line: 60
   - label: bearer b64token grammar
     section: § 2.1
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
@@ -3902,25 +3902,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1917
+      line: 1904
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1858
+      line: 1845
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1896
+      line: 1883
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1889
+      line: 1876
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.html
   fragments:
@@ -4301,7 +4301,7 @@ sources:
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 983
+      line: 970
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 162
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -4557,7 +4557,7 @@ sources:
     snippet: The content negotiation fields defined by this specification use a common parameter, named "q" (case-insensitive), to assign a relative "weight" to the preference for that associated kind of content.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 153
+      line: 164
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 285
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -4587,13 +4587,13 @@ sources:
     snippet: An "identity" token is used as a synonym for "no encoding" in order to communicate when no encoding is preferred.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 99
+      line: 110
   - label: accept_encoding_parameter_valid (5)
     section: § 12.5.3
     snippet: An Accept-Encoding header field with a field value that is empty implies that the user agent does not want any content coding in response.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 77
+      line: 88
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 76
   - label: accept_encoding_parameter_valid (6)
@@ -4601,13 +4601,13 @@ sources:
     snippet: Each codings value MAY be given an associated quality value (weight) representing the preference for that encoding, as defined in Section 12.4.2.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 132
+      line: 143
   - label: accept_encoding_parameter_valid (7)
     section: § 12.5.3
     snippet: The asterisk "*" symbol in an Accept-Encoding field matches any available content coding not explicitly listed in the field.
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 98
+      line: 109
     - file: lint-http-rules/src/rules/content_encoding_registered.rs
       line: 95
   - label: accept_encoding_parameter_valid (8)
@@ -4635,7 +4635,7 @@ sources:
     snippet: content-coding   = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 97
+      line: 108
     - file: lint-http-rules/src/rules/compression_and_transfer_encoding_consistent.rs
       line: 88
   - label: accept_encoding_present
@@ -5087,31 +5087,31 @@ sources:
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 86
+      line: 87
   - label: auth_scheme_registered (2)
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 87
+      line: 88
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 108
+      line: 106
   - label: authentication_challenge_valid (2)
     section: § 11.5
     snippet: Recipients might have to support both token and quoted-string syntax for maximum interoperability with existing clients that have been accepting both notations for a long time.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 78
+      line: 77
   - label: authentication_challenge_valid (3)
     section: § 11.5
     snippet: These realms allow the protected resources on a server to be partitioned into a set of protection spaces, each with its own authentication scheme and/or authorization database.
     cited_by:
     - file: lint-http-rules/src/rules/authentication_challenge_valid.rs
-      line: 107
+      line: 105
   - label: authentication_failure_loop
     section: § 15.5.2
     snippet: If the 401 response contains the same challenge as the prior response, and the user agent has already attempted authentication at least once, then the user agent SHOULD present the enclosed representation to the user, since it usually contains relevant diagnostic information.
@@ -5281,9 +5281,9 @@ sources:
     snippet: A recipient MUST ignore the If-Modified-Since header field if the received field value is not a valid HTTP-date, the field value has more than one member, or if the request method is neither GET nor HEAD.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 121
+      line: 120
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 139
+      line: 138
   - label: conditional_headers_consistent (3)
     section: § 13.1.4
     snippet: A recipient MUST ignore If-Unmodified-Since if the request contains an If-Match header field
@@ -5295,13 +5295,13 @@ sources:
     snippet: A recipient MUST ignore the If-Unmodified-Since header field if the received field value is not a valid HTTP-date (including when the field value appears to be a list of dates).
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 122
+      line: 121
   - label: conditional_headers_consistent (5)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field containing an entity tag that is marked as weak.
     cited_by:
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 94
+      line: 99
   - label: conditional_headers_consistent (6)
     section: § 13.1.5
     snippet: A client MUST NOT generate an If-Range header field in a request that does not contain a Range header field.
@@ -5377,7 +5377,7 @@ sources:
     snippet: a sender SHOULD NOT generate representation metadata other than the above listed fields unless said metadata exists for the purpose of guiding cache updates
     cited_by:
     - file: lint-http-rules/src/rules/content_encoding_and_type_consistent.rs
-      line: 118
+      line: 117
   - label: content_encoding_registered
     section: § 12.5.3
     snippet: codings = content-coding / "identity" / "*"
@@ -5989,7 +5989,7 @@ sources:
     snippet: If-Modified-Since = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 74
+      line: 71
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 39
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -5999,9 +5999,9 @@ sources:
     snippet: A field value does not include leading or trailing whitespace
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 75
+      line: 72
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 74
+      line: 71
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
       line: 58
   - label: if_none_match_etag_syntax
@@ -6017,7 +6017,7 @@ sources:
     snippet: If-Unmodified-Since = HTTP-date
     cited_by:
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 73
+      line: 70
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 40
   - label: keep_alive_header_valid
@@ -6115,9 +6115,9 @@ sources:
     - file: lint-http-core/src/http_date.rs
       line: 100
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 77
+      line: 74
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 76
+      line: 73
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
       line: 60
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
@@ -6211,7 +6211,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 22
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1015
+      line: 1002
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 40
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -6223,7 +6223,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 125
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1050
+      line: 1037
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 108
   - label: lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -6291,7 +6291,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 97
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 580
+      line: 567
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 84
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -6327,11 +6327,11 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 213
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 73
+      line: 74
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
       line: 48
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
-      line: 56
+      line: 53
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
       line: 53
   - label: lint-http-rules/src/helpers/auth.rs (2)
@@ -6359,9 +6359,9 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 60
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1185
+      line: 1172
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1214
+      line: 1201
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 75
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -6381,7 +6381,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 239
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1624
+      line: 1611
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 54
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -6413,9 +6413,9 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 151
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 582
+      line: 569
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 618
+      line: 605
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 86
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -6457,7 +6457,7 @@ sources:
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 151
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 71
+      line: 68
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 265
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
@@ -6589,21 +6589,21 @@ sources:
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 999
+      line: 986
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 11.7.3
     snippet: Proxy-Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1000
+      line: 987
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1826
+      line: 1813
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 179
+      line: 193
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 141
   - label: Vary grammar
@@ -6611,7 +6611,7 @@ sources:
     snippet: 'Vary = #( "*" / field-name )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1115
+      line: 1102
     - file: lint-http-rules/src/rules/vary_header_valid.rs
       line: 49
   - label: If-None-Match weak comparison
@@ -6625,7 +6625,7 @@ sources:
     snippet: If the field is allowable in trailers; by default, it will not be (see Section 6.5.1).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 920
+      line: 907
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5
     snippet: Fields are sent and received within the header and trailer sections of messages
@@ -6641,15 +6641,15 @@ sources:
     snippet: Field names are case-insensitive
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1048
+      line: 1035
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1116
+      line: 1103
   - label: lint-http-rules/src/helpers/headers.rs (6)
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1117
+      line: 1104
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 110
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6681,11 +6681,11 @@ sources:
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1625
+      line: 1612
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
-      line: 118
+      line: 117
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 160
     - file: lint-http-rules/src/rules/content_type_valid.rs
@@ -6693,7 +6693,7 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 64
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 91
+      line: 87
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 285
     - file: lint-http-rules/src/rules/host_header.rs
@@ -6721,7 +6721,7 @@ sources:
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2096
+      line: 2083
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 209
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
@@ -6781,7 +6781,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1622
+      line: 1609
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 159
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -6791,7 +6791,7 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1623
+      line: 1610
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 253
   - label: lint-http-rules/src/helpers/headers.rs (14)
@@ -6805,9 +6805,9 @@ sources:
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 579
+      line: 566
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
-      line: 78
+      line: 89
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 86
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
@@ -6821,9 +6821,9 @@ sources:
     snippet: 'A recipient MUST parse and ignore a reasonable number of empty list elements:'
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 581
+      line: 568
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 617
+      line: 604
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 189
   - label: lint-http-rules/src/helpers/headers.rs (17)
@@ -6831,9 +6831,9 @@ sources:
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 616
+      line: 603
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1687
+      line: 1674
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 76
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6845,7 +6845,7 @@ sources:
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1688
+      line: 1675
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6871,17 +6871,17 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 429
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 583
+      line: 570
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 619
+      line: 606
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1186
+      line: 1173
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1215
+      line: 1202
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1239
+      line: 1226
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2025
+      line: 2012
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 101
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -6895,9 +6895,9 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 139
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 55
+      line: 52
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 55
+      line: 52
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
       line: 160
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6915,7 +6915,7 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1748
+      line: 1735
   - label: lint-http-rules/src/helpers/headers.rs (20)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
@@ -6927,13 +6927,13 @@ sources:
     snippet: Recipients that process the value of a quoted-string MUST handle a quoted-pair as if it were replaced by the octet following the backslash.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1463
+      line: 1450
   - label: lint-http-rules/src/helpers/headers.rs (22)
     section: § 5.6.4
     snippet: qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1461
+      line: 1448
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 33
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6945,11 +6945,11 @@ sources:
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1302
+      line: 1289
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1330
+      line: 1317
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1462
+      line: 1449
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 418
     - file: lint-http-rules/src/rules/link_header_valid.rs
@@ -6959,17 +6959,17 @@ sources:
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1187
+      line: 1174
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1238
+      line: 1225
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1329
+      line: 1316
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1367
+      line: 1354
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1460
+      line: 1447
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1689
+      line: 1676
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 115
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6987,7 +6987,7 @@ sources:
     snippet: Parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2315
+      line: 2302
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 198
     - file: lint-http-rules/src/rules/charset_registered.rs
@@ -6999,9 +6999,9 @@ sources:
     snippet: parameter       = parameter-name "=" parameter-value
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2023
+      line: 2010
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2050
+      line: 2037
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 390
   - label: lint-http-rules/src/helpers/headers.rs (27)
@@ -7009,11 +7009,11 @@ sources:
     snippet: parameter-name  = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2024
+      line: 2011
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2051
+      line: 2038
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2232
+      line: 2219
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 263
     - file: lint-http-rules/src/rules/expect_header_valid.rs
@@ -7023,7 +7023,7 @@ sources:
     snippet: parameter-value = ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2246
+      line: 2233
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 305
     - file: lint-http-rules/src/rules/charset_registered.rs
@@ -7039,9 +7039,9 @@ sources:
     snippet: parameters      = *( OWS ";" OWS [ parameter ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2022
+      line: 2009
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2095
+      line: 2082
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 100
     - file: lint-http-rules/src/rules/expect_header_valid.rs
@@ -7079,7 +7079,7 @@ sources:
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 919
+      line: 906
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 44
     - file: lint-http-rules/src/rules/post_creates_resource.rs
@@ -7107,13 +7107,13 @@ sources:
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 918
+      line: 905
   - label: lint-http-rules/src/helpers/headers.rs (34)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2177
+      line: 2164
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 246
     - file: lint-http-rules/src/rules/charset_present.rs
@@ -7139,7 +7139,7 @@ sources:
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2196
+      line: 2183
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 88
   - label: media-type grammar
@@ -7147,7 +7147,7 @@ sources:
     snippet: media-type = type "/" subtype parameters
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2111
+      line: 2098
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 99
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
@@ -7157,7 +7157,7 @@ sources:
     snippet: type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 2176
+      line: 2163
   - label: Content-Length grammar
     section: § 8.6
     snippet: Content-Length = 1*DIGIT
@@ -7175,9 +7175,9 @@ sources:
     snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1946
+      line: 1933
     - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 74
+      line: 70
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 72
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -7187,13 +7187,13 @@ sources:
     snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1948
+      line: 1935
   - label: lint-http-rules/src/helpers/headers.rs (39)
     section: § 8.8.3.2
     snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 682
+      line: 669
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 10.1.2
     snippet: mailbox = <mailbox, see [RFC5322], Section 3.4>
@@ -8591,7 +8591,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 107
     - file: lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
-      line: 52
+      line: 51
   - label: status_code_semantics (5)
     section: § 11.7.1
     snippet: A proxy MUST send at least one Proxy-Authenticate header field in each 407 (Proxy Authentication Required) response that it generates.
@@ -9214,15 +9214,15 @@ sources:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 118
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 124
+      line: 123
     - file: lint-http-rules/src/rules/no_store_enforced.rs
-      line: 151
+      line: 148
   - label: lint-http-rules/src/helpers/headers.rs
     section: § 4.1
     snippet: A stored response with a Vary header field value containing a member "*" always fails to match.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 1118
+      line: 1105
     - file: lint-http-rules/src/rules/vary_and_cache_consistent.rs
       line: 63
     - file: lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -9232,25 +9232,25 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 758
+      line: 745
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 768
+      line: 755
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 4.2.3
     snippet: corrected_initial_age = max(apparent_age, corrected_age_value)
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 723
+      line: 710
   - label: lint-http-rules/src/helpers/headers.rs (5)
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 722
+      line: 709
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 27
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -9567,9 +9567,9 @@ sources:
     snippet: field-line   = field-name ":" OWS field-value OWS
     cited_by:
     - file: lint-http-rules/src/rules/if_modified_since_date_syntax.rs
-      line: 76
+      line: 73
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
-      line: 75
+      line: 72
     - file: lint-http-rules/src/rules/last_modified_rfc1123_syntax.rs
       line: 59
   - label: HTTP-version
@@ -10138,7 +10138,7 @@ sources:
     snippet: This includes the Connection header field and those listed as having connection-specific semantics in Section 7.6.1 of [HTTP] (that is, Proxy-Connection, Keep-Alive, Transfer-Encoding, and Upgrade).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 973
+      line: 960
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 39
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -10524,7 +10524,7 @@ sources:
     snippet: the server is expected to control the cacheability or the applicability of the cached response by using header fields that control the caching behavior (e.g., Cache-Control, Vary)
     cited_by:
     - file: lint-http-rules/src/rules/priority_and_cacheability_consistent.rs
-      line: 88
+      line: 86
   - label: priority_header_syntax
     section: § 4
     snippet: For both the Priority header field and the PRIORITY_UPDATE frame, the set of priority parameters is encoded as a Dictionary (see Section 3.2 of [STRUCTURED-FIELDS]).
@@ -10739,43 +10739,43 @@ sources:
     snippet: Note that parameters are ordered, and parameter keys cannot contain uppercase letters.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 224
+      line: 228
   - label: lint-http-rules/src/helpers/structured_fields.rs (2)
     section: § 3.1.2
     snippet: The keys are unique within the scope of the Parameters they occur within, and the values are bare items (i.e., they themselves cannot be parameterized; see Section 3.3).
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 604
+      line: 608
   - label: lint-http-rules/src/helpers/structured_fields.rs (3)
     section: § 3.3.2
     snippet: Decimals are numbers with an integer and a fractional component.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 279
+      line: 283
   - label: lint-http-rules/src/helpers/structured_fields.rs (4)
     section: § 3.3.4
     snippet: Tokens are short textual words that begin with an alphabetic character or "*", followed by zero to many token characters, which are the same as those allowed by the "token" ABNF rule defined in [HTTP] plus the ":" and "/" characters.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 291
+      line: 295
   - label: lint-http-rules/src/helpers/structured_fields.rs (5)
     section: § 3.3.7
     snippet: Dates have a data model that is similar to Integers, representing a (possibly negative) delta in seconds from 1970-01-01T00:00:00Z, excluding leap seconds.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 316
+      line: 320
   - label: lint-http-rules/src/helpers/structured_fields.rs (6)
     section: § 3.3.8
     snippet: In textual HTTP fields, Display Strings are represented in a manner similar to Strings, except that non-ASCII characters are percent-encoded; there is a leading "%" to distinguish them from Strings.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 334
+      line: 338
   - label: lint-http-rules/src/helpers/structured_fields.rs (7)
     section: § 4.2
     snippet: Convert input_bytes into an ASCII string input_string; if conversion fails, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 414
+      line: 418
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 66
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
@@ -10785,7 +10785,7 @@ sources:
     snippet: Discard any leading SP characters from input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 452
+      line: 456
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 243
   - label: lint-http-rules/src/helpers/structured_fields.rs (9)
@@ -10793,309 +10793,315 @@ sources:
     snippet: The parsing algorithms for both types allow tab characters, since these might be used to combine field lines by some implementations.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 423
+      line: 427
   - label: lint-http-rules/src/helpers/structured_fields.rs (10)
     section: § 4.2.1
     snippet: Append the result of running Parsing an Item or Inner List (Section 4.2.1.1) with input_string to members.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 512
+      line: 516
   - label: lint-http-rules/src/helpers/structured_fields.rs (11)
+    section: § 4.2.1
+    snippet: Given an ASCII string as input_string, return an array of (item_or_inner_list, parameters) tuples.
+    cited_by:
+    - file: lint-http-rules/src/helpers/structured_fields.rs
+      line: 112
+  - label: lint-http-rules/src/helpers/structured_fields.rs (12)
     section: § 4.2.1
     snippet: If input_string is empty, there is a trailing comma; fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 508
-  - label: lint-http-rules/src/helpers/structured_fields.rs (12)
+      line: 512
+  - label: lint-http-rules/src/helpers/structured_fields.rs (13)
     section: § 4.2.1.1
     snippet: If the first character of input_string is "(", return the result of running Parsing an Inner List (Section 4.2.1.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 528
-  - label: lint-http-rules/src/helpers/structured_fields.rs (13)
+      line: 532
+  - label: lint-http-rules/src/helpers/structured_fields.rs (14)
     section: § 4.2.1.2
     snippet: Discard any leading SP characters from input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 562
-  - label: lint-http-rules/src/helpers/structured_fields.rs (14)
+      line: 566
+  - label: lint-http-rules/src/helpers/structured_fields.rs (15)
     section: § 4.2.1.2
     snippet: Let item be the result of running Parsing an Item (Section 4.2.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 575
-  - label: lint-http-rules/src/helpers/structured_fields.rs (15)
+      line: 579
+  - label: lint-http-rules/src/helpers/structured_fields.rs (16)
     section: § 4.2.1.2
     snippet: The end of the Inner List was not found; fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 544
-  - label: lint-http-rules/src/helpers/structured_fields.rs (16)
+      line: 548
+  - label: lint-http-rules/src/helpers/structured_fields.rs (17)
     section: § 4.2.10
     snippet: If char is in the range %x00-1f or %x7f-ff (i.e., it is not in VCHAR or SP), fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 345
-  - label: lint-http-rules/src/helpers/structured_fields.rs (17)
+      line: 349
+  - label: lint-http-rules/src/helpers/structured_fields.rs (18)
     section: § 4.2.10
     snippet: If octet_hex contains characters outside the range %x30-39 or %x61-66 (i.e., it is not in 0-9 or lowercase a-f), fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 360
-  - label: lint-http-rules/src/helpers/structured_fields.rs (18)
+      line: 364
+  - label: lint-http-rules/src/helpers/structured_fields.rs (19)
     section: § 4.2.10
     snippet: If the first two characters of input_string are not "%" followed by DQUOTE, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 336
-  - label: lint-http-rules/src/helpers/structured_fields.rs (19)
+      line: 340
+  - label: lint-http-rules/src/helpers/structured_fields.rs (20)
     section: § 4.2.10
     snippet: Let octet_hex be the result of consuming two characters from input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 350
-  - label: lint-http-rules/src/helpers/structured_fields.rs (20)
+      line: 354
+  - label: lint-http-rules/src/helpers/structured_fields.rs (21)
     section: § 4.2.10
     snippet: Let unicode_sequence be the result of decoding byte_array as a UTF-8 string (Section 3 of [UTF8]).
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 373
-  - label: lint-http-rules/src/helpers/structured_fields.rs (21)
+      line: 377
+  - label: lint-http-rules/src/helpers/structured_fields.rs (22)
     section: § 4.2.2
     snippet: If input_string is empty, there is a trailing comma; fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 464
-  - label: lint-http-rules/src/helpers/structured_fields.rs (22)
+      line: 468
+  - label: lint-http-rules/src/helpers/structured_fields.rs (23)
     section: § 4.2.2
     snippet: 'If the first character of input_string is "=":'
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 475
-  - label: lint-http-rules/src/helpers/structured_fields.rs (23)
+      line: 479
+  - label: lint-http-rules/src/helpers/structured_fields.rs (24)
     section: § 4.2.2
     snippet: Let member be the result of running Parsing an Item or Inner List (Section 4.2.1.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 488
-  - label: lint-http-rules/src/helpers/structured_fields.rs (24)
+      line: 492
+  - label: lint-http-rules/src/helpers/structured_fields.rs (25)
     section: § 4.2.2
     snippet: Let this_key be the result of running Parsing a Key (Section 4.2.3.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 472
-  - label: lint-http-rules/src/helpers/structured_fields.rs (25)
+      line: 476
+  - label: lint-http-rules/src/helpers/structured_fields.rs (26)
     section: § 4.2.2
     snippet: Let value be Boolean true.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 481
+      line: 485
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 250
     - file: lint-http-rules/src/rules/priority_header_syntax.rs
       line: 343
-  - label: lint-http-rules/src/helpers/structured_fields.rs (26)
+  - label: lint-http-rules/src/helpers/structured_fields.rs (27)
     section: § 4.2.2
     snippet: No structured data has been found; return dictionary (which is empty).
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 457
+      line: 461
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 92
     - file: lint-http-rules/src/rules/structured_headers_valid.rs
       line: 251
-  - label: lint-http-rules/src/helpers/structured_fields.rs (27)
+  - label: lint-http-rules/src/helpers/structured_fields.rs (28)
     section: § 4.2.3
     snippet: Let bare_item be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 590
-  - label: lint-http-rules/src/helpers/structured_fields.rs (28)
+      line: 594
+  - label: lint-http-rules/src/helpers/structured_fields.rs (29)
     section: § 4.2.3
     snippet: Let parameters be the result of running Parsing Parameters (Section 4.2.3.2) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 594
-  - label: lint-http-rules/src/helpers/structured_fields.rs (29)
+      line: 598
+  - label: lint-http-rules/src/helpers/structured_fields.rs (30)
     section: § 4.2.3.1
     snippet: Otherwise, the item type is unrecognized; fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 390
-  - label: lint-http-rules/src/helpers/structured_fields.rs (30)
+      line: 394
+  - label: lint-http-rules/src/helpers/structured_fields.rs (31)
     section: § 4.2.3.2
     snippet: Discard any leading SP characters from input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 554
-  - label: lint-http-rules/src/helpers/structured_fields.rs (31)
+      line: 558
+  - label: lint-http-rules/src/helpers/structured_fields.rs (32)
     section: § 4.2.3.2
     snippet: Let param_key be the result of running Parsing a Key (Section 4.2.3.3) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 615
-  - label: lint-http-rules/src/helpers/structured_fields.rs (32)
+      line: 619
+  - label: lint-http-rules/src/helpers/structured_fields.rs (33)
     section: § 4.2.3.2
     snippet: Let param_value be Boolean true.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 626
-  - label: lint-http-rules/src/helpers/structured_fields.rs (33)
+      line: 630
+  - label: lint-http-rules/src/helpers/structured_fields.rs (34)
     section: § 4.2.3.2
     snippet: Let param_value be the result of running Parsing a Bare Item (Section 4.2.3.1) with input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 619
+      line: 623
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 461
-  - label: lint-http-rules/src/helpers/structured_fields.rs (34)
+  - label: lint-http-rules/src/helpers/structured_fields.rs (35)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not lcalpha or "*", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 225
+      line: 229
     - file: lint-http-rules/src/rules/permissions_policy_directives_valid.rs
       line: 435
-  - label: lint-http-rules/src/helpers/structured_fields.rs (35)
+  - label: lint-http-rules/src/helpers/structured_fields.rs (36)
     section: § 4.2.3.3
     snippet: If the first character of input_string is not one of lcalpha, DIGIT, "_", "-", ".", or "*", return output_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 229
-  - label: lint-http-rules/src/helpers/structured_fields.rs (36)
+      line: 233
+  - label: lint-http-rules/src/helpers/structured_fields.rs (37)
     section: § 4.2.4
     snippet: If input_number contains more than 12 characters, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 253
-  - label: lint-http-rules/src/helpers/structured_fields.rs (37)
+      line: 257
+  - label: lint-http-rules/src/helpers/structured_fields.rs (38)
     section: § 4.2.4
     snippet: If the final character of input_number is ".", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 254
-  - label: lint-http-rules/src/helpers/structured_fields.rs (38)
+      line: 258
+  - label: lint-http-rules/src/helpers/structured_fields.rs (39)
     section: § 4.2.4
     snippet: If the first character of input_string is "-", consume it and set sign to -1.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 249
-  - label: lint-http-rules/src/helpers/structured_fields.rs (39)
+      line: 253
+  - label: lint-http-rules/src/helpers/structured_fields.rs (40)
     section: § 4.2.4
     snippet: If the first character of input_string is not a DIGIT, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 263
-  - label: lint-http-rules/src/helpers/structured_fields.rs (40)
+      line: 267
+  - label: lint-http-rules/src/helpers/structured_fields.rs (41)
     section: § 4.2.4
     snippet: If the number of characters after "." in input_number is greater than three, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 255
-  - label: lint-http-rules/src/helpers/structured_fields.rs (41)
+      line: 259
+  - label: lint-http-rules/src/helpers/structured_fields.rs (42)
     section: § 4.2.4
     snippet: If type is "integer" and input_number contains more than 15 characters, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 264
-  - label: lint-http-rules/src/helpers/structured_fields.rs (42)
+      line: 268
+  - label: lint-http-rules/src/helpers/structured_fields.rs (43)
     section: § 4.2.5
     snippet: Else, if char is DQUOTE, return output_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 62
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 177
-  - label: lint-http-rules/src/helpers/structured_fields.rs (43)
+      line: 181
+  - label: lint-http-rules/src/helpers/structured_fields.rs (44)
     section: § 4.2.5
     snippet: Else, if char is in the range %x00-1f or %x7f-ff (i.e., it is not in VCHAR or SP), fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 179
-  - label: lint-http-rules/src/helpers/structured_fields.rs (44)
+      line: 183
+  - label: lint-http-rules/src/helpers/structured_fields.rs (45)
     section: § 4.2.5
     snippet: 'If char is a backslash ("\"):'
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 41
-  - label: lint-http-rules/src/helpers/structured_fields.rs (45)
+  - label: lint-http-rules/src/helpers/structured_fields.rs (46)
     section: § 4.2.5
     snippet: If next_char is not DQUOTE or "\", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 172
-  - label: lint-http-rules/src/helpers/structured_fields.rs (46)
+      line: 176
+  - label: lint-http-rules/src/helpers/structured_fields.rs (47)
     section: § 4.2.5
     snippet: If the first character of input_string is not DQUOTE, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 163
-  - label: lint-http-rules/src/helpers/structured_fields.rs (47)
+      line: 167
+  - label: lint-http-rules/src/helpers/structured_fields.rs (48)
     section: § 4.2.5
     snippet: Let next_char be the result of consuming the first character of input_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
       line: 42
-  - label: lint-http-rules/src/helpers/structured_fields.rs (48)
+  - label: lint-http-rules/src/helpers/structured_fields.rs (49)
     section: § 4.2.5
     snippet: Reached the end of input_string without finding a closing DQUOTE; fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 185
-  - label: lint-http-rules/src/helpers/structured_fields.rs (49)
+      line: 189
+  - label: lint-http-rules/src/helpers/structured_fields.rs (50)
     section: § 4.2.6
     snippet: If the first character of input_string is not ALPHA or "*", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 294
-  - label: lint-http-rules/src/helpers/structured_fields.rs (50)
+      line: 298
+  - label: lint-http-rules/src/helpers/structured_fields.rs (51)
     section: § 4.2.6
     snippet: If the first character of input_string is not in tchar, ":", or "/", return output_string.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 299
-  - label: lint-http-rules/src/helpers/structured_fields.rs (51)
+      line: 303
+  - label: lint-http-rules/src/helpers/structured_fields.rs (52)
     section: § 4.2.7
     snippet: If b64_content contains a character not included in ALPHA, DIGIT, "+", "/", and "=", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 207
-  - label: lint-http-rules/src/helpers/structured_fields.rs (52)
+      line: 211
+  - label: lint-http-rules/src/helpers/structured_fields.rs (53)
     section: § 4.2.7
     snippet: If the first character of input_string is not ":", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 191
-  - label: lint-http-rules/src/helpers/structured_fields.rs (53)
+      line: 195
+  - label: lint-http-rules/src/helpers/structured_fields.rs (54)
     section: § 4.2.7
     snippet: If there is not a ":" character before the end of input_string, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 192
-  - label: lint-http-rules/src/helpers/structured_fields.rs (54)
+      line: 196
+  - label: lint-http-rules/src/helpers/structured_fields.rs (55)
     section: § 4.2.8
     snippet: If the first character of input_string is not "?", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 402
-  - label: lint-http-rules/src/helpers/structured_fields.rs (55)
+      line: 406
+  - label: lint-http-rules/src/helpers/structured_fields.rs (56)
     section: § 4.2.8
     snippet: No value has matched; fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 403
-  - label: lint-http-rules/src/helpers/structured_fields.rs (56)
+      line: 407
+  - label: lint-http-rules/src/helpers/structured_fields.rs (57)
     section: § 4.2.9
     snippet: If output_date is a Decimal, fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 322
-  - label: lint-http-rules/src/helpers/structured_fields.rs (57)
+      line: 326
+  - label: lint-http-rules/src/helpers/structured_fields.rs (58)
     section: § 4.2.9
     snippet: If the first character of input_string is not "@", fail parsing.
     cited_by:
     - file: lint-http-rules/src/helpers/structured_fields.rs
-      line: 318
+      line: 322
   - label: permissions_policy_directives_valid
     section: § 3.2
     snippet: As with Lists, an empty Dictionary is represented by omitting the entire field.


### PR DESCRIPTION
`field_lines` had eleven callers still writing the ladder it replaced, and a codebase with two spellings of one question has the divergence problem the reader was built to end, just later. Those eleven are converted. The sites that are *not* convertible are the ones whose finding is the unreadable line itself, and they were a six-line `match` with a diverging arm — sixteen of those become the `let ... else` that says the same thing in two lines and one less level of nesting.

`structured_fields` had the same twin-splitter shape `headers` had before this campaign: comma and semicolon, byte-identical but for the delimiter, a fix to one being a silent non-fix in the other. They are one walk now. The space splitter stays its own, and says why: it collapses runs of its delimiter and has its own rule for a value ending in one, so it is not the same function with a different byte.

`extract_strong_validators_from_response` is now defined as the general pair minus the weak ETags, which is what both functions' paragraphs already said the difference was.

`Rule` and `ProtocolRule` provided three method bodies each, identical, one of them carrying a comment explaining that it was the same as the other. A reader who has to be told two functions agree is reading one function too many; the three bodies are free functions both traits call.

Neither metric was traded for the other: no function in the tree grew, except the Cache-Control reader, which absorbed what seven rules shed.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
