### PR TITLE
A defect's severity is tuned on its own

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -8,6 +8,11 @@
 # transport policy, which no rule knows about. Every `[rules.*]` section below
 # is rendered from that rule's `config_example()` metadata, so a change to a
 # rule's example belongs in `lint-http-rules/src/rules/<id>.rs`.
+#
+# The `[violations.*]` sections after them are the defects those rules report,
+# each shown at the default severity its catalogue entry carries. They are
+# overrides: deleting one changes nothing, editing one changes what that single
+# defect reports at.
 
 [general]
 listen = "127.0.0.1:3000"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,14 +66,16 @@ Two flags shape the report:
   the transaction got no response); WebSocket sessions
   (`"kind": "websocket_session"`) carry `session_id`, `transaction_id`,
   `close_code`. Both carry `violations`, each with `rule`, `severity`,
-  `message`.
+  `message`, and — when the rule named the defect it found — `violation`, the
+  catalogue id the `[violations]` config section tunes.
 - `--min-severity info|warn|error` (default `info`): drop findings below the
   given severity from the report *and* from the exit-code decision — with
   `--min-severity error`, warn-level findings no longer fail CI. Stateful rules
   still see every transaction; only the reporting is gated.
 
 The `--config` file is the same TOML used by `run`; `lint` reads only the
