### PR TITLE
A domain name is a domain name

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1055,6 +1055,26 @@ severity = "warn"
 enabled = true
 severity = "warn"
 
+[violations.cookie_domain_empty]
+# Set-Cookie Domain attribute is empty
+severity = "warn"
+
+[violations.cookie_domain_ipv4_address_forbidden]
+# Set-Cookie Domain attribute is an IPv4 address
+severity = "warn"
+
+[violations.cookie_domain_ipv6_literal_forbidden]
+# Set-Cookie Domain attribute is an IPv6 literal
+severity = "warn"
+
+[violations.cookie_domain_leading_dot_obsolete]
+# Set-Cookie Domain attribute keeps the obsolete leading dot
+severity = "info"
+
+[violations.cookie_domain_missing]
+# Set-Cookie Domain attribute carries no value
+severity = "warn"
+
 [violations.cookie_path_control_character_forbidden]
 # Set-Cookie Path attribute holds a control character
 severity = "error"
@@ -1082,3 +1102,27 @@ severity = "warn"
 [violations.cookie_path_whitespace_invalid]
 # Set-Cookie Path attribute holds unencoded whitespace
 severity = "info"
+
+[violations.domain_label_character_forbidden]
+# Domain label holds a character outside letters, digits and hyphen
+severity = "warn"
+
+[violations.domain_label_edge_hyphen_forbidden]
+# Domain label starts or ends with a hyphen
+severity = "warn"
+
+[violations.domain_label_empty]
+# Domain name has an empty label
+severity = "warn"
+
+[violations.domain_label_length_invalid]
+# Domain label is longer than 63 characters
+severity = "warn"
+
+[violations.domain_name_character_forbidden]
+# Domain name holds whitespace or a control character
+severity = "warn"
+
+[violations.domain_name_length_invalid]
+# Domain name is longer than 255 octets
+severity = "warn"

--- a/docs/rules/cookie_domain_valid.md
+++ b/docs/rules/cookie_domain_valid.md
@@ -16,8 +16,10 @@ reported as deprecated.
 
 ## Specifications
 
-- [RFC 6265 §5.2.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3): `Domain` attribute processing — an empty value is undefined (UA ignores it) and a leading dot is stripped; the domain-value *format* is §4.1.1 / RFC 1035
-- [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html): Domain name label rules (length, allowed characters)
+- [RFC 1035 §2.3.1](https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1): Preferred name syntax — labels start with a letter, end with a letter or digit, hold only letters, digits and hyphen, and run to 63 characters
+- [RFC 1035 §2.3.4](https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.4): Size limits — a name is 255 octets or less
+- [RFC 6265 §5.1.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3): Domain matching — a cookie-domain that is not a host name matches only the identical string, so an IP address scopes the cookie to nothing it can be sent for
+- [RFC 6265 §5.2.3](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3): `Domain` attribute processing — an empty value is undefined (the user agent ignores it) and a leading dot is stripped; the value's *format* is § 4.1.1 and RFC 1035
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/cookie_domain_valid.rs
+++ b/lint-http-rules/src/rules/cookie_domain_valid.rs
@@ -4,24 +4,37 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::cookie::{
+    domain_defect, COOKIE_DOMAIN_EMPTY, COOKIE_DOMAIN_IPV4_ADDRESS_FORBIDDEN,
+    COOKIE_DOMAIN_IPV6_LITERAL_FORBIDDEN, COOKIE_DOMAIN_LEADING_DOT_OBSOLETE,
+    COOKIE_DOMAIN_MISSING, RFC_6265_5_1_3, RFC_6265_5_2_3,
+};
+use crate::violations::domain::{
+    DOMAIN_LABEL_CHARACTER_FORBIDDEN, DOMAIN_LABEL_EDGE_HYPHEN_FORBIDDEN, DOMAIN_LABEL_EMPTY,
+    DOMAIN_LABEL_LENGTH_INVALID, DOMAIN_NAME_CHARACTER_FORBIDDEN, DOMAIN_NAME_LENGTH_INVALID,
+    RFC_1035_2_3_1, RFC_1035_2_3_4,
+};
+use crate::violations::ViolationDef;
 
 pub struct CookieDomainValid;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_6265_5_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 6265",
