### PR TITLE
The documentation is a checked artifact, in CI and in just check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,15 @@ jobs:
       - name: Run lint
         run: cargo lint
 
+      # The doc comments in this tree are the design record — longer than the
+      # code in places, and the only written account of several decisions. That
+      # made them the one artifact nothing checked: twenty links resolved to
+      # nothing, some still describing the pre-workspace-split layout.
+      - name: Documentation builds without warnings
+        run: cargo doc --workspace --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -30,6 +30,11 @@ fmt-check:
 lint:
     cargo lint
 
+# The docs build with no warnings — dead intra-doc links included. The comments
+# here are the design record, so this checks the artifact they render into.
+doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
+
 # Workspace tests with all features.
 test:
     cargo test --workspace --all-features
@@ -63,7 +68,7 @@ supply-chain:
     cargo deny check advisories licenses
 
 # Everything CI rejects a PR for, cheapest checks first so failures surface early.
-check: fmt-check citations lint test
+check: fmt-check citations lint doc test
 
 # Enable the versioned pre-commit hook (points core.hooksPath at .githooks).
 install-hooks:


### PR DESCRIPTION
The previous commit made `cargo doc` clean. Nothing kept it that way: the docs were the one output of this tree that no gate looked at, which is how twenty links came to resolve to nothing and how some of them came to describe a crate layout two refactors old.

`RUSTDOCFLAGS="-D warnings"`, in the clippy job and in a `just doc` recipe that `just check` now runs. Both spellings, because a local `check` that passes what CI rejects is the drift the justfile already exists to stop.

Verified by planting a dead link: `just doc` exits 101.
