### PR TITLE
The cookie Path and Domain defects have names

### DIFF
--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -4,6 +4,59 @@
 
 //! Cookie-related helpers used by cookie-related rules.
 
+/// The ways a `Set-Cookie` `Path` attribute fails, named rather than described.
+///
+/// The two halves are not the same kind of finding, and the type is what makes
+/// that legible. [`Empty`](Self::Empty) and [`NotAbsolute`](Self::NotAbsolute)
+/// are not *syntax* errors at all — RFC 6265 § 5.2.4 has the user agent replace
+/// such a value with the default-path, so the cookie still works and the server
+/// has merely written something that does nothing. The remaining four are
+/// grammar: § 4.1.1's `path-value` admits neither of them.
+///
+/// A caller that wants to report the two halves differently now can. Before
+/// this was an enum, one of the tests below asked
+/// `msg.contains("should start with '/'") || msg.contains("invalid")` — an `||`
+/// that exists precisely because a `String` cannot say which defect it is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CookiePathDefect<'a> {
+    /// No value after trimming. § 5.2.4 substitutes the default-path.
+    Empty,
+    /// Present but not rooted at `/`; § 5.2.4 substitutes the default-path.
+    /// Carries the value **as written**, untrimmed, because that is what the
+    /// server sent and the trim is this function's own tolerance.
+    NotAbsolute(&'a str),
+    /// A `%` that no two hex digits follow. Delegated to
+    /// [`crate::helpers::uri::check_percent_encoding`], which owns the
+    /// production and phrases this one.
+    PercentEncoding(String),
+    /// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
+    /// non-ASCII derives from nothing and has to be percent-encoded.
+    NonAscii(usize),
+    /// A `CTL`, which `path-value` excludes by name. HTAB is one of these, not
+    /// a [`Whitespace`](Self::Whitespace).
+    ControlCharacter(usize),
+    /// SP, which `CHAR` admits and this profile does not. Stricter than the
+    /// grammar on purpose.
+    Whitespace(usize),
+}
+
+impl CookiePathDefect<'_> {
+    /// The finding fragment. Callers embed this in a sentence naming the
+    /// attribute, which is why it does not name it itself.
+    pub fn message(&self) -> String {
+        match self {
+            Self::Empty => "Path attribute is empty".to_string(),
+            Self::NotAbsolute(written) => {
+                format!("Path should start with '/': '{written}'")
+            }
+            Self::PercentEncoding(msg) => msg.clone(),
+            Self::NonAscii(at) => format!("Path contains non-ASCII character at byte {at}"),
+            Self::ControlCharacter(at) => format!("Path contains control character at byte {at}"),
+            Self::Whitespace(at) => format!("Path contains whitespace character at byte {at}"),
+        }
+    }
+}
+
 /// Validate a `Path` attribute value from a `Set-Cookie` header.
 ///
 /// Rules enforced:
@@ -12,7 +65,12 @@
 /// - Must not contain ASCII control characters (0x00-0x1F or 0x7F)
 /// - Must not contain literal whitespace characters (space, tab)
 /// - Percent-encodings ("%" followed by two hex digits) are accepted
