### PR TITLE
Cookie path defects get their own names

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1054,3 +1054,31 @@ severity = "warn"
 [rules.websocket_frame_rsv_bits]
 enabled = true
 severity = "warn"
+
+[violations.cookie_path_control_character_forbidden]
+# Set-Cookie Path attribute holds a control character
+severity = "error"
+
+[violations.cookie_path_empty]
+# Set-Cookie Path attribute is empty
+severity = "warn"
+
+[violations.cookie_path_leading_slash_missing]
+# Set-Cookie Path attribute is not rooted at `/`
+severity = "warn"
+
+[violations.cookie_path_missing]
+# Set-Cookie Path attribute carries no value
+severity = "warn"
+
+[violations.cookie_path_non_ascii_character_forbidden]
+# Set-Cookie Path attribute holds a raw non-ASCII character
+severity = "warn"
+
+[violations.cookie_path_percent_encoding_malformed]
+# Set-Cookie Path attribute has a broken percent-encoding
+severity = "warn"
+
+[violations.cookie_path_whitespace_invalid]
+# Set-Cookie Path attribute holds unencoded whitespace
+severity = "info"

--- a/docs/rules/cookie_path_valid.md
+++ b/docs/rules/cookie_path_valid.md
@@ -12,7 +12,9 @@ Validate the `Path` attribute in `Set-Cookie` header fields. The `Path` attribut
 
 ## Specifications
 
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits a `%` in a cookie path still owes
 - [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`
+- [RFC 6265 §5.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2): The Set-Cookie header parsing algorithm — where the `;` split, the WSP trim and the case-insensitive `Path` match come from
 - [RFC 6265 §5.2.4](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4): Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)
 - [RFC 9110 §5.6.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.3): Whitespace — rationale for being conservative about whitespace in header fields; this rule adopts a stricter profile by disallowing unencoded whitespace in cookie paths
 

--- a/lint-http-proxy/src/main.rs
+++ b/lint-http-proxy/src/main.rs
@@ -452,7 +452,20 @@ fn render_lint_report(
                     }
                 }
                 for v in block.violations() {
-                    write!(out, "  {:<5} {}  {}", v.severity.name(), v.rule, v.message)?;
+                    // Both names, when the finding carries both: the rule is
+                    // what ran, the defect is what it found, and they are
+                    // tuned by two different sections of the configuration.
+                    // `rule/defect` rather than either alone — dropping the
+                    // rule would hide which analysis to switch off, and
+                    // dropping the defect would hide the name `[violations.*]`
+                    // takes. A finding from a rule that names no defect prints
+                    // exactly as it always has.
+                    let name = if v.violation.is_empty() {
+                        v.rule.clone()
+                    } else {
+                        format!("{}/{}", v.rule, v.violation)
+                    };
+                    write!(out, "  {:<5} {}  {}", v.severity.name(), name, v.message)?;
                     // The specification text the finding enforces, when the
                     // rule attached one at the violation site.
                     if let Some(cite) = &v.cite {
@@ -1013,6 +1026,40 @@ severity = "warn"
         );
         // The un-cited finding's line is unchanged — no empty bracket.
         assert!(!out.contains("[]"), "{out}");
+        Ok(())
+    }
+
+    /// A finding that names a defect prints both names; one that does not
+    /// prints the rule alone, with no stray separator. The JSON half needs no
+    /// decision of its own — `violation` is a field, and it is present or
+    /// skipped by the same rule.
+    #[test]
+    fn render_lint_report_text_names_the_defect_when_there_is_one() -> anyhow::Result<()> {
+        let mut v = sample_violation();
+        v.violation = "cache_control_missing".to_string();
+        let findings = vec![FindingsBlock::HttpTransaction(TransactionFindings {
+            method: "GET".to_string(),
+            uri: "http://example.test/".to_string(),
+            status: Some(200),
+            violations: vec![v, sample_violation()],
+        })];
+        let out = render_lint_report(&findings, 1, 0, OutputFormat::Text)?;
+        assert!(
+            out.contains("warn  cache_control_present/cache_control_missing  missing"),
+            "{out}"
+        );
+        assert!(
+            out.contains("warn  cache_control_present  missing"),
+            "{out}"
+        );
+
+        let json = render_lint_report(&findings, 1, 0, OutputFormat::Json)?;
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json)?;
+        assert_eq!(
+            parsed[0]["violations"][0]["violation"],
+            "cache_control_missing"
+        );
+        assert!(parsed[0]["violations"][1]["violation"].is_null());
         Ok(())
     }
 

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -4,23 +4,44 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::cookie::{
+    path_defect, COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN, COOKIE_PATH_EMPTY,
+    COOKIE_PATH_LEADING_SLASH_MISSING, COOKIE_PATH_MISSING,
+    COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN, COOKIE_PATH_PERCENT_ENCODING_MALFORMED,
+    COOKIE_PATH_WHITESPACE_INVALID, RFC_3986_2_1, RFC_6265_4_1_1, RFC_6265_5_2_4,
+};
+use crate::violations::ViolationDef;
 
 pub struct CookiePathValid;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_6265_4_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
+/// The defects this rule reports, in the order their severities resolve. A
+/// named `static` because the engine finds a def in here by address, and an
+/// array of references to statics is not const-promotable.
+///
+/// Their definitions — title, default severity, and the sentence each enforces
+/// — are in `violations::cookie`, which is also where the `Path` half of this
+/// rule's specification references now live: a defect belongs to the attribute
+/// it is about, not to whichever rule noticed it.
+static DECLARED: &[&ViolationDef] = &[
+    &COOKIE_PATH_MISSING,
+    &COOKIE_PATH_EMPTY,
+    &COOKIE_PATH_LEADING_SLASH_MISSING,
+    &COOKIE_PATH_PERCENT_ENCODING_MALFORMED,
+    &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN,
+    &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN,
+    &COOKIE_PATH_WHITESPACE_INVALID,
+];
+
+/// The specification references this rule declares that no defect of its own
+/// carries: the parsing algorithm the rule performs before any defect exists,
+/// and the rationale for refusing whitespace the grammar admits.
+/// `specifications()` below is these two plus the three the defects cite, so
+/// the docs name every document the rule answers to.
+const RFC_6265_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 6265",
-    section: Some("4.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
-    note: "Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`",
-};
-const RFC_6265_5_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6265",
-    section: Some("5.2.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4",
-    note: "Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)",
+    section: Some("5.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2",
+    note: "The Set-Cookie header parsing algorithm — where the `;` split, the WSP trim and the case-insensitive `Path` match come from",
 };
 const RFC_9110_5_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -45,7 +66,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_6265_4_1_1, RFC_6265_5_2_4, RFC_9110_5_6_3]
