### PR TITLE
The transaction pipeline stops copying findings nobody reads

### DIFF
--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -33,9 +33,10 @@ where
     if req.method() == Method::CONNECT {
         if shared.ca.is_some() {
             let uri = req.uri().clone();
-            let shared = shared.clone();
-            let conn_metadata = conn_metadata.clone();
-
+            // `shared` and `conn_metadata` are owned `Arc`s and this branch
+            // returns, so the task takes them rather than a second handle to
+            // each. They were cloned here only because the surrounding function
+            // goes on to use them — down a path this branch never reaches.
             tokio::task::spawn(async move {
                 match hyper::upgrade::on(req).await {
                     Ok(upgraded) => {

--- a/lint-http-proxy/src/proxy/pipeline.rs
+++ b/lint-http-proxy/src/proxy/pipeline.rs
@@ -42,17 +42,27 @@ pub(super) struct TransactionPipeline {
 impl TransactionPipeline {
     /// Lint `tx` (populating `tx.violations`), record it to state, then write
     /// it to the capture file — in that order. Consumes the transaction so it
-    /// cannot be re-committed or mutated after capture; returns the
-    /// violations for callers that need them.
-    pub(super) async fn commit(&self, mut tx: HttpTransaction) -> Vec<Violation> {
+    /// cannot be re-committed or mutated after capture.
+    ///
+    /// Returns nothing, and that is the point. This used to hand back a clone
+    /// of `tx.violations`, taken here because the transaction moves into the
+    /// writer on the next line — a full `Vec<Violation>` deep-copied on every
+    /// transaction the proxy handles. No caller ever read it: all four
+    /// production call sites invoke this in statement position, and the two
+    /// that wanted the findings were tests, which now read them from the two
+    /// places `commit` actually puts them.
+    ///
+    /// The violations remain available where they belong: on the recorded
+    /// transaction in the [`StateStore`], and in the capture line. A caller
+    /// needing them for a *response* has the transaction before it commits.
+    ///
+    /// [`StateStore`]: crate::state::StateStore
+    pub(super) async fn commit(&self, mut tx: HttpTransaction) {
         tx.violations = self.engine.lint_transaction(&tx, &self.state);
         self.state.record_transaction(&tx);
-        // Extract violations before moving the transaction into the writer.
-        let violations = tx.violations.clone();
         if let Err(e) = self.captures.write_transaction(tx).await {
             warn!(error = %e, "failed to write transaction capture");
         }
-        violations
     }
 }
 
@@ -139,17 +149,19 @@ mod tests {
         let (shared, tmp, cw) = make_shared_with_cfg(Arc::new(cfg_inner), None, &mut temp).await?;
 
         let tx = make_test_transaction_with_response(200, &[]);
-        let violations = shared.pipeline().commit(tx).await;
+        shared.pipeline().commit(tx).await;
 
-        assert!(!violations.is_empty());
-
+        // Read the findings from the capture rather than from a return value:
+        // the capture line is where `commit` puts them, so asserting on it
+        // checks the thing the proxy actually produces. Both enabled rules fire
+        // on a 200 carrying neither `Cache-Control` nor a validator.
         cw.flush().await?;
         let entries = read_capture(&tmp).await?;
         assert_eq!(entries.len(), 1);
         let captured = entries[0]["violations"]
             .as_array()
             .expect("violations array in capture");
-        assert_eq!(captured.len(), violations.len());
+        assert_eq!(captured.len(), 2);
 
         let _ = fs::remove_file(&tmp).await;
         Ok(())
@@ -167,13 +179,14 @@ mod tests {
         let tx = make_test_transaction_with_response(200, &[]);
         let client = tx.client.clone();
         let uri = tx.request.uri.clone();
-        let violations = shared.pipeline().commit(tx).await;
+        shared.pipeline().commit(tx).await;
 
         // The recorded copy carries the lint result, proving record ran
-        // after lint populated `tx.violations`.
+        // after lint populated `tx.violations`. A recorded transaction with an
+        // empty `violations` would be the ordering bug this test exists for.
         let history = shared.state.get_history(&client, &uri);
         assert_eq!(history.len(), 1);
-        assert_eq!(history[0].violations.len(), violations.len());
+        assert_eq!(history[0].violations.len(), 2);
 
         let _ = fs::remove_file(&tmp).await;
         Ok(())


### PR DESCRIPTION
`TransactionPipeline::commit` deep-copied `tx.violations` on every transaction the proxy handled. The clone was there because the transaction moves into the capture writer on the next line, and the comment said it was "for callers that need them".

No caller needed them. All four production call sites — two in the WebSocket handshake, two in the error-exchange path — invoke `commit` in statement position and drop the result. The only readers were two tests in this file.

So `commit` returns `()`, and the tests read the findings from the two places it actually puts them: the capture line and the recorded transaction in the state store. Both assertions got stronger in the process. They compared a length against a length from the same lint run, which held equally well if every rule had gone silent; they now name the number of findings the two enabled rules produce for a 200 with neither `Cache-Control` nor a validator.

Also on the CONNECT path: `shared` and `conn_metadata` are owned `Arc`s and the branch returns, so the spawned task takes them instead of a second handle.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
