### PR TITLE
The rendered documentation resolves every link it makes

### DIFF
--- a/lint-http-core/src/lint.rs
+++ b/lint-http-core/src/lint.rs
@@ -4,9 +4,11 @@
 
 //! Lint result types.
 //!
-//! The dispatch engine that produces these from a transaction lives in
-//! [`engine`](crate::engine), which sits above the rule catalogue; these data
-//! types sit below it (every rule returns a [`Violation`]).
+//! The dispatch engine that produces these from a transaction lives in the
+//! `lint-http-rules` crate, in its `engine` module — it sits above the rule
+//! catalogue, while these data types sit below it (every rule returns a
+//! [`Violation`]). This crate depends on no other, so the reference is by name:
+//! the arrow only points one way.
 
 use serde::{Deserialize, Serialize};
 

--- a/lint-http-core/src/protocol_event.rs
+++ b/lint-http-core/src/protocol_event.rs
@@ -4,15 +4,17 @@
 
 //! Protocol-level event model for sub-transaction analysis.
 //!
-//! While [`HttpTransaction`] captures complete request/response pairs, some
-//! lint rules need visibility into frame-level and transport-level events that
-//! occur outside or below the HTTP message abstraction: WebSocket frames,
-//! HTTP/3 control frames, QUIC transport parameters, etc.
+//! While [`HttpTransaction`](crate::http_transaction::HttpTransaction) captures
+//! complete request/response pairs, some lint rules need visibility into
+//! frame-level and transport-level events that occur outside or below the HTTP
+//! message abstraction: WebSocket frames, HTTP/3 control frames, QUIC transport
+//! parameters, etc.
 //!
 //! `ProtocolEvent` represents a single observable event on a connection.
 //! Events are stored in [`ProtocolEventStore`](crate::protocol_event_store)
-//! and routed to [`ProtocolRule`](crate::rules::ProtocolRule) implementations
-//! via [`lint_protocol_event`](crate::lint_protocol::lint_protocol_event).
+//! and routed to `ProtocolRule` implementations via `lint_protocol_event` —
+//! both in the `lint-http-rules` crate, which depends on this one and not the
+//! reverse, so they are named here rather than linked.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -50,7 +52,7 @@ fn default_direction_client() -> MessageDirection {
 /// reserved opcodes needs to know whether *any* extension was negotiated, since
 /// the specification hands both to extensions and requires the negotiation to
 /// happen in the opening handshake — which is an HTTP exchange a
-/// [`ProtocolRule`](crate::rules::ProtocolRule) never sees. So the answer
+/// `ProtocolRule` never sees. So the answer
 /// travels with the frame, and *"the server accepted no extension"* is a
 /// different record from *"this capture does not say"*: the first licenses a
 /// finding, and the second is why [`Unrecorded`](Self::Unrecorded) is the