-    section: Some("5.2.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3",
-    note: "`Domain` attribute processing — an empty value is undefined (UA ignores it) and a leading dot is stripped; the domain-value *format* is §4.1.1 / RFC 1035",
-};
-const RFC_1035: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 1035",
-    section: None,
-    url: "https://www.rfc-editor.org/rfc/rfc1035.html",
-    note: "Domain name label rules (length, allowed characters)",
-};
+/// The defects this rule reports. Six of the eleven are not its own: a domain
+/// name is answered by the same sentences wherever a field carries one, so
+/// `domain_*` is what a `From` mailbox's host half will report too. Declaring
+/// them here is what says this rule may report them; it does not own them.
+static DECLARED: &[&ViolationDef] = &[
+    &COOKIE_DOMAIN_MISSING,
+    &COOKIE_DOMAIN_EMPTY,
+    &COOKIE_DOMAIN_LEADING_DOT_OBSOLETE,
+    &COOKIE_DOMAIN_IPV4_ADDRESS_FORBIDDEN,
+    &COOKIE_DOMAIN_IPV6_LITERAL_FORBIDDEN,
+    &DOMAIN_NAME_LENGTH_INVALID,
+    &DOMAIN_NAME_CHARACTER_FORBIDDEN,
+    &DOMAIN_LABEL_EMPTY,
+    &DOMAIN_LABEL_LENGTH_INVALID,
+    &DOMAIN_LABEL_EDGE_HYPHEN_FORBIDDEN,
+    &DOMAIN_LABEL_CHARACTER_FORBIDDEN,
+];
 
 impl RuleMeta for CookieDomainValid {
     fn id(&self) -> &'static str {
@@ -39,7 +52,16 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_6265_5_2_3, RFC_1035]
+        &[
+            RFC_1035_2_3_1,
+            RFC_1035_2_3_4,
+            RFC_6265_5_1_3,
+            RFC_6265_5_2_3,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -103,7 +125,11 @@ impl Rule for CookieDomainValid {
                     ));
                 };
 
