### PR TITLE
Defects get a catalogue of their own

### DIFF
--- a/apycite.toml
+++ b/apycite.toml
@@ -35,6 +35,17 @@ sources = "specs/sources.yaml"
 match = "lint-http-rules/src/rules/*.rs"
 label = "{stem}"
 
+# A cite in src/violations/<subject>.rs is labelled by the subject, for the same
+# routing reason — but this twin also has to exist *before* the first cite moves
+# there. Labels group by quoted sentence: without this line, a cite that moves
+# off a rule and onto the def it belongs to is absorbed into whichever label
+# group already holds that sentence, and the file's own path shows up as the
+# label for everything else. Either way the committed specs_generated.yaml
+# churns on a rename nobody made.
+[[labels]]
+match = "lint-http-rules/src/violations/*.rs"
+label = "{stem}"
+
 [[labels]]
 match = "**/*"
 label = "{path}"
@@ -51,7 +62,9 @@ label = "{path}"
 # reason this widening is allowed to happen. Widening to a non-empty baseline
 # would have traded "every file in scope is cited" for "every file in scope is
 # cited eventually", and there is no second mechanism to hold the difference.
-# 222 files, 210 cited, 12 excluded below, 0 to migrate.
+# 235 files under the scope glob, 13 excluded below, the remaining 222 all
+# cited, 0 to migrate. (The previous count subtracted the excludes twice: the
+# number `apycite ratchet` prints is already net of them.)
 #
 # `lint-http-core` and `lint-http-proxy` are deliberately still out of scope, and
 # not because their cites do not work — they do, and both crates carry some. It is
@@ -69,10 +82,19 @@ baseline = "specs/ratchet.txt"
 # specification, and this is where a reviewer sees the claim. `*` crosses `/`, so
 # the scope above catches the whole crate and each of these has to earn its line.
 #
-# The two `mod.rs` files hold traits, registries and re-exports. `rules/mod.rs`
-# also holds `SpecRef` itself. Neither can ever earn a citation, and without these
+# The three `mod.rs` files hold traits, registries and re-exports. `rules/mod.rs`
+# also holds `SpecRef` itself. None can ever earn a citation, and without these
 # they would sit in the baseline forever — so the baseline could never empty,
 # which is the one thing the ratchet is counting down to.
+#
+# `violations/mod.rs` is the one to re-check as this campaign proceeds, because
+# it is the only exclude whose sibling files are *required* to be cited: every
+# `violations/<subject>.rs` carries the quotes its defs enforce, and the ratchet
+# holds them there. What is excluded is the registry around them — the
+# `ViolationDef` struct, the distributed slice, the sorted view — which states no
+# sentence of any specification. The day a normative fact is written into this
+# file rather than into a def, the exclude is false and the fact is in the wrong
+# place.
 #
 # `engine.rs` dispatches rules and `lint_protocol.rs` is the protocol-event
 # entry point: both decide *which* rule runs, never what any rule means.
