### PR TITLE
Defects declare and register themselves

### DIFF
--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -22,8 +22,7 @@
 use crate::helpers::cookie::CookiePathDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
-use crate::violations::{ViolationDef, REGISTERED_VIOLATIONS};
-use linkme::distributed_slice;
+use crate::violations::{defects, ViolationDef};
 
 /// The `Set-Cookie` grammar, which is what the character defects below are
 /// answered by. Declared here rather than in the rule file because the
@@ -56,94 +55,96 @@ pub const RFC_3986_2_1: SpecRef = SpecRef {
     note: "Percent-Encoding — `pct-encoded = \"%\" HEXDIG HEXDIG`, the two digits a `%` in a cookie path still owes",
 };
 
-/// `Path` written as a bare attribute, with no `=` and nothing after it.
-///
-/// Separate from [`COOKIE_PATH_EMPTY`] because the senders differ: this one
-/// never wrote a value, that one wrote an empty one. The user agent treats
-/// them alike — both take the default-path — but the operator's fix does not,
-/// and neither does the message.
-///
-// cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
-pub static COOKIE_PATH_MISSING: ViolationDef = ViolationDef {
-    id: "cookie_path_missing",
-    title: "Set-Cookie Path attribute carries no value",
-    message: "Set-Cookie attribute 'Path' requires a value",
-    default_severity: Severity::Warn,
-    spec: Some(RFC_6265_5_2_4),
-};
+defects! {
+    /// `Path` written as a bare attribute, with no `=` and nothing after it.
+    ///
+    /// Separate from [`COOKIE_PATH_EMPTY`] because the senders differ: this one
+    /// never wrote a value, that one wrote an empty one. The user agent treats
+    /// them alike — both take the default-path — but the operator's fix does not,
+    /// and neither does the message.
+    ///
+    // cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+    COOKIE_PATH_MISSING = {
+        id: "cookie_path_missing",
+        title: "Set-Cookie Path attribute carries no value",
+        message: "Set-Cookie attribute 'Path' requires a value",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_2_4),
+    }
 
-/// `Path=` with nothing after the `=`.
-///
-// cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
-pub static COOKIE_PATH_EMPTY: ViolationDef = ViolationDef {
-    id: "cookie_path_empty",
-    title: "Set-Cookie Path attribute is empty",
-    message: "",
-    default_severity: Severity::Warn,
-    spec: Some(RFC_6265_5_2_4),
-};
+    /// `Path=` with nothing after the `=`.
+    ///
+    // cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+    COOKIE_PATH_EMPTY = {
+        id: "cookie_path_empty",
+        title: "Set-Cookie Path attribute is empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_2_4),
+    }
 
-/// A `Path` that does not start with `/`, which the user agent discards in
-/// favour of the default-path — so the scope the server asked for is not the
-/// scope the cookie gets.
-///
-// cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
-pub static COOKIE_PATH_LEADING_SLASH_MISSING: ViolationDef = ViolationDef {
-    id: "cookie_path_leading_slash_missing",
-    title: "Set-Cookie Path attribute is not rooted at `/`",
-    message: "",
-    default_severity: Severity::Warn,
-    spec: Some(RFC_6265_5_2_4),
-};
+    /// A `Path` that does not start with `/`, which the user agent discards in
+    /// favour of the default-path — so the scope the server asked for is not the
+    /// scope the cookie gets.
+    ///
+    // cite(RFC 6265 § 5.2.4): "If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):"
+    COOKIE_PATH_LEADING_SLASH_MISSING = {
+        id: "cookie_path_leading_slash_missing",
+        title: "Set-Cookie Path attribute is not rooted at `/`",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_2_4),
+    }
 
-/// A `%` in the path that no two hex digits follow.
-///
-// cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
-pub static COOKIE_PATH_PERCENT_ENCODING_MALFORMED: ViolationDef = ViolationDef {
-    id: "cookie_path_percent_encoding_malformed",
-    title: "Set-Cookie Path attribute has a broken percent-encoding",
-    message: "",
-    default_severity: Severity::Warn,
-    spec: Some(RFC_3986_2_1),
-};
+    /// A `%` in the path that no two hex digits follow.
+    ///
+    // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
+    COOKIE_PATH_PERCENT_ENCODING_MALFORMED = {
+        id: "cookie_path_percent_encoding_malformed",
+        title: "Set-Cookie Path attribute has a broken percent-encoding",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_2_1),
+    }
 
-/// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
-/// non-ASCII derives from nothing in the grammar and has to be percent-encoded.
-///
-// cite(RFC 6265 § 4.1.1): "Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:"
-pub static COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN: ViolationDef = ViolationDef {
-    id: "cookie_path_non_ascii_character_forbidden",
-    title: "Set-Cookie Path attribute holds a raw non-ASCII character",
-    message: "",
-    default_severity: Severity::Warn,
-    spec: Some(RFC_6265_4_1_1),
-};
+    /// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
+    /// non-ASCII derives from nothing in the grammar and has to be percent-encoded.
+    ///
+    // cite(RFC 6265 § 4.1.1): "Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:"
+    COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN = {
+        id: "cookie_path_non_ascii_character_forbidden",
+        title: "Set-Cookie Path attribute holds a raw non-ASCII character",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_4_1_1),
+    }
 