-pub fn validate_cookie_path(s: &str) -> Result<(), String> {
+///
+/// The byte offsets in the character defects count into the **trimmed** value,
+/// while [`CookiePathDefect::NotAbsolute`] carries the value as written. That
+/// asymmetry was already here when the errors were strings; naming the variants
+/// is what made it visible enough to write down.
+pub fn validate_cookie_path(s: &str) -> Result<(), CookiePathDefect<'_>> {
     let v = s.trim();
     // Empty and non-`/` values are not a *syntax* error: §5.2.4 has the user
     // agent replace them with the default-path. That semantics is cited at the
@@ -20,15 +78,15 @@ pub fn validate_cookie_path(s: &str) -> Result<(), String> {
     // latent misconfiguration they are and go on to enforce the character
     // grammar below.
     if v.is_empty() {
-        return Err("Path attribute is empty".into());
+        return Err(CookiePathDefect::Empty);
     }
     if !v.starts_with('/') {
-        return Err(format!("Path should start with '/': '{}'", s));
+        return Err(CookiePathDefect::NotAbsolute(s));
     }
 
     // Validate percent-encodings using shared helper to avoid duplicate logic
     if let Some(msg) = crate::helpers::uri::check_percent_encoding(v) {
-        return Err(msg);
+        return Err(CookiePathDefect::PercentEncoding(msg));
     }
 
     // The loop holds the server to §4.1.1's `path-value = <any CHAR except CTLs
@@ -43,15 +101,15 @@ pub fn validate_cookie_path(s: &str) -> Result<(), String> {
         let b = bytes[i];
         // Reject non-ASCII bytes (require percent-encoding for non-ASCII)
         if b >= 0x80 {
-            return Err(format!("Path contains non-ASCII character at byte {}", i));
+            return Err(CookiePathDefect::NonAscii(i));
         }
         // Reject control chars and DEL
         if b <= 0x1f || b == 0x7f {
-            return Err(format!("Path contains control character at byte {}", i));
+            return Err(CookiePathDefect::ControlCharacter(i));
         }
         // Reject ASCII space and horizontal tab explicitly
         if b == b' ' || b == b'\t' {
-            return Err(format!("Path contains whitespace character at byte {}", i));
+            return Err(CookiePathDefect::Whitespace(i));
         }
         i += 1;
     }

--- a/lint-http-rules/src/helpers/domain.rs
+++ b/lint-http-rules/src/helpers/domain.rs
@@ -13,12 +13,88 @@
 //! which hands the `dot-atom` form of an `addr-spec`'s domain to RFC 1034,
 //! RFC 1035 and RFC 1123 by name.
 
+/// The ways RFC 1035's *preferred name syntax* is not met.
+///
+/// Typed because this function has two callers reading two different documents
+/// — a cookie's `Domain` attribute and the `dot-atom` half of an `addr-spec` —
+/// and a shared answer that hands back prose forces both to embed a sentence
+/// written for neither. Naming the defects lets each caller word its own
+/// finding while agreeing about what went wrong.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreferredNameDefect {
+    /// More than 255 octets in the name as a whole.
+    // cite(RFC 1035 § 2.3.4): "names 255 octets or less"
+    TooLong,
+    /// A `.` with nothing between it and its neighbour.
+    EmptyLabel,
+    /// A single label over 63 octets.
+    // cite(RFC 1035 § 2.3.1): "Labels must be 63 characters or less."
+    LabelTooLong,
+    /// A label opening or closing on `-`. Only the hyphen is checked at the
+    /// ends: § 2.3.1 wanted a letter first, and RFC 1123 § 2 relaxed that to a
+    /// letter *or a digit*, so `1.example.com` is not this function's to refuse.
+    LabelHyphenAtEdge,
+    /// A label octet outside letters, digits and hyphen.
+    LabelBadCharacter,
+}
+
+impl PreferredNameDefect {
+    /// The finding fragment. Every caller embeds this after naming the field it
+    /// read the name out of.
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::TooLong => "domain total length exceeds 255 characters",
+            Self::EmptyLabel => "domain contains empty label",
+            Self::LabelTooLong => "domain label exceeds 63 characters",
+            Self::LabelHyphenAtEdge => "domain label must not start or end with '-'",
+            Self::LabelBadCharacter => "domain label contains invalid character",
+        }
+    }
+}
+
+/// The ways a cookie `Domain` attribute fails.
+///
+/// The first five are this attribute's own rules; [`PreferredName`](Self::PreferredName)
+/// is the shared syntax underneath, kept as a distinct variant so a caller can
+/// tell "you sent an IP address, which a `Domain` may never be" apart from "this
+/// is a domain name and it is malformed".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CookieDomainDefect {
+    /// Nothing there after trimming.
+    Empty,
+    /// Only the tolerated leading dot was there.
+    EmptyAfterLeadingDot,
+    /// Whitespace or a control character anywhere in the value.
+    WhitespaceOrControl,
+    /// A bracketed IPv6 literal.
+    Ipv6Literal,
+    /// Four or more dot-separated all-digit labels — an IPv4 address. The
+    /// four-label floor is what keeps `1.2` from being read as one.
+    Ipv4Address,
+    /// A well-formed-looking domain that fails the preferred name syntax.
+    PreferredName(PreferredNameDefect),
+}
+
+impl CookieDomainDefect {
+    /// The finding fragment.
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::Empty => "empty domain",
+            Self::EmptyAfterLeadingDot => "domain empty after removing leading dot",
+            Self::WhitespaceOrControl => "domain contains whitespace or control characters",
+            Self::Ipv6Literal => "domain must not be an IPv6 literal",
+            Self::Ipv4Address => "domain must not be an IPv4 address",
+            Self::PreferredName(defect) => defect.message(),
+        }
+    }
+}
+
 /// Validate a domain name suitable for a cookie `Domain` attribute.