+        &[
+            RFC_3986_2_1,
+            RFC_6265_4_1_1,
+            RFC_6265_5_2,
+            RFC_6265_5_2_4,
+            RFC_9110_5_6_3,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -110,7 +141,12 @@ impl Rule for CookiePathValid {
                     ));
                 };
 
-                // Split into cookie-pair and attribute segments
+                // Split into cookie-pair and attribute segments. The `;` and
+                // the trim are § 5.2's own parsing algorithm, which is what
+                // this rule enforces of its own accord — the defects it
+                // reports are elsewhere, and so are their sentences.
+                //
+                // cite(RFC 6265 § 5.2): "Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character."
                 let parts = s.split(';').map(|p| p.trim()).collect::<Vec<_>>();
                 if parts.is_empty() {
                     // No segments at all; nothing to validate here
@@ -125,22 +161,19 @@ impl Rule for CookiePathValid {
                     let key = av.next().unwrap().trim();
                     let val_opt = av.next().map(|v| v.trim());
 
+                    // cite(RFC 6265 § 5.2): "If the attribute-name case-insensitively matches the string "Path", the user agent MUST process the cookie-av as follows."
                     if key.eq_ignore_ascii_case("path") {
-                        // cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
                         let v = match val_opt {
                             Some(v) => v,
-                            None => {
-                                return Some(self.cited(
-                                    &RFC_6265_5_2_4,
-                                    ctx.severity,
-                                    "Set-Cookie attribute 'Path' requires a value".into(),
-                                ))
-                            }
+                            None => return Some(ctx.report(&COOKIE_PATH_MISSING)),
                         };
 
                         if let Err(defect) = crate::helpers::cookie::validate_cookie_path(v) {
-                            return Some(self.violation(
-                                ctx.severity,
+                            // The message stays here, where its argument is;
+                            // which defect it is comes from the helper's own
+                            // answer, named in `violations::cookie`.
+                            return Some(ctx.report_with(
+                                path_defect(&defect),
                                 format!(
                                     "Set-Cookie attribute 'Path' invalid: {}",
                                     defect.message()
@@ -219,6 +252,91 @@ mod tests {
     fn message_and_id() {
         let rule = CookiePathValid;
         assert_eq!(rule.id(), "cookie_path_valid");
+    }
+
+    /// One rule, one message shape, three different things said — which is
+    /// what the catalogue buys. A control character in a cookie path is an
+    /// error, a path the user agent will silently replace is a warning, and
+    /// the whitespace this crate refuses past the grammar is information.
+    /// None of the three was expressible while `severity` was the rule's.
+    #[test]
+    fn each_defect_reports_under_its_own_name_and_severity() {
+        for (path, violation, severity) in [
+            (
+                "/has space",
+                "cookie_path_whitespace_invalid",
+                crate::lint::Severity::Info,
+            ),
+            (
+                "login",
+                "cookie_path_leading_slash_missing",
+                crate::lint::Severity::Warn,
+            ),
+            // HTAB is a `CTL`, not this rule's stricter-than-grammar
+            // whitespace — the helper's variants say so and the two defects
+            // report at different levels because of it.
+            (
+                "/has\ttab",
+                "cookie_path_control_character_forbidden",
+                crate::lint::Severity::Error,
+            ),
+        ] {
+            let v = check_set_cookie(&format!("SID=1; Path={path}"))
+                .unwrap_or_else(|| panic!("{path} reports"));
+            assert_eq!(v.rule, "cookie_path_valid");
+            assert_eq!(v.violation, violation);
+            assert_eq!(v.severity, severity);
+        }
+    }
+
+    /// The defect an operator tunes is the defect, not the rule: raising the
+    /// whitespace profile to `error` leaves everything else this rule reports
+    /// where it was.
+    #[test]
+    fn tuning_one_defect_leaves_the_others() {
+        let rule = CookiePathValid;
+        let mut cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]);
+        crate::test_helpers::override_violation_severity(
+            &mut cfg,
+            "cookie_path_whitespace_invalid",
+            "error",
+        );
+
+        let run = |value: &str| {
+            let tx = crate::test_helpers::make_test_transaction_with_response(
+                200,
+                &[("set-cookie", value)],
+            );
+            crate::test_helpers::run_rule(
+                &rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &cfg,
+            )
+            .expect("reports")
+        };
+
+        assert_eq!(
+            run("SID=1; Path=/has space").severity,
+            crate::lint::Severity::Error,
+        );
+        assert_eq!(
+            run("SID=1; Path=login").severity,
+            crate::lint::Severity::Warn,
+        );
+    }
+
+    /// The three defects about a discarded value carry § 5.2.4, and the
+    /// citation reaches the finding from the def — the rule site attaches
+    /// none.
+    #[test]
+    fn a_discarded_path_cites_the_substitution() {
+        let cite = check_set_cookie("SID=1; Path=login")
+            .expect("reports")
+            .cite
+            .expect("cited from the def");
+        assert_eq!(cite.spec, "RFC 6265");
+        assert_eq!(cite.section.as_deref(), Some("5.2.4"));
     }
 
     #[test]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1257,11 +1257,22 @@ severity = "warn"
     /// now one site over both names. Each still cites what it cited; the count
     /// of *sites* is not the count of sentences read, so when a duplicate
     /// disappears, lower the floor and say which one.
+    ///
+    /// **A site converting to the violation catalogue is the second reason,**
+    /// and from here the usual one. `ctx.report`/`report_with` take their
+    /// citation from the def, so a converted site is counted by neither half
+    /// of this test: the sentence did not stop being read, it stopped being
+    /// named here. `every_violation_declares_a_spec` is the ratchet that holds
+    /// it on the other side, and this one keeps the unconverted remainder
+    /// honest until the last site goes. `cookie_path_valid`'s `Path` reading
+    /// is the first, and took one cited site with it.
     #[test]
     fn citation_coverage_does_not_regress() {
-        /// Finding sites that name the specification sentence they enforce, out
-        /// of 578. The rest are the per-rule reading that has not happened yet.
-        const FLOOR: usize = 171;
+        /// Finding sites that name the specification sentence they enforce.
+        /// The rest are the per-rule reading that has not happened yet — the
+        /// denominator is computed below, because merges and conversions both
+        /// move it.
+        const FLOOR: usize = 170;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Cookie defects — today, the seven ways a `Set-Cookie` `Path` attribute is
+//! wrong.
+//!
+//! The subject is the attribute, not the rule that reads it: `cookie_path_*`
+//! names what a server wrote, so a second rule that parses `Set-Cookie` reports
+//! the same defect under the same name and an operator tunes it once.
+//!
+//! Three of these are not syntax errors at all. RFC 6265 § 5.2.4 has the user
+//! agent replace an empty or unrooted `Path` with the default-path, so the
+//! cookie still works and the server has merely written something that does
+//! nothing; the remaining four are the § 4.1.1 grammar and the percent-encoding
+//! it admits. That difference is why the defaults below are not one severity
+//! repeated: a control character is an `error`, the whitespace this crate
+//! refuses past the grammar is `info`, and the rest sit between them. It is the
+//! whole reason a defect carries its own severity — the rule reporting these
+//! could only ever have said one thing about all seven.
+
+use crate::helpers::cookie::CookiePathDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{ViolationDef, REGISTERED_VIOLATIONS};
+use linkme::distributed_slice;
+
+/// The `Set-Cookie` grammar, which is what the character defects below are
+/// answered by. Declared here rather than in the rule file because the
+/// sentence belongs to the defect: it is the same sentence whichever rule
+/// happens to notice the character.
+pub const RFC_6265_4_1_1: SpecRef = SpecRef {
+    spec: "RFC 6265",
+    section: Some("4.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1",
+    note: "Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`",
+};
+
+/// What a user agent does with a `Path` it cannot use — the sentence behind
+/// the three defects that are about a value being discarded rather than about
+/// a value being ungrammatical.
+pub const RFC_6265_5_2_4: SpecRef = SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4",
+    note: "Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)",
+};
+
+/// The triplet a `%` obliges. `path-value` admits `%` as an ordinary
+/// character, so a broken escape is answered by the document that defines the
+/// escape and not by RFC 6265.
+pub const RFC_3986_2_1: SpecRef = SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
+    note: "Percent-Encoding — `pct-encoded = \"%\" HEXDIG HEXDIG`, the two digits a `%` in a cookie path still owes",
+};
+
+/// `Path` written as a bare attribute, with no `=` and nothing after it.
+///
+/// Separate from [`COOKIE_PATH_EMPTY`] because the senders differ: this one
+/// never wrote a value, that one wrote an empty one. The user agent treats
+/// them alike — both take the default-path — but the operator's fix does not,
+/// and neither does the message.
+///
+// cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+pub static COOKIE_PATH_MISSING: ViolationDef = ViolationDef {
+    id: "cookie_path_missing",
+    title: "Set-Cookie Path attribute carries no value",
+    message: "Set-Cookie attribute 'Path' requires a value",
+    default_severity: Severity::Warn,
+    spec: Some(RFC_6265_5_2_4),
+};
+
+/// `Path=` with nothing after the `=`.
+///
+// cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+pub static COOKIE_PATH_EMPTY: ViolationDef = ViolationDef {
+    id: "cookie_path_empty",
+    title: "Set-Cookie Path attribute is empty",
+    message: "",
+    default_severity: Severity::Warn,
+    spec: Some(RFC_6265_5_2_4),
+};
+
+/// A `Path` that does not start with `/`, which the user agent discards in
+/// favour of the default-path — so the scope the server asked for is not the
+/// scope the cookie gets.
+///
+// cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+pub static COOKIE_PATH_LEADING_SLASH_MISSING: ViolationDef = ViolationDef {
+    id: "cookie_path_leading_slash_missing",
+    title: "Set-Cookie Path attribute is not rooted at `/`",
+    message: "",
+    default_severity: Severity::Warn,
+    spec: Some(RFC_6265_5_2_4),
+};
+
+/// A `%` in the path that no two hex digits follow.
+///
+// cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
+pub static COOKIE_PATH_PERCENT_ENCODING_MALFORMED: ViolationDef = ViolationDef {
+    id: "cookie_path_percent_encoding_malformed",
+    title: "Set-Cookie Path attribute has a broken percent-encoding",
+    message: "",
+    default_severity: Severity::Warn,
+    spec: Some(RFC_3986_2_1),
+};
+
+/// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
+/// non-ASCII derives from nothing in the grammar and has to be percent-encoded.
+///
+// cite(RFC 6265 § 4.1.1): "Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:"
+pub static COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN: ViolationDef = ViolationDef {
+    id: "cookie_path_non_ascii_character_forbidden",
+    title: "Set-Cookie Path attribute holds a raw non-ASCII character",
+    message: "",
+    default_severity: Severity::Warn,
+    spec: Some(RFC_6265_4_1_1),
+};
+
+/// A `CTL`, which `path-value` excludes by name. The most serious of the seven
+/// by default: the class it belongs to is the one a header value is split
+/// with, and nothing legitimate puts one in a path.
+///
+// cite(RFC 6265 § 4.1.1): "Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:"
+pub static COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN: ViolationDef = ViolationDef {
+    id: "cookie_path_control_character_forbidden",
+    title: "Set-Cookie Path attribute holds a control character",
+    message: "",
+    default_severity: Severity::Error,
+    spec: Some(RFC_6265_4_1_1),
+};
+
+/// A space, which `CHAR` admits and this crate refuses anyway — the one defect
+/// here that no sentence requires, which is why it carries no `spec` and
+/// defaults to `info`. An operator who wants the grammar and nothing else
+/// leaves it there and never sees it; one who wants unambiguous cookie scopes
+/// raises it. Neither was expressible while a rule had one severity.
+pub static COOKIE_PATH_WHITESPACE_INVALID: ViolationDef = ViolationDef {
+    id: "cookie_path_whitespace_invalid",
+    title: "Set-Cookie Path attribute holds unencoded whitespace",
+    message: "",
+    default_severity: Severity::Info,
+    spec: None,
+};
+
+/// The defect a parsed [`CookiePathDefect`] reports as.
+///
+/// The helper answers *what is wrong* and this answers *what it is called*, so
+/// the two vocabularies are matched in one place instead of at every rule that
+/// validates a cookie path. The match is exhaustive on purpose: a new variant
+/// there does not compile until it is named here, which is the only way a
+/// defect can fail to reach the catalogue.
+pub fn path_defect(defect: &CookiePathDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        CookiePathDefect::Empty => &COOKIE_PATH_EMPTY,
+        CookiePathDefect::NotAbsolute(_) => &COOKIE_PATH_LEADING_SLASH_MISSING,
+        CookiePathDefect::PercentEncoding(_) => &COOKIE_PATH_PERCENT_ENCODING_MALFORMED,
+        CookiePathDefect::NonAscii(_) => &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN,
+        CookiePathDefect::ControlCharacter(_) => &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN,
+        CookiePathDefect::Whitespace(_) => &COOKIE_PATH_WHITESPACE_INVALID,
+    }
+}
+
+/// Registers this subject's defects into the catalogue. One entry per def,
+/// each a `static` reference the linker collects — the same shape a rule file
+/// ends with.
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_MISSING: &ViolationDef = &COOKIE_PATH_MISSING;
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_EMPTY: &ViolationDef = &COOKIE_PATH_EMPTY;
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_LEADING_SLASH_MISSING: &ViolationDef = &COOKIE_PATH_LEADING_SLASH_MISSING;
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_PERCENT_ENCODING_MALFORMED: &ViolationDef =
+    &COOKIE_PATH_PERCENT_ENCODING_MALFORMED;
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN: &ViolationDef =
+    &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN;
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN: &ViolationDef =
+    &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN;
+#[distributed_slice(REGISTERED_VIOLATIONS)]
+static R_COOKIE_PATH_WHITESPACE_INVALID: &ViolationDef = &COOKIE_PATH_WHITESPACE_INVALID;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant maps to a def, and no two share one: a mapping that
+    /// collapsed two variants would silence one defect under the other's
+    /// severity, which nothing downstream could notice.
+    #[test]
+    fn each_path_defect_names_a_defect_of_its_own() {
+        let defects = [
+            CookiePathDefect::Empty,
+            CookiePathDefect::NotAbsolute("login"),
+            CookiePathDefect::PercentEncoding("%ZZ".to_string()),
+            CookiePathDefect::NonAscii(3),
+            CookiePathDefect::ControlCharacter(3),
+            CookiePathDefect::Whitespace(3),
+        ];
+        let mut ids: Vec<&str> = defects.iter().map(|d| path_defect(d).id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), defects.len(), "two variants share one def");
+    }
+
+    /// The six mapped defects format their message at the site, and
+    /// `COOKIE_PATH_MISSING` holds its own — the invariant `report` and
+    /// `report_with` each assert one half of.
+    #[test]
+    fn only_the_unparameterised_defect_holds_a_message() {
+        assert!(!COOKIE_PATH_MISSING.message.is_empty());
+        for defect in [
+            CookiePathDefect::Empty,
+            CookiePathDefect::NotAbsolute("login"),
+            CookiePathDefect::PercentEncoding("%ZZ".to_string()),
+            CookiePathDefect::NonAscii(3),
+            CookiePathDefect::ControlCharacter(3),
+            CookiePathDefect::Whitespace(3),
+        ] {
+            let def = path_defect(&defect);
+            assert!(def.message.is_empty(), "{} holds a message", def.id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -26,6 +26,8 @@ use crate::rules::SpecRef;
 use linkme::distributed_slice;
 use std::sync::LazyLock;
 
+pub mod cookie;
+
 /// One reportable defect.
 ///
 /// # These are `static`, never `const`
@@ -162,6 +164,81 @@ mod tests {
                 rule.id(),
             );
         }
+    }
+
+    /// Every defect a rule declares must be in the catalogue, and the only
+    /// thing that puts it there is its own `#[distributed_slice]` entry beside
+    /// it. A def with no entry still works on the finding path — the rule
+    /// declares it, the severity resolves, findings carry its id — and is
+    /// absent from everything that enumerates the catalogue instead: no
+    /// `[violations.<id>]` section to tune it with, no docs, no gate. Nothing
+    /// else notices, because every other check reads one side or the other.
+    ///
+    /// By identity, not by id: two defs with one id are what
+    /// `violation_ids_are_unique_and_disjoint_from_rule_ids` is for, and a
+    /// declared def whose *twin* is registered is exactly the confusion this
+    /// would otherwise pass.
+    #[test]
+    fn every_declared_violation_is_registered() {
+        for rule in crate::rules::all_rules() {
+            for def in rule.violations() {
+                assert!(
+                    VIOLATIONS.iter().any(|d| std::ptr::eq(*d, *def)),
+                    "{} declares {}, which no distributed_slice entry registers",
+                    rule.id(),
+                    def.id,
+                );
+            }
+        }
+    }
+
+    /// A def's `spec` is what its findings cite, and `specifications()` is
+    /// what the rule's doc page lists — so a def citing a document its rule
+    /// never names would put a reference in a report that the docs do not
+    /// explain. This is `cited`'s debug assertion, moved to a gate: the check
+    /// it made per finding site is answerable once, for the whole catalogue,
+    /// now that the reference lives on the def.
+    ///
+    /// `specifications()` stays deliberately wider than the cited set — it may
+    /// carry further-reading a defect does not enforce — so this is one-way.
+    #[test]
+    fn every_violation_spec_is_declared_by_its_rule() {
+        for rule in crate::rules::all_rules() {
+            for def in rule.violations() {
+                let Some(spec) = def.spec else { continue };
+                assert!(
+                    rule.specifications().contains(&spec),
+                    "{} reports {}, which cites {} {} — not in the rule's specifications()",
+                    rule.id(),
+                    def.id,
+                    spec.spec,
+                    spec.section.unwrap_or("(whole document)"),
+                );
+            }
+        }
+    }
+
+    /// An upward ratchet on the defs, not on the finding sites: the sentence a
+    /// defect enforces is now something the catalogue can hold, and the point
+    /// of the migration is that it does. `citation_coverage_does_not_regress`
+    /// counts sites and keeps the old shape honest until the last one
+    /// converts; this counts entries and keeps the new one honest from the
+    /// first.
+    ///
+    /// Not every defect can have one, which is why this is a floor and not an
+    /// equality. `cookie_path_whitespace_invalid` is the first proof: no
+    /// specification asks for it, this crate refuses the character anyway, and
+    /// carrying a citation there would be a guess dressed as a reference.
+    #[test]
+    fn every_violation_declares_a_spec() {
+        /// Raised by the commit that adds defs with specs; never lowered.
+        const FLOOR: usize = 6;
+        let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
+        assert!(
+            cited >= FLOOR,
+            "{cited} of {} defs cite a sentence, below the floor of {FLOOR}",
+            VIOLATIONS.len(),
+        );
     }
 
     /// The closed vocabulary a violation id ends in. Each word is defined in

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1197,6 +1197,8 @@ sources:
       line: 138
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 49
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 101
   - label: lint-http-rules/src/helpers/uri.rs (7)
     section: § 2.2
     snippet: A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component.
@@ -2088,12 +2090,28 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/cookie_lifecycle.rs
       line: 63
+  - label: cookie_path_valid
+    section: § 5.2
+    snippet: Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character.
+    cited_by:
+    - file: lint-http-rules/src/rules/cookie_path_valid.rs
+      line: 149
+  - label: cookie_path_valid (2)
+    section: § 5.2
+    snippet: If the attribute-name case-insensitively matches the string "Path", the user agent MUST process the cookie-av as follows.
+    cited_by:
+    - file: lint-http-rules/src/rules/cookie_path_valid.rs
+      line: 164
   - label: lint-http-rules/src/helpers/cookie.rs
     section: § 4.1.1
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 97
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 113
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 126
   - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 4.1.1
     snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
@@ -2154,8 +2172,12 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 346
-    - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 129
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 66
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 77
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 90
   - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.


### PR DESCRIPTION
The first subject: the seven ways a `Set-Cookie` `Path` is wrong are named, each with the sentence it enforces and a default severity of its own. A control character is an `error`, a value the user agent will silently replace is a `warn`, and the unencoded space this crate refuses past the grammar is `info` — three things one rule could not say while severity was the rule's. The helper answers what is wrong and `path_defect` answers what it is called, so the mapping is in one place rather than at every rule that reads a path.

The messages do not move: they are formatted where their arguments are, and every existing assertion on them still holds. What moves is the citation — onto the def, which is why the rule file has none of its own left for the `Path` reading and picks up § 5.2 for the parsing it does do. The site count falls by one for the same reason, and the new floor over the defs is what catches it on the other side.

Three gates land with it: every declared defect is registered (a def with no slice entry works on the finding path and is missing from everything that enumerates the catalogue), every def's spec is one its rule declares (the assertion `cited` made per site, answerable once now), and the spec ratchet itself. The text report prints `rule/defect` when a finding names one, since the two are tuned by two different sections of the configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
