### PR TITLE
The auth module records what it owns and what naming its defects found

### DIFF
--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -2,7 +2,43 @@
 //
 // SPDX-License-Identifier: ISC
 
+//! The authentication framework's four helpers, and the one thing they share.
+//!
+//! RFC 9110 § 11 defines `challenge` and `credentials` out of one vocabulary —
+//! an `auth-scheme`, then either a `token68` or a `#auth-param` list — and this
+//! module reads all four sides of it: a `WWW-Authenticate` challenge, an
+//! `Authorization` value, and the credentials of the two schemes whose own
+//! documents say what goes in the `token68` (RFC 7617's `Basic`, RFC 6750's
+//! `Bearer`).
+//!
+//! **Every function here answers with a named defect, and none returns a
+//! sentence.** [`ChallengeDefect`], [`AuthorizationDefect`],
+//! [`BasicCredentialsDefect`] and [`BearerTokenDefect`] each carry what their
+//! finding needs and own its wording; the callers compose only the subject.
+//! Two of them span the same octet complaint under different productions —
+//! `ChallengeDefect::SchemeCharacter` and
+//! `ChallengeDefect::ParameterNameCharacter` — which is the distinction the
+//! `String`s could not draw and the reason the conversion was worth doing.
+//!
+//! **Four unreachable branches came out of naming them, three of one shape.**
+//! `validate_challenge_syntax`, `validate_authorization_syntax` and the
+//! `Content-Range` parser in another module each trimmed a value, rejected it
+//! for emptiness, split at the first whitespace, and then checked whether the
+//! first part was empty — which by then it cannot be, because `str::trim`
+//! removes exactly the characters `char::is_whitespace` matches. Written once
+//! and copied twice. A `Result<_, String>` hides that: a dead `return Err` is a
+//! line, while a variant nothing constructs is a claim the module cannot back.
+//! The fourth was `Basic`'s "decoded credentials empty", which needed base64's
+//! arithmetic rather than a reading — zero octets come out of zero symbols.
+//!
+//! The two remaining `Result<_, String>`s here are deliberate.
+//! `split_and_group_challenges` and `parse_auth_params` have two distinct
+//! defects each, and `parse_nc_hex` has one; an enum with a single variant is a
+//! `bool` with ceremony, and the ranked conversion order stopped where the
+//! count did.
+
 use crate::helpers::list::split_commas_respecting_quotes;
+use base64::Engine;
 
 /// Split a WWW-Authenticate header value into "assembled" challenges.
 ///
@@ -324,8 +360,6 @@ impl AuthorizationDefect {
         }
     }
 }
-
-use base64::Engine;
 
 /// Whether an `Authorization` field value has a valid `auth-scheme` and
 /// non-empty credentials after it, answered as an [`AuthorizationDefect`].

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1618,7 +1618,7 @@ sources:
     snippet: Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 454
+      line: 488
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 210
   - label: lint-http-rules/src/helpers/websocket.rs
@@ -2922,7 +2922,7 @@ sources:
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 546
+      line: 580
 - label: RFC 6797
   url: https://www.rfc-editor.org/rfc/rfc6797.html
   fragments:
@@ -3641,7 +3641,7 @@ sources:
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 607
+      line: 641
 - label: RFC 7617
   url: https://www.rfc-editor.org/rfc/rfc7617.html
   fragments:
@@ -3656,19 +3656,19 @@ sources:
     snippet: The user-id and password MUST NOT contain any control characters
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 467
+      line: 501
   - label: basic-credentials base64
     section: § 2
     snippet: and obtains the basic-credentials by encoding this octet sequence using Base64
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 451
+      line: 485
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 2
     snippet: constructs the user-pass by concatenating the user-id, a single colon (":") character, and the password
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 459
+      line: 493
 - label: RFC 7838
   url: https://www.rfc-editor.org/rfc/rfc7838.html
   fragments:
@@ -6329,7 +6329,7 @@ sources:
     snippet: It uses a case-insensitive token to identify the authentication scheme
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 354
+      line: 388
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
       line: 73
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
@@ -6343,25 +6343,25 @@ sources:
     snippet: 'challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 189
+      line: 225
   - label: lint-http-rules/src/helpers/auth.rs (3)
     section: § 11.4
     snippet: 'credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 366
+      line: 400
   - label: lint-http-rules/src/helpers/auth.rs (4)
     section: § 11.6.1
     snippet: 'WWW-Authenticate = #challenge'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 59
+      line: 95
   - label: 1#element expansion
     section: § 5.6.1.1
     snippet: 1#element => element *( OWS "," OWS element )
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 60
+      line: 96
     - file: lint-http-rules/src/helpers/list.rs
       line: 35
     - file: lint-http-rules/src/helpers/list.rs


### PR DESCRIPTION
It was the only helpers module of its size with no `//!` doc — 745 lines, four public validators, and nothing at the top saying they are four readings of one vocabulary. The doc says that, states the convention the batch established (a named defect, never a sentence), and records the finding that only emerged from converting all four: three of these functions carried the same unreachable guard, written once and copied twice, and a `Result<_, String>` is what let it stay invisible in all three.

The stray `use base64::Engine;` that sat between two functions in the middle of the file joins the import at the top, where the compiler was already treating it as being.

Also stated: the two helpers here that keep `Result<_, String>` do so because the ranked conversion order stopped where the defect count did, not because they were missed.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