-                // split into cookie-pair and attributes
+                // Split into cookie-pair and attributes — § 5.2's own parsing
+                // algorithm, which is the reading this rule does before any
+                // defect exists. The defects' sentences are on their defs.
+                //
+                // cite(RFC 6265 § 5.2): "Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character."
                 let parts = s.split(';').map(|p| p.trim()).collect::<Vec<_>>();
                 for attr in parts.iter().skip(1) {
                     if attr.is_empty() {
@@ -112,31 +138,20 @@ impl Rule for CookieDomainValid {
                     let mut av = attr.splitn(2, '=');
                     let key = av.next().unwrap().trim();
                     let val = av.next().map(|v| v.trim()).unwrap_or("");
+                    // cite(RFC 6265 § 5.2.3): "If the attribute-name case-insensitively matches the string "Domain", the user agent MUST process the cookie-av as follows."
                     if key.eq_ignore_ascii_case("domain") {
-                        // cite(RFC 6265 § 5.2.3): "If the attribute-value is empty, the behavior is undefined."
                         if val.is_empty() {
-                            return Some(self.cited(
-                                &RFC_6265_5_2_3,
-                                ctx.severity,
-                                "Set-Cookie attribute 'Domain' requires a value".into(),
-                            ));
+                            return Some(ctx.report(&COOKIE_DOMAIN_MISSING));
                         }
                         match crate::helpers::domain::validate_cookie_domain(val) {
                             Ok(()) => {
-                                // A leading dot is not a *syntax* error — the user agent
-                                // strips it, so `.example.com` and `example.com` are the same
-                                // cookie-domain. That is exactly why it is flagged: the dot is a
-                                // redundant legacy form (RFC 2965 gave it meaning; RFC 6265 does
-                                // not), so the server should send the registry form without it.
-                                // cite(RFC 6265 § 5.2.3): "Let cookie-domain be the attribute-value without the leading %x2E (".") character."
                                 if val.starts_with('.') {
-                                    return Some(self.cited(&RFC_6265_5_2_3, ctx.severity, "Set-Cookie 'Domain' attribute uses a leading '.' which is deprecated; prefer the registry form without leading dot".into()));
+                                    return Some(ctx.report(&COOKIE_DOMAIN_LEADING_DOT_OBSOLETE));
                                 }
                             }
                             Err(e) => {
-                                return Some(self.cited(
-                                    &RFC_6265_5_2_3,
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    domain_defect(e),
                                     format!(
                                         "Invalid Set-Cookie Domain attribute '{}': {}",
                                         val,
@@ -195,6 +210,54 @@ mod tests {
                 v
             );
         }
+    }
+
+    /// The same rule, five names. The last two are the interesting pair: an
+    /// underscore and a doubled dot are defects of *domain names*, not of
+    /// cookies, so they report under the shared `domain_*` ids that any other
+    /// field carrying a name will report under too.
+    #[rstest]
+    #[case("SID=1; Domain=", "cookie_domain_missing", crate::lint::Severity::Warn)]
+    #[case(
+        "SID=1; Domain=.example.com",
+        "cookie_domain_leading_dot_obsolete",
+        crate::lint::Severity::Info
+    )]
+    #[case(
+        "SID=1; Domain=192.168.0.1",
+        "cookie_domain_ipv4_address_forbidden",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "SID=1; Domain=exa_mple.com",
+        "domain_label_character_forbidden",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "SID=1; Domain=example..com",
+        "domain_label_empty",
+        crate::lint::Severity::Warn
+    )]
+    fn each_defect_reports_under_its_own_name(
+        #[case] cookie: &str,
+        #[case] violation: &str,
+        #[case] severity: crate::lint::Severity,
+    ) {
+        let v = check_set_cookie(cookie).expect("reports");
+        assert_eq!(v.rule, "cookie_domain_valid");
+        assert_eq!(v.violation, violation);
+        assert_eq!(v.severity, severity);
+    }
+
+    /// The leading dot costs nothing at run time and is `info` because of it —
+    /// so a report filtered to warnings and above does not carry it, while the
+    /// same rule's IP-address finding still does. One rule, two audiences.
+    #[test]
+    fn the_obsolete_form_is_below_the_defects_that_break_something() {
+        let dot = check_set_cookie("SID=1; Domain=.example.com").expect("reports");
+        let ip = check_set_cookie("SID=1; Domain=192.168.0.1").expect("reports");
+        assert!(dot.severity < crate::lint::Severity::Warn);
+        assert!(ip.severity >= crate::lint::Severity::Warn);
     }
 
     #[test]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1265,14 +1265,15 @@ severity = "warn"
     /// named here. `every_violation_declares_a_spec` is the ratchet that holds
     /// it on the other side, and this one keeps the unconverted remainder
     /// honest until the last site goes. `cookie_path_valid`'s `Path` reading
-    /// is the first, and took one cited site with it.
+    /// was the first and took one cited site with it; `cookie_domain_valid`
+    /// took three more.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 170;
+        const FLOOR: usize = 167;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -2,14 +2,18 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! Cookie defects — today, the seven ways a `Set-Cookie` `Path` attribute is
-//! wrong.
+//! Cookie defects — the ways a `Set-Cookie` attribute is wrong, `Path` and
+//! `Domain` so far.
 //!
 //! The subject is the attribute, not the rule that reads it: `cookie_path_*`
 //! names what a server wrote, so a second rule that parses `Set-Cookie` reports
-//! the same defect under the same name and an operator tunes it once.
+//! the same defect under the same name and an operator tunes it once. What is
+//! *not* here is the domain syntax underneath `Domain`: a name is a name in
+//! every field that carries one, and those defects live in
+//! [`crate::violations::domain`] where a rule reading a `From` mailbox can
+//! report the same ones.
 //!
-//! Three of these are not syntax errors at all. RFC 6265 § 5.2.4 has the user
+//! Three of the `Path` defects are not syntax errors at all. RFC 6265 § 5.2.4 has the user
 //! agent replace an empty or unrooted `Path` with the default-path, so the
 //! cookie still works and the server has merely written something that does
 //! nothing; the remaining four are the § 4.1.1 grammar and the percent-encoding
@@ -20,8 +24,10 @@
 //! could only ever have said one thing about all seven.
 
 use crate::helpers::cookie::CookiePathDefect;
+use crate::helpers::domain::CookieDomainDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+use crate::violations::domain::preferred_name_defect;
 use crate::violations::{defects, ViolationDef};
 
 /// The `Set-Cookie` grammar, which is what the character defects below are
@@ -53,6 +59,25 @@ pub const RFC_3986_2_1: SpecRef = SpecRef {
     section: Some("2.1"),
     url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
     note: "Percent-Encoding — `pct-encoded = \"%\" HEXDIG HEXDIG`, the two digits a `%` in a cookie path still owes",
+};
+
+/// What a user agent does with a `Domain` it is given: an empty value leaves
+/// the behaviour undefined, and a leading dot is dropped before anything else
+/// happens to it.
+pub const RFC_6265_5_2_3: SpecRef = SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.3",
+    note: "`Domain` attribute processing — an empty value is undefined (the user agent ignores it) and a leading dot is stripped; the value's *format* is § 4.1.1 and RFC 1035",
+};
+
+/// Domain matching, which is where an IP address stops being a cookie domain:
+/// the algorithm only reaches its host-name arm for a string that is not one.
+pub const RFC_6265_5_1_3: SpecRef = SpecRef {
+    spec: "RFC 6265",
+    section: Some("5.1.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.3",
+    note: "Domain matching — a cookie-domain that is not a host name matches only the identical string, so an IP address scopes the cookie to nothing it can be sent for",
 };
 
 defects! {
@@ -144,6 +169,76 @@ defects! {
         default_severity: Severity::Info,
         spec: None,
     }
+
+    /// `Domain` written with no value, or with one that is empty before
+    /// anything reads it. The user agent is left with nothing to scope the
+    /// cookie by, and the specification does not say what it should do.
+    ///
+    // cite(RFC 6265 § 5.2.3): "If the attribute-value is empty, the behavior is undefined."
+    COOKIE_DOMAIN_MISSING = {
+        id: "cookie_domain_missing",
+        title: "Set-Cookie Domain attribute carries no value",
+        message: "Set-Cookie attribute 'Domain' requires a value",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_2_3),
+    }
+
+    /// A `Domain` that is empty once the tolerated leading dot comes off —
+    /// `Domain=.` and nothing more. Reached through the domain reader rather
+    /// than at the attribute, which is why it is not
+    /// [`COOKIE_DOMAIN_MISSING`]: the server wrote something, and it came to
+    /// nothing.
+    ///
+    // cite(RFC 6265 § 5.2.3): "Let cookie-domain be the attribute-value without the leading %x2E (".") character."
+    COOKIE_DOMAIN_EMPTY = {
+        id: "cookie_domain_empty",
+        title: "Set-Cookie Domain attribute is empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_2_3),
+    }
+
+    /// A leading `.`, which is not a syntax error: the user agent strips it,
+    /// so `.example.com` and `example.com` are the same cookie-domain. That is
+    /// exactly why it is reported — RFC 2965 gave the dot a meaning and RFC
+    /// 6265 does not, so it is a form that survives without saying anything.
+    /// `info` by default, because nothing about the cookie is wrong.
+    ///
+    // cite(RFC 6265 § 5.2.3): "Let cookie-domain be the attribute-value without the leading %x2E (".") character."
+    COOKIE_DOMAIN_LEADING_DOT_OBSOLETE = {
+        id: "cookie_domain_leading_dot_obsolete",
+        title: "Set-Cookie Domain attribute keeps the obsolete leading dot",
+        message: "Set-Cookie 'Domain' attribute uses a leading '.' which is deprecated; prefer the registry form without leading dot",
+        default_severity: Severity::Info,
+        spec: Some(RFC_6265_5_2_3),
+    }
+
+    /// A dotted-quad where a host name goes. The cookie is not thereby
+    /// dangerous, it is inert: domain matching reaches its host-name arm only
+    /// for a string that is not an address, so nothing but an identical
+    /// request host can ever be sent it.
+    ///
+    // cite(RFC 6265 § 5.1.3): "The string is a host name (i.e., not an IP address)."
+    COOKIE_DOMAIN_IPV4_ADDRESS_FORBIDDEN = {
+        id: "cookie_domain_ipv4_address_forbidden",
+        title: "Set-Cookie Domain attribute is an IPv4 address",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_1_3),
+    }
+
+    /// A bracketed IPv6 literal, for the same reason as the IPv4 form — kept
+    /// apart from it because the two are written differently and an operator
+    /// looking at a report is looking for one of them.
+    ///
+    // cite(RFC 6265 § 5.1.3): "The string is a host name (i.e., not an IP address)."
+    COOKIE_DOMAIN_IPV6_LITERAL_FORBIDDEN = {
+        id: "cookie_domain_ipv6_literal_forbidden",
+        title: "Set-Cookie Domain attribute is an IPv6 literal",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_6265_5_1_3),
+    }
 }
 
 /// The defect a parsed [`CookiePathDefect`] reports as.
