### PR TITLE
Strong and weak validators are one module that keeps them apart

### DIFF
--- a/lint-http-rules/src/helpers/headers.rs
+++ b/lint-http-rules/src/helpers/headers.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: ISC
 
-use crate::helpers::list::{list_members, split_commas_respecting_quotes};
-use crate::helpers::quoted_string::{unescape_quoted_string, validate_quoted_string};
+use crate::helpers::list::list_members;
+use crate::helpers::quoted_string::unescape_quoted_string;
 use crate::helpers::shown::describe_char;
 use hyper::HeaderMap;
 
@@ -296,169 +296,9 @@ pub fn trim_ows(s: &str) -> &str {
     s.trim_matches(|c| c == ' ' || c == '\t')
 }
 
-/// Weak-compare an `If-None-Match` header value against a known ETag.
-///
-/// Returns `true` if the ETag is present in the comma-separated list of
-/// values.  The comparison ignores leading `W/` prefixes to emulate HTTP's
-/// weak comparison rules.  A lone `"*"` value is treated as **not** matching;
-/// it represents an existence condition rather than a specific validator.
-pub fn inm_matches_known(inm: &str, known: &str) -> bool {
-    fn normalize(s: &str) -> &str {
-        let s = s.trim();
-        // cite(RFC 9110 § 13.1.2, label: If-None-Match weak comparison): "A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match"
-        if let Some(rest) = s.strip_prefix("W/") {
-            rest.trim()
-        } else {
-            s
-        }
-    }
-
-    let known_norm = normalize(known);
-    for member in split_commas_respecting_quotes(inm) {
-        let t = member.trim();
-        if t == "*" {
-            return false;
-        }
-        if normalize(t) == known_norm {
-            return true;
-        }
-    }
-    false
-}
-
-/// Extract validator values from a response's headers, **including weak
-/// ETags**.
-///
-/// This variant is appropriate for semantics that allow weak comparison
-/// (e.g. `If-None-Match` handling).  The tuple is `(etag, last_modified)` and
-/// each component is the trimmed string value if present.  No filtering of
-/// weak tags is performed; callers should apply the appropriate comparison
-/// rules themselves.
-///
-/// For rules that require *strong-only* validators (such as those dealing with
-/// `If-Range` or range revalidation), use
-/// [`extract_strong_validators_from_response`] instead.
-///
-/// See the `cache_validation_chain` rule for an example consumer.
-pub fn extract_validators_from_response(headers: &HeaderMap) -> (Option<String>, Option<String>) {
-    (
-        validator(headers, "etag"),
-        validator(headers, "last-modified"),
-    )
-}
-
-/// One validator field, trimmed, if the response carries a readable one.
-fn validator(headers: &HeaderMap, name: &str) -> Option<String> {
-    get_header_str(headers, name).map(|value| value.trim().to_string())
-}
-
-/// Extract **strong** validators from a response's headers.
-///
-/// This is the original implementation of [`extract_validators_from_response`];
-/// it filters out weak ETags (`W/` prefix) because they are not suitable for
-/// certain cache validation scenarios.  Rules that do not accept weak ETags
-/// (for example, `range_request_and_caching`) should call this
-/// helper instead of `extract_validators_from_response`.
-pub fn extract_strong_validators_from_response(
-    headers: &HeaderMap,
-) -> (Option<String>, Option<String>) {
-    // Exactly the pair above with the weak ETags dropped, which is what the
-    // paragraphs on both functions say the difference is. `Last-Modified` is
-    // not filtered here: whether a timestamp is a strong validator depends on
-    // the origin's clock resolution, not on anything visible in the field.
-    let (etag, last_modified) = extract_validators_from_response(headers);
-    (etag.filter(|etag| !etag.starts_with("W/")), last_modified)
-}
-
-/// Strip an optional weak (`W/`) prefix from an ETag value, leaving the
-/// quoted-string intact.
-///
-/// Reducing both sides to their opaque-tag and comparing those character by
-/// character *is* weak comparison -- that is the sentence below, and it is the
-/// only thing this function is good for. It must not be used to prepare a strong
-/// comparison: the `W/` it discards is exactly what strong comparison turns on.
-///
-/// The pointer that stood here read "RFC 9111 §5.3.2". RFC 9111 § 5.3 is
-/// Expires and has no § 5.3.2 -- the section numbering goes straight to § 5.4,
-/// Pragma. So it was not merely the wrong document, it named nothing at all.
-///
-/// The resulting string is trimmed but otherwise returned verbatim.
-///
-// cite(RFC 9110 § 8.8.3.2): "two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak"."
-pub fn normalize_etag(s: &str) -> String {
-    let trimmed = s.trim();
-    if trimmed.len() >= 2 && (trimmed.starts_with("W/") || trimmed.starts_with("w/")) {
-        trimmed[2..].trim().to_string()
-    } else {
-        trimmed.to_string()
-    }
-}
-
-#[cfg(test)]
-mod validator_extraction_tests {
-    use super::extract_strong_validators_from_response;
-    use super::extract_validators_from_response;
-    use hyper::header::HeaderValue;
-    use hyper::HeaderMap;
-
-    #[test]
-    fn strong_etag_and_last_modified_are_returned() {
-        let mut headers = HeaderMap::new();
-        headers.insert("etag", HeaderValue::from_static("\"abc\""));
-        headers.insert(
-            "last-modified",
-            HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"),
-        );
-        let (etag, lm) = extract_validators_from_response(&headers);
-        assert_eq!(etag.as_deref(), Some("\"abc\""));
-        assert_eq!(lm.as_deref(), Some("Wed, 21 Oct 2015 07:28:00 GMT"));
-    }
-
-    #[test]
-    fn weak_etag_is_returned() {
-        let mut headers = HeaderMap::new();
-        headers.insert("etag", HeaderValue::from_static("W/\"weak\""));
-        let (etag, lm) = extract_validators_from_response(&headers);
-        assert_eq!(etag.as_deref(), Some("W/\"weak\""));
-        assert!(lm.is_none());
-    }
-
-    #[test]
-    fn strong_helper_filters_weak_etag() {
-        let mut headers = HeaderMap::new();
-        headers.insert("etag", HeaderValue::from_static("W/\"weak\""));
-        let (etag, lm): (Option<String>, Option<String>) =
-            extract_strong_validators_from_response(&headers);
-        assert!(etag.is_none(), "strong helper should ignore weak etag");
-        assert!(lm.is_none());
-    }
-
-    #[test]
-    fn missing_headers_return_none() {
-        let headers = HeaderMap::new();
-        let (etag, lm) = extract_validators_from_response(&headers);
-        assert!(etag.is_none());
-        assert!(lm.is_none());
-    }
-
-    #[test]
-    fn non_utf8_headers_are_skipped() {
-        let mut headers = HeaderMap::new();
-        // create invalid bytes
-        let bad = HeaderValue::from_bytes(&[0xff]).unwrap();
-        headers.insert("etag", bad);
-        let (etag, _lm) = extract_validators_from_response(&headers);
-        assert!(
-            etag.is_none(),
-            "invalid etag should not panic or return value"
-        );
-    }
-}
-
 #[cfg(test)]
 mod concat_header_tests {
     use super::get_all_header_values;
-    use super::inm_matches_known;
     use hyper::header::HeaderValue;
     use hyper::HeaderMap;
 
@@ -492,14 +332,6 @@ mod concat_header_tests {
             Some("bar".to_string())
         );
         assert_eq!(get_all_header_values(&headers, "bar"), None);
-    }
-
-    #[test]
-    fn inm_matches_known_behaviour() {
-        assert!(inm_matches_known("\"a\"", "\"a\""));
-        assert!(inm_matches_known("W/\"a\"", "\"a\""));
-        assert!(!inm_matches_known("\"b\"", "\"a\""));
-        assert!(!inm_matches_known("*", "\"a\""));
     }
 }
 /// Field names that cannot appear in a trailer section, by category.