@@ -93,6 +115,7 @@ baseline = "specs/ratchet.txt"
 # not move here with the parser.
 exclude = [
     "lint-http-rules/src/rules/mod.rs",
+    "lint-http-rules/src/violations/mod.rs",
     "lint-http-rules/src/helpers/mod.rs",
     "lint-http-rules/src/helpers/rule_config.rs",
     "lint-http-rules/src/queries/*.rs",

--- a/lint-http-rules/src/lib.rs
+++ b/lint-http-rules/src/lib.rs
@@ -5,8 +5,9 @@
 //! The `lint-http` rule catalogue and lint dispatch.
 //!
 //! This crate holds the [`Rule`](rules::Rule) catalogue (self-registered via
-//! `linkme`), the helper utilities rules build on, the state-query layer, and
-//! the dispatch engine ([`engine::lint_transaction`],
+//! `linkme`), the [`ViolationDef`](violations::ViolationDef) catalogue of the
+//! defects those rules report, the helper utilities rules build on, the
+//! state-query layer, and the dispatch engine ([`engine::lint_transaction`],
 //! [`lint_protocol::lint_protocol_event`]). It depends only on
 //! [`lint_http_core`].
 //!
@@ -33,6 +34,11 @@ pub mod queries;
 // actually be tempted — still covered.
 #[allow(unsafe_code)]
 pub mod rules;
+// The violation catalogue registers the same way and needs the same exemption,
+// for the same reason: one `#[link_section]` per def, inside each
+// `src/violations/*.rs`.
+#[allow(unsafe_code)]
+pub mod violations;
 
 #[cfg(test)]
 mod test_helpers;

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! The violation catalogue: the defects rules report, one entry each.
+//!
+//! A rule is the unit of *analysis* — what gets parsed, when it runs, which
+//! options it reads. A violation is the unit of *report* — what an operator
+//! reads, tunes and silences. The catalogue has been asking one type to be
+//! both: severity is a single scalar per rule, so a rule that says four
+//! different things says them all at the same level, and the same defect
+//! reported by two rules has no name the two can agree on.
+//!
+//! This module holds the second half of that split. A [`ViolationDef`] is a
+//! defect: an id, a title, its default severity, and the specification
+//! sentence it enforces. Defs live in `src/violations/<subject>.rs`, grouped
+//! by subject the way `helpers/` is, and self-register into
+//! [`REGISTERED_VIOLATIONS`] at link time. [`VIOLATIONS`] is the sorted view.
+//!
+//! Nothing emits one yet: rules keep reporting through
+//! [`RuleMeta::violation`](crate::rules::RuleMeta::violation) and its cited
+//! sibling until the two APIs meet. This is the registry they will meet in.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use linkme::distributed_slice;
+use std::sync::LazyLock;
+
+/// One reportable defect.
+///
+/// # These are `static`, never `const`
+///
+/// A rule declares the defs it may report and emits one by reference, and the
+/// engine resolves that reference to a configured severity by identity —
+/// `ptr::eq` against the declared list. A `const` is inlined at each use, so
+/// two `&DEF` written in different functions are two different addresses and
+/// the lookup misses. It compiles, and it is wrong at run time. The same
+/// applies to a rule's declared list: it is a named `static`, because an array
+/// of references to statics is not const-promotable and the inline `&[…]` form
+/// does not typecheck as `'static`.
+pub struct ViolationDef {
+    /// This violation's id: the `[violations.<id>]` section that configures
+    /// it, the `Violation.violation` its findings will carry, and the section
+    /// heading in the owning rule's generated doc page. Disjoint from the rule
+    /// ids — see `violation_ids_are_unique_and_disjoint_from_rule_ids`.
+    pub id: &'static str,
+    /// One line naming the defect, for the docs heading and `rules list`.
+    pub title: &'static str,
+    /// The whole message, when this defect always reads the same way. Empty
+    /// when the message is parameterised, in which case the site formats it —
+    /// the format strings stay where their arguments are.
+    pub message: &'static str,
+    /// The severity a finding carries when nothing in the configuration says
+    /// otherwise. Unlike a rule *option*, which is policy about the traffic
+    /// and must be chosen, this is a preference with a defensible default: a
+    /// catalogue this size cannot be hand-answered entry by entry, and
+    /// `docs/development.md` §6's no-defaults doctrine is reversed here for
+    /// severity alone.
+    pub default_severity: Severity,
+    /// The sentence this defect enforces. `None` while the reading has not
+    /// happened yet — the same shape `cite` has on a finding, and for the same
+    /// reason: an unread sentence is carried as absent, never as a guess.
+    ///
+    /// This is where a `// cite` comment moves to when its statement becomes a
+    /// def. The quote sits beside the reference it quotes, and the rule site
+    /// keeps none.
+    pub spec: Option<SpecRef>,
+}
+
+/// Every violation, self-registered at link time via
+/// `linkme::distributed_slice`. Each `src/violations/<subject>.rs` appends its
+/// defs here, so adding a defect requires no edit to a central list. The link
+/// order is unspecified; [`VIOLATIONS`] sorts a copy by id.
+#[distributed_slice]
+pub static REGISTERED_VIOLATIONS: [&'static ViolationDef] = [..];
+
+/// The whole catalogue of defects, sorted by id so anything that enumerates it
+/// — the generated configuration, the generated docs, a gate — reads the same
+/// order every run whatever order the linker used.
+pub static VIOLATIONS: LazyLock<Vec<&'static ViolationDef>> = LazyLock::new(|| {
+    let mut v: Vec<&'static ViolationDef> = REGISTERED_VIOLATIONS.iter().copied().collect();
+    v.sort_by_key(|d| d.id);
+    v
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A subject file registers by being declared here: `linkme` collects what
+    /// the linker sees, and the linker never sees a module nobody declared. So
+    /// a `src/violations/<subject>.rs` that exists but is missing its `mod`
+    /// line compiles, links, and contributes nothing — the whole subject
+    /// silently absent from the catalogue, with every other gate passing
+    /// because none of them knows the file was supposed to be there.
+    ///
+    /// This is the same safety net `every_rule_file_is_registered` provides
+    /// for `src/rules/`, phrased against declarations rather than a count: a
+    /// rule file holds exactly one rule, a subject file holds as many defs as
+    /// the subject has defects, so counting cannot say which file went missing.
+    #[test]
+    fn every_violation_file_is_registered() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/violations");
+        let source =
+            std::fs::read_to_string(dir.join("mod.rs")).expect("cannot read violations/mod.rs");
+        // A declaration is a whole line, so `mod tests {` below is not one and
+        // neither is a commented-out one.
+        let declared: std::collections::HashSet<&str> = source
+            .lines()
+            .map(str::trim)
+            .filter_map(|l| {
+                l.strip_prefix("mod ")
+                    .or_else(|| l.strip_prefix("pub mod "))
+                    .and_then(|rest| rest.strip_suffix(';'))
+            })
+            .collect();
+        for entry in std::fs::read_dir(&dir).expect("cannot read src/violations") {
+            let path = entry.expect("a directory entry").path();
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if stem == "mod" {
+                continue;
+            }
+            assert!(
+                declared.contains(stem),
+                "src/violations/{stem}.rs is not declared in violations/mod.rs, \
+                 so none of its defs reach the catalogue",
+            );
+        }
+    }
+
+    /// Two things at once, because they are one property: an id names exactly
+    /// one thing in this catalogue.
+    ///
+    /// Disjointness from the rule ids is what keeps the configuration and the
+    /// docs unambiguous. `[rules.<id>]` and `[violations.<id>]` are separate
+    /// tables, but they are read by the same person, and a violation rendered
+    /// as a section inside its rule's page would collide with that page's own
+    /// anchor if the two shared a name.
+    #[test]
+    fn violation_ids_are_unique_and_disjoint_from_rule_ids() {
+        let mut seen = std::collections::HashSet::new();
+        for def in VIOLATIONS.iter() {
+            assert!(!def.id.is_empty(), "a violation id must not be empty");
+            assert!(seen.insert(def.id), "duplicate violation id: {}", def.id);
+        }
+        for rule in crate::rules::all_rules() {
+            assert!(
+                !seen.contains(rule.id()),
+                "{} names both a rule and a violation",
+                rule.id(),
+            );
+        }
+    }
+
+    /// The sorted view must hold exactly what was registered, in id order —
+    /// what everything downstream enumerates.
+    #[test]
+    fn linkme_collects_the_violation_catalogue_in_order() {
+        assert_eq!(VIOLATIONS.len(), REGISTERED_VIOLATIONS.len());
+        let ids: Vec<&str> = VIOLATIONS.iter().map(|d| d.id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted, "VIOLATIONS must be sorted by id");
+    }
+}


