### PR TITLE
The clone gate is on, and its sibling is turned down on the record

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,20 @@ repository = "https://github.com/alganet/lint-http"
 [workspace.lints.clippy]
 cognitive_complexity = "warn"
 
+# Also nursery, also enabled here for the same reason: a clone nothing reads is
+# invisible in review and costs a deep copy at runtime. The two production sites
+# it found were a `Vec<Violation>` copied on every transaction the proxy handled
+# and two `Arc`s on the CONNECT path; the other 69 were in test modules, which
+# is exactly where an unread clone survives longest because nothing is watching.
+#
+# Its sibling `significant_drop_tightening` was assessed and **deliberately not
+# enabled**. Its 25 findings are all requests to shorten a lock scope, and the
+# scopes it objects to are long on purpose — `StateStore::record_transaction`
+# holds one lock across every index update precisely so they cannot be seen
+# apart, which the `Inner` doc comment states. Enabling it would buy nothing and
+# cost either `#[allow]`s or a worse design.
+redundant_clone = "warn"
+
 # No hand-written `unsafe` anywhere, enforced rather than merely true. A linter
 # is a poor place to reach for it: every byte here arrives from a socket and is
 # parsed against a grammar, which is exactly where a manual bounds argument is

--- a/lint-http-core/src/state.rs
+++ b/lint-http-core/src/state.rs
@@ -449,13 +449,13 @@ mod tests {
 
         use crate::test_helpers::make_test_transaction_with_response;
         let mut tx1 = make_test_transaction_with_response(200, &[("etag", "\"e1\"")]);
-        tx1.client = client1.clone();
+        tx1.client = client1;
         tx1.request.uri = resource.to_string();
         tx1.timestamp = chrono::Utc::now();
         store.record_transaction(&tx1);
 
         let mut tx2 = make_test_transaction_with_response(200, &[("etag", "\"e2\"")]);
-        tx2.client = client2.clone();
+        tx2.client = client2;
         tx2.request.uri = resource.to_string();
         tx2.timestamp = chrono::Utc::now() + chrono::Duration::seconds(1);
         store.record_transaction(&tx2);
@@ -574,13 +574,13 @@ mod tests {
 
         let mut tx1 =
             crate::test_helpers::make_test_transaction_with_response(200, &[("etag", "\"a\"")]);
-        tx1.client = client1.clone();
+        tx1.client = client1;
         tx1.request.uri = resource.to_string();
         store.record_transaction(&tx1);
 
         let mut tx2 =
             crate::test_helpers::make_test_transaction_with_response(200, &[("etag", "\"b\"")]);
-        tx2.client = client2.clone();
+        tx2.client = client2;
         tx2.request.uri = resource.to_string();
         store.record_transaction(&tx2);
 
@@ -791,7 +791,7 @@ mod tests {
         store.record_transaction(&tx1);
 
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(201, &[]);
-        tx2.client = client2.clone();
+        tx2.client = client2;
         tx2.request.uri = "http://example.com/a".to_string();
         store.record_transaction(&tx2);
 
@@ -820,7 +820,7 @@ mod tests {
 
         // Different connection
         let mut tx3 = crate::test_helpers::make_test_transaction_with_response(202, &[]);
-        tx3.client = client.clone();
+        tx3.client = client;
         tx3.request.uri = "http://example.com/c".to_string();
         tx3.connection_id = Some(uuid::Uuid::new_v4());
         store.record_transaction(&tx3);
@@ -849,7 +849,7 @@ mod tests {
         let conn_id = uuid::Uuid::new_v4();
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        tx.client = client.clone();
+        tx.client = client;
         tx.request.uri = "http://example.com/x".to_string();
         tx.connection_id = Some(conn_id);
         store.record_transaction(&tx);
@@ -866,7 +866,7 @@ mod tests {
         let conn_id = uuid::Uuid::new_v4();
 
         let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
-        tx.client = client.clone();
+        tx.client = client;
         tx.request.uri = "http://example.com/conn-cleanup".to_string();
         tx.connection_id = Some(conn_id);
         store.record_transaction(&tx);

--- a/lint-http-core/src/transaction_history.rs
+++ b/lint-http-core/src/transaction_history.rs
@@ -127,7 +127,7 @@ mod tests {
         // timestamp than tx2.  This avoids debug assertions in debug builds.
         tx1.timestamp = tx2.timestamp + chrono::Duration::seconds(1);
 
-        let h = TransactionHistory::from_transactions(vec![tx1.clone(), tx2.clone()]);
+        let h = TransactionHistory::from_transactions(vec![tx1.clone(), tx2]);
 
         assert!(!h.is_empty());
         assert_eq!(h.len(), 2);

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -597,10 +597,8 @@ mod tests {
         let mut t2 = t2;
         t2.timestamp = ts - chrono::Duration::seconds(10);
         // history newest first order is provided by constructor
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
-            t2.clone(),
-            t1.clone(),
-        ]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![t2, t1]);
         let store = build_cookie_store(&history, ts);
         assert_eq!(store.len(), 1);
         assert_eq!(store[0].value, "two");

--- a/lint-http-rules/src/queries/by_connection.rs
+++ b/lint-http-rules/src/queries/by_connection.rs
@@ -52,7 +52,7 @@ mod tests {
 
         let mut tx2 =
             crate::test_helpers::make_test_transaction_with_response(200, &[("etag", "\"b\"")]);
-        tx2.client = client.clone();
+        tx2.client = client;
         tx2.request.uri = "http://example.com/b".to_string();
         tx2.connection_id = Some(conn_id);
         tx2.sequence_number = Some(1);
@@ -80,7 +80,7 @@ mod tests {
         store.record_transaction(&tx1);
 
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(201, &[]);
-        tx2.client = client.clone();
+        tx2.client = client;
         tx2.request.uri = "http://example.com/b".to_string();
         tx2.connection_id = Some(conn2);
         tx2.sequence_number = Some(0);

--- a/lint-http-rules/src/queries/by_origin.rs
+++ b/lint-http-rules/src/queries/by_origin.rs
@@ -117,7 +117,7 @@ mod tests {
         store.record_transaction(&tx1);
 
         let mut tx2 = crate::test_helpers::make_test_transaction_with_response(201, &[]);
-        tx2.client = client2.clone();
+        tx2.client = client2;
         tx2.request.uri = "https://example.com/b".to_string();
         store.record_transaction(&tx2);
 

--- a/lint-http-rules/src/rules/conditional_request_handling.rs
+++ b/lint-http-rules/src/rules/conditional_request_handling.rs
@@ -354,9 +354,7 @@ mod tests {
         let v4 = crate::test_helpers::run_rule(
             &rule,
             &tx4,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![
-                prev_empty.clone()
-            ]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev_empty]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -377,7 +375,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -394,7 +392,7 @@ mod tests {
         let v2 = crate::test_helpers::run_rule(
             &rule,
             &tx2,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev2.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev2]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -417,7 +415,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -446,7 +444,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -483,7 +481,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -509,7 +507,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),
@@ -530,7 +528,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &crate::test_helpers::make_test_config_with_enabled_rules(&[
                 "conditional_request_handling",
             ]),

--- a/lint-http-rules/src/rules/cookie_domain_matching.rs
+++ b/lint-http-rules/src/rules/cookie_domain_matching.rs
@@ -297,10 +297,8 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://other.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
-            prev2.clone(),
-            prev1.clone(),
-        ]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2, prev1]);
         assert!(crate::test_helpers::run_rule(
             &rule,
             &tx,

--- a/lint-http-rules/src/rules/cookie_lifecycle.rs
+++ b/lint-http-rules/src/rules/cookie_lifecycle.rs
@@ -423,10 +423,8 @@ mod tests {
         );
         let mut tx = make_tx_with_req("https://example.com/", Some("a=1"));
         tx.timestamp = ts + chrono::Duration::seconds(20);
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
-            prev2.clone(),
-            prev1.clone(),
-        ]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2, prev1]);
         let v = crate::test_helpers::run_rule(
             &rule,
             &tx,
@@ -477,8 +475,8 @@ mod tests {
         let mut tx = make_tx_with_req("http://example.com/specific", Some("a=2"));
         tx.timestamp = ts + chrono::Duration::seconds(10);
         let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
-            prev_nonsecure.clone(),
-            prev_secure.clone(),
+            prev_nonsecure,
+            prev_secure,
         ]);
         let v = crate::test_helpers::run_rule(
             &rule,

--- a/lint-http-rules/src/rules/head_response_headers_match_get.rs
+++ b/lint-http-rules/src/rules/head_response_headers_match_get.rs
@@ -469,7 +469,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag", "content-type", "content-length"]),
         );
         assert!(v.is_none());
@@ -485,7 +485,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_some());
@@ -502,7 +502,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["x-foo"]),
         );
         assert!(v.is_some());
@@ -522,7 +522,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_some());
@@ -539,7 +539,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_none());
@@ -555,7 +555,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["vary"]),
         );
         assert!(v.is_none());