-/// A `CTL`, which `path-value` excludes by name. The most serious of the seven
-/// by default: the class it belongs to is the one a header value is split
-/// with, and nothing legitimate puts one in a path.
-///
-// cite(RFC 6265 § 4.1.1): "Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:"
-pub static COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN: ViolationDef = ViolationDef {
-    id: "cookie_path_control_character_forbidden",
-    title: "Set-Cookie Path attribute holds a control character",
-    message: "",
-    default_severity: Severity::Error,
-    spec: Some(RFC_6265_4_1_1),
-};
+    /// A `CTL`, which `path-value` excludes by name. The most serious of the seven
+    /// by default: the class it belongs to is the one a header value is split
+    /// with, and nothing legitimate puts one in a path.
+    ///
+    // cite(RFC 6265 § 4.1.1): "Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:"
+    COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN = {
+        id: "cookie_path_control_character_forbidden",
+        title: "Set-Cookie Path attribute holds a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_6265_4_1_1),
+    }
 
-/// A space, which `CHAR` admits and this crate refuses anyway — the one defect
-/// here that no sentence requires, which is why it carries no `spec` and
-/// defaults to `info`. An operator who wants the grammar and nothing else
-/// leaves it there and never sees it; one who wants unambiguous cookie scopes
-/// raises it. Neither was expressible while a rule had one severity.
-pub static COOKIE_PATH_WHITESPACE_INVALID: ViolationDef = ViolationDef {
-    id: "cookie_path_whitespace_invalid",
-    title: "Set-Cookie Path attribute holds unencoded whitespace",
-    message: "",
-    default_severity: Severity::Info,
-    spec: None,
-};
+    /// A space, which `CHAR` admits and this crate refuses anyway — the one defect
+    /// here that no sentence requires, which is why it carries no `spec` and
+    /// defaults to `info`. An operator who wants the grammar and nothing else
+    /// leaves it there and never sees it; one who wants unambiguous cookie scopes
+    /// raises it. Neither was expressible while a rule had one severity.
+    COOKIE_PATH_WHITESPACE_INVALID = {
+        id: "cookie_path_whitespace_invalid",
+        title: "Set-Cookie Path attribute holds unencoded whitespace",
+        message: "",
+        default_severity: Severity::Info,
+        spec: None,
+    }
+}
 
 /// The defect a parsed [`CookiePathDefect`] reports as.
 ///
@@ -162,27 +163,6 @@ pub fn path_defect(defect: &CookiePathDefect<'_>) -> &'static ViolationDef {
         CookiePathDefect::Whitespace(_) => &COOKIE_PATH_WHITESPACE_INVALID,
     }
 }
