### PR TITLE
Defect ids get a naming convention

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -53,6 +53,8 @@ Adding a new lint rule involves several steps.
 
 ### 1. Naming Convention
 
+#### Rule ids
+
 Rule ids are `snake_case` and carry no category prefix. The file stem, the id
 returned by `id()`, and the `PascalCase` struct name are the same name in three
 spellings — `cache_control_present.rs`, `"cache_control_present"`,
@@ -91,6 +93,60 @@ rather than leading with the number: `status_426_upgrade_valid`.
 Renaming an existing rule is a breaking change for every configuration naming
 it, and this catalogue does not alias: `validate_rules` fails at startup on an
 id it does not recognise, pointing the operator at `docs/rules.md`.
+
+#### Violation ids
+
+A rule id names a **claim** about the traffic; a violation id names the
+**defect** that breaks it, so the predicate vocabulary inverts. The shape is
+`<subject>[_<part>]_<defect>`, and it reads as a noun phrase closed by the
+adjective that condemns it: `if_match_member_malformed` is "the `If-Match`
+member is malformed".
+
+- The **subject** is the field or protocol element, spelled the way the rules
+  spell it — `if_match`, `content_type`, `www_authenticate`. It is never the id
+  of the rule that reports the defect. Two rules may report one defect and one
+  rule may absorb another, and neither event may rename what an operator has
+  already configured.
+- The **part** is optional, and narrows the subject to the piece of it that is
+  wrong: the noun the grammar uses — `member`, `parameter`, `directive`,
+  `scheme`, `name`, `value`. Leave it out when the whole field is the defect.
+- The **defect** is the last word, and comes from this closed list.
+
+| Meaning | Ending | Claim it breaks |
+| --- | --- | --- |
+| Does not match the field's ABNF grammar | `_malformed` | `_syntax` |
+| Grammatical, but unacceptable past the grammar | `_invalid` | `_valid` |
+| Absent from the IANA registry | `_unregistered` | `_registered` |
+| Not written at all where it is required | `_missing` | `_present` |
+| Two things that must agree do not | `_conflicting` | `_consistent` |
+| A directive was not honoured | `_ignored` | `_enforced` |
+| Written, and left with nothing in it | `_empty` | — |
+| Appears more times than the grammar allows | `_duplicated` | — |
+| Written where the specification prohibits it | `_forbidden` | — |
+| Retired by a later specification | `_obsolete` | — |
+
+`_missing` and `_empty` are not alternatives to pick between: `_missing` is a
+sender that never wrote the thing, `_empty` is a sender that wrote it and put
+nothing in it. Different senders, different fixes, different messages. Same
+relation as `_syntax` to `_valid` above.
+
+The list is closed on purpose, and it is what keeps the two catalogues from
+colliding — no rule id ends in a defect, so
+`violation_ids_are_unique_and_disjoint_from_rule_ids` holds by construction
+rather than by luck, and `every_violation_id_names_a_defect` checks the ending
+against the same words. Extending it is a reviewed act: the row here and the
+word in that test move in one commit.
+
+An id must be a valid Rust identifier, because the def is a `static` named by
+the id in `SCREAMING_SNAKE_CASE` — `IF_MATCH_MEMBER_MALFORMED` — the same
+one-name-several-spellings rule the rule files follow. The def lives in
+`src/violations/<subject>.rs`, grouped by subject the way `helpers/` is; a
+subject file holds every defect of the fields it covers, so the file stem is a
+grouping and not required to prefix the id.
+
+Renaming a violation breaks a configuration exactly as renaming a rule does,
+and for the same reason: `[violations.<id>]` is refused at startup when the id
+names nothing.
 
 ### 2. Implementation
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -43,6 +43,13 @@ pub struct ViolationDef {
     /// it, the `Violation.violation` its findings will carry, and the section
     /// heading in the owning rule's generated doc page. Disjoint from the rule
     /// ids — see `violation_ids_are_unique_and_disjoint_from_rule_ids`.
+    ///
+    /// `<subject>[_<part>]_<defect>`, the defect drawn from the closed list
+    /// "Violation ids" in `docs/development.md` defines and
+    /// `every_violation_id_names_a_defect` checks. A rule id names a claim and
+    /// a violation id names the defect that breaks it, which is why the two
+    /// vocabularies cannot collide — and why the id names the defect rather
+    /// than the rule reporting it, since two rules may report one defect.
     pub id: &'static str,
     /// One line naming the defect, for the docs heading and `rules list`.
     pub title: &'static str,
@@ -153,6 +160,92 @@ mod tests {
                 !seen.contains(rule.id()),
                 "{} names both a rule and a violation",
                 rule.id(),
+            );
+        }
+    }
+
+    /// The closed vocabulary a violation id ends in. Each word is defined in
+    /// "Violation ids" in `docs/development.md`, beside the claim it breaks;
+    /// this array and that table are extended in one commit or not at all.
+    const DEFECT_ENDINGS: &[&str] = &[
+        "conflicting",
+        "duplicated",
+        "empty",
+        "forbidden",
+        "ignored",
+        "invalid",
+        "malformed",
+        "missing",
+        "obsolete",
+        "unregistered",
+    ];
+
+    /// Whether `id` is `<subject>[_<part>]_<defect>`: a defect from the list
+    /// above, with at least one character of subject in front of it.
+    fn names_a_defect(id: &str) -> bool {
+        DEFECT_ENDINGS.iter().any(|defect| {
+            id.strip_suffix(defect)
+                .is_some_and(|subject| subject.len() > 1 && subject.ends_with('_'))
+        })
+    }
+
+    /// Whether `id` can be spelled as the def's `static`, which is the id in
+    /// `SCREAMING_SNAKE_CASE` and therefore a Rust identifier.
+    fn is_snake_case(id: &str) -> bool {
+        id.starts_with(|c: char| c.is_ascii_lowercase())
+            && id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    }
+
+    /// A rule id names a claim about the traffic and a violation id names the
+    /// defect that breaks it, so an id ending in a claim — `..._valid`,
+    /// `..._present` — is a def that copied the id of the rule reporting it.
+    /// That is the mistake this catches, and it is worth catching mechanically
+    /// because it is invisible until an operator reads a report and cannot
+    /// tell which of the two catalogues a name came from.
+    ///
+    /// The closed list is also what makes
+    /// `violation_ids_are_unique_and_disjoint_from_rule_ids` hold by
+    /// construction: no rule id ends in any of these words.
+    #[test]
+    fn every_violation_id_names_a_defect() {
+        let stray: Vec<&str> = VIOLATIONS
+            .iter()
+            .map(|def| def.id)
+            .filter(|id| !names_a_defect(id) || !is_snake_case(id))
+            .collect();
+        assert!(stray.is_empty(), "not <subject>_<defect> ids: {stray:?}");
+    }
+
+    /// The shape check itself, against ids built here rather than against the
+    /// catalogue, so the convention is pinned whatever the catalogue holds.
+    #[test]
+    fn the_id_shape_takes_a_defect_and_refuses_a_claim() {
+        for id in [
+            "if_match_empty",
+            "if_match_member_malformed",
+            "www_authenticate_parameter_value_invalid",
+            "status_426_upgrade_missing",
+        ] {
+            assert!(names_a_defect(id) && is_snake_case(id), "{id} is the shape");
+        }
+        for id in [
+            // A rule id: the claim, not the defect.
+            "if_match_etag_syntax",
+            "content_type_valid",
+            // A defect with no subject in front of it.
+            "malformed",
+            "_malformed",
+            // A defect word that is not the ending.
+            "empty_member_reported",
+            // Spellings the def's `static` cannot take.
+            "IfMatchEmpty",
+            "2_members_conflicting",
+        ] {
+            assert!(
+                !(names_a_defect(id) && is_snake_case(id)),
+                "{id} is not the shape",
             );
         }
     }


### PR DESCRIPTION
A rule id names a claim about the traffic; a defect id names what breaks it, so the predicate vocabulary inverts. `<subject>[_<part>]_<defect>`, with the defect drawn from a closed list of ten endings — six inverting the rule predicates, four with no claim counterpart — documented beside the rule convention it mirrors.

Closing the list is what keeps the two catalogues from colliding: no rule id ends in a defect, so the disjointness gate holds by construction rather than by luck. `every_violation_id_names_a_defect` checks the ending against the same words and refuses an id that copied the reporting rule's; the shape check is unit-tested against ids built in the test, so it is pinned today while the catalogue is still empty.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
