### PR TITLE
Temporary test files are owned by a guard, not by the last line of th…

### DIFF
--- a/lint-http-proxy/src/proxy/connect.rs
+++ b/lint-http-proxy/src/proxy/connect.rs
@@ -148,7 +148,6 @@ mod tests {
     use rstest::rstest;
     use std::sync::Arc as StdArc;
     use tokio::fs;
-    use uuid::Uuid;
 
     #[rstest]
     #[case(false, false, 405u16)]
@@ -167,9 +166,13 @@ mod tests {
         }
         let cfg = StdArc::new(cfg);
 
+        let mut temp = crate::proxy::test_support::TempFiles::new();
         let ca_arc = if ca_present {
-            let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", Uuid::new_v4()));
-            let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", Uuid::new_v4()));
+            // Generated, and never removed until this guard drops: the pair was
+            // written to the temp directory by every run of this test and left
+            // there, since there was no teardown at all.
+            let cert_path = temp.path("test_ca", "crt");
+            let key_path = temp.path("test_ca", "key");
             let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
             Some(ca)
         } else {

--- a/lint-http-proxy/src/proxy/test_support.rs
+++ b/lint-http-proxy/src/proxy/test_support.rs
@@ -17,6 +17,15 @@ use crate::capture::CaptureWriter;
 
 use super::Shared;
 
+/// The temp-file guard the integration tests use, reached across the boundary
+/// Rust puts between a unit test and an integration test: they share no module,
+/// so the alternative to this `#[path]` is a second copy of the same guard —
+/// which is the shape this whole pass exists to remove. Test-only, so the
+/// delivered library never compiles it.
+#[path = "../../tests/common/temp_files.rs"]
+mod temp_files;
+pub(super) use temp_files::TempFiles;
+
 /// Construct a `Shared` wired to a fresh temp capture file. Returns the Shared,
 /// the temp path (so tests can read/cleanup), and a clone of the writer.
 pub(super) async fn make_shared_with_cfg(

--- a/lint-http-proxy/tests/common/mod.rs
+++ b/lint-http-proxy/tests/common/mod.rs
@@ -5,7 +5,16 @@
 // Shared integration-test helpers; each test binary uses a different subset.
 #![allow(dead_code)]
 
+// `TempFiles` is its own file because the crate's *unit* tests need it too, and
+// Rust gives a unit test and an integration test no module in common: one is
+// compiled into the library, the other into its own binary. A `#[path]` include
+// from `src/proxy/test_support.rs` is what bridges that, and it is why this
+// file depends on nothing else here.
+mod temp_files;
+pub use temp_files::TempFiles;
+
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -15,6 +24,33 @@ use tokio::time::sleep;
 use lint_http::capture::CaptureWriter;
 use lint_http::config::Config;
 use lint_http::proxy::run_proxy;
+
+/// A `Config` with TLS enabled and a CA the proxy will generate into the temp
+/// directory, both files owned by `temp`.
+///
+/// The five lines this replaces were written out at every TLS test, and the
+/// two paths in them were exactly the two the teardown had to remember.
+pub fn tls_config(temp: &mut TempFiles) -> Config {
+    let mut cfg = Config::default();
+    cfg.tls.enabled = true;
+    cfg.tls.ca_cert_path = Some(temp.path("test_ca", "crt").to_string_lossy().to_string());
+    cfg.tls.ca_key_path = Some(temp.path("test_ca", "key").to_string_lossy().to_string());
+    cfg
+}
+
+/// Where `cfg` says the proxy's CA certificate is.
+///
+/// The config is the one place that knows, which is why the tests that need to
+/// trust that CA read it back from there rather than keeping a second binding
+/// alongside — a second binding is how the path and the config drift apart.
+pub fn ca_cert_path(cfg: &Config) -> PathBuf {
+    PathBuf::from(
+        cfg.tls
+            .ca_cert_path
+            .clone()
+            .expect("tls_config always names a CA certificate path"),
+    )
+}
 
 /// Deadline budget for the integration-test startup polls. Generous by default
 /// because startup races a saturated CI/dev CPU (the spawned proxy task may not
@@ -29,11 +65,15 @@ pub fn startup_timeout() -> Duration {
 }
 
 // Minimal helper: start run_proxy and wait until it is accepting and CA files exist
+/// The captures file is created here, so `temp` owns it: whoever makes a
+/// temporary file is who knows to remove it, and the split — helper creates,
+/// test body removes — is how the removals came to be missed.
 pub async fn start_run_proxy_and_wait(
     cfg: Config,
+    temp: &mut TempFiles,
 ) -> anyhow::Result<(tokio::task::JoinHandle<()>, SocketAddr, String)> {
     // prepare capture file
-    let tmp = std::env::temp_dir().join(format!("lint_integ_{}.jsonl", uuid::Uuid::new_v4()));
+    let tmp = temp.path("lint_integ", "jsonl");
     let p = tmp
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("tmp path not utf8"))?

--- a/lint-http-proxy/tests/common/temp_files.rs
+++ b/lint-http-proxy/tests/common/temp_files.rs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The temp-file guard shared by this crate's unit tests and its integration
+//! tests. Included by the second through `mod`, by the first through `#[path]`
+//! — see the note in `tests/common/mod.rs`. Depends on nothing but `std` and
+//! `uuid`, so it can be compiled into either.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+/// The temporary files a test was given, removed when the test ends — however
+/// it ends.
+///
+/// **What this replaces was the last statement of each test body**, and each
+/// body reaches its end through dozens of `?` and a handful of assertions.
+/// None of those paths ran the removals: a test that failed left its capture
+/// file and its generated CA behind in the temp directory, and a test that
+/// failed is exactly the one somebody then re-runs. The teardown was also
+/// copied per test — fourteen times in one file — which is what made it easy
+/// to leave a path out of one copy.
+///
+/// Ownership is the fix. The guard removes what it handed out, and it does so
+/// on the way out of the scope, so returning early is not a way to skip it.
+#[derive(Default)]
+pub struct TempFiles {
+    paths: Vec<PathBuf>,
+}
+
+impl TempFiles {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A fresh path in the temp directory, removed when this guard drops.
+    ///
+    /// The name carries a UUID because the tests in a binary run concurrently,
+    /// and two of them naming one file is a race that reads as a flake.
+    pub fn path(&mut self, prefix: &str, extension: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("{prefix}_{}.{extension}", uuid::Uuid::new_v4()));
+        self.paths.push(path.clone());
+        path
+    }
+
+    /// Take ownership of a path the caller made for itself.
+    pub fn keep(&mut self, path: impl Into<PathBuf>) {
+        self.paths.push(path.into());
+    }
+}
+
+impl Drop for TempFiles {
+    fn drop(&mut self) {
+        // `std::fs`, not `tokio::fs`: a `Drop` cannot await, and this runs on
+        // whatever thread the test ended on — including one that is panicking.
+        for path in &self.paths {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}

--- a/lint-http-proxy/tests/proxy_connect_integration.rs
+++ b/lint-http-proxy/tests/proxy_connect_integration.rs
@@ -10,9 +10,7 @@ use tokio_rustls::TlsConnector;
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
-use common::start_run_proxy_and_wait;
-
-use lint_http::config::Config;
+use common::{start_run_proxy_and_wait, tls_config, TempFiles};
 
 // Unified helper: perform CONNECT, do TLS handshake trusting `ca_cert_path`, optionally advertise ALPNs, optionally send an inner request.
 // Returns (negotiated_alpn, optional_response_bytes).
@@ -164,15 +162,12 @@ async fn connect_tls_full_forwarding() -> anyhow::Result<()> {
         .await;
 
     // 2) Build config with TLS enabled and temp CA paths
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut temp = TempFiles::new();
+    let cfg = tls_config(&mut temp);
+    let cert_path = common::ca_cert_path(&cfg);
 
     // 3) Start proxy and wait
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg.clone(), &mut temp).await?;
 
     // 4) Perform CONNECT + TLS + inner request
     let host = "example.com";
@@ -214,9 +209,6 @@ async fn connect_tls_full_forwarding() -> anyhow::Result<()> {
     let _ = handle.await;
 
     // remove temp files
-    let _ = tokio::fs::remove_file(cert_path).await;
-    let _ = tokio::fs::remove_file(key_path).await;
-    let _ = tokio::fs::remove_file(&cap_path).await;
 
     Ok(())
 }
@@ -232,15 +224,12 @@ async fn connect_tls_alpn_client_selects_http1() -> anyhow::Result<()> {
         .await;
 
     // 2) Build config with TLS enabled and temp CA paths
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut temp = TempFiles::new();
+    let cfg = tls_config(&mut temp);
+    let cert_path = common::ca_cert_path(&cfg);
 
     // 3) Start proxy and wait
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg.clone(), &mut temp).await?;
 
     // 4) Perform CONNECT + TLS + inner request, advertising http/1.1
     let host = "example.com";
@@ -281,9 +270,6 @@ async fn connect_tls_alpn_client_selects_http1() -> anyhow::Result<()> {
     let _ = handle.await;
 
     // remove temp files
-    let _ = tokio::fs::remove_file(cert_path).await;
-    let _ = tokio::fs::remove_file(key_path).await;
-    let _ = tokio::fs::remove_file(&cap_path).await;
 
     Ok(())
 }
@@ -299,15 +285,12 @@ async fn connect_tls_alpn_mismatch_fails_handshake() -> anyhow::Result<()> {
         .await;
 
     // 2) Build config with TLS enabled and temp CA paths
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut temp = TempFiles::new();
+    let cfg = tls_config(&mut temp);
+    let cert_path = common::ca_cert_path(&cfg);
 
     // 3) Start proxy and wait
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg.clone(), &mut temp).await?;
 
     // 4) Perform CONNECT + TLS + inner request, advertising only 'h3' which does not match server
     let host = "example.com";
@@ -342,9 +325,6 @@ async fn connect_tls_alpn_mismatch_fails_handshake() -> anyhow::Result<()> {
     let _ = handle.await;
 
     // remove temp files
-    let _ = tokio::fs::remove_file(cert_path).await;
-    let _ = tokio::fs::remove_file(key_path).await;
-    let _ = tokio::fs::remove_file(&cap_path).await;
 
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_connect_passthrough.rs
+++ b/lint-http-proxy/tests/proxy_connect_passthrough.rs
@@ -11,7 +11,7 @@ use tokio::time::timeout;
 use lint_http::config::Config;
 
 mod common;
-use common::start_run_proxy_and_wait;
+use common::{start_run_proxy_and_wait, tls_config, TempFiles};
 
 async fn do_connect_and_get_response(
     proxy_addr: SocketAddr,
@@ -72,16 +72,12 @@ async fn connect_passthrough_tunnels_raw_tcp() -> anyhow::Result<()> {
     });
 
     // Start proxy with passthrough for 127.0.0.1
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut temp = TempFiles::new();
+    let mut cfg = tls_config(&mut temp);
     // Use a literal IP in passthrough domain so the proxy connects to the toy server
     cfg.tls.passthrough_domains = vec!["127.0.0.1".into()];
 
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg.clone(), &mut temp).await?;
 
     // CONNECT and then send raw ping/pong to the toy server IP
     let mut stream = tokio::net::TcpStream::connect(addr).await?;
@@ -115,9 +111,6 @@ async fn connect_passthrough_tunnels_raw_tcp() -> anyhow::Result<()> {
     // cleanup
     handle.abort();
     let _ = handle.await;
-    let _ = tokio::fs::remove_file(cert_path).await;
-    let _ = tokio::fs::remove_file(key_path).await;
-    let _ = tokio::fs::remove_file(cap_path).await;
     let _ = server_task.await;
     Ok(())
 }
@@ -130,16 +123,12 @@ async fn connect_passthrough_upstream_unavailable() -> anyhow::Result<()> {
     drop(listener);
 
     // Start proxy with passthrough for 127.0.0.1
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut temp = TempFiles::new();
+    let mut cfg = tls_config(&mut temp);
     // Use a literal IP in passthrough domain so the proxy connects to the toy server
     cfg.tls.passthrough_domains = vec!["127.0.0.1".into()];
 
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg.clone(), &mut temp).await?;
 
     // CONNECT and expect it to succeed but subsequent I/O to close
     let mut stream = tokio::net::TcpStream::connect(addr).await?;
@@ -182,9 +171,6 @@ async fn connect_passthrough_upstream_unavailable() -> anyhow::Result<()> {
     // cleanup
     handle.abort();
     let _ = handle.await;
-    let _ = tokio::fs::remove_file(cert_path).await;
-    let _ = tokio::fs::remove_file(key_path).await;
-    let _ = tokio::fs::remove_file(cap_path).await;
     Ok(())
 }
 
@@ -193,7 +179,8 @@ async fn connect_without_tls_returns_405() -> anyhow::Result<()> {
     // Start proxy with TLS disabled
     let mut cfg = Config::default();
     cfg.tls.enabled = false;
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg.clone()).await?;
+    let mut temp = TempFiles::new();
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg.clone(), &mut temp).await?;
 
     // CONNECT and read response
     let res = do_connect_and_get_response(addr, "example.com", 12345).await?;
@@ -202,6 +189,5 @@ async fn connect_without_tls_returns_405() -> anyhow::Result<()> {
 
     handle.abort();
     let _ = handle.await;
-    let _ = tokio::fs::remove_file(cap_path).await;
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -17,7 +17,7 @@ use lint_http::capture::CaptureWriter;
 use lint_http::config::Config;
 
 mod common;
-use common::startup_timeout;
+use common::{startup_timeout, tls_config, TempFiles};
 
 /// Build a quinn client endpoint that trusts the CA at `ca_cert_path` and
 /// advertises ALPN `h3`.
@@ -52,24 +52,29 @@ fn build_h3_client(ca_cert_path: &std::path::Path) -> anyhow::Result<quinn::Endp
 }
 
 /// Start the proxy with TLS + h3_listen enabled, return handles and addresses.
+///
+/// Every temporary file this makes belongs to `temp`, including the CA key —
+/// which is why it is no longer returned: it was in the tuple for the teardown
+/// alone, and the teardown is the guard's now.
 #[allow(clippy::type_complexity)]
 async fn start_proxy_with_h3(
     cfg_modifier: Option<Box<dyn FnOnce(&mut Config) + Send>>,
+    temp: &mut TempFiles,
 ) -> anyhow::Result<(
     tokio::task::JoinHandle<()>,
     SocketAddr,         // TCP listen address
     SocketAddr,         // H3/QUIC listen address
     String,             // captures path
     std::path::PathBuf, // CA cert path
-    std::path::PathBuf, // CA key path
 )> {
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-
-    let cert_path = std::env::temp_dir().join(format!("h3_test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("h3_test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut cfg = tls_config(temp);
+    let cert_path = common::ca_cert_path(&cfg);
+    let key_path = std::path::PathBuf::from(
+        cfg.tls
+            .ca_key_path
+            .clone()
+            .expect("tls_config always names a CA key path"),
+    );
 
     // Find free ports for TCP and UDP
     // Keep the listener and hand it to the proxy below: dropping it here would
@@ -90,7 +95,7 @@ async fn start_proxy_with_h3(
         f(&mut cfg);
     }
 
-    let tmp = std::env::temp_dir().join(format!("h3_integ_{}.jsonl", uuid::Uuid::new_v4()));
+    let tmp = temp.path("h3_integ", "jsonl");
     let captures_path = tmp.to_str().unwrap().to_string();
     let cw = CaptureWriter::new(captures_path.clone(), false).await?;
 
@@ -146,14 +151,7 @@ async fn start_proxy_with_h3(
     // Brief pause so the probe connection is cleaned up server-side
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    Ok((
-        handle,
-        tcp_addr,
-        h3_addr,
-        captures_path,
-        cert_path,
-        key_path,
-    ))
+    Ok((handle, tcp_addr, h3_addr, captures_path, cert_path))
 }
 
 /// Send a single HTTP/3 GET request via quinn+h3, return status and body.
@@ -274,8 +272,9 @@ async fn h3_happy_path_forwards_request_and_captures() -> anyhow::Result<()> {
         .mount(&mock)
         .await;
 
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(None).await?;
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
+        start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/hello", mock.address().port());
@@ -310,16 +309,14 @@ async fn h3_happy_path_forwards_request_and_captures() -> anyhow::Result<()> {
     // Cleanup
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn h3_upstream_error_returns_502_and_records_transaction() -> anyhow::Result<()> {
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(None).await?;
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
+        start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     // Port 9 is the discard protocol — very unlikely to have an HTTP server
@@ -345,9 +342,6 @@ async fn h3_upstream_error_returns_502_and_records_transaction() -> anyhow::Resu
     // Cleanup
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -360,11 +354,14 @@ async fn h3_suppress_headers_filters_configured_headers() -> anyhow::Result<()> 
         .mount(&mock)
         .await;
 
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(Some(Box::new(|cfg| {
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, _captures_path, cert_path) = start_proxy_with_h3(
+        Some(Box::new(|cfg| {
             cfg.tls.suppress_headers = vec!["x-secret".to_string()];
-        })))
-        .await?;
+        })),
+        &mut temp,
+    )
+    .await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/sup", mock.address().port());
@@ -387,9 +384,6 @@ async fn h3_suppress_headers_filters_configured_headers() -> anyhow::Result<()> 
     // Cleanup
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -408,8 +402,9 @@ async fn h3_hop_by_hop_headers_stripped_from_response() -> anyhow::Result<()> {
         .mount(&mock)
         .await;
 
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(None).await?;
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, _captures_path, cert_path) =
+        start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/hop", mock.address().port());
@@ -434,9 +429,6 @@ async fn h3_hop_by_hop_headers_stripped_from_response() -> anyhow::Result<()> {
     // Cleanup
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -452,8 +444,9 @@ async fn h3_multiple_requests_on_same_connection_increment_sequence() -> anyhow:
         .mount(&mock)
         .await;
 
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(None).await?;
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
+        start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/seq", mock.address().port());
@@ -516,9 +509,6 @@ async fn h3_multiple_requests_on_same_connection_increment_sequence() -> anyhow:
     // Cleanup
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -531,11 +521,14 @@ async fn h3_large_request_body_streams_and_truncates_capture() -> anyhow::Result
         .mount(&mock)
         .await;
 
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(Some(Box::new(|cfg| {
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) = start_proxy_with_h3(
+        Some(Box::new(|cfg| {
             cfg.general.captures_max_body_bytes = 16;
-        })))
-        .await?;
+        })),
+        &mut temp,
+    )
+    .await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/upload", mock.address().port());
@@ -566,9 +559,6 @@ async fn h3_large_request_body_streams_and_truncates_capture() -> anyhow::Result
 
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -585,11 +575,14 @@ async fn h3_response_over_limit_streams_full_and_truncates_capture() -> anyhow::
         .mount(&mock)
         .await;
 
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(Some(Box::new(|cfg| {
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) = start_proxy_with_h3(
+        Some(Box::new(|cfg| {
             cfg.general.captures_max_body_bytes = 16;
-        })))
-        .await?;
+        })),
+        &mut temp,
+    )
+    .await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/big", mock.address().port());
@@ -630,9 +623,6 @@ async fn h3_response_over_limit_streams_full_and_truncates_capture() -> anyhow::
 
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -643,8 +633,9 @@ async fn h3_request_with_host_header_fallback() -> anyhow::Result<()> {
     // the scheme fallback cannot be tested this way; we verify only that the
     // authority is resolved from Host and that the request is captured with
     // the correct host value.
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path, key_path) =
-        start_proxy_with_h3(None).await?;
+    let mut temp = TempFiles::new();
+    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
+        start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     // Send a path-only URI with explicit Host header.  The upstream will fail
@@ -675,8 +666,5 @@ async fn h3_request_with_host_header_fallback() -> anyhow::Result<()> {
     // Cleanup
     endpoint.close(0u32.into(), b"done");
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_live_stream.rs
+++ b/lint-http-proxy/tests/proxy_live_stream.rs
@@ -15,7 +15,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use lint_http::config::Config;
 
 mod common;
-use common::start_run_proxy_and_wait;
+use common::{start_run_proxy_and_wait, TempFiles};
 
 /// Read from `stream`, accumulating into a buffer, until it contains `needle`
 /// or the deadline passes. Returns everything read so far (headers included).
@@ -59,7 +59,8 @@ async fn live_stream_pushes_committed_transaction() -> anyhow::Result<()> {
     let mut cfg = Config::default();
     cfg.tls.enabled = false;
     cfg.general.live_stream_enabled = true;
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // Open the SSE stream and give the handler a moment to subscribe before any
     // transaction commits.
@@ -99,7 +100,6 @@ async fn live_stream_pushes_committed_transaction() -> anyhow::Result<()> {
     );
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&cap_path).await;
     Ok(())
 }
 
@@ -108,7 +108,8 @@ async fn live_stream_disabled_returns_404() -> anyhow::Result<()> {
     // Default config leaves live_stream_enabled = false.
     let mut cfg = Config::default();
     cfg.tls.enabled = false;
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let mut stream = TcpStream::connect(addr).await?;
     stream
@@ -120,6 +121,5 @@ async fn live_stream_disabled_returns_404() -> anyhow::Result<()> {
     assert!(s.contains("404"), "expected 404 when disabled, got: {s}");
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&cap_path).await;
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_request_headers.rs
+++ b/lint-http-proxy/tests/proxy_request_headers.rs
@@ -17,7 +17,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use lint_http::config::Config;
 
 mod common;
-use common::start_run_proxy_and_wait;
+use common::{start_run_proxy_and_wait, TempFiles};
 
 #[tokio::test]
 async fn request_side_hop_by_hop_headers_are_stripped() -> anyhow::Result<()> {
@@ -30,7 +30,8 @@ async fn request_side_hop_by_hop_headers_are_stripped() -> anyhow::Result<()> {
 
     let mut cfg = Config::default();
     cfg.tls.enabled = false;
-    let (handle, addr, cap_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, addr, _cap_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // Drive a plaintext forward-proxy request carrying a static hop-by-hop
     // header (`Proxy-Authorization`), a dynamically-marked one (`X-Custom`, named
@@ -79,6 +80,5 @@ async fn request_side_hop_by_hop_headers_are_stripped() -> anyhow::Result<()> {
     );
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&cap_path).await;
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_upstream_h3_integration.rs
@@ -25,7 +25,7 @@ use hyper_util::rt::TokioIo;
 use lint_http::config::Config;
 
 mod common;
-use common::{start_run_proxy_and_wait, startup_timeout};
+use common::{start_run_proxy_and_wait, startup_timeout, TempFiles};
 
 /// A self-signed test CA and a leaf certificate (IP SAN 127.0.0.1) signed by it.
 struct TestPki {
@@ -237,8 +237,8 @@ async fn upstream_h3_forwards_with_capture_parity_and_strips_connection_field() 
     let pki = gen_test_pki()?;
 
     // Persist the CA PEM so the proxy can load it as an extra trust root.
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (origin_addr, captured, origin_handle) = start_h3_origin(&pki, udp_any()?)?;
@@ -249,7 +249,8 @@ async fn upstream_h3_forwards_with_capture_parity_and_strips_connection_field() 
     cfg.general.h3_upstream_authorities = vec![origin_authority.clone()];
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // `keep-alive` is a connection-specific field (RFC 9114 §4.2) that must be
     // stripped before the H3 request; `x-forward-me` is an ordinary field that
@@ -304,8 +305,6 @@ async fn upstream_h3_forwards_with_capture_parity_and_strips_connection_field() 
     // Cleanup
     proxy_handle.abort();
     origin_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -328,7 +327,9 @@ async fn upstream_h3_disabled_authority_uses_h1_path() -> anyhow::Result<()> {
     cfg.general.h3_upstream_enabled = true;
     cfg.general.h3_upstream_authorities = vec!["somewhere-else.example:443".to_string()];
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let mock_authority = format!("127.0.0.1:{}", mock.address().port());
     let (status, _headers, body) = proxy_get(proxy_addr, &mock_authority, "/plain", &[]).await?;
@@ -344,7 +345,6 @@ async fn upstream_h3_disabled_authority_uses_h1_path() -> anyhow::Result<()> {
     );
 
     proxy_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
 
@@ -395,7 +395,9 @@ async fn upstream_h3_connect_failure_falls_back_to_h1() -> anyhow::Result<()> {
     // Keep the failed-connect wait short so the fall-back is prompt.
     cfg.general.h3_upstream_connect_timeout_ms = 1500;
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let (status, _headers, body) = proxy_get(proxy_addr, &authority, "/fb", &[]).await?;
     assert_eq!(status, 200, "the H1 fall-back should succeed");
@@ -410,7 +412,6 @@ async fn upstream_h3_connect_failure_falls_back_to_h1() -> anyhow::Result<()> {
     );
 
     proxy_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
 
@@ -431,8 +432,8 @@ async fn upstream_h3_reaches_an_ipv6_origin() -> anyhow::Result<()> {
     };
 
     let pki = gen_test_pki_san(SanType::IpAddress(IpAddr::V6(Ipv6Addr::LOCALHOST)))?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (origin_addr, _captured, origin_task) = start_h3_origin(&pki, udp)?;
@@ -446,7 +447,8 @@ async fn upstream_h3_reaches_an_ipv6_origin() -> anyhow::Result<()> {
     // Left as None on purpose: this asserts the *default* bind is dual-stack.
     assert!(cfg.general.h3_upstream_bind.is_none());
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let (status, headers, body) = proxy_get(proxy_addr, &authority, "/v6", &[]).await?;
     assert_eq!(status, 200, "the v6 origin should be reached over H3");
@@ -466,8 +468,6 @@ async fn upstream_h3_reaches_an_ipv6_origin() -> anyhow::Result<()> {
 
     proxy_handle.abort();
     origin_task.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -481,8 +481,8 @@ async fn upstream_h3_non_idempotent_not_retried_after_midflight_failure() -> any
     use tokio::io::AsyncWriteExt;
 
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     // One port, both transports, both sockets already bound.
@@ -546,7 +546,8 @@ async fn upstream_h3_non_idempotent_not_retried_after_midflight_failure() -> any
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
     cfg.general.h3_upstream_connect_timeout_ms = 3000;
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, _captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let (status, _body) = proxy_post(proxy_addr, &authority, "/x", b"payload").await?;
     assert_eq!(
@@ -565,8 +566,6 @@ async fn upstream_h3_non_idempotent_not_retried_after_midflight_failure() -> any
     proxy_handle.abort();
     h3_origin.abort();
     h1_origin.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -613,8 +612,8 @@ async fn upstream_h3_slow_origin_idempotent_get_falls_back_to_h1() -> anyhow::Re
     use tokio::io::AsyncWriteExt;
 
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (udp, tcp_std) = bind_origin_pair()?;
@@ -646,7 +645,8 @@ async fn upstream_h3_slow_origin_idempotent_get_falls_back_to_h1() -> anyhow::Re
     cfg.general.h3_upstream_connect_timeout_ms = 3000;
     cfg.general.h3_upstream_response_timeout_ms = 300;
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let (status, _headers, body) = proxy_get(proxy_addr, &authority, "/slow", &[]).await?;
     assert_eq!(
@@ -670,8 +670,6 @@ async fn upstream_h3_slow_origin_idempotent_get_falls_back_to_h1() -> anyhow::Re
     proxy_handle.abort();
     h3_origin.abort();
     h1_origin.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -684,8 +682,8 @@ async fn upstream_h3_slow_origin_non_idempotent_post_502s() -> anyhow::Result<()
     use tokio::io::AsyncWriteExt;
 
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (udp, tcp_std) = bind_origin_pair()?;
@@ -715,7 +713,8 @@ async fn upstream_h3_slow_origin_non_idempotent_post_502s() -> anyhow::Result<()
     cfg.general.h3_upstream_connect_timeout_ms = 3000;
     cfg.general.h3_upstream_response_timeout_ms = 300;
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, _captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let (status, _body) = proxy_post(proxy_addr, &authority, "/x", b"payload").await?;
     assert_eq!(
@@ -733,8 +732,6 @@ async fn upstream_h3_slow_origin_non_idempotent_post_502s() -> anyhow::Result<()
     proxy_handle.abort();
     h3_origin.abort();
     h1_origin.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -780,8 +777,8 @@ async fn upstream_h3_origin_early_response_is_delivered_and_captured() -> anyhow
     // proving the body pump handles an origin-reset stream without hanging the
     // capture or mis-recording the leg.
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (origin_addr, origin_handle) = start_h3_origin_early_response(&pki, udp_any()?)?;
@@ -792,7 +789,8 @@ async fn upstream_h3_origin_early_response_is_delivered_and_captured() -> anyhow
     cfg.general.h3_upstream_authorities = vec![authority.clone()];
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let big = vec![b'x'; 256 * 1024];
     let (status, _body) = proxy_post(proxy_addr, &authority, "/gate", &big).await?;
@@ -809,8 +807,6 @@ async fn upstream_h3_origin_early_response_is_delivered_and_captured() -> anyhow
 
     proxy_handle.abort();
     origin_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -825,8 +821,8 @@ async fn upstream_h3_early_response_to_large_upload_commits_without_hanging() ->
     // forever and leaking the capture. A timeout guards against the regression
     // hanging the whole suite.
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_upstream_h3_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_upstream_h3_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (origin_addr, origin_handle) = start_h3_origin_early_response(&pki, udp_any()?)?;
@@ -837,7 +833,8 @@ async fn upstream_h3_early_response_to_large_upload_commits_without_hanging() ->
     cfg.general.h3_upstream_authorities = vec![authority.clone()];
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
 
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // 16 MiB comfortably exceeds quinn's default per-stream receive window, so the
     // pump parks once the origin (which never reads) stops accepting bytes.
@@ -857,8 +854,6 @@ async fn upstream_h3_early_response_to_large_upload_commits_without_hanging() ->
 
     proxy_handle.abort();
     origin_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -897,8 +892,8 @@ async fn upstream_h3_discovered_via_alt_svc_is_used_on_next_request() -> anyhow:
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_disc_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_disc_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     // The advertised H3 endpoint (serves "world" over H3). Its port is read back
@@ -924,7 +919,9 @@ async fn upstream_h3_discovered_via_alt_svc_is_used_on_next_request() -> anyhow:
     cfg.general.h3_upstream_enabled = true;
     // No allowlist: H3 is reached purely through Alt-Svc discovery.
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (proxy_handle, proxy_addr, captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // First request: H1 (wiremock), which advertises Alt-Svc.
     let (s1, _h1, b1) = proxy_get(proxy_addr, &authority, "/d", &[]).await?;
@@ -961,8 +958,6 @@ async fn upstream_h3_discovered_via_alt_svc_is_used_on_next_request() -> anyhow:
 
     proxy_handle.abort();
     e_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -977,8 +972,8 @@ async fn upstream_h3_discovered_endpoint_with_wrong_cert_is_not_used() -> anyhow
 
     // Leaf valid for "wrong.example" only.
     let pki = gen_test_pki_san(SanType::DnsName("wrong.example".try_into()?))?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_disc_badca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_disc_badca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (e_addr, e_captured, e_handle) = start_h3_origin(&pki, udp_any()?)?;
@@ -1000,7 +995,9 @@ async fn upstream_h3_discovered_endpoint_with_wrong_cert_is_not_used() -> anyhow
     cfg.general.h3_upstream_enabled = true;
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
     cfg.general.h3_upstream_connect_timeout_ms = 2000;
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (proxy_handle, proxy_addr, _captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // First request populates discovery; second would use H3 but the cert is
     // not valid for the origin, so it falls back to H1.
@@ -1023,8 +1020,6 @@ async fn upstream_h3_discovered_endpoint_with_wrong_cert_is_not_used() -> anyhow
 
     proxy_handle.abort();
     e_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
@@ -1108,8 +1103,8 @@ fn start_h3_origin_goaway(
 #[tokio::test]
 async fn upstream_h3_pool_reuses_one_connection_across_requests() -> anyhow::Result<()> {
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_pool_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_pool_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (origin_addr, conns, origin_handle) = start_h3_origin_counting(&pki, udp_any()?)?;
@@ -1119,7 +1114,9 @@ async fn upstream_h3_pool_reuses_one_connection_across_requests() -> anyhow::Res
     cfg.general.h3_upstream_enabled = true;
     cfg.general.h3_upstream_authorities = vec![authority.clone()];
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (proxy_handle, proxy_addr, _captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // Three sequential requests to the same origin should share one pooled
     // QUIC connection.
@@ -1137,16 +1134,14 @@ async fn upstream_h3_pool_reuses_one_connection_across_requests() -> anyhow::Res
 
     proxy_handle.abort();
     origin_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn upstream_h3_goaway_refused_request_is_retried_on_fresh_connection() -> anyhow::Result<()> {
     let pki = gen_test_pki()?;
-    let ca_pem_path =
-        std::env::temp_dir().join(format!("lint_goaway_ca_{}.pem", uuid::Uuid::new_v4()));
+    let mut temp = TempFiles::new();
+    let ca_pem_path = temp.path("lint_goaway_ca", "pem");
     tokio::fs::write(&ca_pem_path, pki.ca_pem.as_bytes()).await?;
 
     let (origin_addr, conns, origin_handle) = start_h3_origin_goaway(&pki, udp_any()?)?;
@@ -1156,7 +1151,9 @@ async fn upstream_h3_goaway_refused_request_is_retried_on_fresh_connection() -> 
     cfg.general.h3_upstream_enabled = true;
     cfg.general.h3_upstream_authorities = vec![authority.clone()];
     cfg.general.h3_upstream_extra_ca_certs = vec![ca_pem_path.to_string_lossy().to_string()];
-    let (proxy_handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (proxy_handle, proxy_addr, _captures_path) =
+        start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // First request opens and pools a connection; the origin GOAWAYs it after
     // serving. The second request reuses the pooled connection, is refused, and
@@ -1184,7 +1181,5 @@ async fn upstream_h3_goaway_refused_request_is_retried_on_fresh_connection() -> 
 
     proxy_handle.abort();
     origin_handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&ca_pem_path).await;
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_websocket_relay.rs
+++ b/lint-http-proxy/tests/proxy_websocket_relay.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use lint_http::config::Config;
 
 mod common;
-use common::start_run_proxy_and_wait;
+use common::{start_run_proxy_and_wait, tls_config, TempFiles};
 
 /// Start a minimal WebSocket echo server on a random port.
 /// Returns the address it's listening on.
@@ -50,7 +50,8 @@ async fn websocket_upgrade_through_proxy_captures_session() -> anyhow::Result<()
 
     // Start the proxy
     let cfg = Config::default();
-    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // Connect to the proxy and perform WebSocket handshake via HTTP upgrade
     // Connect TCP to proxy5
@@ -198,7 +199,6 @@ async fn websocket_upgrade_through_proxy_captures_session() -> anyhow::Result<()
 
     // Cleanup
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
 
@@ -213,14 +213,11 @@ async fn websocket_upgrade_through_connect_mitm_tunnel() -> anyhow::Result<()> {
 
     let ws_addr = start_ws_echo_server().await;
 
-    let mut cfg = Config::default();
-    cfg.tls.enabled = true;
-    let cert_path = std::env::temp_dir().join(format!("test_ca_{}.crt", uuid::Uuid::new_v4()));
-    let key_path = std::env::temp_dir().join(format!("test_ca_{}.key", uuid::Uuid::new_v4()));
-    cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
-    cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
+    let mut temp = TempFiles::new();
+    let cfg = tls_config(&mut temp);
+    let cert_path = common::ca_cert_path(&cfg);
 
-    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     // CONNECT to the proxy; the authority names the MITM certificate's domain.
     let mut tcp = tokio::net::TcpStream::connect(proxy_addr).await?;
@@ -355,9 +352,6 @@ async fn websocket_upgrade_through_connect_mitm_tunnel() -> anyhow::Result<()> {
     assert!(found_session, "no websocket session captured: {content}");
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
-    let _ = tokio::fs::remove_file(&cert_path).await;
-    let _ = tokio::fs::remove_file(&key_path).await;
     Ok(())
 }
 
@@ -416,7 +410,8 @@ async fn a_frame_sent_with_the_101_is_relayed_and_recorded() -> anyhow::Result<(
     });
 
     let cfg = Config::default();
-    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let mut tcp = tokio::net::TcpStream::connect(proxy_addr).await?;
     let ws_key = base64::Engine::encode(
@@ -483,7 +478,6 @@ async fn a_frame_sent_with_the_101_is_relayed_and_recorded() -> anyhow::Result<(
     assert!(found, "the with-101 frame never reached the capture");
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
 
@@ -569,7 +563,8 @@ async fn defective_frames_produce_live_findings() -> anyhow::Result<()> {
         ]),
         ..Default::default()
     };
-    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let mut tcp = tokio::net::TcpStream::connect(proxy_addr).await?;
     let ws_key = base64::Engine::encode(
@@ -664,7 +659,6 @@ async fn defective_frames_produce_live_findings() -> anyhow::Result<()> {
     );
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }
 
@@ -736,7 +730,8 @@ async fn extension_negotiation_flows_end_to_end() -> anyhow::Result<()> {
         ]),
         ..Default::default()
     };
-    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg).await?;
+    let mut temp = TempFiles::new();
+    let (handle, proxy_addr, captures_path) = start_run_proxy_and_wait(cfg, &mut temp).await?;
 
     let mut tcp = tokio::net::TcpStream::connect(proxy_addr).await?;
     let ws_key = base64::Engine::encode(
@@ -825,6 +820,5 @@ async fn extension_negotiation_flows_end_to_end() -> anyhow::Result<()> {
     );
 
     handle.abort();
-    let _ = tokio::fs::remove_file(&captures_path).await;
     Ok(())
 }


### PR DESCRIPTION
…e test

Every proxy integration test ended with the same three or four removals, and every one of them was unreachable on the path that mattered. These bodies reach their end through dozens of `?` and a handful of assertions: `proxy_h3_integration` alone has sixty-two fallible statements before its teardown. A test that failed left its capture file and its generated CA in the temp directory — and a test that failed is exactly the one somebody then re-runs, on a machine now carrying the debris of every previous attempt.

Measured before this change, one `cargo test --workspace` left nineteen files behind. It now leaves none.

`TempFiles` owns what it hands out and removes it on the way out of scope, so an early return is no longer a way to skip it. `tls_config` builds the config whose two CA paths were exactly the two the teardown had to remember, and `start_run_proxy_and_wait` registers the capture file it creates — because the split, where the helper made the file and the test body removed it, is how the removals came to be missed in the first place.

The guard is its own file: the crate's unit tests leak the same way and share no module with the integration tests, so `test_support` reaches it through `#[path]`. A second copy would be the shape this pass exists to remove. `connect.rs`'s CA pair, which no teardown ever removed at all, is the first unit-test caller.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
