### PR TITLE
Content-Range's failures are named for where in the value they are

### DIFF
--- a/lint-http-rules/src/helpers/content_range.rs
+++ b/lint-http-rules/src/helpers/content_range.rs
@@ -59,16 +59,157 @@ pub fn split_ranges_specifier(value: &str) -> Option<(String, &str)> {
     Some((unit.to_ascii_lowercase(), range_set.trim()))
 }
 
-/// Parse a `Content-Range` header value. Returns a `ContentRange` or an error string.
-pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
+/// Which of the three numerals a numeric defect was read from.
+///
+/// The names are § 14.4's own. `complete-length` is the one worth stating: this
+/// module's [`ContentRange`] calls the same number `instance_length`, which is
+/// what RFC 7233 called it, and one of the two messages this parser produced
+/// used each name — so a reader comparing two findings about the same numeral
+/// saw two numerals. The grammar quoted throughout this file is 9110's, so the
+/// findings say what it says.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Numeral {
+    /// `first-pos`, before the `-`.
+    FirstPos,
+    /// `last-pos`, after it.
+    LastPos,
+    /// `complete-length`, after the `/`.
+    CompleteLength,
+}
+
+impl Numeral {
+    /// The production's name, as a finding spells it.
+    fn label(self) -> &'static str {
+        match self {
+            Self::FirstPos => "first byte-pos",
+            Self::LastPos => "last byte-pos",
+            Self::CompleteLength => "complete-length",
+        }
+    }
+}
+
+/// What a `Content-Range` field value fails to be.
+///
+/// The variants follow the value left to right — the field, the `range-unit`,
+/// the SP, the `/`, the `-`, the numerals, then the two validity conditions —
+/// which is also the order [`parse_content_range`] reads it in, so a defect
+/// names how far the parse got.
+///
+/// The last two are the ones that are not grammar.
+/// [`FirstPosAfterLastPos`](Self::FirstPosAfterLastPos) and
+/// [`CompleteLengthNotAfterLastPos`](Self::CompleteLengthNotAfterLastPos) come
+/// from § 14.4's one sentence about invalidity, and a value that trips either is
+/// well-formed by the ABNF and invalid by the prose. A `String` filed them
+/// beside the parse failures with nothing marking the difference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentRangeDefect<'a> {
+    /// Nothing there, once the field value's own whitespace is off.
+    Empty,
+    /// A `range-unit` that is not a `token`, carrying it. Not a unit this
+    /// parser fails to model — see the parser, which parses those.
+    Unit(&'a str),
+    /// A value that is a `range-unit` and then stops. `Content-Range` is the
+    /// unit, one SP, and a form after it.
+    MissingRangeResp,
+    /// Whitespace inside the part after the SP, carrying that part. The
+    /// production holds exactly one space and it has already been used.
+    WhitespaceInRangeResp(&'a str),
+    /// No `/`. Both forms have one.
+    MissingSlash,
+    /// Something before the `/` that starts with `*` but is not exactly `*`.
+    /// `unsatisfied-range` opens with a two-character literal, not a wildcard.
+    ValueBeforeSlash,
+    /// No `-` in what should be an `incl-range`.
+    MissingDash,
+    /// A `-` with nothing on one side of it.
+    MissingPosition,
+    /// A numeral that is not `1*DIGIT`, carrying which one and what was there.
+    NotDigits {
+        /// Which of the three.
+        numeral: Numeral,
+        /// The characters found in its place.
+        value: &'a str,
+    },
+    /// A `1*DIGIT` numeral too large to represent, carrying which one and what
+    /// was there. § 14.1.2 asks recipients to anticipate large numerals rather
+    /// than to overflow on them, and this is that anticipation reported: a
+    /// position no recipient can represent addresses the octets of no
+    /// representation.
+    TooLarge {
+        /// Which of the three.
+        numeral: Numeral,
+        /// The numeral as written.
+        value: &'a str,
+    },
+    /// `last-pos` below `first-pos`. The first of § 14.4's two invalidity
+    /// conditions, and what makes `last - first` safe for a caller.
+    FirstPosAfterLastPos,
+    /// `complete-length` at or below `last-pos`. The second condition:
+    /// positions are zero-based and inclusive, so a `last-pos` of 499 needs a
+    /// length of 500 to be the last unit rather than one past the end.
+    CompleteLengthNotAfterLastPos {
+        /// The `complete-length` given.
+        length: u128,
+        /// The `last-pos` it fails to exceed.
+        last: u128,
+    },
+}
+
+impl ContentRangeDefect<'_> {
+    /// The finding fragment. Callers name the field and quote the value around
+    /// it, which is why this names neither.
+    pub fn message(self) -> String {
+        match self {
+            Self::Empty => "empty header value".to_string(),
+            Self::Unit(unit) => format!("invalid range-unit '{}'", unit),
+            Self::MissingRangeResp => "missing range/spec".to_string(),
+            Self::WhitespaceInRangeResp(rest) => {
+                format!("unexpected whitespace in range/spec '{}'", rest)
+            }
+            Self::MissingSlash => "missing '/' in range/spec".to_string(),
+            Self::ValueBeforeSlash => "unexpected value before '/'".to_string(),
+            Self::MissingDash => "missing '-' in byte-range".to_string(),
+            Self::MissingPosition => "missing first or last byte-pos".to_string(),
+            Self::NotDigits { numeral, value } => format!(
+                "invalid {}: '{}' is not a 1*DIGIT value",
+                numeral.label(),
+                value
+            ),
+            Self::TooLarge { numeral, value } => format!(
+                "invalid {}: '{}' is larger than this parser can represent",
+                numeral.label(),
+                value
+            ),
+            Self::FirstPosAfterLastPos => "first byte-pos greater than last".to_string(),
+            Self::CompleteLengthNotAfterLastPos { length, last } => format!(
+                "complete-length {} is not greater than last byte-pos {}",
+                length, last
+            ),
+        }
+    }
+}
+
+/// Parse a `Content-Range` header value into a [`ContentRange`], or name what it
+/// fails to be as a [`ContentRangeDefect`].
+///
+/// **A value that reaches the unit check always has a unit.** The field value is
+/// trimmed and checked for emptiness first, so it opens with a non-space
+/// character; the unit is everything before the first `' '`, so it is non-empty,
+/// and `splitn` always yields a first element. Two guards said otherwise — a
+/// `"missing unit"` behind `ok_or_else` and an `unit.is_empty()` disjunct — and
+/// neither was reachable. They went when the failures were enumerated; a
+/// variant nothing constructs is a claim this module cannot back.
+pub fn parse_content_range(s: &str) -> Result<ContentRange, ContentRangeDefect<'_>> {
     let s = s.trim();
     if s.is_empty() {
-        return Err("empty header value".into());
+        return Err(ContentRangeDefect::Empty);
     }
 
