### PR TITLE
The Authorization header's four failures are four answers

### DIFF
--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -285,16 +285,65 @@ pub fn validate_challenge_syntax(challenge: &str) -> Result<(), ChallengeDefect<
     Ok(())
 }
 
-/// Validate an `Authorization` header value for having both a valid auth-scheme and
-/// non-empty credentials (token68 or auth-param list). Unlike `WWW-Authenticate` challenges,
-/// the `Authorization` header MUST include credentials after the auth-scheme.
-/// Returns Ok(()) on success or Err(String) describing the problem.
+/// What an `Authorization` field value fails to be.
+///
+/// Four variants for one field read in two halves: the `auth-scheme`, and
+/// whatever follows it. [`MissingCredentials`](Self::MissingCredentials) is the
+/// one that is this helper's judgment rather than § 11.4's grammar — see
+/// [`validate_authorization_syntax`], which explains why a bare scheme is
+/// framework-valid and reported anyway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorizationDefect {
+    /// No field value.
+    Empty,
+    /// A non-`token` octet in the `auth-scheme`, carrying the character.
+    SchemeCharacter(char),
+    /// A scheme with nothing after it, or nothing but whitespace.
+    MissingCredentials,
+    /// A control octet in the credentials. This helper reads no further into
+    /// them than that — which scheme's grammar they have to satisfy is the
+    /// scheme's own helper's question.
+    CredentialsControlCharacter,
+}
+
+impl AuthorizationDefect {
+    /// The finding. Each names the field, because the two callers add the
+    /// transaction's context rather than the field's.
+    pub fn message(self) -> String {
+        match self {
+            Self::Empty => "Authorization header is empty".to_string(),
+            Self::SchemeCharacter(c) => {
+                format!("Invalid character '{}' in Authorization auth-scheme", c)
+            }
+            Self::MissingCredentials => {
+                "Authorization header missing credentials after auth-scheme".to_string()
+            }
+            Self::CredentialsControlCharacter => {
+                "Authorization credentials contain control characters".to_string()
+            }
+        }
+    }
+}
+
 use base64::Engine;
 
