### PR TITLE
Three tests wait for the record instead of for 200 milliseconds

### DIFF
--- a/lint-http-proxy/src/proxy/http.rs
+++ b/lint-http-proxy/src/proxy/http.rs
@@ -689,6 +689,10 @@ mod tests {
         let port = listener.local_addr()?.port();
         let server_task = tokio::spawn(async move {
             if let Ok((socket, _)) = listener.accept().await {
+                // Load-bearing: the origin holds the connection open long
+                // enough for the client to start sending, then drops it
+                // mid-stream. The delay *is* the condition under test, not a
+                // wait for one — there is nothing to poll for.
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                 drop(socket);
             }
@@ -1234,15 +1238,13 @@ mod tests {
         // Verify upgrade headers are forwarded
         assert!(resp.headers().get("upgrade").is_some());
 
-        // Give the relay task time to start and check captures
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-        _cw.flush().await?;
-        let content = tokio::fs::read_to_string(&tmp).await?;
-        assert!(!content.is_empty());
-        // The 101 transaction should be recorded
-        let first_line = content.lines().next().unwrap();
-        let v: serde_json::Value = serde_json::from_str(first_line)?;
+        // The 101's commit is detached, like a streamed body's, so wait for the
+        // record rather than for 200ms and hope. The sleep this replaces was
+        // followed by a `flush()`, which cannot help: flushing writes what is
+        // already queued, and the question here is whether the relay task has
+        // queued anything yet.
+        let entries = read_captures_after_stream(&_cw, &tmp).await?;
+        let v = &entries[0];
         assert_eq!(v["response"]["status"].as_u64(), Some(101));
         assert_eq!(v["was_upgraded"].as_bool(), Some(true));
         assert_eq!(v["upgrade_protocol"].as_str(), Some("websocket"));

--- a/lint-http-proxy/src/proxy/test_support.rs
+++ b/lint-http-proxy/src/proxy/test_support.rs
@@ -108,8 +108,13 @@ pub(super) async fn drain_and_read_captures(
     read_captures_after_stream(cw, path).await
 }
 
-/// Poll the capture file until the streamed transaction's commit task has
-/// landed (the commit is detached, firing after the body finishes streaming).
+/// Flush, then poll the capture file until a detached commit has landed.
+///
+/// Two shapes need this and both are detached: a streamed body commits after
+/// the body finishes, and an upgrade commits from the relay task. `flush()`
+/// alone answers neither — it writes what is already queued, and the question
+/// is whether the commit has queued anything yet. A fixed sleep answers it only
+/// on a machine fast enough not to have needed one.
 pub(super) async fn read_captures_after_stream(
     cw: &CaptureWriter,
     path: &str,

--- a/lint-http-proxy/tests/proxy_h3_integration.rs
+++ b/lint-http-proxy/tests/proxy_h3_integration.rs
@@ -180,6 +180,38 @@ async fn start_proxy_with_h3(
     })
 }
 
+/// Read the capture file once at least `want` record(s) have reached it,
+/// polling to a deadline rather than sleeping a guessed interval.
+///
+/// The two callers below used `sleep(200ms)`, which is two failures in one: it
+/// costs 200ms on a fast machine that was ready immediately, and it races on a
+/// loaded CI runner that was not. The writer flushes on its own schedule, so
+/// the only honest wait is for the record itself. Both sibling suites —
+/// `proxy_websocket_relay` and `proxy_upstream_h3_integration` — already do
+/// this; this file was the one left guessing.
+async fn read_captures_when_ready(
+    path: impl AsRef<std::path::Path>,
+    want: usize,
+) -> anyhow::Result<Vec<serde_json::Value>> {
+    let deadline = std::time::Instant::now() + startup_timeout();
+    loop {
+        let content = tokio::fs::read_to_string(path.as_ref())
+            .await
+            .unwrap_or_default();
+        let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+        if lines.len() >= want {
+            return lines.iter().map(|l| Ok(serde_json::from_str(l)?)).collect();
+        }
+        if std::time::Instant::now() > deadline {
+            return Err(anyhow::anyhow!(
+                "timed out waiting for {want} capture record(s); saw {}",
+                lines.len()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 /// Send a single HTTP/3 GET request via quinn+h3, return status and body.
 ///
 /// The H3 connection driver is awaited before returning so no background tasks
@@ -317,15 +349,8 @@ async fn h3_happy_path_forwards_request_and_captures() -> anyhow::Result<()> {
     // x-custom should be forwarded (not a hop-by-hop header)
     assert!(headers.iter().any(|(k, v)| k == "x-custom" && v == "value"));
 
-    // Give captures time to flush
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Verify captures file
-    let content = tokio::fs::read_to_string(&captures_path).await?;
-    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
-    assert!(!lines.is_empty(), "captures file should not be empty");
-
-    let v: serde_json::Value = serde_json::from_str(lines[0])?;
+    let entries = read_captures_when_ready(&captures_path, 1).await?;
+    let v = &entries[0];
     assert_eq!(v["response"]["status"].as_u64(), Some(200));
     assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3.0"));
     // connection_id and sequence_number should be set
@@ -362,15 +387,10 @@ async fn h3_upstream_error_returns_502_and_records_transaction() -> anyhow::Resu
 
     assert_eq!(status, 502);
 
-    // Give captures time to flush
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // The error transaction should still be recorded
-    let content = tokio::fs::read_to_string(&captures_path).await?;
-    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
-    assert!(!lines.is_empty(), "error transaction should be captured");
-
-    let v: serde_json::Value = serde_json::from_str(lines[0])?;
+    // The error transaction is still recorded, so waiting for one record is
+    // waiting for exactly the thing under test.
+    let entries = read_captures_when_ready(&captures_path, 1).await?;
+    let v = &entries[0];
     assert_eq!(v["response"]["status"].as_u64(), Some(502));
     assert_eq!(v["request"]["version"].as_str(), Some("HTTP/3.0"));
     assert!(v["connection_id"].as_str().is_some());


### PR DESCRIPTION
Each of these read a capture file after `sleep(200ms)`, which is two failures in one: it costs 200ms on a machine that was ready immediately, and it races on a loaded runner that was not.

The `proxy_h3_integration` pair get a deadline-polling reader. Both sibling suites already had one — `proxy_websocket_relay`'s comment even says it polls "rather than relying on a fixed sleep (which races on a slow/loaded CI runner)" — so this file was the one left guessing.

The upgrade test in `proxy::http` needed no new code at all: `read_captures_after_stream` already flushes and polls, and the test simply did not call it. Its sleep was followed by a `flush()`, which cannot help — flushing writes what is already queued, and the question there is whether the relay task has queued anything yet. Same shape as a streamed body's detached commit, so the helper's doc now names both.

The sleeps that stay are annotated as load-bearing rather than left to look like the ones just removed: a mock origin holding a connection open before dropping it mid-stream, a 60s stall that exists so a client timeout fires, a pause that makes a GOAWAY rather than a close refuse a retry. In those the delay *is* the condition under test, and there is nothing to poll for.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
