### PR TITLE
The workspace says which Rust it supports, and builds on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,22 @@ jobs:
       - name: Check formatting of rule files
         run: rustfmt --edition 2021 --check lint-http-rules/src/rules/*.rs
 
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pinned to the exact `rust-version` in the workspace manifest. The other
+      # jobs build on stable, which cannot notice that a newly used API raised
+      # the real floor above the declared one — this job is the only thing that
+      # makes the number in Cargo.toml a fact.
+      - name: Install the declared minimum toolchain
+        uses: dtolnay/rust-toolchain@1.94
+
+      - name: Build on the declared minimum
+        run: cargo check --workspace --all-targets --all-features
+
   supply-chain:
     name: Supply chain
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ members = ["lint-http-core", "lint-http-rules", "lint-http-proxy", "xtask"]
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+# The oldest Rust this supports, and a decision rather than an artifact: it is
+# roughly current stable minus three releases, which is a support window, not
+# the accidental floor a bisect would have found. `cargo` refuses to build on
+# anything older, and the `msrv` CI job builds on exactly this to keep the
+# number honest — a claim no one compiles is a claim that drifts.
+rust-version = "1.94"
 authors = ["Alexandre Gomes Gaigalas <alganet@gmail.com>"]
 license = "ISC"
 repository = "https://github.com/alganet/lint-http"

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,6 +26,8 @@ We maintain high standards for code quality and testing.
 - **Linting**: Use `cargo lint` (alias in `.cargo/config.toml`) — clippy warnings are treated as errors.
 - **Formatting**: Code must be formatted with `cargo fmt` (`rustfmt`).
 - **Headers & Docs**: New source, test, and documentation files must include the SPDX header; new rules must include a docs file in `docs/rules/` and an example entry in `config_example.toml`.
+- **Minimum Rust version**: `rust-version` in the workspace `Cargo.toml` — currently **1.94**, about three releases behind stable. It is a support window we choose, not the oldest toolchain that happens to compile. The `msrv` CI job builds on exactly that version; raising it is a deliberate edit to the manifest, not something a new API call does silently.
+- **Dependencies**: A manifest declares only what its code reads, and a crate used only from tests belongs in `[dev-dependencies]`. `cargo machete` gates this.
 
 ### Running QA
 

--- a/lint-http-core/Cargo.toml
+++ b/lint-http-core/Cargo.toml
@@ -7,6 +7,7 @@ name = "lint-http-core"
 description = "Core data types, state, and config for lint-http — usable without the proxy"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/lint-http-proxy/Cargo.toml
+++ b/lint-http-proxy/Cargo.toml
@@ -7,6 +7,7 @@ name = "lint-http-proxy"
 description = "HTTP forward proxy that captures request/response metadata and runs lint rules"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/lint-http-rules/Cargo.toml
+++ b/lint-http-rules/Cargo.toml
@@ -7,6 +7,7 @@ name = "lint-http-rules"
 description = "The lint-http rule catalogue and lint dispatch engine, depending only on lint-http-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,7 @@ name = "xtask"
 description = "Repository maintenance tasks for lint-http. Not shipped, not published."
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Nothing declared a minimum, and every job built on stable — so the real floor was whatever the newest API anyone had reached for, discoverable only by a downstream build failing.

1.94, roughly stable minus three releases. A support window chosen rather than the accidental floor a bisect would have reported, which is a number that moves for reasons no one decided. The `msrv` job builds on exactly that version: stable cannot notice a new API raising the floor above the declared one, so without it the manifest would state a version nothing compiles.

Verified: `cargo +1.94 check --workspace --all-targets --all-features` passes.