### PR DESCRIPTION
A rule is the unit of analysis — what gets parsed, when it runs, which options it reads. It is also, today, the unit of report: severity is one scalar per rule, so a rule that says four different things says them all at the same level, and the same defect found by two rules has no name the two can agree on.

This is the registry for the second half of that split, and nothing else. A `ViolationDef` is one reportable defect: id, title, default severity, and the specification sentence it enforces. Defs will live in `src/violations/<subject>.rs`, grouped by subject the way `helpers/` is, and self-register through `linkme` exactly as rules do; `VIOLATIONS` is the sorted view. The catalogue is empty and nothing emits from it — rules keep reporting through `violation`/`cited` until the two APIs meet.

Three gates come with it. `every_violation_file_is_registered` is phrased against the `mod` declarations rather than a count, because a subject file holds as many defs as the subject has defects and a count cannot say which file went missing — the failure it catches is a file that exists, compiles and links while contributing nothing. Ids must be unique and disjoint from the rule ids, since a violation renders as a section inside its rule's page and a shared name collides with that page's own anchor. And the sorted view must hold what was registered, in order.

A ratchet on how many defs name their sentence is deliberately not here: with an empty catalogue its floor can only be zero, which clippy rightly refuses to compile as a comparison that is always true. It belongs to the commit that lands the first subject.

apycite gets the `violations/*.rs` label twin now rather than later. Labels group by quoted sentence, so without it the first cite to move off a rule and onto the def it belongs to would be absorbed into whichever group already holds that sentence — churn in a 2,390-cite artifact from a rename nobody made. `violations/mod.rs` is excluded, and that exclude is the one to re-check as this proceeds: it is the only excluded file whose siblings are *required* to be cited. What it holds is the registry — a struct, a slice, a sorted view — which states no sentence of any specification. The day a normative fact is written here instead of into a def, the exclude is false and the fact is in the wrong place.

The file count in that comment subtracted the excludes twice; the number `apycite ratchet` prints is already net of them. 235 files under the scope glob, 13 excluded, the remaining 222 all cited.

Coverage 97.70% (21,417/21,921), unchanged — link-time registrations do not reach the denominator.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
