### PR TITLE
Language tags name what is wrong with them

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1126,3 +1126,31 @@ severity = "warn"
 [violations.domain_name_length_invalid]
 # Domain name is longer than 255 octets
 severity = "warn"
+
+[violations.language_tag_character_forbidden]
+# Language tag holds a character outside letters, digits and hyphen
+severity = "warn"
+
+[violations.language_tag_edge_hyphen_forbidden]
+# Language tag starts or ends with a hyphen
+severity = "warn"
+
+[violations.language_tag_empty]
+# Language tag is empty
+severity = "warn"
+
+[violations.language_tag_leading_letter_missing]
+# Language tag does not begin with a letter
+severity = "warn"
+
+[violations.language_tag_subtag_empty]
+# Language tag has an empty subtag
+severity = "warn"
+
+[violations.language_tag_subtag_length_invalid]
+# Language subtag is longer than eight characters
+severity = "warn"
+
+[violations.language_tag_whitespace_or_control_forbidden]
+# Language tag holds whitespace or a control character
+severity = "error"

--- a/lint-http-rules/src/rules/language_tag_syntax.rs
+++ b/lint-http-rules/src/rules/language_tag_syntax.rs
@@ -4,8 +4,28 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::language::{
+    tag_defect, LANGUAGE_TAG_CHARACTER_FORBIDDEN, LANGUAGE_TAG_EDGE_HYPHEN_FORBIDDEN,
+    LANGUAGE_TAG_EMPTY, LANGUAGE_TAG_LEADING_LETTER_MISSING, LANGUAGE_TAG_SUBTAG_EMPTY,
+    LANGUAGE_TAG_SUBTAG_LENGTH_INVALID, LANGUAGE_TAG_WHITESPACE_OR_CONTROL_FORBIDDEN, RFC_5646_2_1,
+};
+use crate::violations::ViolationDef;
 
 pub struct LanguageTagSyntax;
+
+/// The defects this rule reports — the seven the two productions agree on.
+/// They are the tag's, not this rule's: `link_header_valid` reads a tag out of
+/// an `hreflang` parameter through the same validator and will report the same
+/// seven.
+static DECLARED: &[&ViolationDef] = &[
+    &LANGUAGE_TAG_EMPTY,
+    &LANGUAGE_TAG_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &LANGUAGE_TAG_CHARACTER_FORBIDDEN,
+    &LANGUAGE_TAG_EDGE_HYPHEN_FORBIDDEN,
+    &LANGUAGE_TAG_SUBTAG_EMPTY,
+    &LANGUAGE_TAG_LEADING_LETTER_MISSING,
+    &LANGUAGE_TAG_SUBTAG_LENGTH_INVALID,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -15,12 +35,6 @@ const RFC_9110_8_5_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("8.5.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.5.1",
     note: "Language Tags: the sentence that assigns a different production to each of the two fields — `language-range` for Accept-Language, `language-tag` for Content-Language",
-};
-const RFC_5646_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 5646",
-    section: Some("2.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1",
-    note: "Syntax: the `Language-Tag` production Content-Language carries. Its prose properties are enforced; its subtag ordering and length classes are not",
 };
 const RFC_4647_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 4647",
@@ -69,6 +83,10 @@ severity = "warn"
             RFC_9110_8_5,
             RFC_9110_12_5_4,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -150,9 +168,8 @@ impl Rule for LanguageTagSyntax {
             let check_tag = |hdr: &str, tag: &str| -> Option<Violation> {
                 // cite(RFC 9110 § 8.5.1): "A language tag, as defined in [RFC5646], identifies a natural language spoken, written, or otherwise conveyed by human beings for communication of information to other human beings."
                 if let Err(e) = crate::helpers::language::validate_language_tag(tag) {
-                    return Some(self.cited(
-                        &RFC_9110_8_5_1,
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        tag_defect(e),
                         format!("Invalid language tag '{}' in {}: {}", tag, hdr, e.message()),
                     ));
                 }
@@ -343,6 +360,62 @@ mod tests {
         let rule = LanguageTagSyntax;
         assert_eq!(rule.id(), "language_tag_syntax");
         assert_eq!(rule.scope(), crate::rules::RuleScope::Both);
+    }
+
+    /// One message shape, seven names — and the one an operator cannot have
+    /// typed reports a level above the ones a sender chose. A `%01` in a
+    /// language tag is something that happened to the value; `en_US` is a
+    /// sender writing the locale spelling of another ecosystem.
+    #[rstest]
+    #[case(
+        "en_US",
+        "language_tag_character_forbidden",
+        crate::lint::Severity::Warn
+    )]
+    // HTAB rather than a stricter control octet: `HeaderValue` refuses to hold
+    // one at all, and a tab is `is_whitespace` on the same branch.
+    #[case(
+        "en\tUS",
+        "language_tag_whitespace_or_control_forbidden",
+        crate::lint::Severity::Error
+    )]
+    #[case("en--US", "language_tag_subtag_empty", crate::lint::Severity::Warn)]
+    #[case(
+        "-en",
+        "language_tag_edge_hyphen_forbidden",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "1en",
+        "language_tag_leading_letter_missing",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "en-toolongsubtag",
+        "language_tag_subtag_length_invalid",
+        crate::lint::Severity::Warn
+    )]
+    fn each_defect_reports_under_its_own_name(
+        #[case] tag: &str,
+        #[case] violation: &str,
+        #[case] severity: crate::lint::Severity,
+    ) {
+        let rule = LanguageTagSyntax;
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().expect("a response").headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-language", tag)]);
+        let v = crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["language_tag_syntax"]),
+        )
+        .unwrap_or_else(|| panic!("{tag} reports"));
+        assert_eq!(v.violation, violation);
+        assert_eq!(v.severity, severity);
+        // The sentence comes from the def now, and it is the grammar rather
+        // than the definition of what a tag is for.
+        assert_eq!(v.cite.expect("cited from the def").spec, "RFC 5646");
     }
 
     /// `to_str` refuses every octet outside visible US-ASCII, and the whole

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1266,14 +1266,14 @@ severity = "warn"
     /// it on the other side, and this one keeps the unconverted remainder
     /// honest until the last site goes. `cookie_path_valid`'s `Path` reading
     /// was the first and took one cited site with it; `cookie_domain_valid`