-
-/// Registers this subject's defects into the catalogue. One entry per def,
-/// each a `static` reference the linker collects — the same shape a rule file
-/// ends with.
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_MISSING: &ViolationDef = &COOKIE_PATH_MISSING;
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_EMPTY: &ViolationDef = &COOKIE_PATH_EMPTY;
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_LEADING_SLASH_MISSING: &ViolationDef = &COOKIE_PATH_LEADING_SLASH_MISSING;
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_PERCENT_ENCODING_MALFORMED: &ViolationDef =
-    &COOKIE_PATH_PERCENT_ENCODING_MALFORMED;
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN: &ViolationDef =
-    &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN;
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN: &ViolationDef =
-    &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN;
-#[distributed_slice(REGISTERED_VIOLATIONS)]
-static R_COOKIE_PATH_WHITESPACE_INVALID: &ViolationDef = &COOKIE_PATH_WHITESPACE_INVALID;
 
 #[cfg(test)]
 mod tests {

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -14,12 +14,15 @@
 //! This module holds the second half of that split. A [`ViolationDef`] is a
 //! defect: an id, a title, its default severity, and the specification
 //! sentence it enforces. Defs live in `src/violations/<subject>.rs`, grouped
-//! by subject the way `helpers/` is, and self-register into
-//! [`REGISTERED_VIOLATIONS`] at link time. [`VIOLATIONS`] is the sorted view.
+//! by subject the way `helpers/` is, written in a `defects!` block that
+//! self-registers each one into [`REGISTERED_VIOLATIONS`] at link time.
+//! [`VIOLATIONS`] is the sorted view.
 //!
-//! Nothing emits one yet: rules keep reporting through
+//! The two APIs coexist while the catalogue fills: a converted site reports
+//! through [`RuleContext::report`](crate::rules::RuleContext::report), and an
+//! unconverted one still goes through
 //! [`RuleMeta::violation`](crate::rules::RuleMeta::violation) and its cited
-//! sibling until the two APIs meet. This is the registry they will meet in.
+//! sibling, which are deleted when the last site moves.
 
 use crate::lint::Severity;
 use crate::rules::SpecRef;
@@ -40,6 +43,10 @@ pub mod cookie;
 /// applies to a rule's declared list: it is a named `static`, because an array
 /// of references to statics is not const-promotable and the inline `&[…]` form
 /// does not typecheck as `'static`.
+///
+/// Which is why nothing constructs one of these by hand. `defects!` writes
+/// the `static` and its registration together, and
+/// `every_defect_comes_from_the_macro` keeps that the only way in.
 pub struct ViolationDef {
     /// This violation's id: the `[violations.<id>]` section that configures
     /// it, the `Violation.violation` its findings will carry, and the section
@@ -75,6 +82,69 @@ pub struct ViolationDef {
     /// keeps none.
     pub spec: Option<SpecRef>,
 }
+
+/// Define a subject's defects, and register every one of them.
+///
+/// The body is one entry per defect, each written as its `ViolationDef`
+/// fields. The doc comment and the `// cite` comment quoting the sentence the
+/// defect enforces go above the entry, where they would sit on any other item:
+///
+/// ```ignore
+/// defects! {
+///     /// What this defect is, and why it is its own entry.
+///     FIELD_VALUE_MALFORMED = {
+///         id: "field_value_malformed",
+///         title: "Field value does not match the grammar",
+///         message: "",
+///         default_severity: Severity::Warn,
+///         spec: Some(RFC_9110_5_5),
+///     }
+/// }
+/// ```
+///
+/// What it buys, at a catalogue this size, is that the two ways a def can be
+/// written wrong stop being writable:
+///
+/// - **`static`, never `const`.** A `const` is inlined at each use, so the
+///   `ptr::eq` lookup [`crate::rules::RuleContext::report`] does misses and the
+///   configured severity is unreachable. It compiles and it is wrong at run
+///   time, which is the worst shape a mistake can have.
+/// - **Registered, always.** The `#[distributed_slice]` entry is what puts a
+///   def in the catalogue, and it is separate from the def itself. Forgotten,
+///   the defect still reports — the rule declares it, the severity resolves —
+///   and vanishes from everything that *enumerates* the catalogue: no
+///   `[violations.<id>]` section, no docs.
+///
+/// Each entry hides its registration in an anonymous `const` block, so every
+/// one can use the same name for it: the linker collects the section entry, and
+/// nothing needs a second name derived from the first.
+macro_rules! defects {
+    ($(
+        $(#[$attr:meta])*
+        $name:ident = {
+            id: $id:literal,
+            title: $title:literal,
+            message: $message:literal,
+            default_severity: $severity:expr,
+            spec: $spec:expr,
+        }
+    )*) => {$(
+        $(#[$attr])*
+        pub static $name: $crate::violations::ViolationDef = $crate::violations::ViolationDef {
+            id: $id,
+            title: $title,
+            message: $message,
+            default_severity: $severity,
+            spec: $spec,
+        };
+
+        const _: () = {
+            #[linkme::distributed_slice($crate::violations::REGISTERED_VIOLATIONS)]
+            static REGISTRATION: &$crate::violations::ViolationDef = &$name;
+        };
+    )*};
+}
+pub(crate) use defects;
 
 /// Every violation, self-registered at link time via
 /// `linkme::distributed_slice`. Each `src/violations/<subject>.rs` appends its
@@ -163,6 +233,39 @@ mod tests {
                 "{} names both a rule and a violation",
                 rule.id(),
             );
+        }
+    }
+
+    /// A def written out longhand is a def that can be `const` and a def that
+    /// can go unregistered — the two mistakes `defects!` exists to make
+    /// unwritable, one of which is invisible until an operator's
+    /// `[violations.<id>]` silently does nothing. So the macro is not merely
+    /// available, it is the only way in: a subject file states its defects and
+    /// nothing else.
+    ///
+    /// Textual, like `no_rule_constructs_a_violation_literal`, and for the same
+    /// reason — what is being refused is a *shape of source*, which no type can
+    /// express.
+    #[test]
+    fn every_defect_comes_from_the_macro() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/violations");
+        for entry in std::fs::read_dir(&dir).expect("cannot read src/violations") {
+            let path = entry.expect("a directory entry").path();
+            if path.extension().is_none_or(|e| e != "rs")
+                || path.file_name().is_some_and(|n| n == "mod.rs")
+            {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).expect("a subject file");
+            for (i, line) in src.lines().enumerate() {
+                assert!(
+                    !line.contains("= ViolationDef {"),
+                    "{}:{}: defects are declared in a defects! block, which registers them \
+                     and keeps them `static`",
+                    path.display(),
+                    i + 1,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
A def is two items: the `static` and the `#[distributed_slice]` entry that puts it in the catalogue. Written by hand, both can go wrong quietly — a `const` instead of a `static` breaks the identity lookup the severity table depends on, and a forgotten registration leaves a defect that reports fine and cannot be configured, documented or counted. Neither shows up until an operator writes a `[violations.*]` section that does nothing.

`defects!` writes the pair from one entry, and hides the registration in an anonymous const so every def can name it the same thing. `every_defect_comes_from_the_macro` keeps that the only way in, textually, for the reason the finding-literal ban is textual: what is refused is a shape of source. The cookie subject moves onto it, seven defs, no change to what the catalogue holds.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