-/// Returns Ok(()) when syntactically valid, or Err(reason) describing why invalid.
-pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
+/// Returns Ok(()) when syntactically valid, or the named defect.
+pub fn validate_cookie_domain(s: &str) -> Result<(), CookieDomainDefect> {
     let s = s.trim();
     if s.is_empty() {
-        return Err("empty domain".into());
+        return Err(CookieDomainDefect::Empty);
     }
 
     // Leading dot is historically allowed; tolerate and remove it for validation
@@ -29,17 +105,17 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
     };
 
     if s.is_empty() {
-        return Err("domain empty after removing leading dot".into());
+        return Err(CookieDomainDefect::EmptyAfterLeadingDot);
     }
 
     // No whitespace or control characters
     if s.chars().any(|c| c.is_control() || c.is_whitespace()) {
-        return Err("domain contains whitespace or control characters".into());
+        return Err(CookieDomainDefect::WhitespaceOrControl);
     }
 
     // Reject bracketed IPv6 literal
     if s.starts_with('[') && s.ends_with(']') {
-        return Err("domain must not be an IPv6 literal".into());
+        return Err(CookieDomainDefect::Ipv6Literal);
     }
 
     // Quick IPv4-like check: only digits and dots and at least one dot
@@ -47,12 +123,12 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
     if maybe_ipv4 {
         // To avoid false positives like '1.2', require at least 4 dot-separated labels
         if s.split('.').count() >= 4 {
-            return Err("domain must not be an IPv4 address".into());
+            return Err(CookieDomainDefect::Ipv4Address);
         }
     }
 
     match preferred_name_syntax_defect(s) {
-        Some(defect) => Err(defect),
+        Some(defect) => Err(CookieDomainDefect::PreferredName(defect)),
         None => Ok(()),
     }
 }