-pub fn validate_authorization_syntax(value: &str) -> Result<(), String> {
+/// Whether an `Authorization` field value has a valid `auth-scheme` and
+/// non-empty credentials after it, answered as an [`AuthorizationDefect`].
+///
+/// Unlike a `WWW-Authenticate` challenge, this requires the credentials — see
+/// the § 11.4 note in the body for why, which is that every concrete scheme
+/// this serves mandates them even though the framework grammar does not.
+///
+/// **The scheme cannot be missing here either.** Same argument as
+/// [`validate_challenge_syntax`]: the value is trimmed and checked for
+/// emptiness, so what precedes the first `char::is_whitespace` is non-empty and
+/// `str::trim` cannot empty it. That makes three helpers in this module that
+/// carried the same unreachable sentence, all three written the same way, and
+/// naming the failures is what surfaced all three.
+pub fn validate_authorization_syntax(value: &str) -> Result<(), AuthorizationDefect> {
     let v = value.trim();
     if v.is_empty() {
-        return Err("Authorization header is empty".into());
+        return Err(AuthorizationDefect::Empty);
     }
 
     let mut parts = v.splitn(2, char::is_whitespace);
@@ -302,15 +351,9 @@ pub fn validate_authorization_syntax(value: &str) -> Result<(), String> {
         .next()
         .expect("splitn always yields at least one element")
         .trim();
-    if scheme.is_empty() {
-        return Err("Authorization header missing auth-scheme".into());
-    }
     // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
     if let Some(invalid) = crate::helpers::token::find_invalid_token_char(scheme) {
-        return Err(format!(
-            "Invalid character '{}' in Authorization auth-scheme",
-            invalid
-        ));
+        return Err(AuthorizationDefect::SchemeCharacter(invalid));
     }
 
     // §11.4's grammar makes the part after the scheme optional ([ 1*SP … ]), so a
@@ -324,15 +367,15 @@ pub fn validate_authorization_syntax(value: &str) -> Result<(), String> {
     if let Some(rest) = parts.next() {
         let rest = rest.trim();
         if rest.is_empty() {
-            return Err("Authorization header missing credentials after auth-scheme".into());
+            return Err(AuthorizationDefect::MissingCredentials);
         }
         // Basic checks: no control characters
         if rest.chars().any(|c| (c as u32) < 0x20 || c == '\x7f') {
-            return Err("Authorization credentials contain control characters".into());
+            return Err(AuthorizationDefect::CredentialsControlCharacter);
         }
         Ok(())
     } else {
-        Err("Authorization header missing credentials after auth-scheme".into())
+        Err(AuthorizationDefect::MissingCredentials)
     }
 }
 
@@ -614,20 +657,52 @@ mod tests {
         );
     }
 
+    /// Both spellings of the same thing: a scheme with no second half, and a
+    /// scheme whose second half is whitespace. The second reaches a different
+    /// line of the function and used to carry a separately written copy of the
+    /// same sentence.
     #[test]
     fn validate_authorization_missing_credentials() {
-        assert!(validate_authorization_syntax("Basic").is_err());
-        assert!(validate_authorization_syntax("Basic ").is_err());
+        assert_eq!(
+            validate_authorization_syntax("Basic"),
+            Err(AuthorizationDefect::MissingCredentials)
+        );
+        assert_eq!(
+            validate_authorization_syntax("Basic "),
+            Err(AuthorizationDefect::MissingCredentials)
+        );
     }
 
     #[test]
     fn validate_authorization_invalid_scheme_char() {
-        assert!(validate_authorization_syntax("B@sic xyz").is_err());
+        assert_eq!(
+            validate_authorization_syntax("B@sic xyz"),
+            Err(AuthorizationDefect::SchemeCharacter('@'))
+        );
     }
 
     #[test]
     fn validate_authorization_control_chars() {
-        assert!(validate_authorization_syntax("Bearer \u{0001}").is_err());
+        assert_eq!(
+            validate_authorization_syntax("Bearer \u{0001}"),
+            Err(AuthorizationDefect::CredentialsControlCharacter)
+        );
+    }
+
+    /// An empty field value is empty, and a field value that is only
+    /// whitespace is the same thing — § 5.5 does not count either as part of
+    /// the value. Neither is a missing `auth-scheme`, which is a defect this
+    /// function has no variant for because no input reaches it.
+    #[test]
+    fn validate_authorization_empty() {
+        assert_eq!(
+            validate_authorization_syntax(""),
+            Err(AuthorizationDefect::Empty)
+        );
+        assert_eq!(
+            validate_authorization_syntax("   "),
+            Err(AuthorizationDefect::Empty)
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -64,94 +64,93 @@ impl Rule for AuthSchemeRegistered {
     ) -> Vec<Violation> {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
-        let finding =
-            || -> Option<Violation> {
-                let config: &crate::helpers::rule_config::AllowedList = ctx.state();
-                // Helper to check a single scheme token against allowed list
-                let check_scheme =
-                    |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {
-                        // An auth-scheme is a token; the tchar set is helper-owned.
-                        // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
-                        if let Some(c) = crate::helpers::token::find_invalid_token_char(scheme) {
-                            return Some(AuthSchemeRegistered.violation(
-                                ctx.severity,
-                                format!("Invalid character '{}' in {} auth-scheme", c, hdr_name),
-                            ));
-                        }
-                        // The guidance the allowlist stands for: schemes ought to be registered.
-                        // The comparison is lowercase because the scheme token is case-insensitive
-                        // (§11.1). Note this is checked against an operator-configured `allowed`
-                        // list, not the live IANA registry — the allowlist is the operator's chosen
-                        // subset of acceptable (typically registered) schemes, and §16.4.1 is where
-                        // registered ones live.
-                        // cite(RFC 9110 § 11.1): "New and existing authentication schemes are specified independently and ought to be registered"
-                        // cite(RFC 9110 § 16.4.1): "The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials."
-                        if !allowed.contains(&scheme.to_ascii_lowercase()) {
-                            return Some(AuthSchemeRegistered.violation(
-                                ctx.severity,
-                                format!("Unrecognized auth-scheme '{}' in {}", scheme, hdr_name),
-                            ));
-                        }
-                        None
+        let finding = || -> Option<Violation> {
+            let config: &crate::helpers::rule_config::AllowedList = ctx.state();
+            // Helper to check a single scheme token against allowed list
+            let check_scheme =
+                |hdr_name: &str, scheme: &str, allowed: &Vec<String>| -> Option<Violation> {
+                    // An auth-scheme is a token; the tchar set is helper-owned.
+                    // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
+                    if let Some(c) = crate::helpers::token::find_invalid_token_char(scheme) {
+                        return Some(AuthSchemeRegistered.violation(
+                            ctx.severity,
+                            format!("Invalid character '{}' in {} auth-scheme", c, hdr_name),
+                        ));
+                    }
+                    // The guidance the allowlist stands for: schemes ought to be registered.
+                    // The comparison is lowercase because the scheme token is case-insensitive
+                    // (§11.1). Note this is checked against an operator-configured `allowed`
+                    // list, not the live IANA registry — the allowlist is the operator's chosen
+                    // subset of acceptable (typically registered) schemes, and §16.4.1 is where
+                    // registered ones live.
+                    // cite(RFC 9110 § 11.1): "New and existing authentication schemes are specified independently and ought to be registered"
+                    // cite(RFC 9110 § 16.4.1): "The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials."
+                    if !allowed.contains(&scheme.to_ascii_lowercase()) {
+                        return Some(AuthSchemeRegistered.violation(
+                            ctx.severity,
+                            format!("Unrecognized auth-scheme '{}' in {}", scheme, hdr_name),
+                        ));
+                    }
+                    None
+                };
+
+            // Check WWW-Authenticate challenges in responses
+            if let Some(resp) = &tx.response {
+                for hv in resp.headers.get_all("www-authenticate").iter() {
+                    let Ok(s) = hv.to_str() else {
+                        return Some(self.violation(
+                            ctx.severity,
+                            "WWW-Authenticate header contains non-UTF8 value".into(),
+                        ));
                     };
 
-                // Check WWW-Authenticate challenges in responses
-                if let Some(resp) = &tx.response {
-                    for hv in resp.headers.get_all("www-authenticate").iter() {
-                        let Ok(s) = hv.to_str() else {
-                            return Some(self.violation(
-                                ctx.severity,
-                                "WWW-Authenticate header contains non-UTF8 value".into(),
-                            ));
-                        };
-
-                        // split into assembled challenges
-                        match crate::helpers::auth::split_and_group_challenges(s) {
-                            Ok(challenges) => {
-                                for challenge in challenges {
-                                    let scheme =
-                                        challenge.split(char::is_whitespace).next().unwrap().trim();
-                                    if let Some(v) =
-                                        check_scheme("WWW-Authenticate", scheme, &config.allowed)
-                                    {
-                                        return Some(v);
-                                    }
+                    // split into assembled challenges
+                    match crate::helpers::auth::split_and_group_challenges(s) {
+                        Ok(challenges) => {
+                            for challenge in challenges {
+                                let scheme =
+                                    challenge.split(char::is_whitespace).next().unwrap().trim();
+                                if let Some(v) =
+                                    check_scheme("WWW-Authenticate", scheme, &config.allowed)
+                                {
+                                    return Some(v);
                                 }
                             }
-                            Err(e) => {
-                                return Some(self.violation(
-                                    ctx.severity,
-                                    format!("Invalid WWW-Authenticate header: {}", e),
-                                ))
-                            }
+                        }
+                        Err(e) => {
+                            return Some(self.violation(
+                                ctx.severity,
+                                format!("Invalid WWW-Authenticate header: {}", e),
+                            ))
                         }
                     }
                 }
+            }
 
-                // Check Authorization header in requests
-                if let Some(hv) = tx.request.headers.get_all("authorization").iter().next() {
-                    let Ok(v) = hv.to_str() else {
-                        return Some(self.violation(
-                            ctx.severity,
-                            "Authorization header contains non-UTF8 value".into(),
-                        ));
-                    };
-                    // validate basic syntax first
-                    if let Err(e) = crate::helpers::auth::validate_authorization_syntax(v) {
-                        return Some(self.violation(
-                            ctx.severity,
-                            format!("Invalid Authorization header: {}", e),
-                        ));
-                    }
-
-                    let scheme = v.split(char::is_whitespace).next().unwrap().trim();
-                    if let Some(vv) = check_scheme("Authorization", scheme, &config.allowed) {
-                        return Some(vv);
-                    }
+            // Check Authorization header in requests
+            if let Some(hv) = tx.request.headers.get_all("authorization").iter().next() {
+                let Ok(v) = hv.to_str() else {
+                    return Some(self.violation(
+                        ctx.severity,
+                        "Authorization header contains non-UTF8 value".into(),
+                    ));
+                };
+                // validate basic syntax first
+                if let Err(defect) = crate::helpers::auth::validate_authorization_syntax(v) {
+                    return Some(self.violation(
+                        ctx.severity,
+                        format!("Invalid Authorization header: {}", defect.message()),
+                    ));
                 }
 
-                None
-            };
+                let scheme = v.split(char::is_whitespace).next().unwrap().trim();
+                if let Some(vv) = check_scheme("Authorization", scheme, &config.allowed) {
+                    return Some(vv);
+                }
+            }
+
+            None
+        };
         Vec::from_iter(finding())
     }
 

--- a/lint-http-rules/src/rules/authorization_credentials_present.rs
+++ b/lint-http-rules/src/rules/authorization_credentials_present.rs
@@ -56,11 +56,12 @@ impl Rule for AuthorizationCredentialsPresent {
                         // (the framework grammar permits a bare scheme); the helper owns that
                         // reasoning and the §11.4 structure cite.
                         // cite(RFC 9110 § 11.6.2): "Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested"
-                        if let Err(msg) = crate::helpers::auth::validate_authorization_syntax(s) {
+                        if let Err(defect) = crate::helpers::auth::validate_authorization_syntax(s)
+                        {
                             return Some(self.cited(
                                 &RFC_9110_11_6_2,
                                 ctx.severity,
-                                format!("Invalid Authorization header: {}", msg),
+                                format!("Invalid Authorization header: {}", defect.message()),
                             ));
                         }
                     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1618,7 +1618,7 @@ sources:
     snippet: Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 411
+      line: 454
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 210
   - label: lint-http-rules/src/helpers/websocket.rs
@@ -2922,7 +2922,7 @@ sources:
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 503
+      line: 546
 - label: RFC 6797
   url: https://www.rfc-editor.org/rfc/rfc6797.html
   fragments:
@@ -3641,7 +3641,7 @@ sources:
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 564
+      line: 607
 - label: RFC 7617
   url: https://www.rfc-editor.org/rfc/rfc7617.html
   fragments:
@@ -3656,19 +3656,19 @@ sources:
     snippet: The user-id and password MUST NOT contain any control characters
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 424
+      line: 467
   - label: basic-credentials base64
     section: § 2
     snippet: and obtains the basic-credentials by encoding this octet sequence using Base64
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 408
+      line: 451
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 2
     snippet: constructs the user-pass by concatenating the user-id, a single colon (":") character, and the password
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 416
+      line: 459
 - label: RFC 7838
   url: https://www.rfc-editor.org/rfc/rfc7838.html
   fragments:
@@ -5091,13 +5091,13 @@ sources:
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 87
+      line: 86
   - label: auth_scheme_registered (2)
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 88
+      line: 87
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -6329,9 +6329,9 @@ sources:
     snippet: It uses a case-insensitive token to identify the authentication scheme
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 308
+      line: 354
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 74
+      line: 73
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
       line: 48
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
@@ -6349,7 +6349,7 @@ sources:
     snippet: 'credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 323
+      line: 366
   - label: lint-http-rules/src/helpers/auth.rs (4)
     section: § 11.6.1
     snippet: 'WWW-Authenticate = #challenge'


### PR DESCRIPTION
`AuthorizationDefect`: the field, the `auth-scheme`, and the two things that can be wrong with what follows it. `MissingCredentials` is the variant that carries a judgment rather than a grammar — § 11.4 makes the part after the scheme optional, and this helper requires it because every concrete scheme it serves mandates credentials. Naming it puts that where the doc comment explaining it already was.

The two `return`s that produced that sentence were separately written copies of it, reached by a scheme with no second half and by one whose second half is whitespace. The test asserts both spellings land on the one variant.

**The fourth unreachable branch, and the third of exactly this shape.** `"Authorization header missing auth-scheme"` cannot fire for the same reason the challenge's and the Content-Range parser's could not: the value is trimmed and checked for emptiness, so what precedes the first `char::is_whitespace` is non-empty, and `str::trim` removes that same set. Three helpers in this module were written from one another and inherited it. That is worth stating as a pattern rather than as three coincidences — a `trim`-then-`splitn` pair makes the "missing first part" guard dead every time, and a `String` return kept it invisible in all three.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
