### PR TITLE
A manifest declares only what its code reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,13 @@ jobs:
         with:
           command: check advisories licenses
 
+      # A manifest may only declare what the code reads. cargo-deny checks the
+      # tree we pull; this checks that we asked for it — four declarations had
+      # drifted, two of them test-only crates compiled into the binary, and one
+      # (`pem`) that nothing in the workspace had ever called.
+      - name: cargo-machete (declared but unused dependencies)
+        uses: bnjbvr/cargo-machete@main
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
- "tracing",
  "uuid",
 ]
 
@@ -1047,13 +1046,11 @@ dependencies = [
  "h3-quinn",
  "http",
  "http-body-util",
- "httpdate",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "lint-http-core",
  "lint-http-rules",
- "pem 4.0.0",
  "quinn",
  "rcgen",
  "rstest",
@@ -1268,16 +1265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
-dependencies = [
- "base64 0.23.1",
- "serde_core",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,7 +1452,7 @@ version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
- "pem 3.0.6",
+ "pem",
  "ring",
  "rustls-pki-types",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ h3-quinn = "0.0.10"
 
 # Certificate generation / misc
 rcgen = "0.14"
-pem = "4.0"
 http-body-util = "0.1"
 tokio-tungstenite = "0.30"
 futures-util = "0.3"

--- a/lint-http-core/Cargo.toml
+++ b/lint-http-core/Cargo.toml
@@ -28,7 +28,6 @@ hyper = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
 httpdate = { workspace = true }
-tracing = { workspace = true }
 # Only async config-file IO (`tokio::fs`) + the test runtime are needed here.
 tokio = { workspace = true, features = ["fs", "macros", "rt"] }
 parking_lot = { workspace = true }

--- a/lint-http-proxy/Cargo.toml
+++ b/lint-http-proxy/Cargo.toml
@@ -37,13 +37,11 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
-httpdate = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 toml = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
-sha1 = { workspace = true }
 
 # TLS
 tokio-rustls = { workspace = true }
@@ -58,12 +56,15 @@ h3-quinn = { workspace = true }
 
 # Certificate generation / misc
 rcgen = { workspace = true }
-pem = { workspace = true }
 http-body-util = { workspace = true }
 futures-util = { workspace = true }
 rustls-native-certs = { workspace = true }
 
 [dev-dependencies]
+# Test-only: the WebSocket relay tests compute their own `Sec-WebSocket-Accept`
+# to check the handshake the proxy produced. The proxy's own accept value is
+# `lint-http-rules`' answer, computed where the handshake grammar lives.
+sha1 = { workspace = true }
 tokio-tungstenite = { workspace = true }
 lint-http-core = { workspace = true, features = ["test-utils"] }
 wiremock = { workspace = true }

--- a/lint-http-rules/Cargo.toml
+++ b/lint-http-rules/Cargo.toml
@@ -21,7 +21,6 @@ chrono = { workspace = true }
 toml = { workspace = true }
 hyper = { workspace = true }
 bytes = { workspace = true }
-httpdate = { workspace = true }
 base64 = { workspace = true }
 sha1 = { workspace = true }
 linkme = { workspace = true }
@@ -31,6 +30,10 @@ lint-http-core = { workspace = true, features = ["test-utils"] }
 # Test-only: `#[tokio::test]` + `tokio::fs` for the capture-file fixtures.
 tokio = { workspace = true, features = ["fs", "macros", "rt"] }
 rstest = { workspace = true }
+# Test-only: one `Expires` attribute fixture is written with `fmt_http_date`.
+# No rule reads an HTTP-date through this crate — `lint-http-core` owns that
+# question, and the rules read its answer.
+httpdate = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Five declarations had drifted from the code. `tracing` in core and `httpdate` in the proxy had no reader at all; `sha1` in the proxy and `httpdate` in the rules crate are read only from tests, so they were being compiled into the shipped binary to serve a fixture. `pem` was the one no grep of mine found: nothing in the workspace has ever called it, and dropping it also drops a second copy of the crate from the tree, since rcgen brings its own 3.0.6.

The two that moved to dev-dependencies say why in place, because "unused" is the wrong word for them and a later reader would otherwise re-add them.

cargo-machete joins the supply-chain job to keep this true. cargo-deny checks the tree we pull; nothing checked that we had asked for it.