@@ -608,7 +608,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -625,7 +625,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -651,7 +651,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -929,7 +929,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -945,7 +945,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
         );
         assert!(v.is_none());
@@ -961,7 +961,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["transfer-encoding"]),
         );
         assert!(v.is_none());
@@ -977,7 +977,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_none());
@@ -993,7 +993,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["vary"]),
         );
         assert!(v.is_none());
@@ -1009,7 +1009,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["vary"]),
         );
         assert!(v.is_some());
@@ -1056,7 +1056,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -1072,7 +1072,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag", "content-type"]),
         );
         assert!(v.is_some());
@@ -1089,7 +1089,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["accept-encoding"]),
         );
         assert!(v.is_some());
@@ -1168,7 +1168,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());
@@ -1185,7 +1185,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["content-length"]),
         );
         assert!(v.is_none());
@@ -1201,7 +1201,7 @@ mod tests {
         let v = crate::test_helpers::run_rule(
             &rule,
             &head,
-            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev.clone()]),
+            &crate::transaction_history::TransactionHistory::from_transactions(vec![prev]),
             &make_cfg_with_headers(vec!["etag"]),
         );
         assert!(v.is_none());

--- a/lint-http-rules/src/rules/no_store_enforced.rs
+++ b/lint-http-rules/src/rules/no_store_enforced.rs
@@ -386,10 +386,8 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-none-match", "\"a\"")]);
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
-            prev2.clone(),
-            prev1.clone(),
-        ]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2, prev1]);
         assert!(crate::test_helpers::run_rule(
             &rule,
             &tx,
@@ -420,10 +418,8 @@ mod tests {
         tx.request.uri = "/resource".to_string();
         tx.request.headers =
             crate::test_helpers::make_headers_from_pairs(&[("if-modified-since", lm)]);
-        let history = crate::transaction_history::TransactionHistory::from_transactions(vec![
-            prev2.clone(),
-            prev1.clone(),
-        ]);
+        let history =
+            crate::transaction_history::TransactionHistory::from_transactions(vec![prev2, prev1]);
         assert!(crate::test_helpers::run_rule(
             &rule,
             &tx,

--- a/lint-http-rules/src/rules/private_cache_visibility.rs
+++ b/lint-http-rules/src/rules/private_cache_visibility.rs
@@ -244,7 +244,7 @@ mod tests {
 
         let prev = make_prev(client.clone(), Some("private"), Some("\"a\""), None, ts);
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.client = client.clone();
+        tx.client = client;
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
@@ -268,9 +268,9 @@ mod tests {
         let mut client2 = client1.clone();
         client2.user_agent = "other".to_string();
 
-        let prev = make_prev(client2.clone(), Some("private"), Some("\"a\""), None, ts);
+        let prev = make_prev(client2, Some("private"), Some("\"a\""), None, ts);
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.client = client1.clone();
+        tx.client = client1;
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());
@@ -296,9 +296,9 @@ mod tests {
         client2.user_agent = "other".to_string();
 
         let lm = "Wed, 21 Oct 2015 07:28:00 GMT";
-        let prev = make_prev(client2.clone(), Some("private"), None, Some(lm), ts);
+        let prev = make_prev(client2, Some("private"), None, Some(lm), ts);
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.client = client1.clone();
+        tx.client = client1;
         tx.request
             .headers
             .append("if-modified-since", lm.parse().unwrap());
@@ -322,9 +322,9 @@ mod tests {
         let mut client2 = client1.clone();
         client2.user_agent = "other".to_string();
 
-        let prev = make_prev(client2.clone(), None, Some("\"a\""), None, ts);
+        let prev = make_prev(client2, None, Some("\"a\""), None, ts);
         let mut tx = crate::test_helpers::make_test_transaction();
-        tx.client = client1.clone();
+        tx.client = client1;
         tx.request
             .headers
             .append("if-none-match", "\"a\"".parse().unwrap());


### PR DESCRIPTION
`redundant_clone` joins `cognitive_complexity` in the workspace lint block. It is nursery, like that one, and enabled for the same reason: a clone nothing reads is invisible in review and costs a deep copy at runtime.

71 sites cleared to get here. Two were production and were fixed earlier in this campaign — a `Vec<Violation>` copied on every transaction the proxy handled, and two `Arc`s on the CONNECT path. The other 69 were in test modules, which is exactly where an unread clone survives longest, because nothing is watching. `cargo clippy --fix` cleared them all; 6033 tests still pass.

`significant_drop_tightening` was assessed for the same promotion and is deliberately **not** enabled. All 25 of its findings ask to shorten a lock scope, and the scopes it objects to are long on purpose: `StateStore::record_transaction` holds one lock across every index update precisely so no reader can see them apart, which is what the `Inner` doc comment already says. Enabling it would buy nothing and cost either `#[allow]`s — of which this tree has one — or a worse design. That reverses the audit's own recommendation; the reason is written in `Cargo.toml` so it is not re-litigated.

Verified the gate bites: a planted redundant clone fails `cargo lint` with 101.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