@@ -77,19 +153,19 @@ pub fn validate_cookie_domain(s: &str) -> Result<(), String> {
 /// than this function: RFC 1035 § 2.3.1 offers the syntax as the one that *"will
 /// result in fewer problems"*, so a name outside it can still be a conforming
 /// `dot-atom`.
-pub fn preferred_name_syntax_defect(s: &str) -> Option<String> {
+pub fn preferred_name_syntax_defect(s: &str) -> Option<PreferredNameDefect> {
     // cite(RFC 1035 § 2.3.4): "names 255 octets or less"
     if s.len() > 255 {
-        return Some("domain total length exceeds 255 characters".into());
+        return Some(PreferredNameDefect::TooLong);
     }
 
     for label in s.split('.') {
         if label.is_empty() {
-            return Some("domain contains empty label".into());
+            return Some(PreferredNameDefect::EmptyLabel);
         }
         // cite(RFC 1035 § 2.3.1): "Labels must be 63 characters or less."
         if label.len() > 63 {
-            return Some("domain label exceeds 63 characters".into());
+            return Some(PreferredNameDefect::LabelTooLong);
         }
         let first = label.chars().next().expect("label verified non-empty");
         let last = label.chars().next_back().expect("label verified non-empty");
@@ -101,10 +177,10 @@ pub fn preferred_name_syntax_defect(s: &str) -> Option<String> {
         // cite(RFC 1035 § 2.3.1): "end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
         // cite(RFC 1123 § 2): "the restriction on the first character is relaxed to allow either a letter or a digit."
         if first == '-' || last == '-' {
-            return Some("domain label must not start or end with '-'".into());
+            return Some(PreferredNameDefect::LabelHyphenAtEdge);
         }
         if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-            return Some("domain label contains invalid character".into());
+            return Some(PreferredNameDefect::LabelBadCharacter);
         }
     }
 
@@ -157,8 +233,8 @@ mod tests {
     fn a_label_over_63_characters_is_a_defect() {
         let long = format!("{}.example", "a".repeat(64));
         assert_eq!(
-            preferred_name_syntax_defect(&long).as_deref(),
-            Some("domain label exceeds 63 characters")
+            preferred_name_syntax_defect(&long),
+            Some(PreferredNameDefect::LabelTooLong)
         );
     }
 

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -85,7 +85,11 @@ impl Rule for CookieDomainValid {
                                 return Some(self.cited(
                                     &RFC_6265_5_2_3,
                                     ctx.severity,
-                                    format!("Invalid Set-Cookie Domain attribute '{}': {}", val, e),
+                                    format!(
+                                        "Invalid Set-Cookie Domain attribute '{}': {}",
+                                        val,
+                                        e.message()
+                                    ),
                                 ));
                             }
                         }

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -85,10 +85,13 @@ impl Rule for CookiePathValid {
                             }
                         };
 
-                        if let Err(e) = crate::helpers::cookie::validate_cookie_path(v) {
+                        if let Err(defect) = crate::helpers::cookie::validate_cookie_path(v) {
                             return Some(self.violation(
                                 ctx.severity,
-                                format!("Set-Cookie attribute 'Path' invalid: {}", e),
+                                format!(
+                                    "Set-Cookie attribute 'Path' invalid: {}",
+                                    defect.message()
+                                ),
                             ));
                         }
                     }
@@ -180,12 +183,22 @@ mod tests {
         assert!(v.unwrap().message.contains("requires a value"));
     }
 
+    /// The rule still reports through a message, so the message is asserted —
+    /// but the defect underneath is now named, and that is what this checks.
+    /// It read `contains("should start with '/'") || contains("invalid")`, an
+    /// `||` that passed if *any* defect fired, including one about a control
+    /// character. A `String` gave it nothing better to ask.
     #[test]
     fn not_starting_with_slash_reports() {
+        use crate::helpers::cookie::{validate_cookie_path, CookiePathDefect};
+        assert_eq!(
+            validate_cookie_path("login"),
+            Err(CookiePathDefect::NotAbsolute("login"))
+        );
+
         let v = check_set_cookie("SID=1; Path=login");
         assert!(v.is_some());
-        let msg = v.unwrap().message;
-        assert!(msg.contains("should start with '/'") || msg.contains("invalid"));
+        assert!(v.unwrap().message.contains("should start with '/'"));
     }
 
     #[test]

--- a/lint-http-rules/src/rules/from_header_email_syntax.rs
+++ b/lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -224,7 +224,7 @@ impl Rule for FromHeaderEmailSyntax {
                     violation(format!(
                         "From names the domain '{}', which is a conforming `dot-atom` but not an Internet domain name in RFC 1035 §2.3.1's preferred syntax: {}. This is advice, not a violation — RFC 5322 §3.4.1 hands the domain to the host-name documents rather than restricting it itself, and RFC 9110 §10.1.2 asks only that the address be machine-usable",
                         shown_in_finding(&domain),
-                        defect
+                        defect.message()
                     ))
                 }
                 Err(MailboxDefect::ListSeparator) => {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -802,19 +802,23 @@ sources:
     snippet: Labels must be 63 characters or less.
     cited_by:
     - file: lint-http-rules/src/helpers/domain.rs
-      line: 90
+      line: 31
+    - file: lint-http-rules/src/helpers/domain.rs
+      line: 166
   - label: lint-http-rules/src/helpers/domain.rs (2)
     section: § 2.3.1
     snippet: end with a letter or digit, and have as interior characters only letters, digits, and hyphen.
     cited_by:
     - file: lint-http-rules/src/helpers/domain.rs
-      line: 101
+      line: 177
   - label: lint-http-rules/src/helpers/domain.rs (3)
     section: § 2.3.4
     snippet: names 255 octets or less
     cited_by:
     - file: lint-http-rules/src/helpers/domain.rs
-      line: 81
+      line: 26
+    - file: lint-http-rules/src/helpers/domain.rs
+      line: 157
 - label: RFC 1123
   url: https://www.rfc-editor.org/rfc/rfc1123.html
   fragments:
@@ -823,7 +827,7 @@ sources:
     snippet: the restriction on the first character is relaxed to allow either a letter or a digit.
     cited_by:
     - file: lint-http-rules/src/helpers/domain.rs
-      line: 102
+      line: 178
 - label: RFC 2045
   url: https://www.rfc-editor.org/rfc/rfc2045.html
   fragments:
@@ -2089,67 +2093,67 @@ sources:
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 39
+      line: 97
   - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 4.1.1
     snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 158
+      line: 216
   - label: lint-http-rules/src/helpers/cookie.rs (3)
     section: § 4.1.1
     snippet: set-cookie-string = cookie-pair *( ";" SP cookie-av )
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 184
+      line: 242
   - label: cookie domain-match
     section: § 5.1.3
     snippet: A string domain-matches a given domain string if at least one of the following conditions hold
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 109
+      line: 167
   - label: cookie path-match
     section: § 5.1.4
     snippet: A request-path path-matches a given cookie-path if at least one of the following conditions holds
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 129
+      line: 187
   - label: lint-http-rules/src/helpers/cookie.rs (4)
     section: § 5.1.4
     snippet: If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 238
+      line: 296
   - label: lint-http-rules/src/helpers/cookie.rs (5)
     section: § 5.1.4
     snippet: Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 242
+      line: 300
   - label: lint-http-rules/src/helpers/cookie.rs (6)
     section: § 5.1.4
     snippet: 'The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 226
+      line: 284
   - label: lint-http-rules/src/helpers/cookie.rs (7)
     section: § 5.1.4
     snippet: output %x2F ("/") and skip the remaining steps.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 234
+      line: 292
   - label: lint-http-rules/src/helpers/cookie.rs (8)
     section: § 5.2.1
     snippet: If the attribute-name case-insensitively matches the string "Expires", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 166
+      line: 224
   - label: cookie Path attribute
     section: § 5.2.4
     snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 288
+      line: 346
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
       line: 76
   - label: lint-http-rules/src/helpers/cookie.rs (9)
@@ -2157,15 +2161,15 @@ sources:
     snippet: Set the cookie's host-only-flag to true.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 208
+      line: 266
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 327
+      line: 385
   - label: lint-http-rules/src/helpers/cookie.rs (10)
     section: § 5.4
     snippet: The cookie's host-only-flag is true and the canonicalized request-host is identical to the cookie's domain.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 120
+      line: 178
   - label: trace_method_echo
     section: § 4.2.1
     snippet: The user agent sends stored cookies to the origin server in the Cookie header.


### PR DESCRIPTION
Three enums where there were three `Result<_, String>`s, following the model `QuotedStringDefect` set: a variant per distinct failure, each carrying the sentence that makes it one, and a `message()` that owns the wording.

`PreferredNameDefect` is the one that most needed it. RFC 1035's preferred name syntax has two callers reading two different documents — a cookie's `Domain`, and the `dot-atom` half of an `addr-spec` that RFC 5322 § 3.4.1 hands to the host-name RFCs by name — and a shared answer returning prose forces both to embed a sentence written for neither.

`CookieDomainDefect` keeps `PreferredName` as its own variant rather than flattening it, so a caller can tell "a `Domain` may never be an IP address" apart from "this is a domain name and it is malformed". Those are different things to tell someone.

The payoff is visible in a test that could not previously be written. It read

    assert!(msg.contains("should start with '/'") || msg.contains("invalid"));

and that `||` was not caution — a `String` gave it nothing better to ask, so it passed if *any* defect fired, a control-character finding included. It now asserts `Err(CookiePathDefect::NotAbsolute("login"))`.

Recorded while naming them: the byte offsets in the Path character defects count into the trimmed value while `NotAbsolute` carries the value as written. That asymmetry predates this commit; naming the variants is what made it visible enough to write down.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
