### PR TITLE
Every temporary file a test makes has an owner, and no test names a t…

### DIFF
--- a/lint-http-proxy/src/ca.rs
+++ b/lint-http-proxy/src/ca.rs
@@ -160,14 +160,12 @@ impl CertificateAuthority {
 mod tests {
     use super::*;
     use anyhow::Result;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_generate_and_save_ca() -> Result<()> {
-        let temp_dir = std::env::temp_dir();
-        let test_id = Uuid::new_v4();
-        let cert_path = temp_dir.join(format!("test_ca_{}.crt", test_id));
-        let key_path = temp_dir.join(format!("test_ca_{}.key", test_id));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cert_path = temp.path("test_ca", "crt");
+        let key_path = temp.path("test_ca", "key");
 
         // Generate new CA
         let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
@@ -189,10 +187,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_existing_ca() -> Result<()> {
-        let temp_dir = std::env::temp_dir();
-        let test_id = Uuid::new_v4();
-        let cert_path = temp_dir.join(format!("test_ca_{}.crt", test_id));
-        let key_path = temp_dir.join(format!("test_ca_{}.key", test_id));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cert_path = temp.path("test_ca", "crt");
+        let key_path = temp.path("test_ca", "key");
 
         // First generate a CA
         let ca1 = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
@@ -213,10 +210,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_gen_cert_for_domain() -> Result<()> {
-        let temp_dir = std::env::temp_dir();
-        let test_id = Uuid::new_v4();
-        let cert_path = temp_dir.join(format!("test_ca_{}.crt", test_id));
-        let key_path = temp_dir.join(format!("test_ca_{}.key", test_id));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cert_path = temp.path("test_ca", "crt");
+        let key_path = temp.path("test_ca", "key");
 
         let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
 
@@ -234,10 +230,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_cert_cache_hit() -> Result<()> {
-        let temp_dir = std::env::temp_dir();
-        let test_id = Uuid::new_v4();
-        let cert_path = temp_dir.join(format!("test_ca_{}.crt", test_id));
-        let key_path = temp_dir.join(format!("test_ca_{}.key", test_id));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cert_path = temp.path("test_ca", "crt");
+        let key_path = temp.path("test_ca", "key");
 
         let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
 
@@ -258,10 +253,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_domains() -> Result<()> {
-        let temp_dir = std::env::temp_dir();
-        let test_id = Uuid::new_v4();
-        let cert_path = temp_dir.join(format!("test_ca_{}.crt", test_id));
-        let key_path = temp_dir.join(format!("test_ca_{}.key", test_id));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cert_path = temp.path("test_ca", "crt");
+        let key_path = temp.path("test_ca", "key");
 
         let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
 

--- a/lint-http-proxy/src/capture.rs
+++ b/lint-http-proxy/src/capture.rs
@@ -431,7 +431,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_transaction_writes_jsonl() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_capture_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_capture_test", "jsonl");
         let p = tmp
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -473,8 +474,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_transaction_includes_bodies_when_enabled() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_capture_bodies_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_capture_bodies_test", "jsonl");
         let p = tmp
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -528,7 +529,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_reads_jsonl() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_load_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_load_test", "jsonl");
         let p = tmp
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -567,7 +569,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_capture_records_keeps_all_kinds_in_file_order() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_load_all_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_load_all", "jsonl");
         let p = tmp
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -596,8 +599,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_skips_malformed_lines() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_malformed_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_malformed_test", "jsonl");
 
         // Write a mix of valid and invalid transaction JSON
         use crate::test_helpers::{make_test_transaction, make_test_transaction_with_response};
@@ -622,8 +625,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_skips_empty_lines() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_empty_lines_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_empty_lines_test", "jsonl");
 
         // Write a valid record, then an empty line, then another valid record
         use crate::test_helpers::{make_test_transaction, make_test_transaction_with_response};
@@ -643,7 +646,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_skips_whitespace_lines() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_ws_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_test", "jsonl");
 
         use crate::test_helpers::{make_test_transaction, make_test_transaction_with_response};
         let tx1 = make_test_transaction();
@@ -662,8 +666,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_blank_line_returns_empty() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_blank_line_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_blank_line_test", "jsonl");
         // Single blank line should be ignored
         fs::write(&tmp, "\n").await?;
 
@@ -676,7 +680,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_empty_file_returns_empty() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_empty_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_empty_test", "jsonl");
         fs::write(&tmp, "").await?;
 
         let records = load_captures(&tmp).await?;
@@ -688,7 +693,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_nonexistent_file_returns_empty() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_nonexistent_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_nonexistent", "jsonl");
 
         // Should not error, just return empty vector
         let records = load_captures(&tmp).await?;
@@ -698,8 +704,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_websocket_session_writes_jsonl() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_ws_session_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_session_test", "jsonl");
         let p = tmp
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -741,8 +747,8 @@ mod tests {
 
     #[tokio::test]
     async fn load_captures_skips_websocket_session_records() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_mixed_records_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_mixed_records_test", "jsonl");
 
         use crate::test_helpers::make_test_transaction_with_response;
         use crate::websocket_session::{MessageDirection, WebSocketMessageInfo, WebSocketSession};
@@ -821,7 +827,8 @@ mod tests {
 
     #[tokio::test]
     async fn subscribe_receives_written_record() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_stream_sub_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_stream_sub", "jsonl");
         let cw = CaptureWriter::new(tmp.clone(), false).await?;
 
         let mut rx = cw.subscribe();
@@ -844,7 +851,8 @@ mod tests {
 
     #[tokio::test]
     async fn write_without_subscriber_still_writes_file() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_stream_nosub_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_stream_nosub", "jsonl");
         let cw = CaptureWriter::new(tmp.clone(), false).await?;
 
         // No `subscribe()` call: the broadcast tee must be skipped and the
@@ -863,7 +871,8 @@ mod tests {
 
     #[tokio::test]
     async fn capture_new_with_directory_errors() -> anyhow::Result<()> {
-        let dir = std::env::temp_dir().join(format!("lint_capture_dir_{}", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let dir = temp.dir("lint_capture_dir");
         tokio::fs::create_dir(&dir).await?;
         let res = CaptureWriter::new(dir.clone(), false).await;
         assert!(res.is_err());

--- a/lint-http-proxy/src/config.rs
+++ b/lint-http-proxy/src/config.rs
@@ -338,7 +338,6 @@ impl Config {
 mod tests {
     use super::*;
     use tokio::fs;
-    use uuid::Uuid;
 
     #[test]
     fn h3_listen_defaults_to_none() {
@@ -354,8 +353,8 @@ mod tests {
 
     #[tokio::test]
     async fn max_body_bytes_parsed_when_present() -> anyhow::Result<()> {
-        let tmp_toml =
-            std::env::temp_dir().join(format!("lint-http_cfg_test_{}.toml", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp_toml = temp.path("lint-http_cfg_test", "toml");
         let toml = r#"[general]
 listen = "127.0.0.1:3000"
 captures = "captures.jsonl"
@@ -373,8 +372,8 @@ enabled = false
 
     #[tokio::test]
     async fn h3_listen_parsed_when_present() -> anyhow::Result<()> {
-        let tmp_toml =
-            std::env::temp_dir().join(format!("lint-http_cfg_test_{}.toml", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp_toml = temp.path("lint-http_cfg_test", "toml");
         let toml = r#"[general]
 listen = "127.0.0.1:3000"
 captures = "captures.jsonl"
@@ -392,8 +391,8 @@ enabled = true
 
     #[tokio::test]
     async fn h3_listen_without_tls_fails() {
-        let tmp_toml =
-            std::env::temp_dir().join(format!("lint-http_cfg_test_{}.toml", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp_toml = temp.path("lint-http_cfg_test", "toml");
         let toml = r#"[general]
 listen = "127.0.0.1:3000"
 captures = "captures.jsonl"
@@ -416,8 +415,8 @@ enabled = false
 
     #[tokio::test]
     async fn h3_listen_absent_is_none() -> anyhow::Result<()> {
-        let tmp_toml =
-            std::env::temp_dir().join(format!("lint-http_cfg_test_{}.toml", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp_toml = temp.path("lint-http_cfg_test", "toml");
         let toml = r#"[general]
 listen = "127.0.0.1:3000"
 captures = "captures.jsonl"

--- a/lint-http-proxy/src/lib.rs
+++ b/lint-http-proxy/src/lib.rs
@@ -27,6 +27,15 @@ pub use lint_http_rules::{engine, helpers, lint_protocol, queries, rules};
 // from core when the transport surface (`[general]`/`[tls]`) was split away
 // from the rule table; the module path is unchanged for both `lint_http::…`
 // and `crate::…` users.
+// The temp-file guard the tests use, unit and integration alike. Rust gives a
+// unit test and an integration test no module in common — one is compiled into
+// this library, the other into its own binary — so the file is included from
+// where it lives, next to the integration tests that were its first callers. A
+// second copy would be the shape this whole pass exists to remove.
+#[cfg(test)]
+#[path = "../tests/common/temp_files.rs"]
+pub(crate) mod temp_files;
+
 pub mod ca;
 pub mod capture;
 pub mod config;
@@ -37,28 +46,3 @@ pub mod websocket_session;
 
 #[cfg(test)]
 mod test_helpers;
-
-pub fn make_temp_captures_path(prefix: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("{}_{}.jsonl", prefix, uuid::Uuid::new_v4()))
-}
-
-pub fn make_temp_config_path(prefix: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("{}_{}.toml", prefix, uuid::Uuid::new_v4()))
-}
-
-#[cfg(test)]
-#[test]
-fn make_temp_paths_include_prefix() {
-    let p = make_temp_captures_path("testprefix");
-    assert!(p
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .starts_with("testprefix"));
-    let p2 = make_temp_config_path("cfgprefix");
-    assert!(p2
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .starts_with("cfgprefix"));
-}

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: ISC
 
+// The binary is its own compilation unit, so it includes the guard again —
+// the same file, not a second copy of it. See the note in `lib.rs`.
+#[cfg(test)]
+#[path = "../tests/common/temp_files.rs"]
+mod temp_files;
+
 use clap::{Parser, Subcommand, ValueEnum};
 use std::net::SocketAddr;
 
@@ -592,8 +598,11 @@ mod tests {
 
     // Write a minimal config that enables exactly one rule at `warn` and return
     // its temp path.
-    async fn write_config_enabling(rule_id: &str) -> anyhow::Result<std::path::PathBuf> {
-        let tmp = std::env::temp_dir().join(format!("lint_lint_cfg_{}.toml", Uuid::new_v4()));
+    async fn write_config_enabling(
+        rule_id: &str,
+        temp: &mut crate::temp_files::TempFiles,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let tmp = temp.path("lint_lint_cfg", "toml");
         let toml = format!(
             r#"[general]
 listen = "127.0.0.1:3000"
@@ -613,16 +622,19 @@ severity = "warn"
 
     // Enables `cache_control_present` (fires on a 200 response without a
     // Cache-Control header).
-    async fn write_cache_control_config() -> anyhow::Result<std::path::PathBuf> {
-        write_config_enabling("cache_control_present").await
+    async fn write_cache_control_config(
+        temp: &mut crate::temp_files::TempFiles,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        write_config_enabling("cache_control_present", temp).await
     }
 
     // Serialize transactions into a JSONL capture file (one versioned envelope per
     // line) the way the proxy's CaptureWriter would, and return its temp path.
     async fn write_capture_file(
         txs: &[lint_http::http_transaction::HttpTransaction],
+        temp: &mut crate::temp_files::TempFiles,
     ) -> anyhow::Result<std::path::PathBuf> {
-        let tmp = std::env::temp_dir().join(format!("lint_lint_caps_{}.jsonl", Uuid::new_v4()));
+        let tmp = temp.path("lint_lint_caps", "jsonl");
         let mut body = String::new();
         for tx in txs {
             let envelope = capture::CaptureEnvelope {
@@ -640,9 +652,11 @@ severity = "warn"
     async fn lint_reports_violations_and_counts_them() -> anyhow::Result<()> {
         use lint_http_core::test_helpers::make_test_transaction_with_response;
 
-        let cfg = write_cache_control_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_cache_control_config(&mut temp).await?;
         // 200 without Cache-Control -> one violation.
-        let caps = write_capture_file(&[make_test_transaction_with_response(200, &[])]).await?;
+        let caps =
+            write_capture_file(&[make_test_transaction_with_response(200, &[])], &mut temp).await?;
 
         let found = lint_app(
             cfg.to_str().unwrap(),
@@ -660,14 +674,17 @@ severity = "warn"
 
     #[tokio::test]
     async fn lint_clean_capture_reports_zero() -> anyhow::Result<()> {
+        let mut temp = crate::temp_files::TempFiles::new();
         use lint_http_core::test_helpers::make_test_transaction_with_response;
-
-        let cfg = write_cache_control_config().await?;
+        let cfg = write_cache_control_config(&mut temp).await?;
         // 200 *with* Cache-Control -> the rule is satisfied, no violation.
-        let caps = write_capture_file(&[make_test_transaction_with_response(
-            200,
-            &[("cache-control", "no-store")],
-        )])
+        let caps = write_capture_file(
+            &[make_test_transaction_with_response(
+                200,
+                &[("cache-control", "no-store")],
+            )],
+            &mut temp,
+        )
         .await?;
 
         let found = lint_app(
@@ -686,8 +703,9 @@ severity = "warn"
 
     #[tokio::test]
     async fn lint_empty_capture_reports_zero() -> anyhow::Result<()> {
-        let cfg = write_cache_control_config().await?;
-        let caps = std::env::temp_dir().join(format!("lint_lint_empty_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_cache_control_config(&mut temp).await?;
+        let caps = temp.path("lint_lint_empty", "jsonl");
         fs::write(&caps, "").await?;
 
         let found = lint_app(
@@ -706,7 +724,8 @@ severity = "warn"
 
     #[tokio::test]
     async fn lint_missing_capture_file_errors() -> anyhow::Result<()> {
-        let cfg = write_cache_control_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_cache_control_config(&mut temp).await?;
         let result = lint_app(
             cfg.to_str().unwrap(),
             "/nonexistent/does-not-exist.jsonl",
@@ -721,8 +740,10 @@ severity = "warn"
     }
 
     // Enables only the WebSocket opcode-sequence protocol rule.
-    async fn write_ws_opcode_config() -> anyhow::Result<std::path::PathBuf> {
-        write_config_enabling("websocket_frame_opcode_sequence").await
+    async fn write_ws_opcode_config(
+        temp: &mut crate::temp_files::TempFiles,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        write_config_enabling("websocket_frame_opcode_sequence", temp).await
     }
 
     fn ws_message(
@@ -745,8 +766,9 @@ severity = "warn"
     // proxy's CaptureWriter would, and return its temp path.
     async fn write_ws_capture_file(
         session: lint_http::websocket_session::WebSocketSession,
+        temp: &mut crate::temp_files::TempFiles,
     ) -> anyhow::Result<std::path::PathBuf> {
-        let tmp = std::env::temp_dir().join(format!("lint_ws_caps_{}.jsonl", Uuid::new_v4()));
+        let tmp = temp.path("lint_ws_caps", "jsonl");
         let envelope = capture::CaptureEnvelope::new(capture::CaptureRecord::WebsocketSession(
             Box::new(session),
         ));
@@ -757,14 +779,14 @@ severity = "warn"
     #[tokio::test]
     async fn lint_replays_websocket_sessions_through_protocol_rules() -> anyhow::Result<()> {
         use lint_http::websocket_session::{MessageDirection, WebSocketSession};
-
-        let cfg = write_ws_opcode_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_ws_opcode_config(&mut temp).await?;
         // Reserved opcode 3 → one violation from the opcode-sequence rule.
         let mut session = WebSocketSession::new(Uuid::new_v4());
         session
             .messages
             .push(ws_message(MessageDirection::Client, 3, 5));
-        let caps = write_ws_capture_file(session).await?;
+        let caps = write_ws_capture_file(session, &mut temp).await?;
 
         let found = lint_app(
             cfg.to_str().unwrap(),
@@ -783,8 +805,8 @@ severity = "warn"
     #[tokio::test]
     async fn lint_websocket_data_after_close_is_flagged_statefully() -> anyhow::Result<()> {
         use lint_http::websocket_session::{MessageDirection, WebSocketSession};
-
-        let cfg = write_ws_opcode_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_ws_opcode_config(&mut temp).await?;
         // Close then a data frame in the same direction — only detectable when
         // the replay feeds prior frames into the session history.
         let mut session = WebSocketSession::new(Uuid::new_v4());
@@ -795,7 +817,7 @@ severity = "warn"
             .messages
             .push(ws_message(MessageDirection::Client, 1, 4));
         session.close_code = Some(1000);
-        let caps = write_ws_capture_file(session).await?;
+        let caps = write_ws_capture_file(session, &mut temp).await?;
 
         let found = lint_app(
             cfg.to_str().unwrap(),
@@ -814,8 +836,8 @@ severity = "warn"
     #[tokio::test]
     async fn lint_clean_websocket_session_reports_zero() -> anyhow::Result<()> {
         use lint_http::websocket_session::{MessageDirection, WebSocketSession};
-
-        let cfg = write_ws_opcode_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_ws_opcode_config(&mut temp).await?;
         let mut session = WebSocketSession::new(Uuid::new_v4());
         session
             .messages
@@ -827,7 +849,7 @@ severity = "warn"
             .messages
             .push(ws_message(MessageDirection::Client, 8, 2));
         session.close_code = Some(1000);
-        let caps = write_ws_capture_file(session).await?;
+        let caps = write_ws_capture_file(session, &mut temp).await?;
 
         let found = lint_app(
             cfg.to_str().unwrap(),
@@ -846,8 +868,8 @@ severity = "warn"
     #[tokio::test]
     async fn lint_duplicate_session_records_do_not_contaminate() -> anyhow::Result<()> {
         use lint_http::websocket_session::{MessageDirection, WebSocketSession};
-
-        let cfg = write_ws_opcode_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_ws_opcode_config(&mut temp).await?;
         // A clean session (text then close) recorded TWICE in one capture —
         // e.g. concatenated capture files. Each replay must start from a fresh
         // history: the first replay's Close frame must not make the second
@@ -861,7 +883,7 @@ severity = "warn"
             .push(ws_message(MessageDirection::Client, 8, 2));
         session.close_code = Some(1000);
 
-        let tmp = std::env::temp_dir().join(format!("lint_ws_dup_{}.jsonl", Uuid::new_v4()));
+        let tmp = temp.path("lint_ws_dup", "jsonl");
         let envelope = capture::CaptureEnvelope::new(capture::CaptureRecord::WebsocketSession(
             Box::new(session),
         ));
@@ -884,11 +906,13 @@ severity = "warn"
 
     #[tokio::test]
     async fn lint_min_severity_gates_findings_and_exit_code() -> anyhow::Result<()> {
+        let mut temp = crate::temp_files::TempFiles::new();
         use lint_http_core::test_helpers::make_test_transaction_with_response;
 
         // The config rates the rule `warn`, so an `error` gate filters it out…
-        let cfg = write_cache_control_config().await?;
-        let caps = write_capture_file(&[make_test_transaction_with_response(200, &[])]).await?;
+        let cfg = write_cache_control_config(&mut temp).await?;
+        let caps =
+            write_capture_file(&[make_test_transaction_with_response(200, &[])], &mut temp).await?;
 
         let found = lint_app(
             cfg.to_str().unwrap(),
@@ -1063,10 +1087,10 @@ severity = "warn"
     // and legacy arms without the proxy blocking.
     async fn write_port_taken_config(
         addr: std::net::SocketAddr,
+        temp: &mut crate::temp_files::TempFiles,
     ) -> anyhow::Result<(std::path::PathBuf, std::path::PathBuf)> {
-        let cfg = std::env::temp_dir().join(format!("lint_dispatch_cfg_{}.toml", Uuid::new_v4()));
-        let caps =
-            std::env::temp_dir().join(format!("lint_dispatch_caps_{}.jsonl", Uuid::new_v4()));
+        let cfg = temp.path("lint_dispatch_cfg", "toml");
+        let caps = temp.path("lint_dispatch_caps", "jsonl");
         let toml = format!(
             "[general]\nlisten = \"{addr}\"\ncaptures = \"{caps}\"\n\n[tls]\nenabled = false\n",
             addr = addr,
@@ -1079,8 +1103,10 @@ severity = "warn"
     #[tokio::test]
     async fn dispatch_lint_findings_returns_exit_1() -> anyhow::Result<()> {
         use lint_http_core::test_helpers::make_test_transaction_with_response;
-        let cfg = write_cache_control_config().await?;
-        let caps = write_capture_file(&[make_test_transaction_with_response(200, &[])]).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg = write_cache_control_config(&mut temp).await?;
+        let caps =
+            write_capture_file(&[make_test_transaction_with_response(200, &[])], &mut temp).await?;
         let cli = Cli::parse_from([
             "lint-http",
             "lint",
@@ -1096,12 +1122,16 @@ severity = "warn"
 
     #[tokio::test]
     async fn dispatch_lint_clean_returns_exit_0() -> anyhow::Result<()> {
+        let mut temp = crate::temp_files::TempFiles::new();
         use lint_http_core::test_helpers::make_test_transaction_with_response;
-        let cfg = write_cache_control_config().await?;
-        let caps = write_capture_file(&[make_test_transaction_with_response(
-            200,
-            &[("cache-control", "no-store")],
-        )])
+        let cfg = write_cache_control_config(&mut temp).await?;
+        let caps = write_capture_file(
+            &[make_test_transaction_with_response(
+                200,
+                &[("cache-control", "no-store")],
+            )],
+            &mut temp,
+        )
         .await?;
         let cli = Cli::parse_from([
             "lint-http",
@@ -1126,7 +1156,8 @@ severity = "warn"
     async fn dispatch_run_command_routes_to_run_app() -> anyhow::Result<()> {
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
-        let (cfg, caps) = write_port_taken_config(addr).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (cfg, caps) = write_port_taken_config(addr, &mut temp).await?;
         let cli = Cli::parse_from(["lint-http", "run", "--config", cfg.to_str().unwrap()]);
         // run_app binds the already-taken port and errors fast.
         assert!(dispatch(cli).await.is_err());
@@ -1138,9 +1169,10 @@ severity = "warn"
 
     #[tokio::test]
     async fn dispatch_legacy_config_routes_to_run_app() -> anyhow::Result<()> {
+        let mut temp = crate::temp_files::TempFiles::new();
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
-        let (cfg, caps) = write_port_taken_config(addr).await?;
+        let (cfg, caps) = write_port_taken_config(addr, &mut temp).await?;
         let cli = Cli::parse_from(["lint-http", "--config", cfg.to_str().unwrap()]);
         // Legacy bare --config routes to run_app, which errors on the taken port.
         assert!(dispatch(cli).await.is_err());
@@ -1231,7 +1263,8 @@ severity = "warn"
     #[tokio::test]
     async fn rules_list_with_config_annotates_enabled() -> anyhow::Result<()> {
         // The fixture config enables exactly `cache_control_present`.
-        let cfg_path = write_cache_control_config().await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cfg_path = write_cache_control_config(&mut temp).await?;
         let cfg = load_validated_config(cfg_path.to_str().unwrap()).await?;
 
         let text = rules_list(OutputFormat::Text, Some(&cfg))?;
@@ -1275,7 +1308,8 @@ severity = "warn"
 
     #[tokio::test]
     async fn main_cli_config_loads_toml() -> anyhow::Result<()> {
-        let tmp = std::env::temp_dir().join(format!("lint_main_cli_cfg_{}.toml", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_main_cli_cfg", "toml");
         let toml = r#"[rules]
     [rules.cache_control_present]
     enabled = false
@@ -1306,8 +1340,8 @@ severity = "warn"
 
     #[tokio::test]
     async fn main_rejects_invalid_rule_config_before_proxy_starts() -> anyhow::Result<()> {
-        let tmp =
-            std::env::temp_dir().join(format!("lint_main_cli_cfg_invalid_{}.toml", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_main_cli_cfg_invalid", "toml");
         let toml = r#"[general]
 listen = "127.0.0.1:3000"
 captures = "captures.jsonl"
@@ -1338,14 +1372,13 @@ enabled = false
 
     #[tokio::test]
     async fn run_app_with_limit_starts_and_returns() -> anyhow::Result<()> {
+        let mut temp = crate::temp_files::TempFiles::new();
         // Pick a free port
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let port = l.local_addr()?.port();
         drop(l);
-
-        let tmp =
-            std::env::temp_dir().join(format!("lint_main_with_limit_{}.toml", Uuid::new_v4()));
-        let capture_path = std::env::temp_dir().join(format!("captures_{}.jsonl", Uuid::new_v4()));
+        let tmp = temp.path("lint_main_with_limit", "toml");
+        let capture_path = temp.path("captures", "jsonl");
         let toml = format!(
             r#"[rules]
 [rules.cache_control_present]
@@ -1387,7 +1420,6 @@ enabled = false
         assert!(res.is_ok());
 
         let _ = fs::remove_file(&tmp).await;
-        let _ = tokio::fs::remove_file(&capture_path).await;
         Ok(())
     }
 
@@ -1397,9 +1429,9 @@ enabled = false
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
 
-        let tmp =
-            std::env::temp_dir().join(format!("lint_main_port_taken_{}.toml", Uuid::new_v4()));
-        let capture_path = std::env::temp_dir().join(format!("captures_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_main_port_taken", "toml");
+        let capture_path = temp.path("captures", "jsonl");
         let toml = format!(
             r#"[rules]
 [rules.cache_control_present]
@@ -1426,8 +1458,6 @@ enabled = false
         assert!(res.is_err());
 
         // Cleanup
-        let _ = tokio::fs::remove_file(&tmp).await;
-        let _ = tokio::fs::remove_file(&capture_path).await;
         drop(l);
         Ok(())
     }

--- a/lint-http-proxy/src/proxy/connect.rs
+++ b/lint-http-proxy/src/proxy/connect.rs
@@ -171,6 +171,7 @@ mod tests {
             // Generated, and never removed until this guard drops: the pair was
             // written to the temp directory by every run of this test and left
             // there, since there was no teardown at all.
+            let mut temp = crate::temp_files::TempFiles::new();
             let cert_path = temp.path("test_ca", "crt");
             let key_path = temp.path("test_ca", "key");
             let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
@@ -179,7 +180,7 @@ mod tests {
             None
         };
 
-        let (shared, tmp_path, _cw) = make_shared_with_cfg(cfg, ca_arc.clone()).await?;
+        let (shared, tmp_path, _cw) = make_shared_with_cfg(cfg, ca_arc.clone(), &mut temp).await?;
 
         let req = Request::builder()
             .method("CONNECT")

--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -284,7 +284,7 @@ mod tests {
     use hyper::Request;
     use std::sync::Arc as StdArc;
     use tokio::fs;
-    use uuid::Uuid;
+
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -302,7 +302,9 @@ mod tests {
             "cache_control_present",
             "etag_or_last_modified_present",
         ]);
-        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg_inner), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) =
+            make_shared_with_cfg(StdArc::new(cfg_inner), None, &mut temp).await?;
 
         let req = make_request_with_headers("GET", mock.uri(), None)?;
 
@@ -334,7 +336,8 @@ mod tests {
     #[tokio::test]
     async fn handle_request_upstream_error() -> anyhow::Result<()> {
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         // Use a port that is (likely) closed to provoke a client error
         let req = make_request_with_headers("GET", "http://127.0.0.1:9/", None)?;
@@ -379,7 +382,8 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         // Build a relative URI and set Host header so proxy builds absolute URI from Host
         let host = mock.address().to_string();
@@ -424,7 +428,8 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri = format!("{}/ok", mock.uri());
         let req = make_request_with_headers(
@@ -465,12 +470,14 @@ mod tests {
         let cfg = StdArc::new(cfg);
 
         // Create a temporary CA for the test
-        let ca_dir = std::env::temp_dir().join(format!("lint_http_test_ca_{}", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let ca_dir = temp.dir("lint_http_test_ca");
         let cert_path = ca_dir.join("ca.crt");
         let key_path = ca_dir.join("ca.key");
         let ca = CertificateAuthority::load_or_generate(&cert_path, &key_path).await?;
 
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg.clone(), Some(ca.clone())).await?;
+        let (shared, tmp, _cw) =
+            make_shared_with_cfg(cfg.clone(), Some(ca.clone()), &mut temp).await?;
 
         let req = Request::builder()
             .method("GET")
@@ -510,8 +517,13 @@ mod tests {
 
     #[tokio::test]
     async fn handle_request_connect_without_tls_returns_405() -> anyhow::Result<()> {
-        let (shared, tmp, _cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         // Try to use CONNECT method
         let req = Request::builder()
@@ -555,7 +567,8 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let req = make_request_with_headers("GET", format!("{}/hop", mock.uri()), None)?;
 
@@ -623,7 +636,8 @@ mod tests {
     #[tokio::test]
     async fn handle_request_ca_cert_endpoint_without_tls_returns_404() -> anyhow::Result<()> {
         let cfg = StdArc::new(crate::config::Config::default()); // TLS disabled by default
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let req = Request::builder()
             .method("GET")
@@ -680,7 +694,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/error", port).parse()?;
         let req = Request::builder()
@@ -718,7 +733,8 @@ mod tests {
 
         let mut cfg = crate::config::Config::default();
         cfg.general.captures_max_body_bytes = 8;
-        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None, &mut temp).await?;
 
         // The full 64-byte body is streamed to the upstream (no rejection); only
         // the captured copy is bounded to the 8-byte prefix.
@@ -764,7 +780,8 @@ mod tests {
 
         let mut cfg = crate::config::Config::default();
         cfg.general.captures_max_body_bytes = 8;
-        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None, &mut temp).await?;
 
         let req = make_request_with_headers("GET", mock.uri(), None)?;
         let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
@@ -812,7 +829,8 @@ mod tests {
 
         let mut cfg = crate::config::Config::default();
         cfg.general.captures_max_body_bytes = 8;
-        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None, &mut temp).await?;
 
         let req = make_request_with_headers("GET", mock.uri(), None)?;
         let conn_metadata = StdArc::new(crate::connection::ConnectionMetadata::new(
@@ -850,7 +868,8 @@ mod tests {
         let mut cfg_inner = crate::config::Config::default();
         cfg_inner.tls.suppress_headers = vec!["user-agent".to_string()];
         let cfg = StdArc::new(cfg_inner);
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri: Uri = mock.uri().parse()?;
         let req = Request::builder()
@@ -925,7 +944,9 @@ mod tests {
             "etag_or_last_modified_present",
             "status_405_allow_valid",
         ]);
-        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg_inner), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) =
+            make_shared_with_cfg(StdArc::new(cfg_inner), None, &mut temp).await?;
 
         let cases = vec!["/no-content-type", "/no-etag", "/405-no-allow"];
         for path in cases {
@@ -979,8 +1000,13 @@ mod tests {
     #[tokio::test]
     async fn handle_request_relative_uri_with_invalid_host_falls_back_and_returns_502(
     ) -> anyhow::Result<()> {
-        let (shared, tmp, _cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         // Relative URI with invalid Host header should fail to parse and fallback to localhost
         let req = Request::builder()
@@ -1033,7 +1059,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/", addr.port()).parse()?;
         let req = Request::builder()
@@ -1108,7 +1135,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/", addr.port()).parse()?;
         let req = Request::builder()
@@ -1171,7 +1199,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         // Build a WebSocket upgrade request with full URI
         let uri: Uri = format!("http://127.0.0.1:{}/ws", ws_port).parse()?;
@@ -1243,7 +1272,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         // Regular GET — NOT a WebSocket upgrade request
         let uri: Uri = format!("http://127.0.0.1:{}/upgrade", port).parse()?;

--- a/lint-http-proxy/src/proxy/http3.rs
+++ b/lint-http-proxy/src/proxy/http3.rs
@@ -441,7 +441,7 @@ mod tests {
     use std::net::SocketAddr;
     use std::sync::Arc as StdArc;
     use tokio::fs;
-    use uuid::Uuid;
+
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -450,7 +450,8 @@ mod tests {
         cfg.general.h3_listen = Some("127.0.0.1:3443".to_string());
         // TLS is disabled by default
 
-        let tmp = std::env::temp_dir().join(format!("lint_h3_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_h3_test", "jsonl");
         let p = tmp
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -481,7 +482,8 @@ mod tests {
             .await;
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let req = make_request_with_headers("GET", format!("{}/quic-test", mock.uri()), None)?;
 

--- a/lint-http-proxy/src/proxy/mod.rs
+++ b/lint-http-proxy/src/proxy/mod.rs
@@ -551,7 +551,6 @@ mod tests {
     use super::*;
     use std::sync::Arc as StdArc;
     use tokio::fs;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn run_proxy_bind_fails_when_port_taken() -> anyhow::Result<()> {
@@ -559,8 +558,13 @@ mod tests {
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
 
-        let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         // run_proxy should return an error since the port is already in use
         let res = run_proxy(addr, cw, shared.cfg.clone()).await;
@@ -581,10 +585,19 @@ mod tests {
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
 
-        let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
-        let (_shared2, tmp2, cw2) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
+        let (_shared2, tmp2, cw2) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         // By address, while we hold the port: the bind fails.
         assert!(run_proxy(addr, cw, shared.cfg.clone()).await.is_err());
@@ -605,14 +618,15 @@ mod tests {
         let addr = l.local_addr()?;
 
         // Create a path that is a directory so load_captures will error when attempting to open it
-        let dir = std::env::temp_dir().join(format!("lint_proxy_seed_dir_{}", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let dir = temp.dir("lint_proxy_seed_dir");
         tokio::fs::create_dir(&dir).await?;
 
         let mut cfg_inner = crate::config::Config::default();
         cfg_inner.general.captures_seed = true;
         cfg_inner.general.captures = dir.to_string_lossy().to_string();
         let cfg = StdArc::new(cfg_inner);
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None).await?;
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None, &mut temp).await?;
 
         // run_proxy should still return an error due to port being taken, but during
         // startup it should attempt to seed captures and hit the Err branch.
@@ -628,8 +642,13 @@ mod tests {
 
     #[tokio::test]
     async fn run_proxy_starts_and_can_be_aborted() -> anyhow::Result<()> {
-        let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, _tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
 
         let task = tokio::spawn(async move {
@@ -640,7 +659,6 @@ mod tests {
         task.abort();
         let _ = task.await;
 
-        tokio::fs::remove_file(&tmp).await?;
         Ok(())
     }
 
@@ -654,8 +672,13 @@ mod tests {
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
 
-        let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         // spawn the proxy with accept_limit = 1
         let cw_clone = cw.clone();
@@ -699,8 +722,13 @@ mod tests {
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
 
-        let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         let shutdown = CancellationToken::new();
         let cfg_clone = shared.cfg.clone();
@@ -741,8 +769,13 @@ mod tests {
         // pick a free port, and keep the listener rather than racing to rebind it
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
 
-        let (_shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (_shared, tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         // accept_limit = 0 should return quickly
         tokio::time::timeout(
@@ -764,8 +797,13 @@ mod tests {
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
         let addr = l.local_addr()?;
 
-        let (shared, tmp, cw) =
-            make_shared_with_cfg(StdArc::new(crate::config::Config::default()), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(
+            StdArc::new(crate::config::Config::default()),
+            None,
+            &mut temp,
+        )
+        .await?;
 
         let task =
             tokio::spawn(
@@ -806,8 +844,8 @@ mod tests {
         let addr = l.local_addr()?;
 
         // Create a temporary captures JSONL with a single valid transaction
-        let tmp_capture =
-            std::env::temp_dir().join(format!("lint_proxy_seed_ok_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp_capture = temp.path("lint_proxy_seed_ok", "jsonl");
         let pcap = tmp_capture
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?
@@ -824,7 +862,7 @@ mod tests {
         cfg_inner.general.captures_seed = true;
         cfg_inner.general.captures = pcap.clone();
         let cfg = StdArc::new(cfg_inner);
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None).await?;
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg.clone(), None, &mut temp).await?;
 
         // run_proxy should attempt to load captures and then fail on bind
         let res = run_proxy(addr, cw, shared.cfg.clone()).await;
@@ -832,7 +870,6 @@ mod tests {
 
         // Cleanup
         let _ = fs::remove_file(&tmp).await;
-        let _ = tokio::fs::remove_file(&tmp_capture).await;
         drop(l);
         Ok(())
     }
@@ -842,13 +879,14 @@ mod tests {
         let mut cfg = crate::config::Config::default();
         cfg.tls.enabled = true;
         // Use temp paths for CA files
-        let cert_path = std::env::temp_dir().join(format!("test_ca_run_{}.crt", Uuid::new_v4()));
-        let key_path = std::env::temp_dir().join(format!("test_ca_run_{}.key", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let cert_path = temp.path("test_ca_run", "crt");
+        let key_path = temp.path("test_ca_run", "key");
         cfg.tls.ca_cert_path = Some(cert_path.to_string_lossy().to_string());
         cfg.tls.ca_key_path = Some(key_path.to_string_lossy().to_string());
 
         let cfg = StdArc::new(cfg);
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg.clone(), None).await?;
+        let (shared, _tmp, _cw) = make_shared_with_cfg(cfg.clone(), None, &mut temp).await?;
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
 
         let task = tokio::spawn(async move {
@@ -871,9 +909,6 @@ mod tests {
         assert!(cert_path.exists());
         assert!(key_path.exists());
 
-        tokio::fs::remove_file(&cert_path).await?;
-        tokio::fs::remove_file(&key_path).await?;
-        tokio::fs::remove_file(&tmp).await?;
         Ok(())
     }
 }

--- a/lint-http-proxy/src/proxy/pipeline.rs
+++ b/lint-http-proxy/src/proxy/pipeline.rs
@@ -135,7 +135,8 @@ mod tests {
             "cache_control_present",
             "etag_or_last_modified_present",
         ]);
-        let (shared, tmp, cw) = make_shared_with_cfg(Arc::new(cfg_inner), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(Arc::new(cfg_inner), None, &mut temp).await?;
 
         let tx = make_test_transaction_with_response(200, &[]);
         let violations = shared.pipeline().commit(tx).await;
@@ -160,7 +161,8 @@ mod tests {
             "cache_control_present",
             "etag_or_last_modified_present",
         ]);
-        let (shared, tmp, _cw) = make_shared_with_cfg(Arc::new(cfg_inner), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(Arc::new(cfg_inner), None, &mut temp).await?;
 
         let tx = make_test_transaction_with_response(200, &[]);
         let client = tx.client.clone();
@@ -179,8 +181,10 @@ mod tests {
 
     #[tokio::test]
     async fn protocol_event_pipeline_commit_records_and_returns() -> anyhow::Result<()> {
+        let mut temp = crate::temp_files::TempFiles::new();
         let (shared, tmp, _cw) =
-            make_shared_with_cfg(Arc::new(crate::config::Config::default()), None).await?;
+            make_shared_with_cfg(Arc::new(crate::config::Config::default()), None, &mut temp)
+                .await?;
 
         let connection_id = uuid::Uuid::new_v4();
         let pe = ProtocolEvent {

--- a/lint-http-proxy/src/proxy/test_support.rs
+++ b/lint-http-proxy/src/proxy/test_support.rs
@@ -10,30 +10,28 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::Request;
 use std::sync::Arc as StdArc;
-use uuid::Uuid;
 
 use crate::ca::CertificateAuthority;
 use crate::capture::CaptureWriter;
 
 use super::Shared;
 
-/// The temp-file guard the integration tests use, reached across the boundary
-/// Rust puts between a unit test and an integration test: they share no module,
-/// so the alternative to this `#[path]` is a second copy of the same guard —
-/// which is the shape this whole pass exists to remove. Test-only, so the
-/// delivered library never compiles it.
-#[path = "../../tests/common/temp_files.rs"]
-mod temp_files;
-pub(super) use temp_files::TempFiles;
+/// The temp-file guard, included once at the crate root — see the note there.
+pub(super) use crate::temp_files::TempFiles;
 
 /// Construct a `Shared` wired to a fresh temp capture file. Returns the Shared,
-/// the temp path (so tests can read/cleanup), and a clone of the writer.
+/// the temp path (so tests can read it), and a clone of the writer.
+///
+/// The capture file is created here, so `temp` owns it. The doc on this
+/// function used to say the path came back "so tests can read/cleanup", and
+/// that second word was the whole defect: the file was made in one place and
+/// removed in forty-eight others, each of which had to remember.
 pub(super) async fn make_shared_with_cfg(
     cfg: StdArc<crate::config::Config>,
     ca: Option<std::sync::Arc<CertificateAuthority>>,
+    temp: &mut TempFiles,
 ) -> anyhow::Result<(StdArc<Shared>, String, CaptureWriter)> {
-    let tmp =
-        std::env::temp_dir().join(format!("lint_proxy_connect_test_{}.jsonl", Uuid::new_v4()));
+    let tmp = temp.path("lint_proxy_connect_test", "jsonl");
     let p = tmp
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("temp path not utf8"))?

--- a/lint-http-proxy/src/proxy/upstream_h3.rs
+++ b/lint-http-proxy/src/proxy/upstream_h3.rs
@@ -1552,7 +1552,8 @@ mod tests {
     #[tokio::test]
     async fn origin_settings_appear_as_server_events_on_the_upstream_connection() {
         let (ca_pem, leaf, key) = test_certs();
-        let ca_path = std::env::temp_dir().join(format!("lint_p5_ca_{}.pem", uuid::Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let ca_path = temp.path("lint_p5_ca", "pem");
         tokio::fs::write(&ca_path, ca_pem.as_bytes()).await.unwrap();
 
         let origin = spawn_h3_origin(leaf, key);
@@ -1562,8 +1563,8 @@ mod tests {
         cfg.general.h3_upstream_enabled = true;
         cfg.general.h3_upstream_authorities = vec![authority.clone()];
         cfg.general.h3_upstream_extra_ca_certs = vec![ca_path.to_string_lossy().to_string()];
-        let (shared, tmp, _cw) =
-            crate::proxy::test_support::make_shared_with_cfg(Arc::new(cfg), None)
+        let (shared, _tmp, _cw) =
+            crate::proxy::test_support::make_shared_with_cfg(Arc::new(cfg), None, &mut temp)
                 .await
                 .unwrap();
 
@@ -1620,8 +1621,5 @@ mod tests {
             found,
             "origin SETTINGS should be recorded as a Server event on the upstream connection_id"
         );
-
-        let _ = tokio::fs::remove_file(&tmp).await;
-        let _ = tokio::fs::remove_file(&ca_path).await;
     }
 }

--- a/lint-http-proxy/src/proxy/websocket/handshake.rs
+++ b/lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -409,7 +409,8 @@ mod tests {
     async fn handle_websocket_upgrade_upstream_connect_error() -> anyhow::Result<()> {
         // Test that handle_websocket_upgrade returns 502 when upstream is unreachable
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         // Build a request targeting a closed port
         let l = std::net::TcpListener::bind("127.0.0.1:0")?;
@@ -478,7 +479,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let fake_on_upgrade = hyper::upgrade::on(
@@ -532,7 +534,8 @@ mod tests {
 
         let mut cfg = crate::config::Config::default();
         cfg.general.max_body_bytes = 4;
-        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, _cw) = make_shared_with_cfg(StdArc::new(cfg), None, &mut temp).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let fake_on_upgrade = hyper::upgrade::on(
@@ -624,7 +627,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         let uri: Uri = format!("http://127.0.0.1:{}/ws", port).parse()?;
         let fake_on_upgrade = hyper::upgrade::on(
@@ -677,7 +681,8 @@ mod tests {
     #[tokio::test]
     async fn handle_websocket_upgrade_refuses_at_capacity() -> anyhow::Result<()> {
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
 
         // Hold every permit: the proxy is at capacity.
         let total = shared.semaphore.available_permits();
@@ -742,7 +747,8 @@ mod tests {
         });
 
         let cfg = StdArc::new(crate::config::Config::default());
-        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None).await?;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (shared, tmp, cw) = make_shared_with_cfg(cfg, None, &mut temp).await?;
         let total = shared.semaphore.available_permits();
 
         // An OnUpgrade whose request is dropped immediately: the client half

--- a/lint-http-proxy/src/proxy/websocket/observer.rs
+++ b/lint-http-proxy/src/proxy/websocket/observer.rs
@@ -126,8 +126,11 @@ mod tests {
     use crate::capture::CaptureWriter;
     use std::sync::Arc;
 
-    async fn test_observer(direction: MessageDirection) -> (DirectionObserver, String) {
-        let tmp = std::env::temp_dir().join(format!("lint_ws_observer_{}.jsonl", Uuid::new_v4()));
+    async fn test_observer(
+        direction: MessageDirection,
+        temp: &mut crate::temp_files::TempFiles,
+    ) -> (DirectionObserver, String) {
+        let tmp = temp.path("lint_ws_observer", "jsonl");
         let path = tmp.to_str().unwrap().to_string();
         let captures = CaptureWriter::new(path.clone(), false).await.unwrap();
         let cfg = crate::config::Config::default();
@@ -156,7 +159,8 @@ mod tests {
     /// carries its own arrival time.
     #[tokio::test]
     async fn frames_are_recorded_with_real_header_bits_and_timestamps() {
-        let (mut observer, path) = test_observer(MessageDirection::Client).await;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (mut observer, _path) = test_observer(MessageDirection::Client, &mut temp).await;
 
         // Masked text "hi", then an unmasked fragmented binary start.
         let key = [1u8, 2, 3, 4];
@@ -178,14 +182,13 @@ mod tests {
             "the real FIN bit, not a hardcoded true"
         );
         assert_eq!(outcome.close_code, None);
-
-        let _ = tokio::fs::remove_file(&path).await;
     }
 
     /// Each direction reads its own close code, from an unmasked payload.
     #[tokio::test]
     async fn the_close_code_is_read_from_this_directions_close_frame() {
-        let (mut observer, path) = test_observer(MessageDirection::Client).await;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (mut observer, _path) = test_observer(MessageDirection::Client, &mut temp).await;
 
         let key = [7u8, 7, 7, 7];
         let payload = [0x03u8, 0xE9]; // 1001
@@ -198,16 +201,14 @@ mod tests {
         assert_eq!(outcome.close_code, Some(1001));
         assert_eq!(outcome.frames.len(), 1);
         assert_eq!(outcome.frames[0].opcode, 8);
-
-        let _ = tokio::fs::remove_file(&path).await;
     }
 
     /// A truncated direction is visible to the relay for its wind-down log.
     #[tokio::test]
     async fn a_wire_cut_mid_frame_reports_as_such() {
-        let (mut observer, path) = test_observer(MessageDirection::Server).await;
+        let mut temp = crate::temp_files::TempFiles::new();
+        let (mut observer, _path) = test_observer(MessageDirection::Server, &mut temp).await;
         observer.observe(&[0x81, 0x05, b'h']);
         assert!(observer.mid_frame());
-        let _ = tokio::fs::remove_file(&path).await;
     }
 }

--- a/lint-http-proxy/src/proxy/websocket/relay.rs
+++ b/lint-http-proxy/src/proxy/websocket/relay.rs
@@ -228,7 +228,8 @@ mod tests {
         let (proxy_server_side, server_side) = tokio::io::duplex(4096);
 
         let tx_id = Uuid::new_v4();
-        let tmp = std::env::temp_dir().join(format!("lint_ws_relay_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_relay_test", "jsonl");
         let p = tmp.to_str().unwrap().to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
 
@@ -336,7 +337,6 @@ mod tests {
         assert_eq!(session["close_code"].as_u64(), Some(1000));
         assert_eq!(session["client_close_code"].as_u64(), Some(1000));
 
-        let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
 
@@ -350,7 +350,8 @@ mod tests {
         let (proxy_server_side, server_side) = tokio::io::duplex(4096);
 
         let tx_id = Uuid::new_v4();
-        let tmp = std::env::temp_dir().join(format!("lint_ws_s2c_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_s2c_test", "jsonl");
         let p = tmp.to_str().unwrap().to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
 
@@ -431,7 +432,6 @@ mod tests {
         // Server text + server close + client close.
         assert!(messages.len() >= 2);
 
-        let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
 
@@ -442,8 +442,8 @@ mod tests {
         let (proxy_server_side, server_side) = tokio::io::duplex(4096);
 
         let tx_id = Uuid::new_v4();
-        let tmp =
-            std::env::temp_dir().join(format!("lint_ws_abrupt_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_abrupt_test", "jsonl");
         let p = tmp.to_str().unwrap().to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
 
@@ -477,7 +477,6 @@ mod tests {
         let session: serde_json::Value = serde_json::from_str(content.trim())?;
         assert_eq!(session["type"].as_str(), Some("websocket_session"));
 
-        let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
 
@@ -493,8 +492,8 @@ mod tests {
         let _server_side = server_side;
 
         let tx_id = Uuid::new_v4();
-        let tmp =
-            std::env::temp_dir().join(format!("lint_ws_shutdown_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_shutdown_test", "jsonl");
         let p = tmp.to_str().unwrap().to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
 
@@ -529,7 +528,6 @@ mod tests {
         let session: serde_json::Value = serde_json::from_str(content.trim())?;
         assert_eq!(session["type"].as_str(), Some("websocket_session"));
 
-        let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
 
@@ -572,8 +570,8 @@ mod tests {
         let (proxy_server_side, mut server_side) = tokio::io::duplex(4096);
 
         let tx_id = Uuid::new_v4();
-        let tmp =
-            std::env::temp_dir().join(format!("lint_ws_reserved_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_reserved_test", "jsonl");
         let p = tmp.to_str().unwrap().to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
 
@@ -623,7 +621,6 @@ mod tests {
         assert_eq!(messages[0]["masked"].as_bool(), Some(true));
         assert_eq!(messages[0]["payload_length"].as_u64(), Some(2));
 
-        let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
 
@@ -636,8 +633,8 @@ mod tests {
         let (proxy_server_side, server_side) = tokio::io::duplex(4096);
 
         let tx_id = Uuid::new_v4();
-        let tmp =
-            std::env::temp_dir().join(format!("lint_ws_binary_test_{}.jsonl", Uuid::new_v4()));
+        let mut temp = crate::temp_files::TempFiles::new();
+        let tmp = temp.path("lint_ws_binary_test", "jsonl");
         let p = tmp.to_str().unwrap().to_string();
         let cw = CaptureWriter::new(p.clone(), false).await?;
 
@@ -734,7 +731,6 @@ mod tests {
             .expect("ping recorded");
         assert_eq!(ping["direction"].as_str(), Some("client"));
 
-        let _ = tokio::fs::remove_file(&tmp).await;
         Ok(())
     }
 }

--- a/lint-http-proxy/tests/common/temp_files.rs
+++ b/lint-http-proxy/tests/common/temp_files.rs
@@ -27,6 +27,7 @@ use std::path::PathBuf;
 #[derive(Default)]
 pub struct TempFiles {
     paths: Vec<PathBuf>,
+    dirs: Vec<PathBuf>,
 }
 
 impl TempFiles {
@@ -45,6 +46,15 @@ impl TempFiles {
         path
     }
 
+    /// A fresh *directory* path, removed with its contents when this guard
+    /// drops. Kept apart from the files because the removal differs, and
+    /// because a caller that mixes them up should not compile.
+    pub fn dir(&mut self, prefix: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("{prefix}_{}", uuid::Uuid::new_v4()));
+        self.dirs.push(path.clone());
+        path
+    }
+
     /// Take ownership of a path the caller made for itself.
     pub fn keep(&mut self, path: impl Into<PathBuf>) {
         self.paths.push(path.into());
@@ -57,6 +67,9 @@ impl Drop for TempFiles {
         // whatever thread the test ended on — including one that is panicking.
         for path in &self.paths {
             let _ = std::fs::remove_file(path);
+        }
+        for dir in &self.dirs {
+            let _ = std::fs::remove_dir_all(dir);
         }
     }
 }

--- a/lint-http-proxy/tests/integration_captures_seed.rs
+++ b/lint-http-proxy/tests/integration_captures_seed.rs
@@ -4,8 +4,10 @@
 
 //! Integration tests for the captures_seed feature
 
-use lint_http::{make_temp_captures_path, make_temp_config_path};
 use rstest::rstest;
+
+mod common;
+use common::TempFiles;
 use tokio::fs;
 
 #[rstest]
@@ -14,8 +16,9 @@ use tokio::fs;
 #[tokio::test]
 async fn test_captures_seed_behavior(#[case] seed_enabled: bool) -> anyhow::Result<()> {
     let suffix = if seed_enabled { "enabled" } else { "disabled" };
-    let captures_file = make_temp_captures_path(&format!("test_seed_{}", suffix));
-    let config_file = make_temp_config_path(&format!("test_config_{}", suffix));
+    let mut temp = TempFiles::new();
+    let captures_file = temp.path(&format!("test_seed_{}", suffix), "jsonl");
+    let config_file = temp.path(&format!("test_config_{}", suffix), "toml");
 
     use lint_http::http_transaction::{HttpTransaction, ResponseInfo, TimingInfo};
 
@@ -83,16 +86,15 @@ enabled = false
         assert!(prev.is_none(), "State should not be seeded");
     }
 
-    fs::remove_file(&captures_file).await?;
-    fs::remove_file(&config_file).await?;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_captures_seed_with_nonexistent_file() -> anyhow::Result<()> {
     // Create a config pointing to a non-existent captures file
-    let captures_file = make_temp_captures_path("nonexistent");
-    let config_file = make_temp_config_path("test_config_nonexistent");
+    let mut temp = TempFiles::new();
+    let captures_file = temp.path("nonexistent", "jsonl");
+    let config_file = temp.path("test_config_nonexistent", "toml");
 
     let config_toml = format!(
         r#"[general]
@@ -124,6 +126,5 @@ enabled = false
     );
 
     // Cleanup
-    fs::remove_file(&config_file).await?;
     Ok(())
 }

--- a/lint-http-proxy/tests/integration_tls_config.rs
+++ b/lint-http-proxy/tests/integration_tls_config.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: ISC
 
 use hyper::Uri;
-use lint_http::make_temp_captures_path;
+
+mod common;
+use common::TempFiles;
 use std::sync::Arc;
-use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -20,7 +21,8 @@ async fn test_suppress_headers() -> anyhow::Result<()> {
         .mount(&mock)
         .await;
 
-    let tmp_capture = make_temp_captures_path("lint_test_suppress");
+    let mut temp = TempFiles::new();
+    let tmp_capture = temp.path("lint_test_suppress", "jsonl");
     let tmp_capture_str = tmp_capture
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("temp_capture path not utf8"))?
@@ -92,7 +94,6 @@ async fn test_suppress_headers() -> anyhow::Result<()> {
     assert!(received_req.headers.get("x-public").is_some());
     assert!(received_req.headers.get("x-secret").is_none());
 
-    fs::remove_file(&tmp_capture).await?;
     Ok(())
 }
 
@@ -112,7 +113,8 @@ async fn test_passthrough_domains() -> anyhow::Result<()> {
         }
     });
 
-    let tmp_capture = make_temp_captures_path("lint_test_pass");
+    let mut temp = TempFiles::new();
+    let tmp_capture = temp.path("lint_test_pass", "jsonl");
     let tmp_capture_str = tmp_capture
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("temp_capture path not utf8"))?
@@ -183,6 +185,5 @@ async fn test_passthrough_domains() -> anyhow::Result<()> {
     let response = String::from_utf8_lossy(&buf[0..n]);
     assert_eq!(response, "hello");
 
-    fs::remove_file(&tmp_capture).await?;
     Ok(())
 }

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -51,22 +51,43 @@ fn build_h3_client(ca_cert_path: &std::path::Path) -> anyhow::Result<quinn::Endp
     Ok(endpoint)
 }
 
-/// Start the proxy with TLS + h3_listen enabled, return handles and addresses.
+/// A tweak applied to the config before the proxy starts.
+///
+/// Named because the type is the other half of what the removed
+/// `#[allow(type_complexity)]` was covering: the allow sat on the function, so
+/// it silenced the parameter as well as the return.
+type ConfigTweak = Box<dyn FnOnce(&mut Config) + Send>;
+
+/// A proxy under test with HTTP/3 enabled, and what a test needs to reach it.
+///
+/// **This was five positional values behind an `#[allow(type_complexity)]`**,
+/// and the allow was the honest signal: two of them were `SocketAddr` and two
+/// were paths, so a call site that swapped a pair would still compile. Every
+/// field is named at the destructuring now, and a test names only the ones it
+/// uses — which is what retired the `_tcp_addr` and `_captures_path`
+/// placeholders the tuple forced on callers that wanted neither, and what
+/// showed that nothing read the TCP address at all.
+struct H3Proxy {
+    handle: tokio::task::JoinHandle<()>,
+    /// The H3/QUIC listen address. The TCP one is *not* here: no test reads
+    /// it, and it was in the tuple only because the function happened to have
+    /// it — which a positional return makes invisible and a named field asks
+    /// out loud.
+    h3_addr: SocketAddr,
+    captures_path: String,
+    /// Where the proxy generated its CA, for a client that must trust it.
+    cert_path: std::path::PathBuf,
+}
+
+/// Start the proxy with TLS + h3_listen enabled.
 ///
 /// Every temporary file this makes belongs to `temp`, including the CA key —
-/// which is why it is no longer returned: it was in the tuple for the teardown
-/// alone, and the teardown is the guard's now.
-#[allow(clippy::type_complexity)]
+/// which is why that one is not returned at all: it was in the tuple for the
+/// teardown alone, and the teardown is the guard's now.
 async fn start_proxy_with_h3(
-    cfg_modifier: Option<Box<dyn FnOnce(&mut Config) + Send>>,
+    cfg_modifier: Option<ConfigTweak>,
     temp: &mut TempFiles,
-) -> anyhow::Result<(
-    tokio::task::JoinHandle<()>,
-    SocketAddr,         // TCP listen address
-    SocketAddr,         // H3/QUIC listen address
-    String,             // captures path
-    std::path::PathBuf, // CA cert path
-)> {
+) -> anyhow::Result<H3Proxy> {
     let mut cfg = tls_config(temp);
     let cert_path = common::ca_cert_path(&cfg);
     let key_path = std::path::PathBuf::from(
@@ -151,7 +172,12 @@ async fn start_proxy_with_h3(
     // Brief pause so the probe connection is cleaned up server-side
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    Ok((handle, tcp_addr, h3_addr, captures_path, cert_path))
+    Ok(H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+    })
 }
 
 /// Send a single HTTP/3 GET request via quinn+h3, return status and body.
@@ -273,8 +299,13 @@ async fn h3_happy_path_forwards_request_and_captures() -> anyhow::Result<()> {
         .await;
 
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
-        start_proxy_with_h3(None, &mut temp).await?;
+    let H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/hello", mock.address().port());
@@ -315,8 +346,13 @@ async fn h3_happy_path_forwards_request_and_captures() -> anyhow::Result<()> {
 #[tokio::test]
 async fn h3_upstream_error_returns_502_and_records_transaction() -> anyhow::Result<()> {
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
-        start_proxy_with_h3(None, &mut temp).await?;
+    let H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     // Port 9 is the discard protocol — very unlikely to have an HTTP server
@@ -355,7 +391,12 @@ async fn h3_suppress_headers_filters_configured_headers() -> anyhow::Result<()> 
         .await;
 
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, _captures_path, cert_path) = start_proxy_with_h3(
+    let H3Proxy {
+        handle,
+        h3_addr,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(
         Some(Box::new(|cfg| {
             cfg.tls.suppress_headers = vec!["x-secret".to_string()];
         })),
@@ -403,8 +444,12 @@ async fn h3_hop_by_hop_headers_stripped_from_response() -> anyhow::Result<()> {
         .await;
 
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, _captures_path, cert_path) =
-        start_proxy_with_h3(None, &mut temp).await?;
+    let H3Proxy {
+        handle,
+        h3_addr,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/hop", mock.address().port());
@@ -445,8 +490,13 @@ async fn h3_multiple_requests_on_same_connection_increment_sequence() -> anyhow:
         .await;
 
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
-        start_proxy_with_h3(None, &mut temp).await?;
+    let H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     let uri = format!("http://127.0.0.1:{}/seq", mock.address().port());
@@ -522,7 +572,13 @@ async fn h3_large_request_body_streams_and_truncates_capture() -> anyhow::Result
         .await;
 
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) = start_proxy_with_h3(
+    let H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(
         Some(Box::new(|cfg| {
             cfg.general.captures_max_body_bytes = 16;
         })),
@@ -576,7 +632,13 @@ async fn h3_response_over_limit_streams_full_and_truncates_capture() -> anyhow::
         .await;
 
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) = start_proxy_with_h3(
+    let H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(
         Some(Box::new(|cfg| {
             cfg.general.captures_max_body_bytes = 16;
         })),
@@ -634,8 +696,13 @@ async fn h3_request_with_host_header_fallback() -> anyhow::Result<()> {
     // authority is resolved from Host and that the request is captured with
     // the correct host value.
     let mut temp = TempFiles::new();
-    let (handle, _tcp_addr, h3_addr, captures_path, cert_path) =
-        start_proxy_with_h3(None, &mut temp).await?;
+    let H3Proxy {
+        handle,
+        h3_addr,
+        captures_path,
+        cert_path,
+        ..
+    } = start_proxy_with_h3(None, &mut temp).await?;
 
     let endpoint = build_h3_client(&cert_path)?;
     // Send a path-only URI with explicit Host header.  The upstream will fail


### PR DESCRIPTION
…uple

The guard reached the integration tests last commit; this finishes the job on the fifty-two sites in `src/` that make temp files the same way. A full `cargo test --workspace` leaked three files after that commit and leaks none now — and a run with a deliberately panicking test leaks none either, which is the property being bought: the removal is on the way out of the scope, not at the end of a body nothing reaches when an assertion fails.

`make_shared_with_cfg` was the last of the create-here-remove-there splits, and the largest: it made a capture file and handed the path to forty-eight callers, each of which had to remember. Its own doc said the path came back "so tests can read/cleanup", and that second word was the defect.

Two shapes needed the guard to grow. A test that returns the path it made must borrow its caller's guard, or the file dies at the helper's closing brace — five helpers did, and the failures said only "No such file or directory". And three sites make a *directory*, so `dir()` is separate from `path()`: the removal differs, and a caller that confuses them should not compile.

`start_proxy_with_h3` returns a struct now instead of five positional values behind an `#[allow(type_complexity)]`. Two of the five were `SocketAddr` and two were paths, so a caller that swapped a pair would still have compiled. Naming them showed that nothing read the TCP address at all, so that field is gone rather than allowed; the closure parameter the same allow was silently covering is a named type.

`make_temp_captures_path` and `make_temp_config_path` are removed. They were public only so the integration tests could reach them, and those tests use the guard now.