-    /// took three more.
+    /// took three more and `language_tag_syntax` one.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 167;
+        const FLOOR: usize = 166;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/language.rs
+++ b/lint-http-rules/src/violations/language.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Language tag defects — the seven ways a tag or a range is not one.
+//!
+//! Two fields carry two different productions: `Content-Language` a
+//! `language-tag` and `Accept-Language` the broader `language-range`. One
+//! validator serves both and checks only what the two agree on, so these
+//! defects are the agreement — the character set, the hyphen as a separator,
+//! and a first subtag that opens with a letter. A defect that only one of the
+//! two productions has does not belong here, which is why there is no
+//! subtag-ordering entry.
+//!
+//! The severities differ for one reason worth stating: the invisible defects
+//! default higher than the visible ones. A control character in a tag is a
+//! thing nobody typed and something upstream mangled; a subtag that ran to
+//! nine characters is a sender being wrong on purpose.
+
+use crate::helpers::language::LanguageTagDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// What a tag is made of — the sentence behind every entry here except the
+/// empty one. It gives the character set, the hyphen's job as a separator and,
+/// with the ABNF beside it, the eight-character ceiling on a subtag.
+pub const RFC_5646_2_1: SpecRef = SpecRef {
+    spec: "RFC 5646",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1",
+    note: "Syntax: the `Language-Tag` production Content-Language carries. Its prose properties are enforced; its subtag ordering and length classes are not",
+};
+
+defects! {
+    /// A member with nothing in it: `Accept-Language: en,,fr` or a field whose
+    /// whole value is a comma. Nothing is trimmed first, so a member of
+    /// spaces reports as a character defect rather than as this one.
+    ///
+    // cite(RFC 5646 § 2.1): "Language-Tag  = langtag             ; normal language tags"
+    LANGUAGE_TAG_EMPTY = {
+        id: "language_tag_empty",
+        title: "Language tag is empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5646_2_1),
+    }
+
+    /// A control octet or whitespace inside the tag — neither of which any
+    /// sender types. `error` by default: both productions are ASCII
+    /// alphanumerics and hyphens throughout, so an octet outside that set in a
+    /// field this small is something that happened to the value in transit or
+    /// in whatever assembled it.
+    ///
+    // cite(RFC 5646 § 2.1): "are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen"
+    LANGUAGE_TAG_WHITESPACE_OR_CONTROL_FORBIDDEN = {
+        id: "language_tag_whitespace_or_control_forbidden",
+        title: "Language tag holds whitespace or a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_5646_2_1),
+    }
+
+    /// A visible octet outside the alphanumerics and `-`: the underscore of
+    /// `en_US`, most often, which is the locale spelling of a different
+    /// ecosystem.
+    ///
+    // cite(RFC 5646 § 2.1): "alphanum      = (ALPHA / DIGIT)     ; letters and numbers"
+    LANGUAGE_TAG_CHARACTER_FORBIDDEN = {
+        id: "language_tag_character_forbidden",
+        title: "Language tag holds a character outside letters, digits and hyphen",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5646_2_1),
+    }
+
+    /// A leading or trailing `-`. The hyphen separates subtags, so one at
+    /// either end describes a subtag that is not there.
+    ///
+    // cite(RFC 5646 § 2.1): "are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen"
+    LANGUAGE_TAG_EDGE_HYPHEN_FORBIDDEN = {
+        id: "language_tag_edge_hyphen_forbidden",
+        title: "Language tag starts or ends with a hyphen",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5646_2_1),
+    }
+
+    /// Two adjacent hyphens, which is the same missing subtag as the edge case
+    /// with neighbours on both sides.
+    ///
+    // cite(RFC 5646 § 2.1): "are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen"
+    LANGUAGE_TAG_SUBTAG_EMPTY = {
+        id: "language_tag_subtag_empty",
+        title: "Language tag has an empty subtag",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5646_2_1),
+    }
+
+    /// A first subtag opening on a digit. The one property RFC 5646's
+    /// `language` and RFC 4647's `language-range` agree on where they
+    /// otherwise diverge, which is why a validator serving both fields may
+    /// still enforce it.
+    ///
+    // cite(RFC 5646 § 2.1): "language      = 2*3ALPHA            ; shortest ISO 639 code"
+    LANGUAGE_TAG_LEADING_LETTER_MISSING = {
+        id: "language_tag_leading_letter_missing",
+        title: "Language tag does not begin with a letter",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5646_2_1),
+    }
+
+    /// A subtag over eight characters. Every subtag alternative in the grammar
+    /// is bounded at eight, the private-use one included, so nothing longer
+    /// derives from either production.
+    ///
+    // cite(RFC 5646 § 2.1): "privateuse    = "x" 1*("-" (1*8alphanum))"
+    LANGUAGE_TAG_SUBTAG_LENGTH_INVALID = {
+        id: "language_tag_subtag_length_invalid",
+        title: "Language subtag is longer than eight characters",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5646_2_1),
+    }
+}
+
+/// The defect a parsed [`LanguageTagDefect`] reports as.
+pub fn tag_defect(defect: LanguageTagDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        LanguageTagDefect::Empty => &LANGUAGE_TAG_EMPTY,
+        LanguageTagDefect::WhitespaceOrControl => &LANGUAGE_TAG_WHITESPACE_OR_CONTROL_FORBIDDEN,
+        LanguageTagDefect::BadCharacter(_) => &LANGUAGE_TAG_CHARACTER_FORBIDDEN,
+        LanguageTagDefect::HyphenPlacement => &LANGUAGE_TAG_EDGE_HYPHEN_FORBIDDEN,
+        LanguageTagDefect::DoesNotBeginWithLetter => &LANGUAGE_TAG_LEADING_LETTER_MISSING,
+        LanguageTagDefect::EmptySubtag => &LANGUAGE_TAG_SUBTAG_EMPTY,
+        LanguageTagDefect::SubtagTooLong(_) => &LANGUAGE_TAG_SUBTAG_LENGTH_INVALID,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Seven variants, seven ids, spelled out: the helper's split is only
+    /// worth having if it survives the mapping, and a variant answering with
+    /// its neighbour's def would report the right sentence under the wrong
+    /// name at the wrong configured severity.
+    #[test]
+    fn each_language_tag_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (LanguageTagDefect::Empty, "language_tag_empty"),
+            (
+                LanguageTagDefect::WhitespaceOrControl,
+                "language_tag_whitespace_or_control_forbidden",
+            ),
+            (
+                LanguageTagDefect::BadCharacter('_'),
+                "language_tag_character_forbidden",
+            ),
+            (
+                LanguageTagDefect::HyphenPlacement,
+                "language_tag_edge_hyphen_forbidden",
+            ),
+            (
+                LanguageTagDefect::DoesNotBeginWithLetter,
+                "language_tag_leading_letter_missing",
+            ),
+            (LanguageTagDefect::EmptySubtag, "language_tag_subtag_empty"),
+            (
+                LanguageTagDefect::SubtagTooLong("toolongsubtag"),
+                "language_tag_subtag_length_invalid",
+            ),
+        ] {
+            assert_eq!(tag_defect(defect).id, id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -31,6 +31,7 @@ use std::sync::LazyLock;
 
 pub mod cookie;
 pub mod domain;
+pub mod language;
 
 /// One reportable defect.
 ///
@@ -336,7 +337,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 17;
+        const FLOOR: usize = 24;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1619,7 +1619,7 @@ sources:
     snippet: A basic language range differs from the language tags defined in [RFC4646] only in that there is no requirement that it be "well-formed" or be validated against the IANA Language Subtag Registry.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 149
+      line: 167
   - label: lint-http-rules/src/helpers/language.rs
     section: § 2.1
     snippet: language-range   = (1*8ALPHA *("-" 1*8alphanum)) / "*"
@@ -1627,7 +1627,7 @@ sources:
     - file: lint-http-rules/src/helpers/language.rs
       line: 123
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 230
+      line: 247
 - label: RFC 4648
   url: https://www.rfc-editor.org/rfc/rfc4648.html
   fragments:
@@ -1878,6 +1878,34 @@ sources:
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.html
   fragments:
+  - label: language
+    section: § 2.1
+    snippet: Language-Tag  = langtag             ; normal language tags
+    cited_by:
+    - file: lint-http-rules/src/violations/language.rs
+      line: 40
+  - label: language (2)
+    section: § 2.1
+    snippet: alphanum      = (ALPHA / DIGIT)     ; letters and numbers
+    cited_by:
+    - file: lint-http-rules/src/violations/language.rs
+      line: 68
+  - label: language (3)
+    section: § 2.1
+    snippet: are a sequence of alphanumeric characters (letters and digits), distinguished and separated from other subtags in a tag by a hyphen
+    cited_by:
+    - file: lint-http-rules/src/violations/language.rs
+      line: 55
+    - file: lint-http-rules/src/violations/language.rs
+      line: 80
+    - file: lint-http-rules/src/violations/language.rs
+      line: 92
+  - label: language (4)
+    section: § 2.1
+    snippet: privateuse    = "x" 1*("-" (1*8alphanum))
+    cited_by:
+    - file: lint-http-rules/src/violations/language.rs
+      line: 119
   - label: lint-http-rules/src/helpers/language.rs
     section: § 2.1
     snippet: A language tag is composed from a sequence of one or more "subtags", each of which refines or narrows the range of language identified by the overall tag.
@@ -1908,6 +1936,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/language.rs
       line: 126
+    - file: lint-http-rules/src/violations/language.rs
+      line: 106
 - label: RFC 5789
   url: https://www.rfc-editor.org/rfc/rfc5789.html
   fragments:
@@ -4631,7 +4661,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 139
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 221
+      line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 82
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -6091,25 +6121,25 @@ sources:
     snippet: 'Content-Language = #language-tag'
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 196
+      line: 213
   - label: language_tag_syntax (2)
     section: § 8.5
     snippet: The "Content-Language" header field describes the natural language(s) of the intended audience for the representation.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 117
+      line: 135
   - label: language_tag_syntax (3)
     section: § 8.5.1
     snippet: A language tag, as defined in [RFC5646], identifies a natural language spoken, written, or otherwise conveyed by human beings for communication of information to other human beings.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 151
+      line: 169
   - label: language_tag_syntax (4)
     section: § 8.5.1
     snippet: HTTP uses language tags within the Accept-Language and Content-Language header fields.  Accept-Language uses the broader language-range production defined in Section 12.5.4, whereas Content-Language uses the language-tag production defined below.
     cited_by:
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 148
+      line: 166
   - label: last_modified_rfc1123_syntax
     section: § 8.8.2
     snippet: Last-Modified = HTTP-date
@@ -6891,7 +6921,7 @@ sources:
     - file: lint-http-rules/src/rules/if_unmodified_since_date_syntax.rs
       line: 94
     - file: lint-http-rules/src/rules/language_tag_syntax.rs
-      line: 222
+      line: 239
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 260
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs


### PR DESCRIPTION
`language_tag_syntax` converts: one call site, seven defects, and the split the helper enum already made now reaches the report. The names are the tag's rather than the rule's — `link_header_valid` reads a tag out of an `hreflang` parameter through the same validator and will declare the same seven.

Whitespace or a control octet defaults to `error` while the rest stay `warn`. Both productions are ASCII alphanumerics and hyphens throughout, so an invisible octet in a field this small is something that happened to the value rather than something a sender chose; `en_US` is a sender writing another ecosystem's locale spelling. One severity per rule could not tell those apart.

The findings also cite better text than they did. The site cited § 8.5.1's definition of what a language tag is, because a single site had to cite one sentence for seven defects; each def now carries the RFC 5646 § 2.1 grammar line that answers it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