-`[rules]` toggles/severities and the `[general]` `ttl_seconds` / `max_history`
+`[rules]` toggles/severities, the `[violations]` overrides beside them, and the
+`[general]` `ttl_seconds` / `max_history`
 (used to size the replay's history window). The `listen`, `captures`, and
 `[tls]` fields are ignored by `lint`.
 
@@ -198,3 +200,41 @@ paths = ["/logout", "/signout", "/auth/logout", "/api/v1/logout"]
 ```
 
 See [Rules Documentation](rules.md) for details on each rule and their configuration options.
+
+### Violation Severity Overrides
+
+A rule is the unit of analysis; a *violation* is the unit of report — one named
+defect a rule may find. A rule that checks four things reports four violations,
+and the `[violations]` section is where each of them is tuned separately.
+
+Every violation carries a default severity in the catalogue, so this section is
+optional and mostly stays empty: write a table only to disagree with a default.
+
+The shape, with an illustrative id — the real ones are in `config_example.toml`:
+
+```toml
+# The rule runs at its own severity...
+[rules.strict_transport_security_valid]
+enabled = true
+severity = "warn"
+
+# ...but this one defect it reports is an error.
+[violations.strict_transport_security_max_age_absent]
+severity = "error"
+```
+
+`severity` is the only key, and it is required in any table that is written —
+a section that sets nothing is a section that does nothing, and both are
+rejected at startup. Every violation id and its default is listed in
+`config_example.toml`; a table naming an id that does not exist is rejected
+there too, the same way an unknown rule id is.
+
+There is deliberately **no** per-violation `enabled`. Most rules report their
+first finding and stop, so switching off one defect would also silence whatever
+the same branch would have said next — a config whose effect depends on the
+order of checks inside a rule body. To quiet a single defect, set it to
+`severity = "info"` and run the report with `--min-severity warn`.
+
+A finding that names a defect carries both names: `rule` and `violation`. Older
+captures, and findings from rules whose defects have not been named yet, carry
+`rule` alone.

--- a/docs/development.md
+++ b/docs/development.md
@@ -277,12 +277,13 @@ do run it, as does CI.
 ### 6. Configurable Rules Guidelines
 
 - Do not use hardcoded defaults in rule implementations. If a rule requires configuration, it should require an explicit TOML table under `[rules.<rule_id>]` and parse its values in `prepare`.
+- **One exception, and only one: a violation's severity.** A `ViolationDef` carries a `default_severity`, and `[violations.<id>]` overrides it. A rule *option* is policy about the traffic and nobody but the operator can choose it; a severity is a preference, and a catalogue with one entry per defect cannot be made to run at all if every entry must be answered first. Nothing else on a def or a rule gets a default by this argument.
 - On missing or invalid configuration, `prepare` must return an `Err(...)` so engine construction fails fast, by rule name. Do not silently fall back to a default unless this behavior is explicitly documented and desired.
 - A required list of case-insensitive names (the `allowed`/`headers` shape) is parsed by `helpers::rule_config::parse_lowercased_list`; the citation licensing the case-fold stays in the rule's `prepare`, beside the call.
 - Tests should cover both `prepare` errors for invalid/missing config and the runtime behavior when valid configs are provided (including edge cases like negative numbers, invalid types, and boundary values). Dispatch a rule in tests through `test_helpers::run_rule` / `run_protocol_rule`, which prepare and then check the way the engine does.
 - Every registered rule must prepare successfully under `config_example.toml` — the `every_rule_prepares_under_the_example_config` test enforces it, so a new configurable rule needs its example section in the same commit.
 - That example section is `config_example()`, a required `RuleMeta` member returning everything under the `[rules.<id>]` header: the two keys, the rule's own options, and the comment explaining them. It is required for the same reason the options above have no defaults — an example nobody chose is still an example someone will copy.
-- `config_example.toml` is **generated** from those bodies. Do not edit it; edit the rule and run:
+- `config_example.toml` is **generated** from those bodies, plus one `[violations.<id>]` section per catalogue entry rendered from its `default_severity`. Do not edit it; edit the rule or the def and run:
 
 ```bash
 cargo xtask genconfig

--- a/lint-http-core/src/config.rs
+++ b/lint-http-core/src/config.rs
@@ -5,7 +5,8 @@
 //! Rule configuration loading and lookup.
 //!
 //! This module holds only the lint-facing configuration surface: the
-//! `[rules.*]` table. Transport configuration (listen addresses, TLS,
+//! `[rules.*]` and `[violations.*]` tables. Transport configuration (listen
+//! addresses, TLS,
 //! captures, HTTP/3 upstream policy) belongs to the proxy binary and lives in
 //! `lint-http-proxy`, which flattens this struct into its own `Config` — so
 //! the rule layer depends only on what it actually reads, and this crate can
@@ -19,6 +20,19 @@ use std::collections::HashMap;
 pub struct Config {
     #[serde(default)]
     pub rules: HashMap<String, toml::Value>,
+    /// The `[violations.*]` tables: per-defect overrides, keyed by violation
+    /// id. Absent by default and expected to stay mostly absent — a
+    /// violation's severity has a default on its catalogue entry, so a table
+    /// here is what an operator writes when they disagree with it.
+    ///
+    /// A second table rather than keys inside `[rules.<id>]`, because a defect
+    /// is not owned by the rule that reports it: two rules may report the same
+    /// one, and merging two rules must not rename what either of them says.
+    /// Kept as `toml::Value` for the same reason `rules` is — this crate sits
+    /// below the catalogue and cannot know which ids exist.
+    /// `rules::validate_rules` checks them against it.
+    #[serde(default)]
+    pub violations: HashMap<String, toml::Value>,
 }
 
 impl Config {
@@ -51,6 +65,16 @@ impl Config {
     /// Gets the configuration value for a rule.
     pub fn get_rule_config(&self, rule: &str) -> Option<&toml::Value> {
         self.rules.get(rule)
+    }
+
+    /// The `[violations.<id>]` table, when the configuration wrote one.
+    ///
+    /// There is no `is_enabled` twin: a defect cannot be switched off on its
+    /// own, because most rules return their first finding and stop, so
+    /// silencing one defect would silence whatever the same branch would have
+    /// reported after it. Severity is the whole of what this table decides.
+    pub fn get_violation_config(&self, violation: &str) -> Option<&toml::Value> {
+        self.violations.get(violation)
     }
 }
 
@@ -125,6 +149,44 @@ enabled = false
         assert!(config.is_some());
         fs::remove_file(&tmp_toml).await?;
         Ok(())
+    }
+
+    /// The second table loads beside the first, and neither knows about the
+    /// other: a file may carry `[violations]` alone, `[rules]` alone, or both.
+    #[tokio::test]
+    async fn load_violation_severity_override() -> anyhow::Result<()> {
+        let tmp_toml =
+            std::env::temp_dir().join(format!("lint-http_cfg_test_{}.toml", Uuid::new_v4()));
+        let toml = r#"[rules.cache_control_present]
+enabled = true
+severity = "warn"
+
+[violations.cache_control_absent]
+severity = "error"
+"#;
+        fs::write(&tmp_toml, toml).await?;
+        let cfg = Config::load_from_path(&tmp_toml).await?;
+        assert!(cfg.is_enabled("cache_control_present"));
+        let table = cfg
+            .get_violation_config("cache_control_absent")
+            .and_then(toml::Value::as_table)
+            .expect("the override is a table");
+        assert_eq!(
+            table.get("severity").and_then(toml::Value::as_str),
+            Some("error")
+        );
+        fs::remove_file(&tmp_toml).await?;
+        Ok(())
+    }
+
+    /// Nothing is configured by default, which is what makes the table an
+    /// override: a file that writes none reports every defect at the severity
+    /// its catalogue entry carries.
+    #[test]
+    fn no_violation_is_configured_by_default() {
+        let cfg = Config::default();
+        assert!(cfg.violations.is_empty());
+        assert!(cfg.get_violation_config("some_violation").is_none());
     }
 
     #[test]

--- a/lint-http-core/src/lint.rs
+++ b/lint-http-core/src/lint.rs
@@ -51,6 +51,17 @@ impl std::fmt::Display for SpecCitation {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Violation {
     pub rule: String,
+    /// The catalogue id of the defect this finding reports, when the rule named
+    /// one. That is the name `[violations.<id>]` tunes and the one an operator
+    /// grepping a capture for a single defect can use — a rule that says four
+    /// different things reports them under four of these and one `rule`.
+    ///
+    /// Empty when the finding was built the pre-catalogue way, where the rule
+    /// id is the only name a report has. Serde-defaulted both ways, exactly as
+    /// `cite` was: a capture written before the field existed reads back with
+    /// it empty, and a finding that names no defect serializes as it always has.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub violation: String,
     pub severity: Severity,
     pub message: String,
     /// The specification text this finding enforces, when the rule attached
@@ -69,6 +80,7 @@ impl Violation {
     pub fn new(rule: impl Into<String>, severity: Severity, message: impl Into<String>) -> Self {
         Self {
             rule: rule.into(),
+            violation: String::new(),
             severity,
             message: message.into(),
             cite: None,
@@ -86,20 +98,80 @@ pub enum Severity {
     Error,
 }
 
+impl Severity {
+    /// The name this level goes by outside the type: what a configuration
+    /// writes, what a generated configuration renders, and what a report
+    /// prints. One vocabulary, spelled once — the config reader, the config
+    /// generator and the text report each used to spell it out themselves,
+    /// which is three places for a fourth level to be forgotten.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+
+    /// The level a configuration named, or `None` for a name that is not one
+    /// of the three. The exact inverse of [`name`](Severity::name), so what
+    /// the generator writes is always what the reader accepts. Callers phrase
+    /// their own error: what a bad name means differs between a rule's table
+    /// and a violation's.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "info" => Some(Self::Info),
+            "warn" => Some(Self::Warn),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A capture line written before the `cite` field existed still parses,
-    /// and an un-cited finding still serializes byte-identically to what that
-    /// older line held — the capture format is unchanged until a rule
-    /// actually cites.
+    /// A capture line written before the `cite` and `violation` fields existed
+    /// still parses, and a finding carrying neither still serializes
+    /// byte-identically to what that older line held — the capture format is
+    /// unchanged until a rule actually cites or names a defect.
     #[test]
     fn legacy_capture_line_round_trips_without_cite() {
         let legacy = r#"{"rule":"host_header","severity":"warn","message":"m"}"#;
         let v: Violation = serde_json::from_str(legacy).expect("pre-cite line parses");
         assert!(v.cite.is_none());
+        assert!(v.violation.is_empty());
         assert_eq!(serde_json::to_string(&v).expect("serializes"), legacy);
+    }
+
+    /// A finding that names the defect it reports carries both names: the rule
+    /// that ran, and the entry an operator tunes.
+    #[test]
+    fn a_finding_naming_its_defect_round_trips_with_both_names() {
+        let v = Violation {
+            violation: "host_header_absent".to_string(),
+            ..Violation::new("host_header", Severity::Error, "m")
+        };
+        let json = serde_json::to_string(&v).expect("serializes");
+        assert_eq!(
+            json,
+            r#"{"rule":"host_header","violation":"host_header_absent","severity":"error","message":"m"}"#
+        );
+        let back: Violation = serde_json::from_str(&json).expect("parses");
+        assert_eq!(back.violation, v.violation);
+    }
+
+    /// The two halves of the severity vocabulary are inverses, which is what
+    /// lets the generated configuration be read back by the configuration
+    /// reader. A level whose name did not parse back would be a section the
+    /// generator writes and the loader rejects.
+    #[test]
+    fn every_severity_name_parses_back_to_its_level() {
+        for level in [Severity::Info, Severity::Warn, Severity::Error] {
+            assert_eq!(Severity::from_name(level.name()), Some(level));
+        }
+        assert_eq!(Severity::from_name("fatal"), None);
+        assert_eq!(Severity::from_name("Warn"), None);
     }
 
     #[test]

--- a/lint-http-core/src/test_helpers.rs
+++ b/lint-http-core/src/test_helpers.rs
@@ -117,6 +117,23 @@ pub fn make_test_config_with_severity(rule_id: &str, severity: &str) -> crate::c
     cfg
 }
 
+/// Override one violation's severity, the way a `[violations.<id>]` table
+/// does. `severity` must be one of `"info"`, `"warn"`, `"error"` — an
+/// unreadable one is what a validation test writes, so this does not check it.
+pub fn override_violation_severity(
+    cfg: &mut crate::config::Config,
+    violation_id: &str,
+    severity: &str,
+) {
+    let mut table = toml::map::Map::new();
+    table.insert(
+        "severity".to_string(),
+        toml::Value::String(severity.to_string()),
+    );
+    cfg.violations
+        .insert(violation_id.to_string(), toml::Value::Table(table));
+}
+
 /// Create a minimal HTTP transaction for testing.
 /// Contains a GET request to `http://example/` with a standard test user agent.
 pub fn make_test_transaction() -> crate::http_transaction::HttpTransaction {

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -160,14 +160,6 @@ async fn run_app_with_limit(config_path: &str, accept_limit: Option<usize>) -> a
     crate::proxy::run_proxy_with_limit(addr, capture_writer, cfg, accept_limit).await
 }
 
-fn severity_label(severity: lint::Severity) -> &'static str {
-    match severity {
-        lint::Severity::Info => "info",
-        lint::Severity::Warn => "warn",
-        lint::Severity::Error => "error",
-    }
-}
-
 /// Write to stdout, treating a closed pipe as a clean exit. Rust ignores
 /// `SIGPIPE`, so writing to a reader that has gone away (e.g. `rules list | head`)
 /// surfaces as a `BrokenPipe` error that `print!`/`println!` turn into a panic;
@@ -460,13 +452,7 @@ fn render_lint_report(
                     }
                 }
                 for v in block.violations() {
-                    write!(
-                        out,
-                        "  {:<5} {}  {}",
-                        severity_label(v.severity),
-                        v.rule,
-                        v.message
-                    )?;
+                    write!(out, "  {:<5} {}  {}", v.severity.name(), v.rule, v.message)?;
                     // The specification text the finding enforces, when the
                     // rule attached one at the violation site.
                     if let Some(cite) = &v.cite {
@@ -1063,13 +1049,6 @@ severity = "warn"
         assert_eq!(parsed[0]["session_id"], session_id.to_string());
         assert_eq!(parsed[0]["close_code"], 1000);
         Ok(())
-    }
-
-    #[test]
-    fn severity_label_covers_all_levels() {
-        assert_eq!(severity_label(lint::Severity::Info), "info");
-        assert_eq!(severity_label(lint::Severity::Warn), "warn");
-        assert_eq!(severity_label(lint::Severity::Error), "error");
     }
 
     // Write a minimal config whose `listen` points at an already-bound port, so

--- a/lint-http-rules/src/engine.rs
+++ b/lint-http-rules/src/engine.rs
@@ -88,7 +88,7 @@ impl PreparedEngine {
                         rule,
                         query: crate::rules::query_type_for(rule.id()),
                         resolved: rule.prepare(cfg)?,
-                        severities: crate::rules::severities_for(rule),
+                        severities: crate::rules::severities_for(rule, cfg),
                     })
                 })
                 .collect::<anyhow::Result<_>>()
@@ -104,7 +104,7 @@ impl PreparedEngine {
                     Ok(PreparedProtocolRule {
                         rule,
                         resolved: rule.prepare(cfg)?,
-                        severities: crate::rules::severities_for(rule),
+                        severities: crate::rules::severities_for(rule, cfg),
                     })
                 })
                 .collect::<anyhow::Result<_>>()?,

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -179,6 +179,7 @@ impl<'a> RuleContext<'a> {
     fn finding(&self, def: &'static ViolationDef, message: String) -> Violation {
         Violation {
             rule: self.rule_id.into(),
+            violation: def.id.into(),
             severity: self.severity_for(def),
             message,
             cite: def.spec.as_ref().map(SpecRef::citation),
@@ -213,17 +214,39 @@ impl<'a> RuleContext<'a> {
 /// [`RuleMeta::violations`] entry, in that order — the table
 /// [`RuleContext::with_violations`] hands to dispatch.
 ///
-/// Every entry is its def's `default_severity`, which is the whole of the
-/// resolution while nothing in a configuration names a violation. The defaults
-/// live in code, unlike a rule's *options*: an option is policy about the
-/// traffic and has to be chosen, a severity is a preference, and a catalogue
-/// of this many defects cannot be answered entry by entry before it can run at
-/// all.
-pub fn severities_for(rule: &dyn RuleMeta) -> Vec<crate::lint::Severity> {
+/// An entry is its def's `default_severity` unless `[violations.<id>]` says
+/// otherwise. The defaults live in code, unlike a rule's *options*: an option
+/// is policy about the traffic and has to be chosen, a severity is a
+/// preference, and a catalogue of this many defects cannot be answered entry by
+/// entry before it can run at all. So the override is the exception an operator
+/// writes, and the whole table resolves without one.
+pub fn severities_for(
+    rule: &dyn RuleMeta,
+    cfg: &crate::config::Config,
+) -> Vec<crate::lint::Severity> {
     rule.violations()
         .iter()
-        .map(|def| def.default_severity)
+        .map(|def| violation_severity(cfg, def))
         .collect()
+}
+
+/// The severity `def` reports at under `cfg` — its `[violations.<id>]`
+/// override, or the default on the def.
+///
+/// Infallible where [`get_rule_severity_required`] is not, and for a reason
+/// that only holds because of where it runs: [`validate_rules`] has already
+/// refused a malformed `[violations.*]` table by the time an engine prepares
+/// anything, so an unreadable value here is not a configuration this code can
+/// reach. Reading it as "no override" rather than as an error is also the
+/// safe half of being wrong — the defect is still reported, at the severity
+/// its author chose.
+fn violation_severity(cfg: &crate::config::Config, def: &ViolationDef) -> crate::lint::Severity {
+    cfg.get_violation_config(def.id)
+        .and_then(toml::Value::as_table)
+        .and_then(|table| table.get("severity"))
+        .and_then(toml::Value::as_str)
+        .and_then(crate::lint::Severity::from_name)
+        .unwrap_or(def.default_severity)
 }
 
 /// Scope of a rule: whether it applies to client-only traffic (requests),
@@ -407,6 +430,10 @@ pub trait RuleMeta: Send + Sync {
     fn violation(&self, severity: crate::lint::Severity, message: String) -> Violation {
         Violation {
             rule: self.id().into(),
+            // A finding built this way names no defect: the message was
+            // written here rather than looked up, so there is nothing to name
+            // it by. [`RuleContext::report`] fills this in.
+            violation: String::new(),
             severity,
             message,
             cite: None,
@@ -572,18 +599,23 @@ pub fn get_rule_severity_required(
             rule
         ));
     };
-    match s {
-        "info" => Ok(crate::lint::Severity::Info),
-        "warn" => Ok(crate::lint::Severity::Warn),
-        "error" => Ok(crate::lint::Severity::Error),
-        _ => Err(anyhow::anyhow!(
+    crate::lint::Severity::from_name(s).ok_or_else(|| {
+        anyhow::anyhow!(
             "Rule '{}' has invalid severity '{}'. Must be one of: info, warn, error",
             rule,
             s
-        )),
-    }
+        )
+    })
 }
 
+/// Check the whole lint configuration: the `[rules.*]` tables this is named
+/// for, and the `[violations.*]` overrides beside them.
+///
+/// One entry point rather than two, because a second function is a second
+/// thing every caller has to remember — the proxy, the offline `lint`
+/// subcommand and [`crate::engine::PreparedEngine::new`] each call this once
+/// and get everything. A caller that validated only half would start under a
+/// configuration naming a defect that does not exist.
 pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
     // Ensure every rule table specifies valid `enabled` and `severity` entries.
     for (rule_name, val) in &config.rules {
@@ -607,16 +639,14 @@ pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
 
             // Validate `severity` field - must be present and be a valid string
             match table.get("severity") {
-                Some(toml::Value::String(s)) => match s.as_str() {
-                    "info" | "warn" | "error" => {}
-                    _ => {
-                        return Err(anyhow::anyhow!(
-                                "Invalid severity '{}' for rule '{}': must be one of 'info', 'warn', 'error'",
-                                s,
-                                rule_name
-                            ));
-                    }
-                },
+                Some(toml::Value::String(s)) if crate::lint::Severity::from_name(s).is_some() => {}
+                Some(toml::Value::String(s)) => {
+                    return Err(anyhow::anyhow!(
+                        "Invalid severity '{}' for rule '{}': must be one of 'info', 'warn', 'error'",
+                        s,
+                        rule_name
+                    ));
+                }
                 Some(_) => {
                     return Err(anyhow::anyhow!(
                         "Invalid severity for rule '{}': must be a string 'info', 'warn', or 'error'",
@@ -656,13 +686,96 @@ pub fn validate_rules(config: &crate::config::Config) -> anyhow::Result<()> {
         }
     }
 
+    validate_violation_overrides(config)?;
+
     // Per-rule validation: every enabled rule parses its own config section so
     // a malformed section (including custom fields) fails fast at startup.
+    // Last, because it is the only part that runs rule code.
     for rule in all_rules() {
         if config.is_enabled(rule.id()) {
             rule.prepare(config).map_err(|e| {
                 anyhow::anyhow!("Invalid configuration for rule '{}': {}", rule.id(), e)
             })?;
+        }
+    }
+    Ok(())
+}
+
+/// Check every `[violations.<id>]` table: it sets a severity, it sets nothing
+/// else, and it names a defect in the catalogue.
+///
+/// Stricter than the rule tables in the one way that matters here. A rule's
+/// table is required and carries the rule's own options, so an unknown key is
+/// the rule's business and its `prepare` judges it; a violation's table is
+/// optional, exists only to disagree with a default, and has exactly one key.
+/// An unrecognised key in it is therefore always a mistake — and one mistake
+/// in particular, `enabled = false`, would otherwise look like it worked.
+fn validate_violation_overrides(config: &crate::config::Config) -> anyhow::Result<()> {
+    for (id, value) in &config.violations {
+        let Some(table) = value.as_table() else {
+            return Err(anyhow::anyhow!(
+                "Violation '{}' configuration must be a table",
+                id
+            ));
+        };
+        // First, because the key most likely to be here is one that will never
+        // be: `[violations.<id>] enabled = false`. Judged before the severity
+        // is missed, so that section hears why it cannot work rather than that
+        // it forgot a key it never meant to write.
+        for key in table.keys() {
+            if key != "severity" {
+                return Err(anyhow::anyhow!(
+                    "Unknown key '{}' for violation '{}': a violation table configures \
+                     'severity' only. A single defect cannot be switched off — most rules \
+                     report their first finding and stop, so silencing one would silence \
+                     whatever the same branch would have said next. Set severity = \"info\" \
+                     and report with --min-severity warn instead",
+                    key,
+                    id
+                ));
+            }
+        }
+        match table.get("severity") {
+            Some(toml::Value::String(s)) if crate::lint::Severity::from_name(s).is_some() => {}
+            Some(toml::Value::String(s)) => {
+                return Err(anyhow::anyhow!(
+                    "Invalid severity '{}' for violation '{}': must be one of 'info', 'warn', \
+                     'error'",
+                    s,
+                    id
+                ));
+            }
+            Some(_) => {
+                return Err(anyhow::anyhow!(
+                    "Invalid severity for violation '{}': must be a string 'info', 'warn', or \
+                     'error'",
+                    id
+                ));
+            }
+            // Required *within* a table that was written, though the table
+            // itself is optional: the only thing it can say is a severity, so
+            // one that says nothing is a section its author expected to do
+            // something.
+            None => {
+                return Err(anyhow::anyhow!(
+                    "Missing required 'severity' key for violation '{}'. A violation table \
+                     overrides the default severity on its catalogue entry, and has nothing \
+                     else to say",
+                    id
+                ));
+            }
+        }
+        // Last, so that a well-formed section naming nothing is the error an
+        // operator hears about a typo — and a malformed one is judged on its
+        // shape whichever name it carries. Same order the rule tables are
+        // checked in, for the same reason.
+        if !crate::violations::VIOLATIONS.iter().any(|def| def.id == id) {
+            return Err(anyhow::anyhow!(
+                "Configuration names a violation '{}' that does not exist. A violation is one \
+                 defect a rule reports, not the rule itself; every violation id is listed in \
+                 config_example.toml",
+                id
+            ));
         }
     }
     Ok(())
@@ -1307,6 +1420,65 @@ severity = "warn"
         assert!(validate_rules(&cfg).is_err());
     }
 
+    /// Every way a `[violations.<id>]` section can be wrong, in the order they
+    /// are judged: a table that is not one, a section that says nothing, a
+    /// severity that is not a string or not a name, and last a name the
+    /// catalogue does not have.
+    #[test]
+    fn validate_rules_rejects_a_malformed_violation_table() {
+        let section = |value: toml::Value| {
+            let mut cfg = crate::config::Config::default();
+            cfg.violations.insert("some_defect".to_string(), value);
+            validate_rules(&cfg)
+                .expect_err("a malformed violation table must fail validation")
+                .to_string()
+        };
+
+        let msg = section(toml::Value::String("error".into()));
+        assert!(msg.contains("must be a table"), "{msg}");
+
+        let mut table = toml::map::Map::new();
+        let msg = section(toml::Value::Table(table.clone()));
+        assert!(msg.contains("Missing required 'severity'"), "{msg}");
+
+        table.insert("severity".to_string(), toml::Value::Boolean(true));
+        let msg = section(toml::Value::Table(table.clone()));
+        assert!(msg.contains("must be a string"), "{msg}");
+
+        table.insert(
+            "severity".to_string(),
+            toml::Value::String("shouting".into()),
+        );
+        let msg = section(toml::Value::Table(table.clone()));
+        assert!(msg.contains("Invalid severity 'shouting'"), "{msg}");
+
+        table.insert("severity".to_string(), toml::Value::String("error".into()));
+        let msg = section(toml::Value::Table(table));
+        assert!(msg.contains("does not exist"), "{msg}");
+        assert!(msg.contains("some_defect"), "{msg}");
+    }
+
+    /// The unknown-key arm exists for one key in particular: a defect cannot be
+    /// switched off on its own, and `enabled = false` is what someone reaches
+    /// for first. Accepting and ignoring it would leave the defect reporting
+    /// under a configuration that says it does not.
+    ///
+    /// Written alone, which is how it would actually be written, so this also
+    /// pins the arm's position: judged before the missing severity, or the
+    /// section hears that it forgot a key it never meant to write.
+    #[test]
+    fn validate_rules_rejects_switching_one_violation_off() {
+        let mut table = toml::map::Map::new();
+        table.insert("enabled".to_string(), toml::Value::Boolean(false));
+        let mut cfg = crate::config::Config::default();
+        cfg.violations
+            .insert("some_defect".to_string(), toml::Value::Table(table));
+        let err = validate_rules(&cfg).expect_err("a violation has no enabled flag");
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown key 'enabled'"), "{msg}");
+        assert!(msg.contains("--min-severity"), "{msg}");
+    }
+
     #[test]
     fn validate_rules_ok_when_enabled_rule_has_valid_config() -> anyhow::Result<()> {
         let mut cfg = crate::config::Config::default();
@@ -1769,12 +1941,77 @@ severity = "warn"
     }
 
     /// The table is the defs' own defaults, in declaration order — the order
-    /// the index lookup depends on. Nothing overrides them: no configuration
-    /// names a violation yet.
+    /// the index lookup depends on. A configuration that names no violation
+    /// resolves the whole catalogue, which is what the defaults are for.
     #[test]
     fn severities_default_to_the_catalogue_in_declaration_order() {
         assert_eq!(
-            severities_for(&ReportingRule),
+            severities_for(&ReportingRule, &crate::config::Config::default()),
+            vec![crate::lint::Severity::Warn, crate::lint::Severity::Error],
+        );
+    }
+
+    /// One defect of a rule reconfigured, the other left alone — the split the
+    /// catalogue exists for. Under the rule-wide severity these two could only
+    /// ever have said the same thing.
+    #[test]
+    fn a_violation_table_overrides_that_defects_default_alone() {
+        let mut cfg = crate::config::Config::default();
+        crate::test_helpers::override_violation_severity(
+            &mut cfg,
+            "test_fixture_defect_fixed",
+            "info",
+        );
+        assert_eq!(
+            severities_for(&ReportingRule, &cfg),
+            vec![crate::lint::Severity::Info, crate::lint::Severity::Error],
+        );
+
+        let resolved = unit_resolved();
+        let severities = severities_for(&ReportingRule, &cfg);
+        let v = reporting_context(&resolved, &severities).report(&FIXED);
+        assert_eq!(v.severity, crate::lint::Severity::Info);
+        assert_eq!(
+            v.violation, "test_fixture_defect_fixed",
+            "a report names the defect it reports, and that is the name the table used",
+        );
+    }
+
+    /// A section naming a defect this rule does not declare changes nothing
+    /// about it. Resolution is per violation id, not per rule, so the two
+    /// rules that report one defect are configured together and a rule that
+    /// does not report it is untouched.
+    #[test]
+    fn a_section_for_a_defect_the_rule_never_declared_changes_nothing() {
+        let mut cfg = crate::config::Config::default();
+        crate::test_helpers::override_violation_severity(
+            &mut cfg,
+            "test_fixture_defect_foreign",
+            "info",
+        );
+        assert_eq!(
+            severities_for(&ReportingRule, &cfg),
+            vec![crate::lint::Severity::Warn, crate::lint::Severity::Error],
+        );
+    }
+
+    /// Validation refuses a malformed table before an engine exists, so the
+    /// resolver never sees one — and if it somehow did, the defect is still
+    /// reported at its author's level rather than dropped or guessed.
+    #[test]
+    fn an_unreadable_override_falls_back_to_the_defs_default() {
+        let mut cfg = crate::config::Config::default();
+        cfg.violations.insert(
+            "test_fixture_defect_fixed".to_string(),
+            toml::Value::Boolean(true),
+        );
+        crate::test_helpers::override_violation_severity(
+            &mut cfg,
+            "test_fixture_defect_parameterised",
+            "shouting",
+        );
+        assert_eq!(
+            severities_for(&ReportingRule, &cfg),
             vec![crate::lint::Severity::Warn, crate::lint::Severity::Error],
         );
     }

--- a/lint-http-rules/src/test_helpers.rs
+++ b/lint-http-rules/src/test_helpers.rs
@@ -44,7 +44,7 @@ pub fn run_rule_all(
     let Ok(resolved) = rule.prepare(cfg) else {
         return Vec::new();
     };
-    let severities = crate::rules::severities_for(rule);
+    let severities = crate::rules::severities_for(rule, cfg);
     let ctx = crate::rules::RuleContext::new(&resolved).with_violations(rule, &severities);
     rule.findings(tx, history, &ctx)
 }
@@ -63,7 +63,7 @@ pub fn run_protocol_rule(
     cfg: &crate::config::Config,
 ) -> Option<crate::lint::Violation> {
     let resolved = rule.prepare(cfg).ok()?;
-    let severities = crate::rules::severities_for(rule);
+    let severities = crate::rules::severities_for(rule, cfg);
     let ctx = crate::rules::RuleContext::new(&resolved).with_violations(rule, &severities);
     rule.findings(event, history, &ctx).into_iter().next()
 }

--- a/xtask/src/genconfig.rs
+++ b/xtask/src/genconfig.rs
@@ -22,6 +22,7 @@
 //! (or `just genconfig`) to fix drift.
 
 use lint_http_rules::rules::all_rules;
+use lint_http_rules::violations::{ViolationDef, VIOLATIONS};
 use std::path::Path;
 
 /// Everything above the first `[rules.*]` section, verbatim.
@@ -47,6 +48,11 @@ const PREAMBLE: &str = r#"# SPDX-FileCopyrightText: 2025 Alexandre Gomes Gaigala
 # transport policy, which no rule knows about. Every `[rules.*]` section below
 # is rendered from that rule's `config_example()` metadata, so a change to a
 # rule's example belongs in `lint-http-rules/src/rules/<id>.rs`.
+#
+# The `[violations.*]` sections after them are the defects those rules report,
+# each shown at the default severity its catalogue entry carries. They are
+# overrides: deleting one changes nothing, editing one changes what that single
+# defect reports at.
 
 [general]
 listen = "127.0.0.1:3000"
@@ -136,12 +142,35 @@ suppress_headers = ["X-Sensitive-Header"]
 "#;
 // REUSE-IgnoreEnd
 
+/// One `[violations.<id>]` section: the def's own default severity, written
+/// out so the file an operator copies shows what every defect reports at and
+/// where to change it.
+///
+/// The value is what the catalogue already resolves to, which makes the whole
+/// table redundant by construction — and that is the point of shipping it.
+/// A severity default lives in code precisely because a catalogue this size
+/// cannot be hand-answered; the generated file is how it stays visible anyway.
+fn violation_section(def: &ViolationDef) -> String {
+    format!(
+        "[violations.{}]\n# {}\nseverity = \"{}\"\n",
+        def.id,
+        def.title,
+        def.default_severity.name(),
+    )
+}
+
 /// The whole file, as bytes on disk: the preamble, then one `[rules.<id>]`
 /// section per catalogue entry in [`all_rules`] order (transaction rules by id,
-/// then protocol rules by id), separated by a blank line.
+/// then protocol rules by id), then one `[violations.<id>]` section per defect
+/// in [`VIOLATIONS`] order, every section separated by a blank line.
 ///
-/// The header is rendered from `id()` rather than stored, so a section can
-/// never name a rule other than the one whose body it holds.
+/// The rule tables come first and the violation tables after, rather than each
+/// defect under the rule that reports it: a defect is not owned by one rule,
+/// and TOML would read a `[violations.x]` header between two `[rules.*]`
+/// headers as ending the rule table above it anyway.
+///
+/// Every header is rendered from an id rather than stored, so a section can
+/// never name something other than what its body configures.
 pub fn render() -> String {
     let mut out = String::from(PREAMBLE);
     for rule in all_rules() {
@@ -149,6 +178,10 @@ pub fn render() -> String {
         out.push_str(&format!("[rules.{}]\n", rule.id()));
         out.push_str(rule.config_example().trim_end_matches('\n'));
         out.push('\n');
+    }
+    for def in VIOLATIONS.iter() {
+        out.push('\n');
+        out.push_str(&violation_section(def));
     }
     out
 }
@@ -165,15 +198,55 @@ mod tests {
     use lint_http_rules::rules::{PROTOCOL_RULES, RULES};
 
     #[test]
-    fn render_starts_with_the_preamble_and_ends_with_the_last_rule() {
+    fn render_starts_with_the_preamble_and_carries_the_last_rule() {
         let out = render();
         assert!(out.starts_with("# SPDX-FileCopyrightText"));
         assert!(out.contains("\n[tls]\n"));
         let last = all_rules().last().expect("catalogue is non-empty");
         assert!(
-            out.ends_with(&format!("[rules.{}]\n{}", last.id(), last.config_example())),
-            "the file ends with the last rule's section and one newline"
+            out.contains(&format!("[rules.{}]\n{}", last.id(), last.config_example())),
+            "the last rule's section is rendered whole"
         );
+        assert!(out.ends_with('\n'), "the file ends with one newline");
+    }
+
+    /// What a `[violations.*]` section looks like, asserted against a def built
+    /// here rather than one out of the catalogue: this is the shape of the
+    /// section, and it should not change when the first real defect lands or
+    /// when the catalogue is reordered.
+    #[test]
+    fn a_violation_section_is_its_id_title_and_default_severity() {
+        let def = ViolationDef {
+            id: "example_field_empty",
+            title: "Example field is present but empty",
+            message: "Example field is present but empty",
+            default_severity: lint_http_rules::lint::Severity::Error,
+            spec: None,
+        };
+        assert_eq!(
+            violation_section(&def),
+            "[violations.example_field_empty]\n\
+             # Example field is present but empty\n\
+             severity = \"error\"\n",
+        );
+    }
+
+    /// Every defect is configurable by name, and named once. The catalogue is
+    /// empty until the first subject moves over, which makes this vacuous now
+    /// and load-bearing the moment it is not: a def that never reaches the file
+    /// is a severity nobody can find, let alone change.
+    #[test]
+    fn render_emits_one_section_per_violation() {
+        let out = render();
+        assert_eq!(out.matches("\n[violations.").count(), VIOLATIONS.len());
+        for def in VIOLATIONS.iter() {
+            assert_eq!(
+                out.matches(&format!("\n[violations.{}]\n", def.id)).count(),
+                1,
+                "{} should head exactly one section",
+                def.id
+            );
+        }
     }
 
     /// Every rule contributes exactly one section, headed by its own id. The


### PR DESCRIPTION
Severity has been one scalar per rule, so a rule that says four different things says them all at the same level. A violation now carries its own default in the catalogue and `[violations.<id>]` overrides it, keyed by violation id rather than by rule: two rules reporting one defect are configured together, and merging two rules cannot rename what either says.

The table is optional — a default in code is what makes a catalogue this size runnable at all — but a section that exists must set `severity`, and may set nothing else. The unknown-key arm is judged first because the key someone will write is `enabled = false`, which cannot work: most rules report their first finding and stop, so silencing one defect would silence whatever the same branch would have said next. The error says so, and says to use `severity = "info"` with `--min-severity` instead. The unknown-id arm is judged last, matching the rule tables.

`severities_for` takes the config and stays infallible: `validate_rules` refuses a malformed section before any engine exists, and a value that somehow got past it falls back to the def's own default, which reports the defect rather than dropping it. Validation grew a violations pass rather than a sibling function, for the reason engine construction already documents — a second entry point is a second thing every caller has to remember.

Findings gain `violation`, the defect's catalogue id, beside `rule`. Additive and skipped when empty, exactly as `cite` was, so a capture written before the field parses and a finding that names no defect serializes unchanged.

`config_example.toml` renders a `[violations.<id>]` section per entry, id and title and default severity; it is empty today and the byte-diff gate already proves the file holds every entry. `Severity::name`/`from_name` in core replace three hand-written copies of the same three names, so what the generator writes is what the reader accepts.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