@@ -161,6 +256,28 @@ pub fn path_defect(defect: &CookiePathDefect<'_>) -> &'static ViolationDef {
         CookiePathDefect::NonAscii(_) => &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN,
         CookiePathDefect::ControlCharacter(_) => &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN,
         CookiePathDefect::Whitespace(_) => &COOKIE_PATH_WHITESPACE_INVALID,
+    }
+}
+
+/// The defect a parsed [`CookieDomainDefect`] reports as.
+///
+/// Both empty forms answer with [`COOKIE_DOMAIN_EMPTY`]: the reader trims
+/// before it strips the dot, so `Domain=` and `Domain=.` arrive here as two
+/// variants of one thing an operator fixes one way. The last arm hands the
+/// question to [`crate::violations::domain`], which is the point of that
+/// module — the name syntax under a `Domain` is the same syntax as under any
+/// other field, and reports under the same names.
+pub fn domain_defect(defect: CookieDomainDefect) -> &'static ViolationDef {
+    match defect {
+        CookieDomainDefect::Empty | CookieDomainDefect::EmptyAfterLeadingDot => {
+            &COOKIE_DOMAIN_EMPTY
+        }
+        CookieDomainDefect::WhitespaceOrControl => {
+            &crate::violations::domain::DOMAIN_NAME_CHARACTER_FORBIDDEN
+        }
+        CookieDomainDefect::Ipv6Literal => &COOKIE_DOMAIN_IPV6_LITERAL_FORBIDDEN,
+        CookieDomainDefect::Ipv4Address => &COOKIE_DOMAIN_IPV4_ADDRESS_FORBIDDEN,
+        CookieDomainDefect::PreferredName(defect) => preferred_name_defect(defect),
     }
 }
 
