### PR TITLE
A mailbox names each way it is not one

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1151,6 +1151,78 @@ severity = "warn"
 # Language tag holds whitespace or a control character
 severity = "error"
 
+[violations.mailbox_angle_addr_missing]
+# Mailbox has no angle-addr where the name-addr wants one
+severity = "warn"
+
+[violations.mailbox_angle_addr_terminator_missing]
+# Mailbox angle-addr is never closed
+severity = "warn"
+
+[violations.mailbox_at_sign_missing]
+# Mailbox has no at-sign
+severity = "warn"
+
+[violations.mailbox_atom_character_forbidden]
+# Mailbox atom holds a character outside atext
+severity = "warn"
+
+[violations.mailbox_atom_empty]
+# Mailbox atom is empty beside a dot
+severity = "warn"
+
+[violations.mailbox_comment_character_forbidden]
+# Mailbox comment holds a character outside ctext
+severity = "warn"
+
+[violations.mailbox_comment_terminator_missing]
+# Mailbox comment is never closed
+severity = "warn"
+
+[violations.mailbox_display_name_word_missing]
+# Mailbox display-name holds no word
+severity = "warn"
+
+[violations.mailbox_domain_literal_character_forbidden]
+# Mailbox domain-literal holds a character outside dtext
+severity = "warn"
+
+[violations.mailbox_domain_literal_terminator_missing]
+# Mailbox domain-literal is never closed
+severity = "warn"
+
+[violations.mailbox_domain_missing]
+# Mailbox has no domain
+severity = "warn"
+
+[violations.mailbox_empty]
+# Mailbox field is present with an empty value
+severity = "warn"
+
+[violations.mailbox_list_separator_forbidden]
+# Mailbox holds a comma where one address goes
+severity = "warn"
+
+[violations.mailbox_local_part_missing]
+# Mailbox has no local-part
+severity = "warn"
+
+[violations.mailbox_quoted_pair_malformed]
+# Mailbox escape is not a quoted-pair
+severity = "warn"
+
+[violations.mailbox_quoted_string_character_forbidden]
+# Mailbox quoted-string holds a character outside qtext
+severity = "warn"
+
+[violations.mailbox_quoted_string_terminator_missing]
+# Mailbox quoted-string is never closed
+severity = "warn"
+
+[violations.mailbox_trailing_character_forbidden]
+# Mailbox is followed by something else
+severity = "warn"
+
 [violations.percent_encoding_digits_missing]
 # Percent-encoding stops before its two hexadecimal digits
 severity = "warn"

