### PR TITLE
A broken escape is not the cookie's

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1095,10 +1095,6 @@ severity = "warn"
 # Set-Cookie Path attribute holds a raw non-ASCII character
 severity = "warn"
 
-[violations.cookie_path_percent_encoding_malformed]
-# Set-Cookie Path attribute has a broken percent-encoding
-severity = "warn"
-
 [violations.cookie_path_whitespace_invalid]
 # Set-Cookie Path attribute holds unencoded whitespace
 severity = "info"
@@ -1154,3 +1150,11 @@ severity = "warn"
 [violations.language_tag_whitespace_or_control_forbidden]
 # Language tag holds whitespace or a control character
 severity = "error"
+
+[violations.percent_encoding_digits_missing]
+# Percent-encoding stops before its two hexadecimal digits
+severity = "warn"
+
+[violations.percent_encoding_malformed]
+# Percent-encoding is not two hexadecimal digits
+severity = "warn"

--- a/docs/rules/cookie_path_valid.md
+++ b/docs/rules/cookie_path_valid.md
@@ -12,7 +12,7 @@ Validate the `Path` attribute in `Set-Cookie` header fields. The `Path` attribut
 
 ## Specifications
 
-- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits a `%` in a cookie path still owes
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 - [RFC 6265 §4.1.1](https://www.rfc-editor.org/rfc/rfc6265.html#section-4.1.1): Set-Cookie syntax — servers SHOULD NOT send a non-conforming Set-Cookie; `path-value` excludes control characters and `;`
 - [RFC 6265 §5.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2): The Set-Cookie header parsing algorithm — where the `;` split, the WSP trim and the case-insensitive `Path` match come from
 - [RFC 6265 §5.2.4](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4): Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)