@@ -185,6 +302,39 @@ mod tests {
         ids.sort_unstable();
         ids.dedup();
         assert_eq!(ids.len(), defects.len(), "two variants share one def");
+    }
+
+    /// The `Domain` mapping, spelled out — including the one place two
+    /// variants answer with one def, which is a decision and not an oversight.
+    #[test]
+    fn each_domain_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (CookieDomainDefect::Empty, "cookie_domain_empty"),
+            (
+                CookieDomainDefect::EmptyAfterLeadingDot,
+                "cookie_domain_empty",
+            ),
+            (
+                CookieDomainDefect::WhitespaceOrControl,
+                "domain_name_character_forbidden",
+            ),
+            (
+                CookieDomainDefect::Ipv6Literal,
+                "cookie_domain_ipv6_literal_forbidden",
+            ),
+            (
+                CookieDomainDefect::Ipv4Address,
+                "cookie_domain_ipv4_address_forbidden",
+            ),
+            (
+                CookieDomainDefect::PreferredName(
+                    crate::helpers::domain::PreferredNameDefect::EmptyLabel,
+                ),
+                "domain_label_empty",
+            ),
+        ] {
+            assert_eq!(domain_defect(defect).id, id);
+        }
     }
 
     /// The six mapped defects format their message at the site, and