-    // Expect unit SP range / instance-length
+    // Expect unit SP range-resp / unsatisfied-range
     let mut parts = s.splitn(2, ' ');
-    let unit = parts.next().ok_or_else(|| "missing unit".to_string())?;
+    let unit = parts
+        .next()
+        .expect("splitn always yields at least one element");
 
     // A unit this parser does not model is not a malformed unit. Range units are a
     // token and an open set, so the only thing checkable here is that the name is
@@ -78,13 +219,11 @@ pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
     //
     // cite(RFC 9110 § 14.1): "All range unit names are case-insensitive and ought to be registered within the "HTTP Range Unit Registry", as defined in Section 16.5.1."
     // cite(RFC 9110 § 14.1): "Range units are intended to be extensible, as described in Section 16.5."
-    if unit.is_empty() || crate::helpers::token::find_invalid_token_char(unit).is_some() {
-        return Err(format!("invalid range-unit '{}'", unit));
+    if crate::helpers::token::find_invalid_token_char(unit).is_some() {
+        return Err(ContentRangeDefect::Unit(unit));
     }
-    let unit = unit.to_ascii_lowercase();
-    let rest = parts
-        .next()
-        .ok_or_else(|| "missing range/spec".to_string())?;
+    let lowercased_unit = unit.to_ascii_lowercase();
+    let rest = parts.next().ok_or(ContentRangeDefect::MissingRangeResp)?;
 
     // The production holds exactly one space, the SP after the range-unit, and
     // neither alternative after it admits another: no OWS sits beside the "/",
@@ -97,12 +236,10 @@ pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
     // cite(RFC 9110 § 14.4, label: Content-Range grammar): "Content-Range = range-unit SP ( range-resp / unsatisfied-range )"
     // cite(RFC 9110 § 5.5): "A field value does not include leading or trailing whitespace."
     if rest.chars().any(|c| c.is_ascii_whitespace()) {
-        return Err(format!("unexpected whitespace in range/spec '{}'", rest));
+        return Err(ContentRangeDefect::WhitespaceInRangeResp(rest));
     }
 
-    let slash_idx = rest
-        .find('/')
-        .ok_or_else(|| "missing '/' in range/spec".to_string())?;
+    let slash_idx = rest.find('/').ok_or(ContentRangeDefect::MissingSlash)?;
     let left = &rest[..slash_idx];
     let right = &rest[slash_idx + 1..];
 
@@ -115,14 +252,13 @@ pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
     if !left.is_empty() && left.starts_with('*') {
         // Left "*" should be exact
         if left != "*" {
-            return Err("unexpected value before '/'".into());
+            return Err(ContentRangeDefect::ValueBeforeSlash);
         }
-        // Right must be a number (instance-length)
+        // Right must be a number (complete-length)
         // cite(RFC 9110 § 14.4): "complete-length = 1*DIGIT"
-        let instance_length =
-            parse_u128(right).map_err(|e| format!("invalid instance-length: {}", e))?;
+        let instance_length = parse_u128(right, Numeral::CompleteLength)?;
         return Ok(ContentRange::Unsatisfiable {
-            unit,
+            unit: lowercased_unit,
             instance_length,
         });
     }
@@ -130,31 +266,29 @@ pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
     // Otherwise expect first-last
     // cite(RFC 9110 § 14.4): "range-resp = incl-range "/" ( complete-length / "*" )"
     // cite(RFC 9110 § 14.4): "incl-range = first-pos "-" last-pos"
-    let dash_idx = left
-        .find('-')
-        .ok_or_else(|| "missing '-' in byte-range".to_string())?;
+    let dash_idx = left.find('-').ok_or(ContentRangeDefect::MissingDash)?;
     let first = &left[..dash_idx];
     let last = &left[dash_idx + 1..];
 
     if first.is_empty() || last.is_empty() {
-        return Err("missing first or last byte-pos".into());
+        return Err(ContentRangeDefect::MissingPosition);
     }
 
-    let first_v = parse_u128(first).map_err(|e| format!("invalid first byte-pos: {}", e))?;
-    let last_v = parse_u128(last).map_err(|e| format!("invalid last byte-pos: {}", e))?;
+    let first_v = parse_u128(first, Numeral::FirstPos)?;
+    let last_v = parse_u128(last, Numeral::LastPos)?;
     // The first of the sentence's two invalidity conditions. It is also what makes
     // `last - first` safe for callers, who are otherwise one unsigned subtraction
     // away from an underflow.
     //
     // cite(RFC 9110 § 14.4): "A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value."
     if first_v > last_v {
-        return Err("first byte-pos greater than last".into());
+        return Err(ContentRangeDefect::FirstPosAfterLastPos);
     }
 
     let instance_length = if right == "*" {
         None
     } else {
-        Some(parse_u128(right).map_err(|e| format!("invalid instance-length: {}", e))?)
+        Some(parse_u128(right, Numeral::CompleteLength)?)
     };
 
     // The second condition of the same sentence. "Less than or equal to" is the
@@ -165,15 +299,15 @@ pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
     // cite(RFC 9110 § 14.4): "A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value."
     if let Some(len) = instance_length {
         if len <= last_v {
-            return Err(format!(
-                "complete-length {} is not greater than last byte-pos {}",
-                len, last_v
-            ));
+            return Err(ContentRangeDefect::CompleteLengthNotAfterLastPos {
+                length: len,
+                last: last_v,
+            });
         }
     }
 
     Ok(ContentRange::Satisfied {
-        unit,
+        unit: lowercased_unit,
         first: first_v,
         last: last_v,
         instance_length,
@@ -193,13 +327,21 @@ pub fn parse_content_range(s: &str) -> Result<ContentRange, String> {
 /// 39-digit numeral to reach, and the same bound is argued the same way in
 /// `validate_content_length`.
 ///
+/// The `numeral` argument is which of the three this is, and it is taken rather
+/// than fixed up afterwards because the caller is the only one that knows.
+/// Overflow is the only way `str::parse` can fail once the digits are checked,
+/// which is why it maps to a variant of its own rather than to the parser's
+/// sentence: the `ParseIntError` text this used to embed said "number too large
+/// to fit in target type", naming Rust's type in a finding about HTTP.
+///
 // cite(RFC 9110 § 14.4): "complete-length = 1*DIGIT"
 // cite(RFC 9110 § 14.1.2): "In the byte-range syntax, first-pos, last-pos, and suffix-length are expressed as decimal number of octets.  Since there is no predefined limit to the length of content, recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows."
-fn parse_u128(s: &str) -> Result<u128, String> {
+fn parse_u128(s: &str, numeral: Numeral) -> Result<u128, ContentRangeDefect<'_>> {
     if s.is_empty() || !s.chars().all(|c| c.is_ascii_digit()) {
-        return Err(format!("'{}' is not a 1*DIGIT value", s));
+        return Err(ContentRangeDefect::NotDigits { numeral, value: s });
     }
-    s.parse::<u128>().map_err(|e| e.to_string())
+    s.parse::<u128>()
+        .map_err(|_| ContentRangeDefect::TooLarge { numeral, value: s })
 }
 
 #[cfg(test)]
@@ -232,8 +374,13 @@ mod tests {
 
         // A value whose only defect is the whitespace around its separators is
         // still a value no sender may generate. This assertion used to say the
-        // opposite, which is how the leniency stayed.
-        assert!(parse_content_range("bytes  0-0 /  *").is_err());
+        // opposite, which is how the leniency stayed. The SP the production
+        // holds is the one after `bytes`; everything after it is the part the
+        // defect names.
+        assert_eq!(
+            parse_content_range("bytes  0-0 /  *"),
+            Err(ContentRangeDefect::WhitespaceInRangeResp(" 0-0 /  *"))
+        );
 
         // Whitespace *around the field value* is not part of it, so it is trimmed
         // rather than reported.
@@ -250,12 +397,50 @@ mod tests {
 
     /// `1*DIGIT` is digits and nothing else; Rust's integer parser also takes a
     /// leading "+", which would have read `+0-499` as the range 0-499.
+    ///
+    /// Each numeral names itself now, which is what the four assertions were
+    /// always about and could not say: `is_err()` passed whichever of the three
+    /// had rejected the value.
     #[test]
     fn signed_positions_are_not_digits() {
-        assert!(parse_content_range("bytes +0-499/1234").is_err());
-        assert!(parse_content_range("bytes 0-+499/1234").is_err());
-        assert!(parse_content_range("bytes 0-499/+1234").is_err());
-        assert!(parse_content_range("bytes */+1234").is_err());
+        let not_digits = |numeral, value| Err(ContentRangeDefect::NotDigits { numeral, value });
+        assert_eq!(
+            parse_content_range("bytes +0-499/1234"),
+            not_digits(Numeral::FirstPos, "+0")
+        );
+        assert_eq!(
+            parse_content_range("bytes 0-+499/1234"),
+            not_digits(Numeral::LastPos, "+499")
+        );
+        assert_eq!(
+            parse_content_range("bytes 0-499/+1234"),
+            not_digits(Numeral::CompleteLength, "+1234")
+        );
+        assert_eq!(
+            parse_content_range("bytes */+1234"),
+            not_digits(Numeral::CompleteLength, "+1234")
+        );
+    }
+
+    /// The ceiling is a tolerance and reports as one. § 14.1.2 asks recipients
+    /// to anticipate large numerals rather than overflow on them; what a reader
+    /// used to get here was `ParseIntError`'s "number too large to fit in
+    /// target type", which names a Rust type in a finding about HTTP.
+    #[test]
+    fn a_numeral_past_the_ceiling_names_itself_and_not_a_rust_type() {
+        let past = "340282366920938463463374607431768211456"; // u128::MAX + 1
+        let value = format!("bytes 0-1/{past}");
+        assert_eq!(
+            parse_content_range(&value),
+            Err(ContentRangeDefect::TooLarge {
+                numeral: Numeral::CompleteLength,
+                value: past,
+            })
+        );
+        assert_eq!(
+            parse_content_range(&value).unwrap_err().message(),
+            format!("invalid complete-length: '{past}' is larger than this parser can represent")
+        );
     }
 
     #[test]
@@ -286,9 +471,16 @@ mod tests {
                 instance_length: Some(3)
             }
         );
-        // The generic validity conditions still apply to it.
-        assert!(parse_content_range("items 1-0/3").is_err());
-        assert!(parse_content_range("items 0-5/3").is_err());
+        // The generic validity conditions still apply to it, and they are the
+        // two that are prose rather than grammar.
+        assert_eq!(
+            parse_content_range("items 1-0/3"),
+            Err(ContentRangeDefect::FirstPosAfterLastPos)
+        );
+        assert_eq!(
+            parse_content_range("items 0-5/3"),
+            Err(ContentRangeDefect::CompleteLengthNotAfterLastPos { length: 3, last: 5 })
+        );
     }
 
     #[test]
@@ -296,20 +488,68 @@ mod tests {
         assert_eq!(parse_content_range("BYTES 0-1/3").unwrap().unit(), "bytes");
     }
 
+    /// The second value is the one worth naming: it has no unit *missing*, it
+    /// has a unit of `0-1/3`, because the field value's own whitespace comes
+    /// off before anything is read. A value cannot reach here without a unit,
+    /// which is why there is no variant for one.
     #[test]
     fn invalid_unit() {
         // Not a token: "(" is not a tchar.
-        assert!(parse_content_range("by(tes 0-1/3").is_err());
-        assert!(parse_content_range(" 0-1/3").is_err());
+        assert_eq!(
+            parse_content_range("by(tes 0-1/3"),
+            Err(ContentRangeDefect::Unit("by(tes"))
+        );
+        assert_eq!(
+            parse_content_range(" 0-1/3"),
+            Err(ContentRangeDefect::Unit("0-1/3"))
+        );
     }
 
+    /// Five malformed values that `is_err()` could not tell apart, and which
+    /// fail at five different points of the value.
     #[test]
     fn malformed_values() {
-        assert!(parse_content_range("bytes 5-3/10").is_err());
-        assert!(parse_content_range("bytes 5- /10").is_err());
-        assert!(parse_content_range("bytes -5/10").is_err());
-        assert!(parse_content_range("bytes */*").is_err());
-        assert!(parse_content_range("bytes */x").is_err());
+        assert_eq!(
+            parse_content_range("bytes 5-3/10"),
+            Err(ContentRangeDefect::FirstPosAfterLastPos)
+        );
+        assert_eq!(
+            parse_content_range("bytes 5- /10"),
+            Err(ContentRangeDefect::WhitespaceInRangeResp("5- /10"))
+        );
+        assert_eq!(
+            parse_content_range("bytes -5/10"),
+            Err(ContentRangeDefect::MissingPosition)
+        );
+        assert_eq!(
+            parse_content_range("bytes */*"),
+            Err(ContentRangeDefect::NotDigits {
+                numeral: Numeral::CompleteLength,
+                value: "*"
+            })
+        );
+        assert_eq!(
+            parse_content_range("bytes */x"),
+            Err(ContentRangeDefect::NotDigits {
+                numeral: Numeral::CompleteLength,
+                value: "x"
+            })
+        );
+        // The two the list did not reach: a unit and nothing after it, and a
+        // range-resp with no "/" to divide it.
+        assert_eq!(
+            parse_content_range("bytes"),
+            Err(ContentRangeDefect::MissingRangeResp)
+        );
+        assert_eq!(
+            parse_content_range("bytes 0-1"),
+            Err(ContentRangeDefect::MissingSlash)
+        );
+        assert_eq!(
+            parse_content_range("bytes 01/3"),
+            Err(ContentRangeDefect::MissingDash)
+        );
+        assert_eq!(parse_content_range("   "), Err(ContentRangeDefect::Empty));
     }
 
     /// The examples § 14.4 states in its own prose, all of which describe a
@@ -333,8 +573,20 @@ mod tests {
     fn complete_length_must_exceed_last_pos() {
         // last-pos 499 needs at least 500 bytes to exist.
         assert!(parse_content_range("bytes 0-499/500").is_ok());
-        assert!(parse_content_range("bytes 0-499/499").is_err());
-        assert!(parse_content_range("bytes 0-499/10").is_err());
+        assert_eq!(
+            parse_content_range("bytes 0-499/499"),
+            Err(ContentRangeDefect::CompleteLengthNotAfterLastPos {
+                length: 499,
+                last: 499
+            })
+        );
+        assert_eq!(
+            parse_content_range("bytes 0-499/10"),
+            Err(ContentRangeDefect::CompleteLengthNotAfterLastPos {
+                length: 10,
+                last: 499
+            })
+        );
         // Unknown complete length says nothing about last-pos.
         assert!(parse_content_range("bytes 0-499/*").is_ok());
     }
@@ -366,8 +618,9 @@ mod tests {
 
     #[test]
     fn unexpected_star_prefix_reports_error() {
-        let r = parse_content_range("bytes *1/1234");
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("unexpected value"));
+        assert_eq!(
+            parse_content_range("bytes *1/1234"),
+            Err(ContentRangeDefect::ValueBeforeSlash)
+        );
     }
 }

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -296,7 +296,7 @@ impl Rule for RangeAndContentRangeConsistent {
                     Err(e) => {
                         return Some(self.violation(
                             config.severity,
-                            format!("Invalid Content-Range header '{}': {}", cr, e),
+                            format!("Invalid Content-Range header '{}': {}", cr, e.message()),
                         ));
                     }
                 }
@@ -361,7 +361,7 @@ impl Rule for RangeAndContentRangeConsistent {
                         return Some(self.cited(
                             &RFC_9110_14_4,
                             config.severity,
-                            format!("Invalid Content-Range header '{}': {}", cr, e),
+                            format!("Invalid Content-Range header '{}': {}", cr, e.message()),
                         ));
                     }
                 }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6249,7 +6249,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 52
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 79
+      line: 220
     - file: lint-http-rules/src/rules/accept_ranges_on_partial_content.rs
       line: 47
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
@@ -6267,7 +6267,7 @@ sources:
     - file: lint-http-rules/src/helpers/accept_ranges.rs
       line: 103
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 80
+      line: 221
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 301
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -6547,7 +6547,7 @@ sources:
     snippet: In the byte-range syntax, first-pos, last-pos, and suffix-length are expressed as decimal number of octets.  Since there is no predefined limit to the length of content, recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows.
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 197
+      line: 338
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 386
   - label: lint-http-rules/src/helpers/content_range.rs (4)
@@ -6555,15 +6555,15 @@ sources:
     snippet: A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value.
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 149
+      line: 283
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 165
+      line: 299
   - label: Content-Range grammar
     section: § 14.4
     snippet: Content-Range = range-unit SP ( range-resp / unsatisfied-range )
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 97
+      line: 236
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 36
   - label: lint-http-rules/src/helpers/content_range.rs (5)
@@ -6571,33 +6571,33 @@ sources:
     snippet: complete-length = 1*DIGIT
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 121
+      line: 258
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 196
+      line: 337
   - label: lint-http-rules/src/helpers/content_range.rs (6)
     section: § 14.4
     snippet: incl-range = first-pos "-" last-pos
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 132
+      line: 268
   - label: lint-http-rules/src/helpers/content_range.rs (7)
     section: § 14.4
     snippet: range-resp = incl-range "/" ( complete-length / "*" )
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 131
+      line: 267
   - label: lint-http-rules/src/helpers/content_range.rs (8)
     section: § 14.4
     snippet: unsatisfied-range = "*/" complete-length
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 114
+      line: 251
   - label: lint-http-rules/src/helpers/content_range.rs (9)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
-      line: 98
+      line: 237
     - file: lint-http-rules/src/helpers/product.rs
       line: 69
     - file: lint-http-rules/src/rules/host_header.rs


### PR DESCRIPTION
`ContentRangeDefect`, ordered the way the parser reads the value: the field, the `range-unit`, the SP, the `/`, the `-`, the numerals, then § 14.4's two invalidity conditions. That order is the point — a defect now says how far the parse got, and the last two say something the rest do not, that the value is well-formed by the ABNF and invalid by the prose.

`Numeral` is why the numeric defects can be one variant instead of three near-identical strings. It also settles a name: `ContentRange` calls the number `instance_length`, RFC 7233's word, while the complete-length check next to it already said `complete-length`, so one parser reported one numeral under two names. The findings now use 9110's, which is the grammar this file quotes throughout.

A numeral past the ceiling stops borrowing `ParseIntError`'s sentence. "number too large to fit in target type" names a Rust type in a finding about HTTP; `TooLarge` names the numeral and the value. Overflow is the only way `str::parse` can fail once the digits are checked, so nothing else was hiding in that arm.

**Two more unreachable branches, found the same way as the challenge's.** The value is trimmed and checked for emptiness before the split, so it opens with a non-space character — the unit is therefore non-empty, and `splitn` always yields a first element. `"missing unit"` and the `unit.is_empty()` disjunct could not fire. The test `invalid_unit` proves it from outside: ` 0-1/3` has a unit, and it is `0-1/3`.

The tests are where this pays. `malformed_values` asserted `is_err()` five times over five values that fail at five different points; `signed_positions` asserted it four times without being able to say which of the three numerals had rejected the `+`.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