--- a/lint-http-rules/src/helpers/cookie.rs
+++ b/lint-http-rules/src/helpers/cookie.rs
@@ -26,9 +26,11 @@ pub enum CookiePathDefect<'a> {
     /// server sent and the trim is this function's own tolerance.
     NotAbsolute(&'a str),
     /// A `%` that no two hex digits follow. Delegated to
-    /// [`crate::helpers::uri::check_percent_encoding`], which owns the
-    /// production and phrases this one.
-    PercentEncoding(String),
+    /// [`crate::helpers::uri::percent_encoding_defect`], which owns the
+    /// production and phrases this one — and is carried typed rather than
+    /// rendered, so a caller can report *which* of the two it was under the
+    /// name the whole tree uses for it.
+    PercentEncoding(crate::helpers::uri::PercentEncodingDefect<'a>),
     /// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
     /// non-ASCII derives from nothing and has to be percent-encoded.
     NonAscii(usize),
@@ -49,7 +51,7 @@ impl CookiePathDefect<'_> {
             Self::NotAbsolute(written) => {
                 format!("Path should start with '/': '{written}'")
             }
-            Self::PercentEncoding(msg) => msg.clone(),
+            Self::PercentEncoding(defect) => defect.message(),
             Self::NonAscii(at) => format!("Path contains non-ASCII character at byte {at}"),
             Self::ControlCharacter(at) => format!("Path contains control character at byte {at}"),
             Self::Whitespace(at) => format!("Path contains whitespace character at byte {at}"),
@@ -85,8 +87,8 @@ pub fn validate_cookie_path(s: &str) -> Result<(), CookiePathDefect<'_>> {
     }
 
     // Validate percent-encodings using shared helper to avoid duplicate logic
-    if let Some(msg) = crate::helpers::uri::check_percent_encoding(v) {
-        return Err(CookiePathDefect::PercentEncoding(msg));
+    if let Some(defect) = crate::helpers::uri::percent_encoding_defect(v) {
+        return Err(CookiePathDefect::PercentEncoding(defect));
     }
 
     // The loop holds the server to §4.1.1's `path-value = <any CHAR except CTLs

--- a/lint-http-rules/src/rules/cookie_path_valid.rs
+++ b/lint-http-rules/src/rules/cookie_path_valid.rs
@@ -7,8 +7,11 @@ use crate::rules::{Rule, RuleMeta};
 use crate::violations::cookie::{
     path_defect, COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN, COOKIE_PATH_EMPTY,
     COOKIE_PATH_LEADING_SLASH_MISSING, COOKIE_PATH_MISSING,
-    COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN, COOKIE_PATH_PERCENT_ENCODING_MALFORMED,
-    COOKIE_PATH_WHITESPACE_INVALID, RFC_3986_2_1, RFC_6265_4_1_1, RFC_6265_5_2_4,
+    COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN, COOKIE_PATH_WHITESPACE_INVALID, RFC_6265_4_1_1,
+    RFC_6265_5_2_4,
+};
+use crate::violations::uri::{
+    PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED, RFC_3986_2_1,
 };
 use crate::violations::ViolationDef;
 
@@ -19,14 +22,16 @@ pub struct CookiePathValid;
 /// array of references to statics is not const-promotable.
 ///
 /// Their definitions — title, default severity, and the sentence each enforces
-/// — are in `violations::cookie`, which is also where the `Path` half of this
-/// rule's specification references now live: a defect belongs to the attribute
-/// it is about, not to whichever rule noticed it.
+/// — are in `violations::cookie`, except the two percent-encoding entries,
+/// which are `violations::uri`'s: a `%` owes two hex digits wherever it is
+/// written, so that defect is not the cookie's to name. A defect belongs to
+/// the thing it is about, not to whichever rule noticed it.
 static DECLARED: &[&ViolationDef] = &[
     &COOKIE_PATH_MISSING,
     &COOKIE_PATH_EMPTY,
     &COOKIE_PATH_LEADING_SLASH_MISSING,
-    &COOKIE_PATH_PERCENT_ENCODING_MALFORMED,
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
     &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN,
     &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN,
     &COOKIE_PATH_WHITESPACE_INVALID,

--- a/lint-http-rules/src/violations/cookie.rs
+++ b/lint-http-rules/src/violations/cookie.rs
@@ -28,6 +28,7 @@ use crate::helpers::domain::CookieDomainDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::domain::preferred_name_defect;
+use crate::violations::uri::percent_encoding;
 use crate::violations::{defects, ViolationDef};
 
 /// The `Set-Cookie` grammar, which is what the character defects below are
@@ -49,16 +50,6 @@ pub const RFC_6265_5_2_4: SpecRef = SpecRef {
     section: Some("5.2.4"),
     url: "https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.4",
     note: "Path attribute — the user agent replaces an empty or non-`/` Path with the default-path (why those forms are flagged)",
-};
-
-/// The triplet a `%` obliges. `path-value` admits `%` as an ordinary
-/// character, so a broken escape is answered by the document that defines the
-/// escape and not by RFC 6265.
-pub const RFC_3986_2_1: SpecRef = SpecRef {
-    spec: "RFC 3986",
-    section: Some("2.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
-    note: "Percent-Encoding — `pct-encoded = \"%\" HEXDIG HEXDIG`, the two digits a `%` in a cookie path still owes",
 };
 
 /// What a user agent does with a `Domain` it is given: an empty value leaves
@@ -119,17 +110,6 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_6265_5_2_4),
-    }
-
-    /// A `%` in the path that no two hex digits follow.
-    ///
-    // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
-    COOKIE_PATH_PERCENT_ENCODING_MALFORMED = {
-        id: "cookie_path_percent_encoding_malformed",
-        title: "Set-Cookie Path attribute has a broken percent-encoding",
-        message: "",
-        default_severity: Severity::Warn,
-        spec: Some(RFC_3986_2_1),
     }
 
     /// A byte at or above %x80. `path-value` is built on `CHAR` = %x01-7F, so
@@ -252,7 +232,7 @@ pub fn path_defect(defect: &CookiePathDefect<'_>) -> &'static ViolationDef {
     match defect {
         CookiePathDefect::Empty => &COOKIE_PATH_EMPTY,
         CookiePathDefect::NotAbsolute(_) => &COOKIE_PATH_LEADING_SLASH_MISSING,
-        CookiePathDefect::PercentEncoding(_) => &COOKIE_PATH_PERCENT_ENCODING_MALFORMED,
+        CookiePathDefect::PercentEncoding(defect) => percent_encoding(*defect),
         CookiePathDefect::NonAscii(_) => &COOKIE_PATH_NON_ASCII_CHARACTER_FORBIDDEN,
         CookiePathDefect::ControlCharacter(_) => &COOKIE_PATH_CONTROL_CHARACTER_FORBIDDEN,
         CookiePathDefect::Whitespace(_) => &COOKIE_PATH_WHITESPACE_INVALID,
@@ -293,7 +273,9 @@ mod tests {
         let defects = [
             CookiePathDefect::Empty,
             CookiePathDefect::NotAbsolute("login"),
-            CookiePathDefect::PercentEncoding("%ZZ".to_string()),
+            CookiePathDefect::PercentEncoding(
+                crate::helpers::uri::PercentEncodingDefect::NotHexDigits("%ZZ"),
+            ),
             CookiePathDefect::NonAscii(3),
             CookiePathDefect::ControlCharacter(3),
             CookiePathDefect::Whitespace(3),
@@ -346,7 +328,9 @@ mod tests {
         for defect in [
             CookiePathDefect::Empty,
             CookiePathDefect::NotAbsolute("login"),
-            CookiePathDefect::PercentEncoding("%ZZ".to_string()),
+            CookiePathDefect::PercentEncoding(
+                crate::helpers::uri::PercentEncodingDefect::NotHexDigits("%ZZ"),
+            ),
             CookiePathDefect::NonAscii(3),
             CookiePathDefect::ControlCharacter(3),
             CookiePathDefect::Whitespace(3),

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -32,6 +32,7 @@ use std::sync::LazyLock;
 pub mod cookie;
 pub mod domain;
 pub mod language;
+pub mod uri;
 
 /// One reportable defect.
 ///
@@ -337,7 +338,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 24;
+        const FLOOR: usize = 25;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/uri.rs
+++ b/lint-http-rules/src/violations/uri.rs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! URI defects — today, the two ways a percent-encoded triplet is not one.
+//!
+//! A `%` obliges two hexadecimal digits wherever it is written, and this crate
+//! reads escapes in a request target, a `Location`, a cookie `Path`, an
+//! `Alt-Svc` parameter and a dozen other places. The sentence answering all of
+//! them is the same one, so the defect is too: naming it after the field that
+//! happened to carry it would give an operator one name per field for one
+//! mistake.
+//!
+//! That is a correction to this campaign's first subject, made while the
+//! catalogue was small enough for corrections to be free. `cookie_path` shipped
+//! a `cookie_path_percent_encoding_malformed` of its own, which was the same
+//! reasoning error the rule-shaped catalogue is being split to fix.
+
+use crate::helpers::uri::PercentEncodingDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The triplet a `%` obliges, and the only sentence either defect here needs.
+pub const RFC_3986_2_1: SpecRef = SpecRef {
+    spec: "RFC 3986",
+    section: Some("2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1",
+    note: "Percent-Encoding — `pct-encoded = \"%\" HEXDIG HEXDIG`, the two digits every `%` still owes",
+};
+
+defects! {
+    /// A `%` with fewer than two characters after it, because the value ended.
+    /// Kept apart from the malformed triplet because the fix differs: this one
+    /// is a value that was cut, most often by something that truncated it.
+    ///
+    // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
+    PERCENT_ENCODING_DIGITS_MISSING = {
+        id: "percent_encoding_digits_missing",
+        title: "Percent-encoding stops before its two hexadecimal digits",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_2_1),
+    }
+
+    /// Two characters after the `%` that are not both `HEXDIG` — a literal
+    /// percent that was never escaped, most often.
+    ///
+    // cite(RFC 3986 § 2.1): "pct-encoded = "%" HEXDIG HEXDIG"
+    PERCENT_ENCODING_MALFORMED = {
+        id: "percent_encoding_malformed",
+        title: "Percent-encoding is not two hexadecimal digits",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_2_1),
+    }
+}
+
+/// The defect a parsed [`PercentEncodingDefect`] reports as.
+pub fn percent_encoding(defect: PercentEncodingDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        PercentEncodingDefect::Incomplete => &PERCENT_ENCODING_DIGITS_MISSING,
+        PercentEncodingDefect::NotHexDigits(_) => &PERCENT_ENCODING_MALFORMED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_percent_encoding_defect_maps_to_its_own_id() {
+        assert_eq!(
+            percent_encoding(PercentEncodingDefect::Incomplete).id,
+            "percent_encoding_digits_missing",
+        );
+        assert_eq!(
+            percent_encoding(PercentEncodingDefect::NotHexDigits("%ZZ")).id,
+            "percent_encoding_malformed",
+        );
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1213,8 +1213,10 @@ sources:
       line: 138
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 49
-    - file: lint-http-rules/src/violations/cookie.rs
-      line: 126
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 37
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 49
   - label: lint-http-rules/src/helpers/uri.rs (7)
     section: § 2.2
     snippet: A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component.
@@ -2051,23 +2053,23 @@ sources:
     snippet: The string is a host name (i.e., not an IP address).
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 221
+      line: 201
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 234
+      line: 214
   - label: cookie (2)
     section: § 5.2.3
     snippet: If the attribute-value is empty, the behavior is undefined.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 177
+      line: 157
   - label: cookie (3)
     section: § 5.2.3
     snippet: Let cookie-domain be the attribute-value without the leading %x2E (".") character.
     cited_by:
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 192
+      line: 172
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 207
+      line: 187
   - label: cookie_attribute_consistent
     section: § 4.1.1
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
@@ -2129,7 +2131,7 @@ sources:
     - file: lint-http-rules/src/rules/cookie_domain_valid.rs
       line: 132
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 149
+      line: 154
   - label: cookie_domain_valid (2)
     section: § 5.2.3
     snippet: If the attribute-name case-insensitively matches the string "Domain", the user agent MUST process the cookie-av as follows.
@@ -2165,97 +2167,97 @@ sources:
     snippet: If the attribute-name case-insensitively matches the string "Path", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_path_valid.rs
-      line: 164
+      line: 169
   - label: lint-http-rules/src/helpers/cookie.rs
     section: § 4.1.1
     snippet: 'Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 97
+      line: 99
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 138
+      line: 118
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 151
+      line: 131
   - label: lint-http-rules/src/helpers/cookie.rs (2)
     section: § 4.1.1
     snippet: cookie-av         = expires-av / max-age-av / domain-av / path-av / secure-av / httponly-av / extension-av
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 216
+      line: 218
   - label: lint-http-rules/src/helpers/cookie.rs (3)
     section: § 4.1.1
     snippet: set-cookie-string = cookie-pair *( ";" SP cookie-av )
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 242
+      line: 244
   - label: cookie domain-match
     section: § 5.1.3
     snippet: A string domain-matches a given domain string if at least one of the following conditions hold
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 167
+      line: 169
   - label: cookie path-match
     section: § 5.1.4
     snippet: A request-path path-matches a given cookie-path if at least one of the following conditions holds
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 187
+      line: 189
   - label: lint-http-rules/src/helpers/cookie.rs (4)
     section: § 5.1.4
     snippet: If the uri-path contains no more than one %x2F ("/") character, output %x2F ("/") and skip the remaining step.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 296
+      line: 298
   - label: lint-http-rules/src/helpers/cookie.rs (5)
     section: § 5.1.4
     snippet: Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/").
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 300
+      line: 302
   - label: lint-http-rules/src/helpers/cookie.rs (6)
     section: § 5.1.4
     snippet: 'The user agent MUST use an algorithm equivalent to the following algorithm to compute the default-path of a cookie:'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 284
+      line: 286
   - label: lint-http-rules/src/helpers/cookie.rs (7)
     section: § 5.1.4
     snippet: output %x2F ("/") and skip the remaining steps.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 292
+      line: 294
   - label: lint-http-rules/src/helpers/cookie.rs (8)
     section: § 5.2.1
     snippet: If the attribute-name case-insensitively matches the string "Expires", the user agent MUST process the cookie-av as follows.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 224
+      line: 226
   - label: cookie Path attribute
     section: § 5.2.4
     snippet: 'If the attribute-value is empty or if the first character of the attribute-value is not %x2F ("/"):'
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 346
+      line: 348
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 91
+      line: 82
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 102
+      line: 93
     - file: lint-http-rules/src/violations/cookie.rs
-      line: 115
+      line: 106
   - label: lint-http-rules/src/helpers/cookie.rs (9)
     section: § 5.3
     snippet: Set the cookie's host-only-flag to true.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 266
+      line: 268
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 385
+      line: 387
   - label: lint-http-rules/src/helpers/cookie.rs (10)
     section: § 5.4
     snippet: The cookie's host-only-flag is true and the canonicalized request-host is identical to the cookie's domain.
     cited_by:
     - file: lint-http-rules/src/helpers/cookie.rs
-      line: 178
+      line: 180
   - label: trace_method_echo
     section: § 4.2.1
     snippet: The user agent sends stored cookies to the origin server in the Cookie header.


### PR DESCRIPTION
The first subject named a percent-encoding defect after the field that happened to carry it, which is the same reasoning error the catalogue is being split to fix: a `%` owes two hexadecimal digits in a request target, a `Location`, an `Alt-Svc` parameter and a cookie `Path` alike, and an operator should not need one name per field for one mistake.

So `violations::uri` names the two — the triplet that stops early and the one whose digits are not digits — and `cookie_path_valid` declares them instead of a `cookie_path_` entry of its own. The cookie helper carries the typed defect rather than a rendered string to make the split reachable, which is what `validate_uri_host` already does with the same type; the messages are unchanged, since they were always that type's own.

Cheap now, at twenty-six entries. The correction is the argument for making the catalogue's shared subjects early rather than at the end.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
