### PR TITLE
Hand-written unsafe is refused, and the one exemption names itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,26 @@ repository = "https://github.com/alganet/lint-http"
 [workspace.lints.clippy]
 cognitive_complexity = "warn"
 
+# No hand-written `unsafe` anywhere, enforced rather than merely true. A linter
+# is a poor place to reach for it: every byte here arrives from a socket and is
+# parsed against a grammar, which is exactly where a manual bounds argument is
+# worth least and costs most. Nothing has needed it, including the hand-rolled
+# WebSocket frame scanner — the closest this tree comes to a case for one.
+#
+# `deny` and not `forbid`, which was the first spelling and does not compile.
+# `linkme`'s `distributed_slice` — the mechanism the whole rule catalogue
+# self-registers through — expands to a `#[link_section]` static, which this
+# lint counts; under `forbid`, which also refuses the `#[allow]` that would
+# lift it, all 193 rules stop building.
+#
+# The one exemption is written on `pub mod rules;` in `lint-http-rules/src/lib.rs`
+# and is scoped to that subtree, because the lint fires once per registration
+# inside each `src/rules/*.rs` rather than at the two declarations they expand
+# through. `helpers`, `engine`, `queries` and `lint_protocol` stay covered, and
+# so does every other crate.
+[workspace.lints.rust]
+unsafe_code = "deny"
+
 [workspace.dependencies]
 # Internal crates
 lint-http-core = { path = "lint-http-core" }

--- a/lint-http-rules/src/lib.rs
+++ b/lint-http-rules/src/lib.rs
@@ -23,6 +23,15 @@ pub mod engine;
 pub mod helpers;
 pub mod lint_protocol;
 pub mod queries;
+// `unsafe_code` is denied workspace-wide (see the root `Cargo.toml`), and this
+// subtree is the one exemption. `linkme::distributed_slice` places each rule's
+// registration in a named `#[link_section]`, which the lint counts as unsafe;
+// it fires once per registration, inside each `src/rules/*.rs`, so the
+// exemption has to reach the whole subtree rather than the two declarations in
+// `rules/mod.rs`. Scoped to this `mod` and not to the crate, which leaves
+// `helpers`, `engine`, `queries` and `lint_protocol` — where a parser might
+// actually be tempted — still covered.
+#[allow(unsafe_code)]
 pub mod rules;
 
 #[cfg(test)]


### PR DESCRIPTION
There is no `unsafe` in this tree. That was true and unenforced, which is the state where it stops being true without anyone noticing.

`forbid` was the first spelling and it does not compile: linkme's `distributed_slice`, which the whole rule catalogue self-registers through, expands to a `#[link_section]` static that this lint counts, and `forbid` refuses the `#[allow]` that would lift it — all 193 rules stop building. So `deny`, with one exemption.

The exemption sits on `pub mod rules;` rather than on the two declarations in `rules/mod.rs`, because the lint fires at each registration site inside `src/rules/*.rs`, not where they expand from. That scoping is the point: `helpers`, `engine`, `queries` and `lint_protocol` stay covered — the parsers, where a bounds argument might actually tempt someone — and so does every other crate. Verified by probe in all three directions.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