@@ -217,8 +219,9 @@ pub struct QuicTransportParameters {
 /// Pre-queried protocol event history passed to protocol rules.
 ///
 /// Contains zero or more previous events for the same connection,
-/// ordered **newest first**.  Mirrors [`TransactionHistory`] for the
-/// protocol event pipeline.
+/// ordered **newest first**.  Mirrors
+/// [`TransactionHistory`](crate::transaction_history::TransactionHistory) for
+/// the protocol event pipeline.
 #[derive(Debug, Clone)]
 pub struct ProtocolEventHistory {
     entries: Vec<ProtocolEvent>,

--- a/lint-http-proxy/src/h3_instrument.rs
+++ b/lint-http-proxy/src/h3_instrument.rs
@@ -335,7 +335,7 @@ impl FrameObserver {
 // ── Instrumented RecvStream ──────────────────────────────────────────
 
 /// A transparent wrapper around [`h3_quinn::RecvStream`] that feeds incoming
-/// bytes through a [`FrameObserver`] before returning them to `h3`.
+/// bytes through a `FrameObserver` before returning them to `h3`.
 pub struct InstrumentedRecvStream {
     inner: h3_quinn::RecvStream,
     observer: FrameObserver,
@@ -383,7 +383,7 @@ impl InstrumentedConnection {
     /// Wrap an existing [`h3_quinn::Connection`], observing the peer identified
     /// by `direction`.
     ///
-    /// Every unidirectional stream accepted via [`poll_accept_recv`] will be
+    /// Every unidirectional stream accepted via `poll_accept_recv` will be
     /// wrapped in an [`InstrumentedRecvStream`] whose frame observer emits
     /// events through `sink`, tagged with `direction`.
     pub fn new(conn: h3_quinn::Connection, sink: EventSink, direction: MessageDirection) -> Self {

--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -7,9 +7,10 @@
 //! [`PreparedEngine`] precomputes the enabled rule set once per [`Config`]
 //! (immutable after startup), then dispatches transactions and protocol events
 //! against it — building each rule's required cross-transaction history lazily
-//! from the [`StateStore`] and collecting the violations. It sits *above* the
+//! from the [`StateStore`](crate::state::StateStore) and collecting the
+//! violations. It sits *above* the
 //! rule catalogue and the query layer (it references both), so it lives in the
-//! rules crate rather than with the [`Violation`](crate::lint::Violation) data
+//! rules crate rather than with the [`Violation`] data
 //! type in core.
 
 use crate::config::Config;

--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -12,7 +12,7 @@ use crate::helpers::headers::split_commas_respecting_quotes;
 /// members without a leading scheme are treated as continuation parameters for
 /// the current challenge.
 ///
-/// Returns Ok(Vec<String>) on success or Err(String) describing a parsing
+/// Returns `Ok(Vec<String>)` on success or `Err(String)` describing a parsing
 /// problem: an empty member, or a parameter with no challenge before it. There
 /// was a third — *missing scheme on a member that starts with whitespace* — and
 /// it was the same problem read off a character the list grammar puts outside

--- a/lint-http-rules/src/helpers/domain.rs
+++ b/lint-http-rules/src/helpers/domain.rs
@@ -64,7 +64,7 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
 /// host name are one question however the name reached the reader — a cookie's
 /// `Domain` attribute, or the `dot-atom` half of an `addr-spec`, which RFC 5322
 /// § 3.4.1 says *"is interpreted as an Internet domain name … as described in
-/// [RFC1034], [RFC1035], and [RFC1123]"*. The second caller had a hand copy of
+/// \[RFC1034], \[RFC1035], and \[RFC1123]"*. The second caller had a hand copy of
 /// the same four checks with neither cite and without either length bound, so a
 /// 300-character domain was clean there and reported here.
 ///

--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -488,7 +488,7 @@ pub fn inm_matches_known(inm: &str, known: &str) -> bool {
 /// `If-Range` or range revalidation), use
 /// [`extract_strong_validators_from_response`] instead.
 ///
-/// See [`cache_validation_chain`] for an example consumer.
+/// See the `cache_validation_chain` rule for an example consumer.
 pub fn extract_validators_from_response(headers: &HeaderMap) -> (Option<String>, Option<String>) {
     (
         validator(headers, "etag"),
@@ -2079,8 +2079,8 @@ pub fn parameter_of(segment: &str) -> Option<Result<Parameter<'_>, ParameterDefe
 /// What is trimmed is the whole value (§ 5.5) and the run before the first
 /// semicolon, where `parameters` does print `OWS`.
 ///
-/// cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
-/// cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value."
+// cite(RFC 9110 § 5.6.6): "parameters      = *( OWS ";" OWS [ parameter ] )"
+// cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value."
 pub fn parse_media_type(val: &str) -> Result<ParsedMediaType<'_>, String> {
     let trimmed = trim_ows(val);
     if trimmed.is_empty() {

--- a/lint-http-rules/src/helpers/mailbox.rs
+++ b/lint-http-rules/src/helpers/mailbox.rs
@@ -30,11 +30,11 @@
 //! sentence licensing that is § 4's, which forbids *generating* them while
 //! requiring a receiver to parse them — this crate reports on senders.
 //!
-//! cite(RFC 9110 § 10.1.2): "mailbox = <mailbox, see [RFC5322], Section 3.4>"
-//! cite(RFC 5322 § 3.4): "mailbox = name-addr / addr-spec"
-//! cite(RFC 5322 § 3.4): "mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list"
-//! cite(RFC 5322 § 3.2.2): "FWS = ([*WSP CRLF] 1*WSP) / obs-FWS"
-//! cite(RFC 5322 § 4): "Though these syntactic forms MUST NOT be generated according to the grammar in section 3, they MUST be accepted and parsed by a conformant receiver."
+// cite(RFC 9110 § 10.1.2): "mailbox = <mailbox, see [RFC5322], Section 3.4>"
+// cite(RFC 5322 § 3.4): "mailbox = name-addr / addr-spec"
+// cite(RFC 5322 § 3.4): "mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list"
+// cite(RFC 5322 § 3.2.2): "FWS = ([*WSP CRLF] 1*WSP) / obs-FWS"
+// cite(RFC 5322 § 4): "Though these syntactic forms MUST NOT be generated according to the grammar in section 3, they MUST be accepted and parsed by a conformant receiver."
 
 use crate::helpers::headers::describe_char;
 
@@ -49,7 +49,7 @@ pub struct Mailbox {
     /// domain name"* and so has a host-name syntax behind it as well as this
     /// one, and a bracketed literal has an address inside it instead.
     ///
-    /// cite(RFC 5322 § 3.4.1): "In the dot-atom form, this is interpreted as an Internet domain name (either a host name or a mail exchanger name) as described in [RFC1034], [RFC1035], and [RFC1123]."
+    // cite(RFC 5322 § 3.4.1): "In the dot-atom form, this is interpreted as an Internet domain name (either a host name or a mail exchanger name) as described in [RFC1034], [RFC1035], and [RFC1123]."
     pub domain_name: Option<String>,
 }
 

--- a/lint-http-rules/src/lint_protocol.rs
+++ b/lint-http-rules/src/lint_protocol.rs
@@ -4,9 +4,9 @@
 
 //! Protocol-event linting entry point.
 //!
-//! Mirrors [`lint_transaction`](crate::lint::lint_transaction) but evaluates
+//! Mirrors [`lint_transaction`](crate::engine::lint_transaction) but evaluates
 //! [`ProtocolRule`](crate::rules::ProtocolRule) implementations against
-//! [`ProtocolEvent`](crate::protocol_event::ProtocolEvent) instances.
+//! [`ProtocolEvent`] instances.
 
 use crate::config::Config;
 use crate::engine::PreparedEngine;

--- a/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
+++ b/lint-http-rules/src/rules/sec_websocket_extensions_syntax.rs
@@ -271,7 +271,7 @@ impl Rule for SecWebsocketExtensionsSyntax {
     /// grammar, and its malformed-value MUST names *"either the client or the
     /// server"*.
     ///
-    /// cite(RFC 6455 § 9.1): "A client requests extensions by including a |Sec-WebSocket-Extensions| header field, which follows the normal rules for HTTP header fields (see [RFC2616], Section 4.2) and the value of the header field is defined by the following ABNF [RFC2616]."
+    // cite(RFC 6455 § 9.1): "A client requests extensions by including a |Sec-WebSocket-Extensions| header field, which follows the normal rules for HTTP header fields (see [RFC2616], Section 4.2) and the value of the header field is defined by the following ABNF [RFC2616]."
     fn scope(&self) -> crate::rules::RuleScope {
         crate::rules::RuleScope::Both
     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -2269,7 +2269,7 @@ sources:
     snippet: The endpoints of a connection MUST negotiate the use of any extensions during the opening handshake.
     cited_by:
     - file: lint-http-core/src/protocol_event.rs
-      line: 70
+      line: 72
     - file: lint-http-rules/src/rules/websocket_frame_opcode_sequence.rs
       line: 111
   - label: lint-http-core/src/protocol_event.rs (2)
@@ -2277,13 +2277,13 @@ sources:
     snippet: Note that the client is only offering to use any advertised extensions and MUST NOT use them unless the server indicates that it wishes to use the extension.
     cited_by:
     - file: lint-http-core/src/protocol_event.rs
-      line: 72
+      line: 74
   - label: lint-http-core/src/protocol_event.rs (3)
     section: § 9.1
     snippet: The extensions listed by the server in response represent the extensions actually in use for the connection.
     cited_by:
     - file: lint-http-core/src/protocol_event.rs
-      line: 71
+      line: 73
     - file: lint-http-proxy/src/proxy/websocket/mod.rs
       line: 73
     - file: lint-http-rules/src/rules/websocket_handshake_valid.rs

--- a/xtask/src/gendocs.rs
+++ b/xtask/src/gendocs.rs
@@ -4,7 +4,7 @@
 
 //! Documentation generator: renders `docs/rules/<id>.md` and the
 //! `docs/rules.md` index from rule metadata
-//! ([`Rule::description`](lint_http_rules::rules::Rule::description),
+//! ([`Rule::description`],
 //! [`specifications`](lint_http_rules::rules::Rule::specifications),
 //! [`examples`](lint_http_rules::rules::Rule::examples),
 //! [`title`](lint_http_rules::rules::Rule::title)) plus the per-rule

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Regenerate the rule documentation under <out>/ from rule metadata.
+    /// Regenerate the rule documentation under the --out directory from rule metadata.
     Gendocs(GendocsArgs),
 }
 


### PR DESCRIPTION
Twenty intra-doc links pointed at nothing, and nothing checked, so the docs for a tree whose comments carry its design record rendered with dead references.

Half were stale layout. `lint-http-core` still linked to `crate::engine`, `crate::rules::ProtocolRule` and `crate::lint_protocol::lint_protocol_event` — all of which moved to `lint-http-rules` in the workspace split. Core depends on no other crate, so those cannot be links at all; they now name the crate in prose, which is also the more honest rendering of a one-way arrow.

The rest were prose that markdown read as a link. `[RFC1034]` and its siblings appear inside quoted specification text, where the brackets belong to the document being quoted, and `[ parameter ]` is ABNF. Those quotes are verified byte-for-byte by the citation gate, so none of them were reworded: the cite lines move from `///` to `//`, which is where cites are written elsewhere in the tree anyway, and the prose paraphrase in `domain.rs` escapes its brackets. The cite count is unchanged at 2383.

Also cleared: three redundant explicit link targets, `Vec<String>` and `<out>` read as unclosed HTML, and a public item linking to a private `FrameObserver`. `RUSTDOCFLAGS="-D warnings" cargo doc` is now clean, which the next commit gates.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