--- a/lint-http-rules/src/violations/domain.rs
+++ b/lint-http-rules/src/violations/domain.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Domain name defects — the preferred name syntax, wherever a field carries a
+//! host name.
+//!
+//! These are the clearest case for a catalogue that is not indexed by rule.
+//! A `Set-Cookie` `Domain`, a `From` mailbox's domain half and every other
+//! field holding a name are all answered by the same five sentences of RFC
+//! 1035, through the same helper — so an operator who does not care about a
+//! hyphen at the edge of a label should be able to say so once, not once per
+//! field. Each rule that reads a name declares these; none of them owns one.
+//!
+//! The `name` defects are about the whole string and the `label` defects about
+//! one dot-separated piece of it, which is also the order the helper checks
+//! them in.
+
+use crate::helpers::domain::PreferredNameDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The preferred name syntax: what a label may be made of, and how long it may
+/// be. One section behind four of the five defects here, which is why they are
+/// four entries rather than one — the sentence does not distinguish them, and
+/// an operator tuning them does.
+pub const RFC_1035_2_3_1: SpecRef = SpecRef {
+    spec: "RFC 1035",
+    section: Some("2.3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1",
+    note: "Preferred name syntax — labels start with a letter, end with a letter or digit, hold only letters, digits and hyphen, and run to 63 characters",
+};
+
+/// The size limits, which are stated where the sizes are, not with the
+/// grammar.
+pub const RFC_1035_2_3_4: SpecRef = SpecRef {
+    spec: "RFC 1035",
+    section: Some("2.3.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.4",
+    note: "Size limits — a name is 255 octets or less",
+};
+
+defects! {
+    /// A name over 255 octets. Not a grammar failure — every label in it may
+    /// be well formed — which is why it is `_invalid` and not `_malformed`.
+    ///
+    // cite(RFC 1035 § 2.3.4): "names 255 octets or less"
+    DOMAIN_NAME_LENGTH_INVALID = {
+        id: "domain_name_length_invalid",
+        title: "Domain name is longer than 255 octets",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_1035_2_3_4),
+    }
+
+    /// Whitespace or a control character anywhere in the name — checked over
+    /// the whole string, before it is split into labels, because neither can
+    /// appear in any of them.
+    ///
+    // cite(RFC 1035 § 2.3.1): "They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
+    DOMAIN_NAME_CHARACTER_FORBIDDEN = {
+        id: "domain_name_character_forbidden",
+        title: "Domain name holds whitespace or a control character",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_1035_2_3_1),
+    }
+
+    /// A `.` with nothing between it and its neighbour: `a..example` or a name
+    /// that opens on the separator.
+    ///
+    // cite(RFC 1035 § 2.3.1): "They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
+    DOMAIN_LABEL_EMPTY = {
+        id: "domain_label_empty",
+        title: "Domain name has an empty label",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_1035_2_3_1),
+    }
+
+    /// One label over 63 characters, in a name that may be inside its own
+    /// limit.
+    ///
+    // cite(RFC 1035 § 2.3.1): "Labels must be 63 characters or less."
+    DOMAIN_LABEL_LENGTH_INVALID = {
+        id: "domain_label_length_invalid",
+        title: "Domain label is longer than 63 characters",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_1035_2_3_1),
+    }
+
+    /// A label opening or closing on `-`. Only the hyphen is checked at the
+    /// ends: § 2.3.1 asks for a letter first and RFC 1123 § 2 relaxed that to
+    /// a letter or a digit, so a leading digit is not this defect.
+    ///
+    // cite(RFC 1035 § 2.3.1): "They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
+    DOMAIN_LABEL_EDGE_HYPHEN_FORBIDDEN = {
+        id: "domain_label_edge_hyphen_forbidden",
+        title: "Domain label starts or ends with a hyphen",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_1035_2_3_1),
+    }
+
+    /// A label octet outside letters, digits and hyphen — an underscore, most
+    /// often.
+    ///
+    // cite(RFC 1035 § 2.3.1): "They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen."
+    DOMAIN_LABEL_CHARACTER_FORBIDDEN = {
+        id: "domain_label_character_forbidden",
+        title: "Domain label holds a character outside letters, digits and hyphen",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_1035_2_3_1),
+    }
+}
+
+/// The defect a [`PreferredNameDefect`] reports as, for every field that reads
+/// a name through the shared syntax.
+pub fn preferred_name_defect(defect: PreferredNameDefect) -> &'static ViolationDef {
+    match defect {
+        PreferredNameDefect::TooLong => &DOMAIN_NAME_LENGTH_INVALID,
+        PreferredNameDefect::EmptyLabel => &DOMAIN_LABEL_EMPTY,
+        PreferredNameDefect::LabelTooLong => &DOMAIN_LABEL_LENGTH_INVALID,
+        PreferredNameDefect::LabelHyphenAtEdge => &DOMAIN_LABEL_EDGE_HYPHEN_FORBIDDEN,
+        PreferredNameDefect::LabelBadCharacter => &DOMAIN_LABEL_CHARACTER_FORBIDDEN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The mapping, spelled out: a variant answering with the wrong def would
+    /// report the right complaint under the wrong name and the wrong
+    /// configured severity, and every other gate here would pass.
+    #[test]
+    fn each_preferred_name_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (PreferredNameDefect::TooLong, "domain_name_length_invalid"),
+            (PreferredNameDefect::EmptyLabel, "domain_label_empty"),
+            (
+                PreferredNameDefect::LabelTooLong,
+                "domain_label_length_invalid",
+            ),
+            (
+                PreferredNameDefect::LabelHyphenAtEdge,
+                "domain_label_edge_hyphen_forbidden",
+            ),
+            (
+                PreferredNameDefect::LabelBadCharacter,
+                "domain_label_character_forbidden",
+            ),
+        ] {
+            assert_eq!(preferred_name_defect(defect).id, id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -30,6 +30,7 @@ use linkme::distributed_slice;
 use std::sync::LazyLock;
 
 pub mod cookie;
+pub mod domain;
 
 /// One reportable defect.
 ///
@@ -335,7 +336,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 6;
+        const FLOOR: usize = 17;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -797,6 +797,18 @@ sources:
 - label: RFC 1035
   url: https://www.rfc-editor.org/rfc/rfc1035.html
   fragments:
+  - label: domain
+    section: § 2.3.1
+    snippet: They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen.
+    cited_by:
+    - file: lint-http-rules/src/violations/domain.rs
+      line: 61
+    - file: lint-http-rules/src/violations/domain.rs
+      line: 73
+    - file: lint-http-rules/src/violations/domain.rs
+      line: 98
+    - file: lint-http-rules/src/violations/domain.rs
+      line: 110
   - label: lint-http-rules/src/helpers/domain.rs
     section: § 2.3.1
     snippet: Labels must be 63 characters or less.
@@ -805,6 +817,8 @@ sources:
       line: 31
     - file: lint-http-rules/src/helpers/domain.rs
       line: 166
+    - file: lint-http-rules/src/violations/domain.rs
+      line: 85
   - label: lint-http-rules/src/helpers/domain.rs (2)
     section: § 2.3.1
     snippet: end with a letter or digit, and have as interior characters only letters, digits, and hyphen.
@@ -819,6 +833,8 @@ sources:
       line: 26
     - file: lint-http-rules/src/helpers/domain.rs
       line: 157
+    - file: lint-http-rules/src/violations/domain.rs
+      line: 48
 - label: RFC 1123
   url: https://www.rfc-editor.org/rfc/rfc1123.html
   fragments:
@@ -1198,7 +1214,7 @@ sources:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 49
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 101
+      line: 126
   - label: lint-http-rules/src/helpers/uri.rs (7)
     section: § 2.2
     snippet: A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component.
@@ -2000,6 +2016,28 @@ sources:
 - label: RFC 6265
   url: https://www.rfc-editor.org/rfc/rfc6265.html
   fragments:
+  - label: cookie
+    section: § 5.1.3
+    snippet: The string is a host name (i.e., not an IP address).
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 221
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 234
+  - label: cookie (2)
+    section: § 5.2.3
+    snippet: If the attribute-value is empty, the behavior is undefined.
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 177
+  - label: cookie (3)
+    section: § 5.2.3
+    snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
+    cited_by:
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 192
+    - file: lint-http-rules/src/violations/cookie.rs
+      line: 207
   - label: cookie_attribute_consistent
     section: § 4.1.1
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
@@ -2055,17 +2093,19 @@ sources:
     - file: lint-http-rules/src/rules/cookie_domain_matching.rs
       line: 173
   - label: cookie_domain_valid
-    section: § 5.2.3
-    snippet: If the attribute-value is empty, the behavior is undefined.
+    section: § 5.2
+    snippet: Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 116
+      line: 132
+    - file: lint-http-rules/src/rules/cookie_path_valid.rs
+      line: 149
   - label: cookie_domain_valid (2)
     section: § 5.2.3
-    snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
+    snippet: If the attribute-name case-insensitively matches the string "Domain", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
-      line: 131
+      line: 141
   - label: cookie_lifecycle
     section: § 4.1.2.5
     snippet: The Secure attribute limits the scope of the cookie to "secure" channels
@@ -2092,12 +2132,6 @@ sources:
       line: 63
   - label: cookie_path_valid
     section: § 5.2
-    snippet: Consume the characters of the unparsed-attributes up to, but not including, the first %x3B (";") character.
-    cited_by:
-    - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 149
-  - label: cookie_path_valid (2)
-    section: § 5.2
     snippet: If the attribute-name case-insensitively matches the string "Path", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
@@ -2109,9 +2143,9 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 97
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 113
+      line: 138
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 126
+      line: 151
   - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 4.1.1
     snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
@@ -2173,11 +2207,11 @@ sources:
     - file: lint-http-rules/src/helpers/cookie.rs
       line: 346
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 66
+      line: 91
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 77
+      line: 102
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 90
+      line: 115
   - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.


### PR DESCRIPTION
`cookie_domain_valid` converts, and its eleven defects split in two. Five are the cookie's own — no value, empty after the tolerated dot, the obsolete leading dot, an IPv4 address, an IPv6 literal. Six are not: the preferred name syntax answers a `Set-Cookie` `Domain` and a `From` mailbox's host half with the same five sentences of RFC 1035, so those live under `domain_` and every rule that reads a name declares them. An operator who does not care about a hyphen at the edge of a label now says so once.

The leading dot defaults to `info`. Nothing about the cookie is wrong — the user agent strips it, so the form survives without saying anything — and a report filtered to warnings and above no longer carries it while the same rule's IP-address finding still does.

Both empty forms answer with one defect, because the reader trims before it strips the dot and an operator fixes them the same way; the mapping is asserted variant by variant rather than by distinctness, which is what makes that a decision instead of an oversight.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
