### PR TITLE
An expiry sweep happens at one instant

### DIFF
--- a/lint-http-core/src/protocol_event_store.rs
+++ b/lint-http-core/src/protocol_event_store.rs
@@ -10,7 +10,7 @@
 //! [`ProtocolEvent`] instead of `HttpTransaction`.
 
 use crate::protocol_event::ProtocolEvent;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -87,18 +87,26 @@ impl ProtocolEventStore {
         let ttl_chrono =
             chrono::Duration::from_std(self.ttl).unwrap_or_else(|_| chrono::Duration::seconds(0));
 
-        Self::cleanup_map(&self.by_connection, ttl_chrono);
-        Self::cleanup_map(&self.by_session, ttl_chrono);
+        // One reading of the clock for both maps, because they index the same
+        // events. Each `cleanup_map` used to read its own, so an event sitting
+        // exactly on the TTL boundary could be dropped from `by_connection` and
+        // kept in `by_session` — the two views of one connection disagreeing
+        // about what the store holds, for no reason but the microseconds
+        // between two lock acquisitions.
+        let now = Utc::now();
+        Self::cleanup_map(&self.by_connection, ttl_chrono, now);
+        Self::cleanup_map(&self.by_session, ttl_chrono, now);
     }
 
     fn cleanup_map(
         map: &Arc<RwLock<HashMap<Uuid, VecDeque<ProtocolEvent>>>>,
         ttl: chrono::Duration,
+        now: DateTime<Utc>,
     ) {
         let mut store = map.write();
         for deque in store.values_mut() {
             deque.retain(|evt| {
-                let age = Utc::now().signed_duration_since(evt.timestamp);
+                let age = now.signed_duration_since(evt.timestamp);
                 if age < chrono::Duration::zero() {
                     return false;
                 }

--- a/lint-http-core/src/state.rs
+++ b/lint-http-core/src/state.rs
@@ -246,9 +246,17 @@ impl StateStore {
         let ttl_chrono =
             chrono::Duration::from_std(self.ttl).unwrap_or_else(|_| chrono::Duration::seconds(0));
 
+        // One reading of the clock for the whole sweep, and it is the cutoff
+        // that matters rather than the syscall it saves. Read inside the
+        // closure, `now` advanced as the pass walked the store, so two entries
+        // with the same timestamp could be judged against different instants —
+        // the later deque held to a stricter deadline for no reason but its
+        // position in a HashMap iteration. A sweep is one moment.
+        let now = Utc::now();
+
         for deque in inner.store.values_mut() {
             deque.retain(|tx| {
-                let age = Utc::now().signed_duration_since(tx.timestamp);
+                let age = now.signed_duration_since(tx.timestamp);
                 // If timestamp is in the future (age < 0), treat as expired (remove)
                 if age < chrono::Duration::zero() {
                     return false;


### PR DESCRIPTION
Both stores read the clock inside the retain closure — once per stored transaction, once per stored event, under the write lock. The syscalls are the smaller half of it.

The larger half is that the cutoff moved while the sweep ran. Two entries with the same timestamp could be judged against different instants, the later deque held to a stricter deadline than the earlier one for no reason but where a HashMap iteration reached it.

`ProtocolEventStore` had the sharper version: `by_connection` and `by_session` index the same events, and each `cleanup_map` call read its own clock, so an event sitting on the TTL boundary could be dropped from one view and kept in the other. Two answers to "what does this connection hold", differing by the microseconds between two lock acquisitions.

One `now` per sweep, threaded through both maps.