@@ -756,7 +588,7 @@ pub enum WordDefect {
 /// The content returned is what the field means by the value: a `token` as
 /// written, a `quoted-string` after `quoted-pair` substitution. A caller that
 /// only judges the value may discard it — [`unescape_quoted_string`] opens by
-/// asking [`validate_quoted_string`], so the two accept exactly the same strings
+/// asking [`validate_quoted_string`](crate::helpers::quoted_string::validate_quoted_string), so the two accept exactly the same strings
 /// and the `Err` is the same `Err`.
 ///
 /// RFC 7230 named this pair `word`; RFC 9110 kept both halves and dropped the
@@ -992,33 +824,6 @@ pub fn validate_ext_value(val: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Validate an entity-tag, which may be weak (prefix `W/`). Returns `Ok(())` on
-/// success or `Err(msg)` describing the problem.
-///
-/// **`*` is not one, and this function used to say it was.** The production has
-/// two parts and neither generates it; the `*` belongs to `If-Match` and
-/// `If-None-Match`, whose own grammars are `"*" / #entity-tag` — an alternation,
-/// so there the `*` is the **whole field value** and never a member of the list.
-/// Accepting it here put it in both places at once, and every caller answered
-/// that the same way: three of the five excluded `*` on the line before calling
-/// (`etag_syntax` with a finding of its own, `range_request_and_caching`
-/// with a `return`), and the two that did not were the two the `*` was
-/// ostensibly for — where it made `If-None-Match: "abc", *` a conforming list.
-/// **A tolerance that every honest caller has to undo is not a tolerance.**
-// cite(RFC 9110 § 8.8.3): "An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator."
-pub fn validate_entity_tag(val: &str) -> Result<(), String> {
-    // cite(RFC 9110 § 8.8.3, label: entity-tag grammar): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
-    let s = val.trim();
-
-    let rest = if let Some(stripped) = s.strip_prefix("W/") {
-        stripped
-    } else {
-        s
-    };
-    // rest must be a quoted-string
-    validate_quoted_string(rest)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1195,24 +1000,6 @@ mod tests {
             token_or_quoted_string(&bare),
             Err(WordDefect::NotToken('\u{E9}'))
         );
-    }
-
-    // Entity-tag helper tests
-    #[test]
-    fn validate_entity_tag_cases() {
-        // The production is `[ weak ] opaque-tag` and neither part generates a
-        // `*`. This asserted the opposite, which is how `If-None-Match: "abc", *`
-        // passed as a conforming list; the `*` is the *other* alternative of the
-        // two conditional fields' own grammars, and each of them decides it on
-        // the whole field value now.
-        assert!(validate_entity_tag("*").is_err());
-        assert!(validate_entity_tag("\"abc\"").is_ok());
-        // `etagc` admits the comma, so this is one tag and not two.
-        assert!(validate_entity_tag("\"a,b\"").is_ok());
-        assert!(validate_entity_tag("W/\"abc\"").is_ok());
-        assert!(validate_entity_tag(" W/\"abc\" ").is_ok()); // leading/trailing whitespace tolerated
-        assert!(validate_entity_tag("abc").is_err()); // missing quotes
-        assert!(validate_entity_tag("W/abc").is_err()); // weak prefix without quoted-string
     }
 
     /// `%` is not an attr-char. It reaches this function only as the opening of a

--- a/lint-http-rules/src/helpers/mod.rs
+++ b/lint-http-rules/src/helpers/mod.rs
@@ -62,5 +62,6 @@ pub mod status;
 pub mod structured_fields;
 pub mod token;
 pub mod uri;
+pub mod validator;
 pub mod vary;
 pub mod websocket;

--- a/lint-http-rules/src/helpers/validator.rs
+++ b/lint-http-rules/src/helpers/validator.rs
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Validators: the `ETag` and `Last-Modified` a response offers, and how a
+//! request's `If-None-Match` is compared against one.
+//!
+//! **Strong and weak are two questions, and the module keeps them apart.**
+//! [`extract_validators_from_response`] answers "what did this response offer",
+//! [`extract_strong_validators_from_response`] answers the narrower "what may a
+//! `Range` or `If-Range` turn on" — a weak validator is a validator, and is
+//! still not one of those. [`normalize_etag`] strips the `W/` and is therefore
+//! only ever the *weak* comparison; the prefix it discards is exactly what a
+//! strong comparison turns on, which is why it must not be used to prepare one.
+//!
+//! [`validate_entity_tag`] is the grammar underneath all of it.
+
+use crate::helpers::headers::get_header_str;
+use crate::helpers::list::split_commas_respecting_quotes;
+use crate::helpers::quoted_string::validate_quoted_string;
+use hyper::HeaderMap;
+
+/// Weak-compare an `If-None-Match` header value against a known ETag.
+///
+/// Returns `true` if the ETag is present in the comma-separated list of
+/// values.  The comparison ignores leading `W/` prefixes to emulate HTTP's
+/// weak comparison rules.  A lone `"*"` value is treated as **not** matching;
+/// it represents an existence condition rather than a specific validator.
+pub fn inm_matches_known(inm: &str, known: &str) -> bool {
+    fn normalize(s: &str) -> &str {
+        let s = s.trim();
+        // cite(RFC 9110 § 13.1.2, label: If-None-Match weak comparison): "A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match"
+        if let Some(rest) = s.strip_prefix("W/") {
+            rest.trim()
+        } else {
+            s
+        }
+    }
+
+    let known_norm = normalize(known);
+    for member in split_commas_respecting_quotes(inm) {
+        let t = member.trim();
+        if t == "*" {
+            return false;
+        }
+        if normalize(t) == known_norm {
+            return true;
+        }
+    }
+    false
+}
+
+/// Extract validator values from a response's headers, **including weak
+/// ETags**.
+///
+/// This variant is appropriate for semantics that allow weak comparison
+/// (e.g. `If-None-Match` handling).  The tuple is `(etag, last_modified)` and
+/// each component is the trimmed string value if present.  No filtering of
+/// weak tags is performed; callers should apply the appropriate comparison
+/// rules themselves.
+///
+/// For rules that require *strong-only* validators (such as those dealing with
+/// `If-Range` or range revalidation), use
+/// [`extract_strong_validators_from_response`] instead.
+///
+/// See the `cache_validation_chain` rule for an example consumer.
+pub fn extract_validators_from_response(headers: &HeaderMap) -> (Option<String>, Option<String>) {
+    (
+        validator(headers, "etag"),
+        validator(headers, "last-modified"),
+    )
+}
+
+/// One validator field, trimmed, if the response carries a readable one.
+fn validator(headers: &HeaderMap, name: &str) -> Option<String> {
+    get_header_str(headers, name).map(|value| value.trim().to_string())
+}
+
+/// Extract **strong** validators from a response's headers.
+///
+/// This is the original implementation of [`extract_validators_from_response`];
+/// it filters out weak ETags (`W/` prefix) because they are not suitable for
+/// certain cache validation scenarios.  Rules that do not accept weak ETags
+/// (for example, `range_request_and_caching`) should call this
+/// helper instead of `extract_validators_from_response`.
+pub fn extract_strong_validators_from_response(
+    headers: &HeaderMap,
+) -> (Option<String>, Option<String>) {
+    // Exactly the pair above with the weak ETags dropped, which is what the
+    // paragraphs on both functions say the difference is. `Last-Modified` is
+    // not filtered here: whether a timestamp is a strong validator depends on
+    // the origin's clock resolution, not on anything visible in the field.
+    let (etag, last_modified) = extract_validators_from_response(headers);
+    (etag.filter(|etag| !etag.starts_with("W/")), last_modified)
+}
+
+/// Strip an optional weak (`W/`) prefix from an ETag value, leaving the
+/// quoted-string intact.
+///
+/// Reducing both sides to their opaque-tag and comparing those character by
+/// character *is* weak comparison -- that is the sentence below, and it is the
+/// only thing this function is good for. It must not be used to prepare a strong
+/// comparison: the `W/` it discards is exactly what strong comparison turns on.
+///
+/// The pointer that stood here read "RFC 9111 §5.3.2". RFC 9111 § 5.3 is
+/// Expires and has no § 5.3.2 -- the section numbering goes straight to § 5.4,
+/// Pragma. So it was not merely the wrong document, it named nothing at all.
+///
+/// The resulting string is trimmed but otherwise returned verbatim.
+///
+// cite(RFC 9110 § 8.8.3.2): "two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak"."
+pub fn normalize_etag(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.len() >= 2 && (trimmed.starts_with("W/") || trimmed.starts_with("w/")) {
+        trimmed[2..].trim().to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Validate an entity-tag, which may be weak (prefix `W/`). Returns `Ok(())` on
+/// success or `Err(msg)` describing the problem.
+///
+/// **`*` is not one, and this function used to say it was.** The production has
+/// two parts and neither generates it; the `*` belongs to `If-Match` and
+/// `If-None-Match`, whose own grammars are `"*" / #entity-tag` — an alternation,
+/// so there the `*` is the **whole field value** and never a member of the list.
+/// Accepting it here put it in both places at once, and every caller answered
+/// that the same way: three of the five excluded `*` on the line before calling
+/// (`etag_syntax` with a finding of its own, `range_request_and_caching`
+/// with a `return`), and the two that did not were the two the `*` was
+/// ostensibly for — where it made `If-None-Match: "abc", *` a conforming list.
+/// **A tolerance that every honest caller has to undo is not a tolerance.**
+// cite(RFC 9110 § 8.8.3): "An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator."
+pub fn validate_entity_tag(val: &str) -> Result<(), String> {
+    // cite(RFC 9110 § 8.8.3, label: entity-tag grammar): "entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE"
+    let s = val.trim();
+
+    let rest = if let Some(stripped) = s.strip_prefix("W/") {
+        stripped
+    } else {
+        s
+    };
+    // rest must be a quoted-string
+    validate_quoted_string(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::header::HeaderValue;
+
+    #[test]
+    fn strong_etag_and_last_modified_are_returned() {
+        let mut headers = HeaderMap::new();
+        headers.insert("etag", HeaderValue::from_static("\"abc\""));
+        headers.insert(
+            "last-modified",
+            HeaderValue::from_static("Wed, 21 Oct 2015 07:28:00 GMT"),
+        );
+        let (etag, lm) = extract_validators_from_response(&headers);
+        assert_eq!(etag.as_deref(), Some("\"abc\""));
+        assert_eq!(lm.as_deref(), Some("Wed, 21 Oct 2015 07:28:00 GMT"));
+    }
+
+    #[test]
+    fn weak_etag_is_returned() {
+        let mut headers = HeaderMap::new();
+        headers.insert("etag", HeaderValue::from_static("W/\"weak\""));
+        let (etag, lm) = extract_validators_from_response(&headers);
+        assert_eq!(etag.as_deref(), Some("W/\"weak\""));
+        assert!(lm.is_none());
+    }
+
+    #[test]
+    fn strong_helper_filters_weak_etag() {
+        let mut headers = HeaderMap::new();
+        headers.insert("etag", HeaderValue::from_static("W/\"weak\""));
+        let (etag, lm): (Option<String>, Option<String>) =
+            extract_strong_validators_from_response(&headers);
+        assert!(etag.is_none(), "strong helper should ignore weak etag");
+        assert!(lm.is_none());
+    }
+
+    #[test]
+    fn missing_headers_return_none() {
+        let headers = HeaderMap::new();
+        let (etag, lm) = extract_validators_from_response(&headers);
+        assert!(etag.is_none());
+        assert!(lm.is_none());
+    }
+
+    #[test]
+    fn non_utf8_headers_are_skipped() {
+        let mut headers = HeaderMap::new();
+        // create invalid bytes
+        let bad = HeaderValue::from_bytes(&[0xff]).unwrap();
+        headers.insert("etag", bad);
+        let (etag, _lm) = extract_validators_from_response(&headers);
+        assert!(
+            etag.is_none(),
+            "invalid etag should not panic or return value"
+        );
+    }
+
+    #[test]
+    fn inm_matches_known_behaviour() {
+        assert!(inm_matches_known("\"a\"", "\"a\""));
+        assert!(inm_matches_known("W/\"a\"", "\"a\""));
+        assert!(!inm_matches_known("\"b\"", "\"a\""));
+        assert!(!inm_matches_known("*", "\"a\""));
+    }
+
+    // Entity-tag helper tests
+    #[test]
+    fn validate_entity_tag_cases() {
+        // The production is `[ weak ] opaque-tag` and neither part generates a
+        // `*`. This asserted the opposite, which is how `If-None-Match: "abc", *`
+        // passed as a conforming list; the `*` is the *other* alternative of the
+        // two conditional fields' own grammars, and each of them decides it on
+        // the whole field value now.
+        assert!(validate_entity_tag("*").is_err());
+        assert!(validate_entity_tag("\"abc\"").is_ok());
+        // `etagc` admits the comma, so this is one tag and not two.
+        assert!(validate_entity_tag("\"a,b\"").is_ok());
+        assert!(validate_entity_tag("W/\"abc\"").is_ok());
+        assert!(validate_entity_tag(" W/\"abc\" ").is_ok()); // leading/trailing whitespace tolerated
+        assert!(validate_entity_tag("abc").is_err()); // missing quotes
+        assert!(validate_entity_tag("W/abc").is_err()); // weak prefix without quoted-string
+    }
+}

--- a/lint-http-rules/src/rules/cache_validation_chain.rs
+++ b/lint-http-rules/src/rules/cache_validation_chain.rs
@@ -101,7 +101,7 @@ impl Rule for CacheValidationChain {
             let (etag, last_modified) = history
                 .responses()
                 .map(|(_, resp)| {
-                    crate::helpers::headers::extract_validators_from_response(&resp.headers)
+                    crate::helpers::validator::extract_validators_from_response(&resp.headers)
                 })
                 .find(|(etag, last_modified)| etag.is_some() || last_modified.is_some())?;
 
@@ -113,7 +113,7 @@ impl Rule for CacheValidationChain {
             if let Some(known_etag) = etag {
                 if has_inm
                     && !inm_lines()
-                        .any(|line| crate::helpers::headers::inm_matches_known(line, &known_etag))
+                        .any(|line| crate::helpers::validator::inm_matches_known(line, &known_etag))
                 {
                     // A field line that is not text matched nothing, and is what
                     // the finding has to quote when it is all the request sent.

--- a/lint-http-rules/src/rules/etag_syntax.rs
+++ b/lint-http-rules/src/rules/etag_syntax.rs
@@ -74,7 +74,7 @@ impl Rule for EtagSyntax {
                 }
 
                 // The entity-tag grammar itself (§8.8.3) is owned by `validate_entity_tag`.
-                if let Err(msg) = crate::helpers::headers::validate_entity_tag(t) {
+                if let Err(msg) = crate::helpers::validator::validate_entity_tag(t) {
                     return Some(
                         self.violation(ctx.severity, format!("ETag header invalid: {}", msg)),
                     );

--- a/lint-http-rules/src/rules/head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/head_response_headers_match_get.rs
@@ -62,7 +62,7 @@ fn selected_representation_changed(prev: &hyper::HeaderMap, cur: &hyper::HeaderM
 
     // Entity tags compare by opaque-tag, which is `normalize_etag`'s § 8.8.3.2
     // weak comparison; `Last-Modified` is an HTTP-date and compares as written.
-    differs("etag", crate::helpers::headers::normalize_etag)
+    differs("etag", crate::helpers::validator::normalize_etag)
         || differs("last-modified", str::to_string)
 }
 

--- a/lint-http-rules/src/rules/if_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -103,7 +103,7 @@ impl Rule for IfMatchEtagSyntax {
                         "If-Match header contains an empty list element".into(),
                     ));
                 }
-                if let Err(msg) = crate::helpers::headers::validate_entity_tag(member) {
+                if let Err(msg) = crate::helpers::validator::validate_entity_tag(member) {
                     return Some(self.violation(
                         ctx.severity,
                         format!(

--- a/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+++ b/lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -104,7 +104,7 @@ impl Rule for IfNoneMatchEtagSyntax {
                         "If-None-Match header contains an empty list element".into(),
                     ));
                 }
-                if let Err(msg) = crate::helpers::headers::validate_entity_tag(member) {
+                if let Err(msg) = crate::helpers::validator::validate_entity_tag(member) {
                     return Some(self.violation(
                         ctx.severity,
                         format!(

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -92,7 +92,7 @@ impl Rule for NoStoreEnforced {
                 let is_no_store = header_has_no_store(&resp.headers);
 
                 if let Some(etag) = crate::helpers::headers::get_header_str(&resp.headers, "etag") {
-                    let normalized = crate::helpers::headers::normalize_etag(etag);
+                    let normalized = crate::helpers::validator::normalize_etag(etag);
                     if seen_etags.insert(normalized.clone()) && is_no_store {
                         no_store_etags.insert(normalized);
                     }
@@ -117,7 +117,7 @@ impl Rule for NoStoreEnforced {
             // HeaderMap.get_all() returns all values in order.
             for s in crate::helpers::headers::field_lines(&tx.request.headers, "if-none-match") {
                 for member in crate::helpers::list::list_members(s) {
-                    let normalized = crate::helpers::headers::normalize_etag(member);
+                    let normalized = crate::helpers::validator::normalize_etag(member);
                     // A validator echoed back from a no-store response is proof the client
                     // stored the thing it was told not to store.
                     // cite(RFC 9111 § 5.2.2.5): "The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request."

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -76,7 +76,7 @@ impl Rule for PrivateCacheVisibility {
                 .filter_map(|(_, resp)| {
                     crate::helpers::headers::get_header_str(&resp.headers, "etag")
                 })
-                .map(crate::helpers::headers::normalize_etag)
+                .map(crate::helpers::validator::normalize_etag)
                 .collect();
             let private_last_modified: Vec<chrono::DateTime<chrono::Utc>> = private_responses()
                 .filter_map(|(_, resp)| {
@@ -99,7 +99,7 @@ impl Rule for PrivateCacheVisibility {
                 .filter_map(|hv| hv.to_str().ok())
                 .flat_map(crate::helpers::list::list_members)
             {
-                if private_etags.contains(&crate::helpers::headers::normalize_etag(member)) {
+                if private_etags.contains(&crate::helpers::validator::normalize_etag(member)) {
                     return Some(self.cited(
                         &RFC_9111_5_2_2_7,
                         ctx.severity,

--- a/lint-http-rules/src/rules/range_request_and_caching.rs
+++ b/lint-http-rules/src/rules/range_request_and_caching.rs
@@ -147,7 +147,7 @@ impl Rule for RangeRequestAndCaching {
             for past in history.iter() {
                 if let Some(resp) = &past.response {
                     let (etag, last_modified) =
-                        crate::helpers::headers::extract_validators_from_response(&resp.headers);
+                        crate::helpers::validator::extract_validators_from_response(&resp.headers);
                     if etag.is_some() || last_modified.is_some() {
                         newest_validators = Some((etag, last_modified));
                         break;
@@ -178,7 +178,7 @@ impl Rule for RangeRequestAndCaching {
             // charging one party for another's field. The `stored_etag == "*"` beside
             // this was a workaround for `validate_entity_tag` admitting a `*`, which
             // no `entity-tag` generates; the helper answers it now.
-            if crate::helpers::headers::validate_entity_tag(&stored_etag).is_err() {
+            if crate::helpers::validator::validate_entity_tag(&stored_etag).is_err() {
                 return None;
             }
 
@@ -655,7 +655,7 @@ mod tests {
                 // date would make *both* halves false and fail the `!=` below
                 // with a message about the value not being either — so the fix
                 // is the example, not this line.
-                let tag_ok = crate::helpers::headers::validate_entity_tag(value).is_ok();
+                let tag_ok = crate::helpers::validator::validate_entity_tag(value).is_ok();
                 let date_ok = crate::http_date::is_valid_imf_fixdate(value);
                 match name.to_ascii_lowercase().as_str() {
                     "etag" | "if-none-match" => {

--- a/lint-http-rules/src/rules/vary_header_cache_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_cache_valid.rs
@@ -133,7 +133,7 @@ impl Rule for VaryHeaderCacheValid {
                             // `If-None-Match: "eta` / `If-None-Match: g1"` two
                             // members where § 5.2 makes them one entity-tag.
                             if let Some(inm) = inm_value.as_deref() {
-                                if crate::helpers::headers::inm_matches_known(inm, etag) {
+                                if crate::helpers::validator::inm_matches_known(inm, etag) {
                                     matched_past = Some(past);
                                     matched_validator = Some(etag.trim().to_string());
                                     break;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3902,25 +3902,25 @@ sources:
     snippet: attr-char     = ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" ; token except ( "*" / "'" / "%" )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 979
+      line: 811
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 3.2.1
     snippet: ext-value = charset  "'" [ language ] "'" value-chars
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 920
+      line: 752
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 3.2.1
     snippet: pct-encoded   = "%" HEXDIG HEXDIG
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 958
+      line: 790
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 3.2.1
     snippet: value-chars   = *( pct-encoded / attr-char )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 951
+      line: 783
 - label: RFC 8246
   url: https://www.rfc-editor.org/rfc/rfc8246.html
   fragments:
@@ -4301,7 +4301,7 @@ sources:
     snippet: An Early-Data header field MUST NOT be included in responses or request trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 596
+      line: 428
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
       line: 162
     - file: lint-http-rules/src/rules/early_data_header_safe_method.rs
@@ -6211,7 +6211,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 22
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 628
+      line: 460
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 40
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs
@@ -6223,7 +6223,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 125
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 663
+      line: 495
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
       line: 109
   - label: lint-http-proxy/src/proxy/websocket/handshake.rs
@@ -6383,7 +6383,7 @@ sources:
     - file: lint-http-rules/src/helpers/headers.rs
       line: 104
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 705
+      line: 537
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 54
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -6617,35 +6617,29 @@ sources:
     snippet: Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 612
+      line: 444
   - label: lint-http-rules/src/helpers/headers.rs (2)
     section: § 11.7.3
     snippet: Proxy-Authentication-Info can be sent as a trailer field (Section 6.5) when the authentication scheme explicitly allows this.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 613
+      line: 445
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 888
+      line: 720
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 193
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 141
-  - label: If-None-Match weak comparison
-    section: § 13.1.2
-    snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
-    cited_by:
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 308
   - label: lint-http-rules/src/helpers/headers.rs (3)
     section: § 16.3.2
     snippet: If the field is allowable in trailers; by default, it will not be (see Section 6.5.1).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 533
+      line: 365
   - label: lint-http-rules/src/helpers/headers.rs (4)
     section: § 5
     snippet: Fields are sent and received within the header and trailer sections of messages
@@ -6661,7 +6655,7 @@ sources:
     snippet: Field names are case-insensitive
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 661
+      line: 493
     - file: lint-http-rules/src/helpers/vary.rs
       line: 78
   - label: lint-http-rules/src/helpers/headers.rs (6)
@@ -6687,7 +6681,7 @@ sources:
     snippet: a sender MUST NOT generate multiple field lines with the same name in a message (whether in the headers or trailers) or append a field line when a field line of the same name already exists in the message, unless that field's definition allows multiple field line values to be recombined as a comma-separated list
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 706
+      line: 538
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 28
     - file: lint-http-rules/src/rules/conditional_headers_consistent.rs
@@ -6757,7 +6751,7 @@ sources:
     snippet: Fields that only anticipate a single member as the field value are referred to as "singleton fields".
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 703
+      line: 535
     - file: lint-http-rules/src/rules/content_disposition_token_valid.rs
       line: 159
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
@@ -6767,7 +6761,7 @@ sources:
     snippet: This is true for both list-based and singleton fields, since a singleton field might be erroneously sent with multiple members and detecting such errors improves interoperability.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 704
+      line: 536
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 253
   - label: lint-http-rules/src/helpers/headers.rs (12)
@@ -6781,7 +6775,7 @@ sources:
     snippet: Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}").
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 768
+      line: 600
     - file: lint-http-rules/src/helpers/list.rs
       line: 121
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
@@ -6795,7 +6789,7 @@ sources:
     snippet: token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 769
+      line: 601
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -6867,7 +6861,7 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 829
+      line: 661
   - label: lint-http-rules/src/helpers/headers.rs (16)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
@@ -6879,7 +6873,7 @@ sources:
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 770
+      line: 602
     - file: lint-http-rules/src/helpers/list.rs
       line: 199
     - file: lint-http-rules/src/helpers/list.rs
@@ -6919,7 +6913,7 @@ sources:
     snippet: A sender MUST NOT generate a trailer field unless the sender knows the corresponding header field name's definition permits the field to be sent in trailers.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 532
+      line: 364
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 44
     - file: lint-http-rules/src/rules/post_creates_resource.rs
@@ -6947,31 +6941,7 @@ sources:
     snippet: Many fields cannot be processed outside the header section because their evaluation is necessary prior to receiving the content, such as those that describe message framing, routing, authentication, request modifiers, response controls, or content format.
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 531
-  - label: lint-http-rules/src/helpers/headers.rs (21)
-    section: § 8.8.3
-    snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
-    cited_by:
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 1008
-    - file: lint-http-rules/src/rules/etag_syntax.rs
-      line: 70
-    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
-      line: 72
-    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
-      line: 73
-  - label: entity-tag grammar
-    section: § 8.8.3
-    snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
-    cited_by:
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 1010
-  - label: lint-http-rules/src/helpers/headers.rs (22)
-    section: § 8.8.3.2
-    snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
-    cited_by:
-    - file: lint-http-rules/src/helpers/headers.rs
-      line: 387
+      line: 363
   - label: lint-http-rules/src/helpers/list.rs
     section: § 5.6.1.2
     snippet: '#element => [ element ] *( OWS "," OWS [ element ] )'
@@ -7292,6 +7262,36 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 382
+  - label: If-None-Match weak comparison
+    section: § 13.1.2
+    snippet: A recipient MUST use the weak comparison function when comparing entity tags for If-None-Match
+    cited_by:
+    - file: lint-http-rules/src/helpers/validator.rs
+      line: 32
+  - label: lint-http-rules/src/helpers/validator.rs
+    section: § 8.8.3
+    snippet: An entity tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.
+    cited_by:
+    - file: lint-http-rules/src/helpers/validator.rs
+      line: 134
+    - file: lint-http-rules/src/rules/etag_syntax.rs
+      line: 70
+    - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
+      line: 72
+    - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
+      line: 73
+  - label: entity-tag grammar
+    section: § 8.8.3
+    snippet: entity-tag = [ weak ] opaque-tag weak = %s"W/" opaque-tag = DQUOTE *etagc DQUOTE
+    cited_by:
+    - file: lint-http-rules/src/helpers/validator.rs
+      line: 136
+  - label: lint-http-rules/src/helpers/validator.rs (2)
+    section: § 8.8.3.2
+    snippet: two entity tags are equivalent if their opaque-tags match character-by-character, regardless of either or both being tagged as "weak".
+    cited_by:
+    - file: lint-http-rules/src/helpers/validator.rs
+      line: 111
   - label: Vary grammar
     section: § 12.5.5
     snippet: 'Vary = #( "*" / field-name )'
@@ -10146,7 +10146,7 @@ sources:
     snippet: This includes the Connection header field and those listed as having connection-specific semantics in Section 7.6.1 of [HTTP] (that is, Proxy-Connection, Keep-Alive, Transfer-Encoding, and Upgrade).
     cited_by:
     - file: lint-http-rules/src/helpers/headers.rs
-      line: 586
+      line: 418
     - file: lint-http-rules/src/rules/no_connection_specific_fields.rs
       line: 39
     - file: lint-http-rules/src/rules/upgrade_and_connection_consistent.rs


### PR DESCRIPTION
`ETag`, `Last-Modified`, and the `If-None-Match` comparison, with the distinction that matters kept visible in the names. `extract_validators_from_response` answers what a response offered; `extract_strong_validators_from_response` answers the narrower question of what a `Range` or `If-Range` may turn on. A weak validator is a validator and is still not one of those, so the two are separate functions rather than one with a flag.

`normalize_etag` comes along and its warning comes with it: stripping `W/` *is* weak comparison, and the prefix it discards is exactly what a strong comparison turns on — so it must never be used to prepare one.

Removed on the way out: a `#[cfg(test)] mod validator_extraction_tests` left holding nothing but four `use` lines once its tests moved.

headers.rs: 2344 → 788 non-test lines, from 70 top-level items to 20.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