--- a/docs/rules/from_header_email_syntax.md
+++ b/docs/rules/from_header_email_syntax.md
@@ -17,13 +17,16 @@ This rule measures the `From` request header against the one production RFC 9110
 - [RFC 9110 §5.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.3): A sender MUST NOT write a second field line for a field whose value is not a comma-separated list
 - [RFC 9110 §5.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5): Singleton fields, and the `OWS` a parser must exclude before evaluating a field value
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): The MUST NOT that makes a value outside the field's ABNF a finding
-- [RFC 5322 §3.4](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4): `mailbox = name-addr / addr-spec`, and `mailbox-list` beside it — the production this field does *not* import
-- [RFC 5322 §3.4.1](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1): `addr-spec = local-part "@" domain`, `domain-literal`, and the sentence handing a `dot-atom` domain to the host-name documents
-- [RFC 5322 §3.2.2](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.2): `CFWS` — folding whitespace and nested parenthesised comments, admitted around nearly every token of a mailbox
-- [RFC 5322 §3.2.3](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3): `atext`, `atom` and `dot-atom-text` — the `1*atext` floors either side of every dot
-- [RFC 5322 §3.2.4](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.4): `quoted-string` and `qtext`, the alternative a local-part or a display-name word may take
+- [RFC 5322 §3.2.1](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.1): `quoted-pair` — the backslash and the one `VCHAR` or `WSP` it owes
+- [RFC 5322 §3.2.2](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.2): `CFWS`, `comment` and `ctext` — the comment names itself, so what it holds is balanced and its character class stops at %x7E
+- [RFC 5322 §3.2.3](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3): `atext`, `atom` and `dot-atom-text` — the printable US-ASCII an atom is made of, and the floor a dot may not leave empty
+- [RFC 5322 §3.2.4](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.4): `quoted-string` and `qtext` — the quoted alternative, and the class it admits between the two DQUOTEs
+- [RFC 5322 §3.2.5](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.5): `phrase = 1*word` — a display-name holds at least one atom or quoted-string, and `obs-phrase`'s bare `.` is not one
+- [RFC 5322 §3.4](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4): `mailbox = name-addr / addr-spec`, `angle-addr` beside it, and `mailbox-list` — the neighbouring production a top-level comma derives from
+- [RFC 5322 §3.4.1](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1): `addr-spec = local-part "@" domain`, and the `domain-literal` alternative with the `dtext` inside it
 - [RFC 5322 §4](https://www.rfc-editor.org/rfc/rfc5322.html#section-4): Obsolete syntax: MUST NOT be generated, MUST be accepted by a receiver — this rule reports on the generator
-- [RFC 1035 §2.3.1](https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1): Preferred name syntax for the `dot-atom` form of a domain — advisory, and the one finding here that is reported as advice
+- [RFC 1035 §2.3.1](https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1): Preferred name syntax — labels start with a letter, end with a letter or digit, hold only letters, digits and hyphen, and run to 63 characters
+- [RFC 1035 §2.3.4](https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.4): Size limits — a name is 255 octets or less
 - [RFC 1123 §2.1](https://www.rfc-editor.org/rfc/rfc1123.html): Relaxes RFC 1035's first-character rule to a letter or a digit
 
 ## Configuration

--- a/lint-http-proxy/tests/helpers_additional.rs
+++ b/lint-http-proxy/tests/helpers_additional.rs
@@ -48,7 +48,8 @@ fn validate_ext_value_invalid_charset_non_ascii() {
 #[test]
 fn a_mailbox_whose_angle_addr_holds_no_addr_spec_is_refused() {
     match parse_mailbox("Alice <not-an-email>") {
-        Err(MailboxDefect::Syntax(msg)) => {
+        Err(MailboxDefect::Syntax(defect)) => {
+            let msg = defect.message();
             assert!(msg.contains("where the addr-spec has its \"@\""), "{msg}")
         }
         Err(MailboxDefect::ListSeparator) => panic!("read as a mailbox-list"),

--- a/lint-http-rules/src/helpers/mailbox.rs
+++ b/lint-http-rules/src/helpers/mailbox.rs
@@ -73,8 +73,150 @@ pub enum MailboxDefect {
     /// into "malformed" would be telling an operator to fix a comma, when what
     /// happened is that a list was written where one address goes.
     ListSeparator,
-    /// Any other departure from § 3's grammar, described.
-    Syntax(String),
+    /// Any other departure from § 3's grammar, named by the production that
+    /// refused the value.
+    Syntax(MailboxSyntaxDefect),
+}
+
+/// Where § 3's grammar stopped, and in which production.
+///
+/// Typed rather than rendered, for the reason the whole catalogue is being
+/// split: a caller that receives a sentence can only report one thing about a
+/// value, and these are seventeen things — a `ctext` refusing an octet nobody
+/// typed, an atom with a doubled dot, a comment nobody closed. The sentence
+/// each of them is answered by is a different line of RFC 5322, and an operator
+/// tuning one is not tuning the others.
+///
+/// The wording of every one is [`MailboxSyntaxDefect::message`]'s, so a caller
+/// embedding it says what this reader found and not what it guessed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MailboxSyntaxDefect {
+    /// An octet inside a `comment` that `ctext` does not admit.
+    CommentCharacter(char),
+    /// A `comment` opened and never closed.
+    CommentUnterminated,
+    /// An octet inside a `quoted-string` that `qtext` does not admit.
+    QuotedStringCharacter(char),
+    /// A `quoted-string` opened and never closed.
+    QuotedStringUnterminated,
+    /// An octet inside a `domain-literal` that `dtext` does not admit.
+    DomainLiteralCharacter(char),
+    /// A `domain-literal` opened and never closed.
+    DomainLiteralUnterminated,
+    /// A backslash with nothing after it to quote, in the named construct.
+    QuotedPairAtEnd {
+        /// The construct holding the backslash — `comment` or `quoted-string`.
+        inside: &'static str,
+    },
+    /// A backslash quoting an octet that is neither `VCHAR` nor `WSP`.
+    QuotedPairCharacter {
+        /// The construct holding the pair — `comment` or `quoted-string`.
+        inside: &'static str,
+        /// What it tried to quote.
+        character: char,
+    },
+    /// An octet in a `dot-atom` that `atext` does not admit.
+    AtomCharacter {
+        /// Which `dot-atom` — `local-part` or `domain`.
+        what: &'static str,
+        /// The octet.
+        character: char,
+    },
+    /// A `.` in a `dot-atom` with no `atext` after it: a trailing or a doubled
+    /// one, either way an atom the `1*atext` floor has nothing to fill.
+    AtomEmpty {
+        /// Which `dot-atom` — `local-part` or `domain`.
+        what: &'static str,
+    },
+    /// The value ends where the `addr-spec` has its `local-part`.
+    LocalPartMissing,
+    /// The `addr-spec`'s `"@"` is not where the production puts it.
+    AtSignMissing(Option<char>),
+    /// The value ends where the `addr-spec` has its `domain`.
+    DomainMissing,
+    /// The `angle-addr`'s `"<"` is not where the `name-addr` puts it — which
+    /// is what an `obs-phrase`'s bare `.` in a display-name comes to.
+    AngleAddrMissing(Option<char>),
+    /// The `angle-addr`'s closing `">"` is not where the production puts it.
+    AngleAddrUnterminated(Option<char>),
+    /// A display-name was opened and holds no `word`.
+    DisplayNameWordMissing(Option<char>),
+    /// A complete `mailbox` with something after it.
+    TrailingCharacter(char),
+}
+
+impl MailboxSyntaxDefect {
+    /// The finding fragment. Every caller embeds this after naming the field
+    /// the value came out of.
+    pub fn message(self) -> String {
+        match self {
+            Self::CommentCharacter(c) => format!(
+                "a comment holds {}, which no ctext admits",
+                describe_char(c)
+            ),
+            Self::CommentUnterminated => "a comment is opened and never closed".to_string(),
+            Self::QuotedStringCharacter(c) => format!(
+                "a quoted-string holds {}, which no qtext admits",
+                describe_char(c)
+            ),
+            Self::QuotedStringUnterminated => {
+                "a quoted-string is opened and never closed".to_string()
+            }
+            Self::DomainLiteralCharacter(c) => format!(
+                "a domain-literal holds {}, which no dtext admits",
+                describe_char(c)
+            ),
+            Self::DomainLiteralUnterminated => {
+                "a domain-literal is opened and never closed".to_string()
+            }
+            Self::QuotedPairAtEnd { inside } => {
+                format!("a {inside} ends on a backslash with nothing after it to quote")
+            }
+            Self::QuotedPairCharacter { inside, character } => format!(
+                "a {inside} quotes {}, where quoted-pair admits only VCHAR and WSP",
+                describe_char(character)
+            ),
+            Self::AtomCharacter { what, character } => format!(
+                "the {what} holds {}, which no atext admits",
+                describe_char(character)
+            ),
+            Self::AtomEmpty { what } => {
+                format!("the {what} has a \".\" with no atext after it")
+            }
+            Self::LocalPartMissing => {
+                "the value ends where the addr-spec has a local-part".to_string()
+            }
+            Self::AtSignMissing(at) => {
+                format!("{} where the addr-spec has its \"@\"", stopped_at(at))
+            }
+            Self::DomainMissing => "the value ends where the addr-spec has a domain".to_string(),
+            Self::AngleAddrMissing(at) => format!(
+                "{} where the mailbox has the \"<\" of its angle-addr",
+                stopped_at(at)
+            ),
+            Self::AngleAddrUnterminated(at) => {
+                format!("{} where the angle-addr has its \">\"", stopped_at(at))
+            }
+            Self::DisplayNameWordMissing(at) => {
+                format!("{} where the display-name has a word", stopped_at(at))
+            }
+            Self::TrailingCharacter(c) => {
+                format!("{} follows a complete mailbox", describe_char(c))
+            }
+        }
+    }
+}
+
+/// What a construct stopped at, as the subject of a finding's sentence.
+///
+/// One rendering for both endings — a character the grammar has no room for,
+/// and the value running out — so the four defects that carry a position state
+/// what they wanted once each instead of twice.
+fn stopped_at(at: Option<char>) -> String {
+    match at {
+        Some(c) => describe_char(c),
+        None => "the value ends".to_string(),
+    }
 }
 
 /// Parse one `mailbox`.
@@ -108,10 +250,9 @@ pub fn parse_mailbox(value: &str) -> Result<Mailbox, MailboxDefect> {
     match r.peek() {
         None => Ok(parsed),
         Some(',') => Err(MailboxDefect::ListSeparator),
-        Some(c) => Err(MailboxDefect::Syntax(format!(
-            "{} follows a complete mailbox",
-            describe_char(c)
-        ))),
+        Some(c) => Err(MailboxDefect::Syntax(
+            MailboxSyntaxDefect::TrailingCharacter(c),
+        )),
     }
 }
 
@@ -234,22 +375,10 @@ impl<'a> Reader<'a> {
         false
     }
 
-    /// What a construct stopped at, as the subject of a finding's sentence.
-    ///
-    /// One rendering for both endings — a character the grammar has no room for,
-    /// and the value running out — so the six sites below state what they wanted
-    /// once each instead of twice.
-    fn stopped_at(&self) -> String {
-        match self.peek() {
-            Some(c) => describe_char(c),
-            None => "the value ends".to_string(),
-        }
-    }
-
     /// Consume `[CFWS]`.
     ///
     /// cite(RFC 5322 § 3.2.2): "CFWS = (1*([FWS] comment) [FWS]) / FWS"
-    fn skip_cfws(&mut self) -> Result<(), String> {
+    fn skip_cfws(&mut self) -> Result<(), MailboxSyntaxDefect> {
         loop {
             while matches!(self.peek(), Some(c) if is_wsp(c)) {
                 self.i += 1;
@@ -263,7 +392,7 @@ impl<'a> Reader<'a> {
 
     /// cite(RFC 5322 § 3.2.2): "comment = "(" *([FWS] ccontent) [FWS] ")""
     /// cite(RFC 5322 § 3.2.2): "ccontent = ctext / quoted-pair / comment"
-    fn comment(&mut self) -> Result<(), String> {
+    fn comment(&mut self) -> Result<(), MailboxSyntaxDefect> {
         self.i += 1;
         // `comment` names itself, so the count is the production and not a
         // convenience: `(a (b) c)` ends at the last parenthesis and a single
@@ -282,34 +411,27 @@ impl<'a> Reader<'a> {
                     self.quoted_pair("comment")?;
                 }
                 c if is_ctext(c) || is_wsp(c) => {}
-                c => {
-                    return Err(format!(
-                        "a comment holds {}, which no ctext admits",
-                        describe_char(c)
-                    ))
-                }
+                c => return Err(MailboxSyntaxDefect::CommentCharacter(c)),
             }
         }
-        Err("a comment is opened and never closed".into())
+        Err(MailboxSyntaxDefect::CommentUnterminated)
     }
 
     /// The octet after a backslash, in whichever construct is quoting it.
-    fn quoted_pair(&mut self, inside: &str) -> Result<char, String> {
+    fn quoted_pair(&mut self, inside: &'static str) -> Result<char, MailboxSyntaxDefect> {
         match self.bump() {
-            None => Err(format!(
-                "a {inside} ends on a backslash with nothing after it to quote"
-            )),
+            None => Err(MailboxSyntaxDefect::QuotedPairAtEnd { inside }),
             Some(c) if is_quotable(c) => Ok(c),
-            Some(c) => Err(format!(
-                "a {inside} quotes {}, where quoted-pair admits only VCHAR and WSP",
-                describe_char(c)
-            )),
+            Some(c) => Err(MailboxSyntaxDefect::QuotedPairCharacter {
+                inside,
+                character: c,
+            }),
         }
     }
 
     /// cite(RFC 5322 § 3.2.4): "quoted-string = [CFWS] DQUOTE *([FWS] qcontent) [FWS] DQUOTE [CFWS]"
     /// cite(RFC 5322 § 3.2.4): "qcontent = qtext / quoted-pair"
-    fn quoted_string(&mut self) -> Result<(), String> {
+    fn quoted_string(&mut self) -> Result<(), MailboxSyntaxDefect> {
         self.i += 1;
         while let Some(ch) = self.bump() {
             match ch {
@@ -318,15 +440,10 @@ impl<'a> Reader<'a> {
                     self.quoted_pair("quoted-string")?;
                 }
                 c if is_qtext(c) || is_wsp(c) => {}
-                c => {
-                    return Err(format!(
-                        "a quoted-string holds {}, which no qtext admits",
-                        describe_char(c)
-                    ))
-                }
+                c => return Err(MailboxSyntaxDefect::QuotedStringCharacter(c)),
             }
         }
-        Err("a quoted-string is opened and never closed".into())
+        Err(MailboxSyntaxDefect::QuotedStringUnterminated)
     }
 
     /// cite(RFC 5322 § 3.2.3): "dot-atom = [CFWS] dot-atom-text [CFWS]"
@@ -335,7 +452,7 @@ impl<'a> Reader<'a> {
     /// the `domain` caller keeps the text, and the local-part — which every
     /// well-formed `From` has — would otherwise pay for a string it drops on
     /// the next statement.
-    fn dot_atom_text(&mut self, what: &str) -> Result<&'a [char], String> {
+    fn dot_atom_text(&mut self, what: &'static str) -> Result<&'a [char], MailboxSyntaxDefect> {
         let start = self.i;
         let mut after_dot = false;
         loop {
@@ -349,15 +466,14 @@ impl<'a> Reader<'a> {
             // doubled `.` derives from nothing and reads as clean.
             if self.i == run {
                 return Err(match self.peek() {
-                    Some(c) if !after_dot => format!(
-                        "the {what} holds {}, which no atext admits",
-                        describe_char(c)
-                    ),
+                    Some(c) if !after_dot => {
+                        MailboxSyntaxDefect::AtomCharacter { what, character: c }
+                    }
                     // The value running out on the *first* pass is unreachable:
                     // both callers test for the end before entering the
                     // production. So a `None` here has always just followed the
                     // `.` this loop consumed, and reads as that arm does.
-                    _ => format!("the {what} has a \".\" with no atext after it"),
+                    _ => MailboxSyntaxDefect::AtomEmpty { what },
                 });
             }
             if self.peek() == Some('.') {
@@ -370,27 +486,22 @@ impl<'a> Reader<'a> {
     }
 
     /// cite(RFC 5322 § 3.4.1): "domain-literal = [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]"
-    fn domain_literal(&mut self) -> Result<(), String> {
+    fn domain_literal(&mut self) -> Result<(), MailboxSyntaxDefect> {
         self.i += 1;
         while let Some(ch) = self.bump() {
             match ch {
                 ']' => return Ok(()),
                 c if is_dtext(c) || is_wsp(c) => {}
-                c => {
-                    return Err(format!(
-                        "a domain-literal holds {}, which no dtext admits",
-                        describe_char(c)
-                    ))
-                }
+                c => return Err(MailboxSyntaxDefect::DomainLiteralCharacter(c)),
             }
         }
-        Err("a domain-literal is opened and never closed".into())
+        Err(MailboxSyntaxDefect::DomainLiteralUnterminated)
     }
 
     /// cite(RFC 5322 § 3.4.1): "addr-spec = local-part "@" domain"
     /// cite(RFC 5322 § 3.4.1): "local-part = dot-atom / quoted-string / obs-local-part"
     /// cite(RFC 5322 § 3.4.1): "domain = dot-atom / domain-literal / obs-domain"
-    fn addr_spec(&mut self) -> Result<Option<String>, String> {
+    fn addr_spec(&mut self) -> Result<Option<String>, MailboxSyntaxDefect> {
         self.skip_cfws()?;
         // The alternation is decided by one character, and the sentence beside
         // the grammar says which: a quoted-string can only open on a DQUOTE, and
@@ -402,16 +513,13 @@ impl<'a> Reader<'a> {
             Some(_) => {
                 self.dot_atom_text("local-part")?;
             }
-            None => return Err("the value ends where the addr-spec has a local-part".into()),
+            None => return Err(MailboxSyntaxDefect::LocalPartMissing),
         }
 
         self.skip_cfws()?;
         // cite(RFC 5322 § 3.4.1): "An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain."
         if self.peek() != Some('@') {
-            return Err(format!(
-                "{} where the addr-spec has its \"@\"",
-                self.stopped_at()
-            ));
+            return Err(MailboxSyntaxDefect::AtSignMissing(self.peek()));
         }
         self.i += 1;
 
@@ -422,13 +530,13 @@ impl<'a> Reader<'a> {
                 None
             }
             Some(_) => Some(self.dot_atom_text("domain")?.iter().collect()),
-            None => return Err("the value ends where the addr-spec has a domain".into()),
+            None => return Err(MailboxSyntaxDefect::DomainMissing),
         };
         self.skip_cfws()?;
         Ok(domain_name)
     }
 
-    fn name_addr(&mut self) -> Result<Mailbox, String> {
+    fn name_addr(&mut self) -> Result<Mailbox, MailboxSyntaxDefect> {
         self.skip_cfws()?;
         // The display-name is optional, so `<user@example.com>` is a whole
         // `name-addr` and the branch below is not entered for it.
@@ -441,20 +549,14 @@ impl<'a> Reader<'a> {
         // because a parser that panics on its own invariant is worse than one
         // that reports a sentence nobody reads.
         if self.peek() != Some('<') {
-            return Err(format!(
-                "{} where the mailbox has the \"<\" of its angle-addr",
-                self.stopped_at()
-            ));
+            return Err(MailboxSyntaxDefect::AngleAddrMissing(self.peek()));
         }
         self.i += 1;
 
         let domain_name = self.addr_spec()?;
 
         if self.peek() != Some('>') {
-            return Err(format!(
-                "{} where the angle-addr has its \">\"",
-                self.stopped_at()
-            ));
+            return Err(MailboxSyntaxDefect::AngleAddrUnterminated(self.peek()));
         }
         self.i += 1;
         self.skip_cfws()?;
@@ -465,7 +567,7 @@ impl<'a> Reader<'a> {
     /// cite(RFC 5322 § 3.2.5): "phrase = 1*word / obs-phrase"
     /// cite(RFC 5322 § 3.2.5): "word = atom / quoted-string"
     /// cite(RFC 5322 § 3.2.3): "atom = [CFWS] 1*atext [CFWS]"
-    fn display_name(&mut self) -> Result<(), String> {
+    fn display_name(&mut self) -> Result<(), MailboxSyntaxDefect> {
         let mut saw_a_word = false;
         loop {
             self.skip_cfws()?;
@@ -484,10 +586,7 @@ impl<'a> Reader<'a> {
             }
         }
         if !saw_a_word {
-            return Err(format!(
-                "{} where the display-name has a word",
-                self.stopped_at()
-            ));
+            return Err(MailboxSyntaxDefect::DisplayNameWordMissing(self.peek()));
         }
         Ok(())
     }
@@ -502,7 +601,7 @@ mod tests {
         match parse_mailbox(v) {
             Ok(m) => m,
             Err(MailboxDefect::ListSeparator) => panic!("{v:?} read as a mailbox-list"),
-            Err(MailboxDefect::Syntax(e)) => panic!("{v:?} rejected: {e}"),
+            Err(MailboxDefect::Syntax(e)) => panic!("{v:?} rejected: {}", e.message()),
         }
     }
 
@@ -510,7 +609,7 @@ mod tests {
         match parse_mailbox(v) {
             Ok(_) => panic!("{v:?} accepted"),
             Err(MailboxDefect::ListSeparator) => "list separator".to_string(),
-            Err(MailboxDefect::Syntax(e)) => e,
+            Err(MailboxDefect::Syntax(e)) => e.message(),
         }
     }
 
@@ -593,6 +692,20 @@ mod tests {
     )]
     #[case("Team: a@example.com;", "':' where the addr-spec has its \"@\"")]
     #[case("alice@exa mple.com", "'m' follows a complete mailbox")]
+    // The four productions whose refusal nothing above reaches: `dtext`,
+    // either half of a `quoted-pair`, and a display-name opened on something
+    // that is no `word`. Each names a defect of its own, so each is worded
+    // once and asserted here rather than trusted to the parse it shares.
+    #[case("alice@[a\u{e9}b]", "a domain-literal holds 0xE9")]
+    #[case(
+        "a@example.com (x\\",
+        "a comment ends on a backslash with nothing after it to quote"
+    )]
+    #[case(
+        "\"a\\\u{e9}b\"@example.com",
+        "a quoted-string quotes 0xE9, where quoted-pair admits only VCHAR and WSP"
+    )]
+    #[case(". <alice@example.com>", "'.' where the display-name has a word")]
     fn section_4_and_worse_is_refused(#[case] value: &str, #[case] expected: &str) {
         let e = err(value);
         assert!(e.contains(expected), "{value:?} was rejected as {e:?}");

--- a/lint-http-rules/src/rules/from_header_email_syntax.rs
+++ b/lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -8,8 +8,58 @@ use crate::helpers::mailbox::{parse_mailbox, MailboxDefect};
 use crate::helpers::shown::shown_in_finding;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::domain::{
+    preferred_name_defect, DOMAIN_LABEL_CHARACTER_FORBIDDEN, DOMAIN_LABEL_EDGE_HYPHEN_FORBIDDEN,
+    DOMAIN_LABEL_EMPTY, DOMAIN_LABEL_LENGTH_INVALID, DOMAIN_NAME_LENGTH_INVALID, RFC_1035_2_3_1,
+    RFC_1035_2_3_4,
+};
+use crate::violations::mailbox::{
+    syntax_defect, MAILBOX_ANGLE_ADDR_MISSING, MAILBOX_ANGLE_ADDR_TERMINATOR_MISSING,
+    MAILBOX_ATOM_CHARACTER_FORBIDDEN, MAILBOX_ATOM_EMPTY, MAILBOX_AT_SIGN_MISSING,
+    MAILBOX_COMMENT_CHARACTER_FORBIDDEN, MAILBOX_COMMENT_TERMINATOR_MISSING,
+    MAILBOX_DISPLAY_NAME_WORD_MISSING, MAILBOX_DOMAIN_LITERAL_CHARACTER_FORBIDDEN,
+    MAILBOX_DOMAIN_LITERAL_TERMINATOR_MISSING, MAILBOX_DOMAIN_MISSING, MAILBOX_EMPTY,
+    MAILBOX_LIST_SEPARATOR_FORBIDDEN, MAILBOX_LOCAL_PART_MISSING, MAILBOX_QUOTED_PAIR_MALFORMED,
+    MAILBOX_QUOTED_STRING_CHARACTER_FORBIDDEN, MAILBOX_QUOTED_STRING_TERMINATOR_MISSING,
+    MAILBOX_TRAILING_CHARACTER_FORBIDDEN, RFC_5322_3_2_1, RFC_5322_3_2_2, RFC_5322_3_2_3,
+    RFC_5322_3_2_4, RFC_5322_3_2_5, RFC_5322_3_4, RFC_5322_3_4_1,
+};
+use crate::violations::ViolationDef;
 
 pub struct FromHeaderEmailSyntax;
+
+/// The defects this rule reports. None of them is its own: the eighteen
+/// `mailbox_*` belong to the production RFC 9110 § 10.1.2 imports rather than
+/// to the field that imports it, and the five `domain_*` are the preferred name
+/// syntax any field carrying a host name is answered by — `cookie_domain_valid`
+/// declares those same five. What is missing from this list is the second field
+/// line, which is not this rule's defect either: it belongs to the shared
+/// singleton reading, and converts with that subject.
+static DECLARED: &[&ViolationDef] = &[
+    &MAILBOX_EMPTY,
+    &MAILBOX_LIST_SEPARATOR_FORBIDDEN,
+    &MAILBOX_COMMENT_CHARACTER_FORBIDDEN,
+    &MAILBOX_COMMENT_TERMINATOR_MISSING,
+    &MAILBOX_QUOTED_STRING_CHARACTER_FORBIDDEN,
+    &MAILBOX_QUOTED_STRING_TERMINATOR_MISSING,
+    &MAILBOX_QUOTED_PAIR_MALFORMED,
+    &MAILBOX_ATOM_CHARACTER_FORBIDDEN,
+    &MAILBOX_ATOM_EMPTY,
+    &MAILBOX_LOCAL_PART_MISSING,
+    &MAILBOX_AT_SIGN_MISSING,
+    &MAILBOX_DOMAIN_MISSING,
+    &MAILBOX_DOMAIN_LITERAL_CHARACTER_FORBIDDEN,
+    &MAILBOX_DOMAIN_LITERAL_TERMINATOR_MISSING,
+    &MAILBOX_ANGLE_ADDR_MISSING,
+    &MAILBOX_ANGLE_ADDR_TERMINATOR_MISSING,
+    &MAILBOX_DISPLAY_NAME_WORD_MISSING,
+    &MAILBOX_TRAILING_CHARACTER_FORBIDDEN,
+    &DOMAIN_NAME_LENGTH_INVALID,
+    &DOMAIN_LABEL_EMPTY,
+    &DOMAIN_LABEL_LENGTH_INVALID,
+    &DOMAIN_LABEL_EDGE_HYPHEN_FORBIDDEN,
+    &DOMAIN_LABEL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -44,48 +94,11 @@ const RFC_9110_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2",
     note: "The MUST NOT that makes a value outside the field's ABNF a finding",
 };
-const RFC_5322_3_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 5322",
-    section: Some("3.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4",
-    note: "`mailbox = name-addr / addr-spec`, and `mailbox-list` beside it — the production this field does *not* import",
-};
-const RFC_5322_3_4_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 5322",
-    section: Some("3.4.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1",
-    note: "`addr-spec = local-part \"@\" domain`, `domain-literal`, and the sentence handing a `dot-atom` domain to the host-name documents",
-};
-const RFC_5322_3_2_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 5322",
-    section: Some("3.2.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.2",
-    note: "`CFWS` — folding whitespace and nested parenthesised comments, admitted around nearly every token of a mailbox",
-};
-const RFC_5322_3_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 5322",
-    section: Some("3.2.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3",
-    note: "`atext`, `atom` and `dot-atom-text` — the `1*atext` floors either side of every dot",
-};
-const RFC_5322_3_2_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 5322",
-    section: Some("3.2.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.4",
-    note:
-        "`quoted-string` and `qtext`, the alternative a local-part or a display-name word may take",
-};
 const RFC_5322_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 5322",
     section: Some("4"),
     url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-4",
     note: "Obsolete syntax: MUST NOT be generated, MUST be accepted by a receiver — this rule reports on the generator",
-};
-const RFC_1035_2_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 1035",
-    section: Some("2.3.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc1035.html#section-2.3.1",
-    note: "Preferred name syntax for the `dot-atom` form of a domain — advisory, and the one finding here that is reported as advice",
 };
 const RFC_1123_2_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 1123",
@@ -116,15 +129,22 @@ severity = "warn"
             RFC_9110_5_3,
             RFC_9110_5_5,
             RFC_9110_2_2,
-            RFC_5322_3_4,
-            RFC_5322_3_4_1,
+            RFC_5322_3_2_1,
             RFC_5322_3_2_2,
             RFC_5322_3_2_3,
             RFC_5322_3_2_4,
+            RFC_5322_3_2_5,
+            RFC_5322_3_4,
+            RFC_5322_3_4_1,
             RFC_5322_4,
             RFC_1035_2_3_1,
+            RFC_1035_2_3_4,
             RFC_1123_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -274,19 +294,18 @@ impl Rule for FromHeaderEmailSyntax {
             let value = trim_ows(&value);
 
             if value.is_empty() {
-                // Both of `mailbox`'s alternatives contain an `addr-spec`, and
-                // `addr-spec` writes a literal `"@"` — so the shortest value the
-                // field's grammar generates is not the empty one, whichever
-                // alternative each half takes. That is the whole argument, and it is
-                // deliberately about the at-sign rather than about a `1*atext` floor:
-                // a `quoted-string` local-part has no such floor (`""` derives), and
-                // neither does a `domain-literal` (`[]` derives).
+                // The argument is on the def, which is the mailbox production's
+                // and not this field's. What is this rule's own is the sentence
+                // that makes an off-grammar value reportable at all: RFC 9110
+                // hands `From` a production and forbids generating anything that
+                // does not derive from it.
                 //
                 // cite(RFC 9110 § 2.2): "A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules."
-                return violation(
+                return Some(ctx.report_with(
+                    &MAILBOX_EMPTY,
                     "From is present with an empty value. `From = mailbox`, both of that production's alternatives contain an `addr-spec`, and `addr-spec = local-part \"@\" domain` writes an at-sign the value does not have — so no empty value derives from the field's grammar (RFC 5322 §3.4.1)"
                         .to_string(),
-                );
+                ));
             }
 
             match parse_mailbox(value) {
@@ -315,12 +334,20 @@ impl Rule for FromHeaderEmailSyntax {
                     // address, not a name, so the helper is asked only for the
                     // `dot-atom` form.
                     //
+                    // The five defects it can answer with are the shared
+                    // `domain_*` ones, which is what an operator who considers
+                    // the preferred name syntax advisory now tunes once for
+                    // every field carrying a name rather than once per rule.
+                    //
                     // cite(RFC 5322 § 3.4.1): "In the dot-atom form, this is interpreted as an Internet domain name (either a host name or a mail exchanger name) as described in [RFC1034], [RFC1035], and [RFC1123]."
                     // cite(RFC 5322 § 3.4.1): "It is therefore incumbent upon implementations to conform to the syntax of addresses for the context in which they are used."
-                    violation(format!(
-                        "From names the domain '{}', which is a conforming `dot-atom` but not an Internet domain name in RFC 1035 §2.3.1's preferred syntax: {}. This is advice, not a violation — RFC 5322 §3.4.1 hands the domain to the host-name documents rather than restricting it itself, and RFC 9110 §10.1.2 asks only that the address be machine-usable",
-                        shown_in_finding(&domain),
-                        defect.message()
+                    Some(ctx.report_with(
+                        preferred_name_defect(defect),
+                        format!(
+                            "From names the domain '{}', which is a conforming `dot-atom` but not an Internet domain name in RFC 1035 §2.3.1's preferred syntax: {}. This is advice, not a violation — RFC 5322 §3.4.1 hands the domain to the host-name documents rather than restricting it itself, and RFC 9110 §10.1.2 asks only that the address be machine-usable",
+                            shown_in_finding(&domain),
+                            defect.message()
+                        ),
                     ))
                 }
                 Err(MailboxDefect::ListSeparator) => {
@@ -332,12 +359,12 @@ impl Rule for FromHeaderEmailSyntax {
                     // The previous rule validated a `mailbox-list`, published
                     // `From: Alice <alice@example.com>, bob@example.org` to operators
                     // as a compliant example, and so had nothing to report here.
-                    //
-                    // cite(RFC 5322 § 3.4): "mailbox = name-addr / addr-spec"
-                    // cite(RFC 5322 § 3.4): "mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list"
-                    violation(format!(
-                        "From value '{}' carries a comma outside every quoted-string, comment and angle-addr — `mailbox-list`'s separator, in a field whose value is one `mailbox`. RFC 5322 §3.4 defines the list form two lines below the one RFC 9110 §10.1.2 imports, so a request that means to name two people has no way to say so in this field",
-                        shown_in_finding(value)
+                    Some(ctx.report_with(
+                        &MAILBOX_LIST_SEPARATOR_FORBIDDEN,
+                        format!(
+                            "From value '{}' carries a comma outside every quoted-string, comment and angle-addr — `mailbox-list`'s separator, in a field whose value is one `mailbox`. RFC 5322 §3.4 defines the list form two lines below the one RFC 9110 §10.1.2 imports, so a request that means to name two people has no way to say so in this field",
+                            shown_in_finding(value)
+                        ),
                     ))
                 }
                 Err(MailboxDefect::Syntax(defect)) => {
@@ -346,13 +373,18 @@ impl Rule for FromHeaderEmailSyntax {
                     // `obs-angle-addr`'s source route, `obs-domain`'s whitespace
                     // around the dots. § 4 admits them for a *receiver* and forbids
                     // generating them in the same sentence, which is the half that
-                    // applies to the party this rule reports on.
+                    // applies to the party this rule reports on — the sentence this
+                    // rule reads, where the sentence each defect breaks is on its
+                    // own def.
                     //
                     // cite(RFC 5322 § 4): "Though these syntactic forms MUST NOT be generated according to the grammar in section 3, they MUST be accepted and parsed by a conformant receiver."
-                    violation(format!(
-                        "From value '{}' is not an RFC 5322 §3.4 `mailbox`: {} (RFC 9110 §10.1.2)",
-                        shown_in_finding(value),
-                        defect
+                    Some(ctx.report_with(
+                        syntax_defect(defect),
+                        format!(
+                            "From value '{}' is not an RFC 5322 §3.4 `mailbox`: {} (RFC 9110 §10.1.2)",
+                            shown_in_finding(value),
+                            defect.message()
+                        ),
                     ))
                 }
             }
@@ -508,6 +540,58 @@ mod tests {
         assert!(v.message.contains("preferred syntax"), "{}", v.message);
         // And the bracketed form is not asked the question at all.
         assert_eq!(judge_value("alice@[192.0.2.1]").map(|v| v.message), None);
+    }
+
+    /// One message shape, many names. Each row is a value whose defect the
+    /// grammar refuses in a different production, and the last two are the
+    /// interesting pair: a comma keeps a name of its own because what it says
+    /// is that a list was written where one address goes, and an underscore in
+    /// the domain half reports under the *shared* name every field carrying a
+    /// host name reports it under — the same id `cookie_domain_valid` emits.
+    #[rstest]
+    #[case("", "mailbox_empty")]
+    #[case("not-an-email", "mailbox_at_sign_missing")]
+    #[case("alice@", "mailbox_domain_missing")]
+    #[case("@example.com", "mailbox_atom_character_forbidden")]
+    #[case("alice.@example.com", "mailbox_atom_empty")]
+    #[case("Alice <alice@example.com", "mailbox_angle_addr_terminator_missing")]
+    #[case("John Q. Public <jqp@example.com>", "mailbox_angle_addr_missing")]
+    #[case("alice@exa mple.com", "mailbox_trailing_character_forbidden")]
+    #[case("a@b.com (unclosed", "mailbox_comment_terminator_missing")]
+    #[case("\"unclosed@example.com", "mailbox_quoted_string_terminator_missing")]
+    #[case("alice@[192.0.2.1", "mailbox_domain_literal_terminator_missing")]
+    #[case(
+        "Alice <alice@example.com>, bob@example.org",
+        "mailbox_list_separator_forbidden"
+    )]
+    #[case("alice@my_host.example", "domain_label_character_forbidden")]
+    fn each_finding_names_the_defect_behind_it(#[case] from: &str, #[case] violation: &str) {
+        let v = judge_value(from).unwrap_or_else(|| panic!("expected a finding for {from:?}"));
+        assert_eq!(v.violation, violation, "{}", v.message);
+    }
+
+    /// The rule's configured severity no longer answers for what it reports.
+    /// It is set to `error` here and the finding still arrives at the defect's
+    /// own `warn`, which is the whole point of the split: `[violations.
+    /// mailbox_at_sign_missing]` is what moves this one, and it moves it in
+    /// every rule that reports it.
+    #[test]
+    fn the_defect_carries_its_severity_and_the_rule_does_not() {
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("from", "not-an-email")]);
+        let config = crate::test_helpers::make_test_config_with_severity(
+            "from_header_email_syntax",
+            "error",
+        );
+        let v = crate::test_helpers::run_rule(
+            &FromHeaderEmailSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &config,
+        )
+        .expect("a finding");
+        assert_eq!(v.severity, crate::lint::Severity::Warn);
     }
 
     #[test]

--- a/lint-http-rules/src/violations/mailbox.rs
+++ b/lint-http-rules/src/violations/mailbox.rs
@@ -1,0 +1,477 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Mailbox defects — the ways a value is not RFC 5322's `mailbox`.
+//!
+//! The subject is the production, not the field: RFC 9110 § 10.1.2 gives `From`
+//! a value of `mailbox` and imports it by reference, so every defect here is
+//! answered by a document HTTP does not own and by a sentence that says nothing
+//! about which field carried the value.
+//!
+//! Eighteen entries, because the grammar refuses a value in eighteen places and
+//! each one has its own line of ABNF behind it. That is the shape a fan-out
+//! site takes when it converts: one call site cited RFC 5322 § 3.4 — the
+//! greatest common sentence over everything the reader can find — and each
+//! defect now carries the production that actually stopped.
+//!
+//! Two things this subject does *not* split, both deliberate. There is no
+//! whitespace-or-control entry beside the character ones: RFC 5322 writes
+//! `atext`, `qtext`, `ctext` and `dtext` as ranges that stop at %x7E, so the
+//! octet nobody typed and the special nobody may write are refused by the same
+//! sentence, in the same construct, and an operator fixing one fixes the other.
+//! And the two `quoted-pair` failures — a backslash quoting nothing, a
+//! backslash quoting an octet the pair does not admit — are one def, because
+//! the fix is one fix: the escape.
+//!
+//! The severities are all `warn`, which is the first subject where that is
+//! true. Nothing here is a value a user agent quietly discards (the cookie's
+//! `Path`) and nothing is an octet a US-ASCII grammar admits and this crate
+//! refuses anyway (the cookie's whitespace): every entry is one production
+//! refusing one value, and RFC 9110 § 2.2's MUST NOT reaches all of them
+//! equally.
+
+use crate::helpers::mailbox::MailboxSyntaxDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The `quoted-pair`, which is one production and one defect.
+pub const RFC_5322_3_2_1: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.1",
+    note: "`quoted-pair` — the backslash and the one `VCHAR` or `WSP` it owes",
+};
+
+/// `CFWS`, and the `comment` inside it: folding whitespace and nested
+/// parenthesised comments, admitted around nearly every token of a mailbox.
+pub const RFC_5322_3_2_2: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.2",
+    note: "`CFWS`, `comment` and `ctext` — the comment names itself, so what it holds is balanced and its character class stops at %x7E",
+};
+
+/// `atext` and the `dot-atom` built on it — the `1*atext` floor either side of
+/// every dot.
+pub const RFC_5322_3_2_3: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.3",
+    note: "`atext`, `atom` and `dot-atom-text` — the printable US-ASCII an atom is made of, and the floor a dot may not leave empty",
+};
+
+/// The `quoted-string`, the alternative a local-part or a display-name's word
+/// may take instead of an atom.
+pub const RFC_5322_3_2_4: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.4",
+    note: "`quoted-string` and `qtext` — the quoted alternative, and the class it admits between the two DQUOTEs",
+};
+
+/// The `phrase` a display-name is, and the `word` it is made of.
+pub const RFC_5322_3_2_5: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.2.5"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.2.5",
+    note: "`phrase = 1*word` — a display-name holds at least one atom or quoted-string, and `obs-phrase`'s bare `.` is not one",
+};
+
+/// `mailbox` itself: the two alternatives, and `mailbox-list` printed two lines
+/// below the one a field imports.
+pub const RFC_5322_3_4: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4",
+    note: "`mailbox = name-addr / addr-spec`, `angle-addr` beside it, and `mailbox-list` — the neighbouring production a top-level comma derives from",
+};
+
+/// The `addr-spec`: the at-sign, the two halves it separates, and the bracketed
+/// literal a domain may be instead of a name.
+pub const RFC_5322_3_4_1: SpecRef = SpecRef {
+    spec: "RFC 5322",
+    section: Some("3.4.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc5322.html#section-3.4.1",
+    note: "`addr-spec = local-part \"@\" domain`, and the `domain-literal` alternative with the `dtext` inside it",
+};
+
+defects! {
+    /// A field that is present and carries nothing. Both of `mailbox`'s
+    /// alternatives contain an `addr-spec`, and `addr-spec` writes a literal
+    /// `"@"`, so the shortest value the production generates is not the empty
+    /// one — whichever alternative each half takes.
+    ///
+    /// The argument is deliberately about the at-sign and not about a `1*atext`
+    /// floor: a `quoted-string` local-part has no such floor (`""` derives), and
+    /// neither does a `domain-literal` (`[]` derives). Only the literal
+    /// character between them is owed by every derivation.
+    ///
+    // cite(RFC 5322 § 3.4.1): "addr-spec = local-part "@" domain"
+    MAILBOX_EMPTY = {
+        id: "mailbox_empty",
+        title: "Mailbox field is present with an empty value",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4_1),
+    }
+
+    /// A comma outside every `quoted-string`, `comment` and `angle-addr`. The
+    /// one defect here whose answer is a *neighbouring production*: the value
+    /// derives from `mailbox-list`, printed two lines below `mailbox` in the
+    /// same section, so what happened is not a stray character but a list
+    /// written where one address goes.
+    ///
+    // cite(RFC 5322 § 3.4): "mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list"
+    MAILBOX_LIST_SEPARATOR_FORBIDDEN = {
+        id: "mailbox_list_separator_forbidden",
+        title: "Mailbox holds a comma where one address goes",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4),
+    }
+
+    /// An octet inside a parenthesised `comment` that `ctext` does not admit.
+    ///
+    // cite(RFC 5322 § 3.2.2): "ctext = %d33-39 / ; Printable US-ASCII %d42-91 / ; characters not including %d93-126 / ; "(", ")", or "\" obs-ctext"
+    MAILBOX_COMMENT_CHARACTER_FORBIDDEN = {
+        id: "mailbox_comment_character_forbidden",
+        title: "Mailbox comment holds a character outside ctext",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_2),
+    }
+
+    /// A `comment` opened and never closed. The count is the production and
+    /// not a convenience — `comment` names itself — so this is a parenthesis
+    /// missing at whatever depth the value reached.
+    ///
+    // cite(RFC 5322 § 3.2.2): "comment = "(" *([FWS] ccontent) [FWS] ")""
+    MAILBOX_COMMENT_TERMINATOR_MISSING = {
+        id: "mailbox_comment_terminator_missing",
+        title: "Mailbox comment is never closed",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_2),
+    }
+
+    /// An octet between two DQUOTEs that `qtext` does not admit — and that no
+    /// `quoted-pair` escaped, since the backslash form is checked first.
+    ///
+    // cite(RFC 5322 § 3.2.4): "qtext = %d33 / ; Printable US-ASCII %d35-91 / ; characters not including %d93-126 / ; "\" or the quote character obs-qtext"
+    MAILBOX_QUOTED_STRING_CHARACTER_FORBIDDEN = {
+        id: "mailbox_quoted_string_character_forbidden",
+        title: "Mailbox quoted-string holds a character outside qtext",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_4),
+    }
+
+    /// A `quoted-string` opened and never closed — the closing DQUOTE is not
+    /// there, so everything after the opening one was read as quoted text.
+    ///
+    // cite(RFC 5322 § 3.2.4): "quoted-string = [CFWS] DQUOTE *([FWS] qcontent) [FWS] DQUOTE [CFWS]"
+    MAILBOX_QUOTED_STRING_TERMINATOR_MISSING = {
+        id: "mailbox_quoted_string_terminator_missing",
+        title: "Mailbox quoted-string is never closed",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_4),
+    }
+
+    /// A backslash quoting nothing, or quoting an octet that is neither
+    /// `VCHAR` nor `WSP`. One def for both, because the fix is one fix — the
+    /// escape — wherever the pair sits.
+    ///
+    // cite(RFC 5322 § 3.2.1): "quoted-pair = ("\" (VCHAR / WSP)) / obs-qp"
+    MAILBOX_QUOTED_PAIR_MALFORMED = {
+        id: "mailbox_quoted_pair_malformed",
+        title: "Mailbox escape is not a quoted-pair",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_1),
+    }
+
+    /// An octet in a `dot-atom` — the `local-part` or the `domain` — that
+    /// `atext` does not admit. Every `special` is here as well as every octet
+    /// above %x7E: `@` inside a local-part reports as this and not as a missing
+    /// at-sign, because the at-sign the `addr-spec` wants is the one *after*
+    /// the atom.
+    ///
+    // cite(RFC 5322 § 3.2.3): "atext = ALPHA / DIGIT / ; Printable US-ASCII "!" / "#" / ; characters not including "$" / "%" / ; specials. Used for atoms. "&" / "'" / "*" / "+" / "-" / "/" / "=" / "?" / "^" / "_" / "`" / "{" / "|" / "}" / "~""
+    MAILBOX_ATOM_CHARACTER_FORBIDDEN = {
+        id: "mailbox_atom_character_forbidden",
+        title: "Mailbox atom holds a character outside atext",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_3),
+    }
+
+    /// A `.` with no `atext` after it: a trailing dot, or two of them in a row.
+    /// The dot separates atoms and every atom has a `1*atext` floor, so a dot
+    /// at either end of nothing describes an atom that is not there.
+    ///
+    // cite(RFC 5322 § 3.2.3): "dot-atom-text = 1*atext *("." 1*atext)"
+    MAILBOX_ATOM_EMPTY = {
+        id: "mailbox_atom_empty",
+        title: "Mailbox atom is empty beside a dot",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_3),
+    }
+
+    /// The value ends where the `addr-spec` has its `local-part` — the half
+    /// before the at-sign, which is either a `dot-atom` or a `quoted-string`
+    /// and cannot be nothing.
+    ///
+    // cite(RFC 5322 § 3.4.1): "local-part = dot-atom / quoted-string / obs-local-part"
+    MAILBOX_LOCAL_PART_MISSING = {
+        id: "mailbox_local_part_missing",
+        title: "Mailbox has no local-part",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4_1),
+    }
+
+    /// No `"@"` where the `addr-spec` writes one — the defect a value with no
+    /// address in it at all comes to, `not-an-email` being the shortest
+    /// example.
+    ///
+    // cite(RFC 5322 § 3.4.1): "An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain."
+    MAILBOX_AT_SIGN_MISSING = {
+        id: "mailbox_at_sign_missing",
+        title: "Mailbox has no at-sign",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4_1),
+    }
+
+    /// The value ends where the `addr-spec` has its `domain` — `alice@` and
+    /// nothing after it.
+    ///
+    // cite(RFC 5322 § 3.4.1): "domain = dot-atom / domain-literal / obs-domain"
+    MAILBOX_DOMAIN_MISSING = {
+        id: "mailbox_domain_missing",
+        title: "Mailbox has no domain",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4_1),
+    }
+
+    /// An octet inside a bracketed `domain-literal` that `dtext` does not
+    /// admit. The literal is an address written where a name would go, and its
+    /// class is its own — wider than `atext`, and stopping at %x7E like the
+    /// rest.
+    ///
+    // cite(RFC 5322 § 3.4.1): "dtext = %d33-90 / ; Printable US-ASCII %d94-126 / ; characters not including obs-dtext ; "[", "]", or "\""
+    MAILBOX_DOMAIN_LITERAL_CHARACTER_FORBIDDEN = {
+        id: "mailbox_domain_literal_character_forbidden",
+        title: "Mailbox domain-literal holds a character outside dtext",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4_1),
+    }
+
+    /// A `domain-literal` opened and never closed: the `]` is missing, so the
+    /// address inside it runs to the end of the value.
+    ///
+    // cite(RFC 5322 § 3.4.1): "domain-literal = [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]"
+    MAILBOX_DOMAIN_LITERAL_TERMINATOR_MISSING = {
+        id: "mailbox_domain_literal_terminator_missing",
+        title: "Mailbox domain-literal is never closed",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4_1),
+    }
+
+    /// Something between the display-name and the `angle-addr` that no `word`
+    /// admits — `John Q. Public <jqp@example.com>`, where the bare `.` is
+    /// `obs-phrase` and § 4 forbids generating it.
+    ///
+    // cite(RFC 5322 § 3.4): "name-addr = [display-name] angle-addr"
+    MAILBOX_ANGLE_ADDR_MISSING = {
+        id: "mailbox_angle_addr_missing",
+        title: "Mailbox has no angle-addr where the name-addr wants one",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4),
+    }
+
+    /// An `angle-addr` opened and never closed — the `>` is missing, or
+    /// something else is where it must be.
+    ///
+    // cite(RFC 5322 § 3.4): "angle-addr = [CFWS] "<" addr-spec ">" [CFWS] / obs-angle-addr"
+    MAILBOX_ANGLE_ADDR_TERMINATOR_MISSING = {
+        id: "mailbox_angle_addr_terminator_missing",
+        title: "Mailbox angle-addr is never closed",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4),
+    }
+
+    /// A display-name that was opened and holds no `word` at all. The
+    /// display-name is optional — `<alice@example.com>` is a whole `name-addr`
+    /// — so this is a value that started one and put nothing an atom or a
+    /// quoted-string admits in it.
+    ///
+    // cite(RFC 5322 § 3.2.5): "phrase = 1*word / obs-phrase"
+    MAILBOX_DISPLAY_NAME_WORD_MISSING = {
+        id: "mailbox_display_name_word_missing",
+        title: "Mailbox display-name holds no word",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_2_5),
+    }
+
+    /// A complete `mailbox` with something after it that is not a comma. One
+    /// address is the whole production, so whatever follows derives from
+    /// nothing — a space inside a domain is the usual way to reach this.
+    ///
+    // cite(RFC 5322 § 3.4): "mailbox = name-addr / addr-spec"
+    MAILBOX_TRAILING_CHARACTER_FORBIDDEN = {
+        id: "mailbox_trailing_character_forbidden",
+        title: "Mailbox is followed by something else",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_5322_3_4),
+    }
+}
+
+/// The defect a parsed [`MailboxSyntaxDefect`] reports as.
+///
+/// The reader answers *what the grammar refused* and this answers *what it is
+/// called*, matched in one place rather than at every field that carries a
+/// mailbox. Exhaustive on purpose: a new variant in the reader does not compile
+/// until it is named here, which is the only way a defect can fail to reach the
+/// catalogue.
+pub fn syntax_defect(defect: MailboxSyntaxDefect) -> &'static ViolationDef {
+    match defect {
+        MailboxSyntaxDefect::CommentCharacter(_) => &MAILBOX_COMMENT_CHARACTER_FORBIDDEN,
+        MailboxSyntaxDefect::CommentUnterminated => &MAILBOX_COMMENT_TERMINATOR_MISSING,
+        MailboxSyntaxDefect::QuotedStringCharacter(_) => &MAILBOX_QUOTED_STRING_CHARACTER_FORBIDDEN,
+        MailboxSyntaxDefect::QuotedStringUnterminated => &MAILBOX_QUOTED_STRING_TERMINATOR_MISSING,
+        MailboxSyntaxDefect::QuotedPairAtEnd { .. }
+        | MailboxSyntaxDefect::QuotedPairCharacter { .. } => &MAILBOX_QUOTED_PAIR_MALFORMED,
+        MailboxSyntaxDefect::AtomCharacter { .. } => &MAILBOX_ATOM_CHARACTER_FORBIDDEN,
+        MailboxSyntaxDefect::AtomEmpty { .. } => &MAILBOX_ATOM_EMPTY,
+        MailboxSyntaxDefect::LocalPartMissing => &MAILBOX_LOCAL_PART_MISSING,
+        MailboxSyntaxDefect::AtSignMissing(_) => &MAILBOX_AT_SIGN_MISSING,
+        MailboxSyntaxDefect::DomainMissing => &MAILBOX_DOMAIN_MISSING,
+        MailboxSyntaxDefect::DomainLiteralCharacter(_) => {
+            &MAILBOX_DOMAIN_LITERAL_CHARACTER_FORBIDDEN
+        }
+        MailboxSyntaxDefect::DomainLiteralUnterminated => {
+            &MAILBOX_DOMAIN_LITERAL_TERMINATOR_MISSING
+        }
+        MailboxSyntaxDefect::AngleAddrMissing(_) => &MAILBOX_ANGLE_ADDR_MISSING,
+        MailboxSyntaxDefect::AngleAddrUnterminated(_) => &MAILBOX_ANGLE_ADDR_TERMINATOR_MISSING,
+        MailboxSyntaxDefect::DisplayNameWordMissing(_) => &MAILBOX_DISPLAY_NAME_WORD_MISSING,
+        MailboxSyntaxDefect::TrailingCharacter(_) => &MAILBOX_TRAILING_CHARACTER_FORBIDDEN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The mapping, spelled out — including the one place two variants answer
+    /// with one def, which is a decision and not an oversight. A variant
+    /// answering with its neighbour's def would report the right sentence under
+    /// the wrong name at the wrong configured severity, and every other gate
+    /// here would pass.
+    #[test]
+    fn each_syntax_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (
+                MailboxSyntaxDefect::CommentCharacter('\u{e9}'),
+                "mailbox_comment_character_forbidden",
+            ),
+            (
+                MailboxSyntaxDefect::CommentUnterminated,
+                "mailbox_comment_terminator_missing",
+            ),
+            (
+                MailboxSyntaxDefect::QuotedStringCharacter('\u{e9}'),
+                "mailbox_quoted_string_character_forbidden",
+            ),
+            (
+                MailboxSyntaxDefect::QuotedStringUnterminated,
+                "mailbox_quoted_string_terminator_missing",
+            ),
+            (
+                MailboxSyntaxDefect::QuotedPairAtEnd {
+                    inside: "quoted-string",
+                },
+                "mailbox_quoted_pair_malformed",
+            ),
+            (
+                MailboxSyntaxDefect::QuotedPairCharacter {
+                    inside: "comment",
+                    character: '\u{e9}',
+                },
+                "mailbox_quoted_pair_malformed",
+            ),
+            (
+                MailboxSyntaxDefect::AtomCharacter {
+                    what: "local-part",
+                    character: '@',
+                },
+                "mailbox_atom_character_forbidden",
+            ),
+            (
+                MailboxSyntaxDefect::AtomEmpty { what: "domain" },
+                "mailbox_atom_empty",
+            ),
+            (
+                MailboxSyntaxDefect::LocalPartMissing,
+                "mailbox_local_part_missing",
+            ),
+            (
+                MailboxSyntaxDefect::AtSignMissing(None),
+                "mailbox_at_sign_missing",
+            ),
+            (MailboxSyntaxDefect::DomainMissing, "mailbox_domain_missing"),
+            (
+                MailboxSyntaxDefect::DomainLiteralCharacter('\u{e9}'),
+                "mailbox_domain_literal_character_forbidden",
+            ),
+            (
+                MailboxSyntaxDefect::DomainLiteralUnterminated,
+                "mailbox_domain_literal_terminator_missing",
+            ),
+            (
+                MailboxSyntaxDefect::AngleAddrMissing(Some('.')),
+                "mailbox_angle_addr_missing",
+            ),
+            (
+                MailboxSyntaxDefect::AngleAddrUnterminated(None),
+                "mailbox_angle_addr_terminator_missing",
+            ),
+            (
+                MailboxSyntaxDefect::DisplayNameWordMissing(Some('.')),
+                "mailbox_display_name_word_missing",
+            ),
+            (
+                MailboxSyntaxDefect::TrailingCharacter('m'),
+                "mailbox_trailing_character_forbidden",
+            ),
+        ] {
+            assert_eq!(syntax_defect(defect).id, id);
+        }
+    }
+
+    /// Every defect here formats its message at the site — the reader holds the
+    /// octet and the production, and neither fits in a catalogue entry. This is
+    /// the half of the `report`/`report_with` invariant a subject can assert on
+    /// its own.
+    #[test]
+    fn no_mailbox_defect_holds_its_own_message() {
+        for def in crate::violations::VIOLATIONS
+            .iter()
+            .filter(|d| d.id.starts_with("mailbox_"))
+        {
+            assert!(def.message.is_empty(), "{} holds a message", def.id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -32,6 +32,7 @@ use std::sync::LazyLock;
 pub mod cookie;
 pub mod domain;
 pub mod language;
+pub mod mailbox;
 pub mod uri;
 
 /// One reportable defect.
@@ -338,7 +339,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 25;
+        const FLOOR: usize = 43;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1679,7 +1679,7 @@ sources:
     snippet: WSP            =  SP / HTAB ; white space
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 180
+      line: 321
 - label: RFC 5322
   url: https://www.rfc-editor.org/rfc/rfc5322.html
   fragments:
@@ -1688,19 +1688,21 @@ sources:
     snippet: It is therefore incumbent upon implementations to conform to the syntax of addresses for the context in which they are used.
     cited_by:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 319
+      line: 343
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 3.2.1
     snippet: quoted-pair = ("\" (VCHAR / WSP)) / obs-qp
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 164
+      line: 305
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 187
   - label: lint-http-rules/src/helpers/mailbox.rs (2)
     section: § 3.2.2
     snippet: CFWS = (1*([FWS] comment) [FWS]) / FWS
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 251
+      line: 380
   - label: lint-http-rules/src/helpers/mailbox.rs (3)
     section: § 3.2.2
     snippet: FWS = ([*WSP CRLF] 1*WSP) / obs-FWS
@@ -1712,119 +1714,139 @@ sources:
     snippet: ccontent = ctext / quoted-pair / comment
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 265
+      line: 394
   - label: lint-http-rules/src/helpers/mailbox.rs (5)
     section: § 3.2.2
     snippet: comment = "(" *([FWS] ccontent) [FWS] ")"
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 264
+      line: 393
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 150
   - label: lint-http-rules/src/helpers/mailbox.rs (6)
     section: § 3.2.2
     snippet: ctext = %d33-39 / ; Printable US-ASCII %d42-91 / ; characters not including %d93-126 / ; "(", ")", or "\" obs-ctext
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 150
+      line: 291
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 137
   - label: lint-http-rules/src/helpers/mailbox.rs (7)
     section: § 3.2.3
     snippet: atext = ALPHA / DIGIT / ; Printable US-ASCII "!" / "#" / ; characters not including "$" / "%" / ; specials. Used for atoms. "&" / "'" / "*" / "+" / "-" / "/" / "=" / "?" / "^" / "_" / "`" / "{" / "|" / "}" / "~"
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 118
+      line: 259
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 202
   - label: lint-http-rules/src/helpers/mailbox.rs (8)
     section: § 3.2.3
     snippet: atom = [CFWS] 1*atext [CFWS]
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 467
+      line: 569
   - label: lint-http-rules/src/helpers/mailbox.rs (9)
     section: § 3.2.3
     snippet: dot-atom = [CFWS] dot-atom-text [CFWS]
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 332
+      line: 449
   - label: lint-http-rules/src/helpers/mailbox.rs (10)
     section: § 3.2.3
     snippet: dot-atom-text = 1*atext *("." 1*atext)
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 333
+      line: 450
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 215
   - label: lint-http-rules/src/helpers/mailbox.rs (11)
     section: § 3.2.3
     snippet: specials = "(" / ")" / ; Special characters that do "<" / ">" / ; not appear in atext "[" / "]" / ":" / ";" / "@" / "\" / "," / "." / DQUOTE
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 97
+      line: 239
   - label: lint-http-rules/src/helpers/mailbox.rs (12)
     section: § 3.2.4
     snippet: qcontent = qtext / quoted-pair
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 311
+      line: 433
   - label: lint-http-rules/src/helpers/mailbox.rs (13)
     section: § 3.2.4
     snippet: qtext = %d33 / ; Printable US-ASCII %d35-91 / ; characters not including %d93-126 / ; "\" or the quote character obs-qtext
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 144
+      line: 285
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 162
   - label: lint-http-rules/src/helpers/mailbox.rs (14)
     section: § 3.2.4
     snippet: quoted-string = [CFWS] DQUOTE *([FWS] qcontent) [FWS] DQUOTE [CFWS]
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 310
+      line: 432
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 174
   - label: lint-http-rules/src/helpers/mailbox.rs (15)
     section: § 3.2.5
     snippet: phrase = 1*word / obs-phrase
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 465
+      line: 567
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 318
   - label: lint-http-rules/src/helpers/mailbox.rs (16)
     section: § 3.2.5
     snippet: word = atom / quoted-string
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 466
+      line: 568
   - label: lint-http-rules/src/helpers/mailbox.rs (17)
     section: § 3.4
     snippet: angle-addr = [CFWS] "<" addr-spec ">" [CFWS] / obs-angle-addr
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 96
+      line: 238
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 304
   - label: lint-http-rules/src/helpers/mailbox.rs (18)
     section: § 3.4
     snippet: display-name = phrase
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 464
+      line: 566
   - label: lint-http-rules/src/helpers/mailbox.rs (19)
     section: § 3.4
     snippet: mailbox = name-addr / addr-spec
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 34
-    - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 336
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 331
   - label: lint-http-rules/src/helpers/mailbox.rs (20)
     section: § 3.4
     snippet: mailbox-list = (mailbox *("," mailbox)) / obs-mbox-list
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 35
-    - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 337
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 126
   - label: lint-http-rules/src/helpers/mailbox.rs (21)
     section: § 3.4
     snippet: name-addr = [display-name] angle-addr
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 95
+      line: 237
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 292
   - label: lint-http-rules/src/helpers/mailbox.rs (22)
     section: § 3.4.1
     snippet: An addr-spec is a specific Internet identifier that contains a locally interpreted string followed by the at-sign character ("@", ASCII value 64) followed by an Internet domain.
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 409
+      line: 520
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 241
   - label: lint-http-rules/src/helpers/mailbox.rs (23)
     section: § 3.4.1
     snippet: In the dot-atom form, this is interpreted as an Internet domain name (either a host name or a mail exchanger name) as described in [RFC1034], [RFC1035], and [RFC1123].
@@ -1832,43 +1854,53 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 52
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 318
+      line: 342
   - label: lint-http-rules/src/helpers/mailbox.rs (24)
     section: § 3.4.1
     snippet: The locally interpreted string is either a quoted-string or a dot-atom.
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 399
+      line: 510
   - label: lint-http-rules/src/helpers/mailbox.rs (25)
     section: § 3.4.1
     snippet: addr-spec = local-part "@" domain
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 390
+      line: 501
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 111
   - label: lint-http-rules/src/helpers/mailbox.rs (26)
     section: § 3.4.1
     snippet: domain = dot-atom / domain-literal / obs-domain
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 392
+      line: 503
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 253
   - label: lint-http-rules/src/helpers/mailbox.rs (27)
     section: § 3.4.1
     snippet: domain-literal = [CFWS] "[" *([FWS] dtext) [FWS] "]" [CFWS]
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 372
+      line: 488
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 279
   - label: lint-http-rules/src/helpers/mailbox.rs (28)
     section: § 3.4.1
     snippet: dtext = %d33-90 / ; Printable US-ASCII %d94-126 / ; characters not including obs-dtext ; "[", "]", or "\"
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 156
+      line: 297
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 267
   - label: lint-http-rules/src/helpers/mailbox.rs (29)
     section: § 3.4.1
     snippet: local-part = dot-atom / quoted-string / obs-local-part
     cited_by:
     - file: lint-http-rules/src/helpers/mailbox.rs
-      line: 391
+      line: 502
+    - file: lint-http-rules/src/violations/mailbox.rs
+      line: 228
   - label: lint-http-rules/src/helpers/mailbox.rs (30)
     section: § 4
     snippet: Though these syntactic forms MUST NOT be generated according to the grammar in section 3, they MUST be accepted and parsed by a conformant receiver.
@@ -1876,7 +1908,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 37
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 351
+      line: 380
 - label: RFC 5646
   url: https://www.rfc-editor.org/rfc/rfc5646.html
   fragments:
@@ -5113,7 +5145,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 325
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 285
+      line: 303
     - file: lint-http-rules/src/rules/http_version_syntax.rs
       line: 124
     - file: lint-http-rules/src/rules/http_version_syntax.rs
@@ -5643,7 +5675,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 129
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 202
+      line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 212
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -5663,7 +5695,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 16
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 233
+      line: 253
   - label: context_fields_direction (4)
     section: § 10.1.3
     snippet: The "Referer" [sic] header field allows the user agent to specify a URI reference for the resource from which the target URI was obtained (i.e., the "referrer", though the field name is misspelled).
@@ -5897,7 +5929,7 @@ sources:
     snippet: The address ought to be machine-usable, as defined by "mailbox" in Section 3.4 of [RFC5322]
     cited_by:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 234
+      line: 254
   - label: head_response_headers_match_get
     section: § 12.5.5
     snippet: A Vary field value is either the wildcard member "*" or a list of request field names, known as the selecting header fields, that might have had a role in selecting the representation for this response.
@@ -7041,7 +7073,7 @@ sources:
     - file: lint-http-rules/src/helpers/mailbox.rs
       line: 33
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 235
+      line: 255
   - label: lint-http-rules/src/helpers/media_type.rs
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.  When a specific version of HTTP allows such whitespace to appear in a message, a field parsing implementation MUST exclude such whitespace prior to evaluating the field value.
@@ -7057,7 +7089,7 @@ sources:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 51
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
-      line: 273
+      line: 293
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 397
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs


### PR DESCRIPTION
`from_header_email_syntax` converts. The reader behind it answered every malformed value with a rendered sentence, so one call site stood for seventeen productions refusing a value — a comment nobody closed, an atom with a doubled dot, an octet no `dtext` admits — and one severity answered for all of them. The reader hands back the defect it found now, and eighteen entries name them, each carrying the line of ABNF that actually stopped. The site cited RFC 5322 §3.4, which is the greatest common sentence over everything a parse of a mailbox can refuse.

The names are the production's rather than the field's, since `mailbox` is what RFC 9110 §10.1.2 imports by reference. The domain half of an `addr-spec` is not even that: the preferred-name finding reports under the five shared `domain_*` ids `cookie_domain_valid` already declares, so an operator who reads that syntax as advice — which this rule's own wording does — sets one severity for every field carrying a host name instead of one per rule.

All eighteen default to `warn`, the first subject whose severities came out the same. Nothing here is a value a user agent quietly discards, and nothing is an octet the grammar admits and this crate refuses anyway: RFC 5322 writes `atext`, `qtext`, `ctext` and `dtext` as ranges that stop at %x7E, so the octet nobody typed and the special nobody may write are refused by the same sentence in the same construct.

The second `From` field line stays on the old API deliberately. It is not this field's defect — the singleton reading is shared by seven rules — and it converts with the subject that owns it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
