### PR TITLE
A challenge names the part that failed

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1055,6 +1055,50 @@ severity = "warn"
 enabled = true
 severity = "warn"
 
+[violations.challenge_empty]
+# Authentication challenge is empty
+severity = "warn"
+
+[violations.challenge_member_empty]
+# Authentication challenge list has an empty member
+severity = "warn"
+
+[violations.challenge_parameter_empty]
+# Authentication challenge has an empty parameter
+severity = "warn"
+
+[violations.challenge_parameter_name_character_forbidden]
+# Authentication parameter name holds a character outside token
+severity = "warn"
+
+[violations.challenge_parameter_name_empty]
+# Authentication parameter has an empty name
+severity = "warn"
+
+[violations.challenge_parameter_value_character_forbidden]
+# Authentication parameter value holds a character outside token
+severity = "warn"
+
+[violations.challenge_parameter_value_missing]
+# Authentication parameter has no value
+severity = "warn"
+
+[violations.challenge_scheme_character_forbidden]
+# Authentication scheme holds a character outside token
+severity = "warn"
+
+[violations.challenge_scheme_missing]
+# Authentication parameter arrives before any scheme
+severity = "warn"
+
+[violations.challenge_token68_character_forbidden]
+# Authentication token68 holds a control character
+severity = "error"
+
+[violations.challenge_token68_invalid]
+# Authentication token68 is indistinguishable from a parameter
+severity = "info"
+
 [violations.cookie_domain_empty]
 # Set-Cookie Domain attribute is empty
 severity = "warn"
@@ -1229,4 +1273,20 @@ severity = "warn"
 
 [violations.percent_encoding_malformed]
 # Percent-encoding is not two hexadecimal digits
+severity = "warn"
+
+[violations.quoted_string_control_character_forbidden]
+# Quoted-string holds a control character
+severity = "error"
+
+[violations.quoted_string_delimiter_missing]
+# Quoted-string is missing one of its DQUOTEs
+severity = "warn"
+
+[violations.quoted_string_quote_escape_missing]
+# Quoted-string holds an unescaped DQUOTE
+severity = "warn"
+
+[violations.quoted_string_quoted_pair_malformed]
+# Quoted-string holds an escape that is not a quoted-pair
 severity = "warn"

--- a/docs/rules/auth_scheme_registered.md
+++ b/docs/rules/auth_scheme_registered.md
@@ -13,6 +13,8 @@ Validate authentication schemes used in `WWW-Authenticate` and `Authorization` h
 ## Specifications
 
 - [RFC 9110 §11.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.1): Authentication Scheme — `auth-scheme = token`, and where new schemes are registered
+- [RFC 9110 §11.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3): Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`
+- [RFC 9110 §11.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1): `WWW-Authenticate = #challenge` — the list whose members are grouped into challenges before any of them is read
 - [RFC 9110 §16.4.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-16.4.1): Authentication Scheme Registry
 - [IANA HTTP Authentication Schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml): IANA HTTP Authentication Scheme Registry
 

--- a/docs/rules/www_authenticate_challenge_syntax.md
+++ b/docs/rules/www_authenticate_challenge_syntax.md
@@ -18,8 +18,10 @@ This rule validates that each challenge:
 
 ## Specifications
 
-- [RFC 9110 §11.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1): WWW-Authenticate
-- [RFC 9110 §11.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3): Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]` (RFC 7235, which defined this, is obsoleted by RFC 9110; `token68` itself is defined in §11.2)
+- [RFC 9110 §11.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1): `WWW-Authenticate = #challenge` — the list whose members are grouped into challenges before any of them is read
+- [RFC 9110 §11.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3): Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`
+- [RFC 9110 §11.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2): Authentication Parameters — `auth-scheme = token`, `auth-param = token BWS "=" BWS ( token / quoted-string )`, and `token68`'s alphabet
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/auth.rs
+++ b/lint-http-rules/src/helpers/auth.rs
@@ -31,11 +31,14 @@
 //! The fourth was `Basic`'s "decoded credentials empty", which needed base64's
 //! arithmetic rather than a reading — zero octets come out of zero symbols.
 //!
-//! The two remaining `Result<_, String>`s here are deliberate.
-//! `split_and_group_challenges` and `parse_auth_params` have two distinct
-//! defects each, and `parse_nc_hex` has one; an enum with a single variant is a
-//! `bool` with ceremony, and the ranked conversion order stopped where the
-//! count did.
+//! `split_and_group_challenges` answers with [`ChallengeDefect`] too, rather
+//! than with a type of its own: it reads the same field value as
+//! `validate_challenge_syntax`, one half each, and a caller that has to match
+//! on two types to report one field is a split made for the reader's
+//! convenience and not for the operator's. The remaining `Result<_, String>`s
+//! are deliberate — `parse_auth_params` has two distinct defects and
+//! `parse_nc_hex` one, and an enum with a single variant is a `bool` with
+//! ceremony.
 
 use crate::helpers::list::split_commas_respecting_quotes;
 use base64::Engine;
@@ -48,12 +51,17 @@ use base64::Engine;
 /// members without a leading scheme are treated as continuation parameters for
 /// the current challenge.
 ///
-/// Returns `Ok(Vec<String>)` on success or `Err(String)` describing a parsing
-/// problem: an empty member, or a parameter with no challenge before it. There
-/// was a third — *missing scheme on a member that starts with whitespace* — and
-/// it was the same problem read off a character the list grammar puts outside
-/// the element.
-pub fn split_and_group_challenges(s: &str) -> Result<Vec<String>, String> {
+/// Returns `Ok(Vec<String>)` on success or the [`ChallengeDefect`] naming a
+/// parsing problem: an empty member, or a parameter with no challenge before
+/// it. There was a third — *missing scheme on a member that starts with
+/// whitespace* — and it was the same problem read off a character the list
+/// grammar puts outside the element.
+///
+/// The two it can answer with are the list's rather than one challenge's, and
+/// they are variants of the same type as the rest because a caller reports them
+/// the same way: this function and [`validate_challenge_syntax`] are two halves
+/// of reading one field value.
+pub fn split_and_group_challenges(s: &str) -> Result<Vec<String>, ChallengeDefect<'_>> {
     let members: Vec<&str> = split_commas_respecting_quotes(s);
     let mut challenges: Vec<String> = Vec::new();
 
@@ -64,7 +72,7 @@ pub fn split_and_group_challenges(s: &str) -> Result<Vec<String>, String> {
         // are two of the octets the `auth-scheme` check below exists to name.
         let mm = m;
         if mm.is_empty() {
-            return Err("WWW-Authenticate header contains empty challenge/member".into());
+            return Err(ChallengeDefect::EmptyMember);
         }
 
         let is_new = {
@@ -94,7 +102,7 @@ pub fn split_and_group_challenges(s: &str) -> Result<Vec<String>, String> {
             // one thing to say about it.
             // cite(RFC 9110 § 11.6.1): "WWW-Authenticate = #challenge"
             // cite(RFC 9110 § 5.6.1.1): "1#element => element *( OWS "," OWS element )"
-            return Err("WWW-Authenticate contains parameter before any auth-scheme".into());
+            return Err(ChallengeDefect::SchemeMissing);
         }
     }
 
@@ -120,6 +128,15 @@ pub fn split_and_group_challenges(s: &str) -> Result<Vec<String>, String> {
 pub enum ChallengeDefect<'a> {
     /// Nothing between the commas the challenge was assembled from.
     Empty,
+    /// An empty member of `WWW-Authenticate = #challenge`, found while the
+    /// members were being grouped rather than while one challenge was read.
+    /// Kept apart from [`Empty`](Self::Empty) because the two are found by
+    /// different halves of the reading and one of them may be a stray comma
+    /// between two well-formed challenges.
+    EmptyMember,
+    /// A member that continues a challenge with no challenge before it: an
+    /// `auth-param` arriving where the list has not yet had an `auth-scheme`.
+    SchemeMissing,
     /// A non-`token` octet in the `auth-scheme`, carrying the character.
     SchemeCharacter(char),
     /// A control octet where a `token68` was read. `token68`'s alphabet is
@@ -164,6 +181,12 @@ impl ChallengeDefect<'_> {
     pub fn message(self) -> String {
         match self {
             Self::Empty => "WWW-Authenticate header contains empty challenge".to_string(),
+            Self::EmptyMember => {
+                "WWW-Authenticate header contains empty challenge/member".to_string()
+            }
+            Self::SchemeMissing => {
+                "WWW-Authenticate contains parameter before any auth-scheme".to_string()
+            }
             Self::SchemeCharacter(c) => {
                 format!("Invalid character '{}' in WWW-Authenticate auth-scheme", c)
             }
@@ -766,15 +789,13 @@ mod tests {
     #[test]
     fn empty_member_is_error() {
         let r = split_and_group_challenges(", Basic realm=\"x\"");
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("empty"));
+        assert_eq!(r.unwrap_err(), ChallengeDefect::EmptyMember);
     }
 
     #[test]
     fn parameter_before_scheme_is_error() {
         let r = split_and_group_challenges("error=\"x\"");
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("parameter before any auth-scheme"));
+        assert_eq!(r.unwrap_err(), ChallengeDefect::SchemeMissing);
     }
 
     /// The leading space is `#challenge`'s own `OWS`, so this member is the one
@@ -787,7 +808,7 @@ mod tests {
             let r = split_and_group_challenges(value);
             assert!(
                 r.as_ref()
-                    .is_err_and(|e| e.contains("parameter before any auth-scheme")),
+                    .is_err_and(|e| *e == ChallengeDefect::SchemeMissing),
                 "{value}: {r:?}"
             );
         }
@@ -796,8 +817,7 @@ mod tests {
     #[test]
     fn consecutive_commas_report_error() {
         let r = split_and_group_challenges("Basic realm=\"x\", , error=\"y\"");
-        assert!(r.is_err());
-        assert!(r.unwrap_err().contains("empty"));
+        assert_eq!(r.unwrap_err(), ChallengeDefect::EmptyMember);
     }
 
     #[test]

--- a/lint-http-rules/src/rules/auth_scheme_registered.rs
+++ b/lint-http-rules/src/rules/auth_scheme_registered.rs
@@ -4,8 +4,21 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::challenge::{
+    challenge_defect, CHALLENGE_MEMBER_EMPTY, CHALLENGE_SCHEME_MISSING, RFC_9110_11_3,
+    RFC_9110_11_6_1,
+};
+use crate::violations::ViolationDef;
 
 pub struct AuthSchemeRegistered;
+
+/// The two defects this rule reports so far, and neither is about a registry:
+/// they are the `#challenge` list's, reported here because reading a scheme out
+/// of `WWW-Authenticate` means grouping its members first.
+/// `www_authenticate_challenge_syntax` declares the same two, which is what a
+/// shared subject is for — one `[violations.challenge_member_empty]` answers
+/// for both rules. The registry findings themselves are still on the old API.
+static DECLARED: &[&ViolationDef] = &[&CHALLENGE_MEMBER_EMPTY, &CHALLENGE_SCHEME_MISSING];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -66,9 +79,15 @@ allowed = ["Basic", "Bearer", "Digest"]
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[
             RFC_9110_11_1,
+            RFC_9110_11_3,
+            RFC_9110_11_6_1,
             RFC_9110_16_4_1,
             IANA_HTTP_AUTHENTICATION_SCHEMES,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -154,10 +173,10 @@ impl Rule for AuthSchemeRegistered {
                                 }
                             }
                         }
-                        Err(e) => {
-                            return Some(self.violation(
-                                ctx.severity,
-                                format!("Invalid WWW-Authenticate header: {}", e),
+                        Err(defect) => {
+                            return Some(ctx.report_with(
+                                challenge_defect(defect),
+                                format!("Invalid WWW-Authenticate header: {}", defect.message()),
                             ))
                         }
                     }

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1266,14 +1266,16 @@ severity = "warn"
     /// it on the other side, and this one keeps the unconverted remainder
     /// honest until the last site goes. `cookie_path_valid`'s `Path` reading
     /// was the first and took one cited site with it; `cookie_domain_valid`
-    /// took three more and `language_tag_syntax` one.
+    /// took three more, `language_tag_syntax` one, and
+    /// `www_authenticate_challenge_syntax` the one that read the `#challenge`
+    /// list before its members were grouped.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 166;
+        const FLOOR: usize = 165;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -4,24 +4,44 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::challenge::{
+    challenge_defect, CHALLENGE_EMPTY, CHALLENGE_MEMBER_EMPTY, CHALLENGE_PARAMETER_EMPTY,
+    CHALLENGE_PARAMETER_NAME_CHARACTER_FORBIDDEN, CHALLENGE_PARAMETER_NAME_EMPTY,
+    CHALLENGE_PARAMETER_VALUE_CHARACTER_FORBIDDEN, CHALLENGE_PARAMETER_VALUE_MISSING,
+    CHALLENGE_SCHEME_CHARACTER_FORBIDDEN, CHALLENGE_SCHEME_MISSING,
+    CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN, CHALLENGE_TOKEN68_INVALID, RFC_9110_11_2, RFC_9110_11_3,
+    RFC_9110_11_6_1,
+};
+use crate::violations::quoted_string::{
+    QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN, QUOTED_STRING_DELIMITER_MISSING,
+    QUOTED_STRING_QUOTED_PAIR_MALFORMED, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::ViolationDef;
 
 pub struct WwwAuthenticateChallengeSyntax;
 
-/// The specification references this rule declares, each named so a finding
-/// site can cite the one it enforces. `specifications()` below is built from
-/// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_11_6_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("11.6.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
-    note: "WWW-Authenticate",
-};
-const RFC_9110_11_3: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("11.3"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3",
-    note: "Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]` (RFC 7235, which defined this, is obsoleted by RFC 9110; `token68` itself is defined in §11.2)",
-};
+/// The defects this rule reports, and none of them is its own. The eleven
+/// `challenge_*` belong to `challenge = auth-scheme [ 1*SP ( token68 /
+/// #auth-param ) ]`, which `Proxy-Authenticate` carries under another name; the
+/// four `quoted_string_*` belong to the production a parameter's value may
+/// take, which seven other rules read through the same helper.
+static DECLARED: &[&ViolationDef] = &[
+    &CHALLENGE_EMPTY,
+    &CHALLENGE_MEMBER_EMPTY,
+    &CHALLENGE_SCHEME_MISSING,
+    &CHALLENGE_SCHEME_CHARACTER_FORBIDDEN,
+    &CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN,
+    &CHALLENGE_TOKEN68_INVALID,
+    &CHALLENGE_PARAMETER_EMPTY,
+    &CHALLENGE_PARAMETER_NAME_EMPTY,
+    &CHALLENGE_PARAMETER_VALUE_MISSING,
+    &CHALLENGE_PARAMETER_NAME_CHARACTER_FORBIDDEN,
+    &CHALLENGE_PARAMETER_VALUE_CHARACTER_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 impl RuleMeta for WwwAuthenticateChallengeSyntax {
     fn id(&self) -> &'static str {
@@ -39,7 +59,16 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_11_6_1, RFC_9110_11_3]
+        &[
+            RFC_9110_11_6_1,
+            RFC_9110_11_3,
+            RFC_9110_11_2,
+            RFC_9110_5_6_4,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -103,8 +132,10 @@ impl Rule for WwwAuthenticateChallengeSyntax {
                     // cite(RFC 9110 § 11.6.1): "The "WWW-Authenticate" response header field indicates the authentication scheme(s) and parameters applicable to the target resource."
                     let challenges = match crate::helpers::auth::split_and_group_challenges(s) {
                         Ok(c) => c,
-                        Err(msg) => {
-                            return Some(self.cited(&RFC_9110_11_6_1, ctx.severity, msg));
+                        Err(defect) => {
+                            return Some(
+                                ctx.report_with(challenge_defect(defect), defect.message()),
+                            );
                         }
                     };
 
@@ -113,7 +144,9 @@ impl Rule for WwwAuthenticateChallengeSyntax {
                         if let Err(defect) =
                             crate::helpers::auth::validate_challenge_syntax(challenge)
                         {
-                            return Some(self.violation(ctx.severity, defect.message()));
+                            return Some(
+                                ctx.report_with(challenge_defect(defect), defect.message()),
+                            );
                         }
                     }
                 }
@@ -165,6 +198,75 @@ mod tests {
         } else {
             assert!(v.is_none(), "val='{}' expected no violation", val);
         }
+    }
+
+    /// Fifteen names where the rule had one, and two severities among the rows
+    /// below where it had one: the bare word after a scheme is `info`, because
+    /// `token68` admits it and only this crate finds it suspicious, while
+    /// everything else here is a grammar failure at `warn`. The last two rows
+    /// leave the subject entirely — a value between DQUOTEs is a
+    /// `quoted-string` defect wherever it is read, and reports under the id
+    /// seven other rules will report it under.
+    #[rstest]
+    #[case(
+        ", Basic realm=\"x\"",
+        "challenge_member_empty",
+        crate::lint::Severity::Warn
+    )]
+    #[case("realm=\"x\"", "challenge_scheme_missing", crate::lint::Severity::Warn)]
+    #[case(
+        "Basic realm=\"x\", , error=\"y\"",
+        "challenge_member_empty",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "Basic =\"x\"",
+        "challenge_parameter_name_empty",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "Basic realm=",
+        "challenge_parameter_value_missing",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "Basic re@alm=\"x\"",
+        "challenge_parameter_name_character_forbidden",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "NewScheme word",
+        "challenge_token68_invalid",
+        crate::lint::Severity::Info
+    )]
+    #[case(
+        "Basic realm=\"unfinished",
+        "quoted_string_delimiter_missing",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "Basic realm=\"a\\\"",
+        "quoted_string_quoted_pair_malformed",
+        crate::lint::Severity::Warn
+    )]
+    fn each_finding_names_the_defect_and_carries_its_severity(
+        #[case] val: &str,
+        #[case] violation: &str,
+        #[case] severity: crate::lint::Severity,
+    ) {
+        let cfg = crate::test_helpers::make_test_config_with_enabled_rules(&[
+            "www_authenticate_challenge_syntax",
+        ]);
+        let tx = make_resp(val);
+        let v = crate::test_helpers::run_rule(
+            &WwwAuthenticateChallengeSyntax,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &cfg,
+        )
+        .unwrap_or_else(|| panic!("expected a finding for {val:?}"));
+        assert_eq!(v.violation, violation, "{}", v.message);
+        assert_eq!(v.severity, severity, "{}", v.message);
     }
 
     #[test]

--- a/lint-http-rules/src/violations/challenge.rs
+++ b/lint-http-rules/src/violations/challenge.rs
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Challenge defects — the ways an authentication challenge is not one.
+//!
+//! The subject is `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`,
+//! RFC 9110 § 11.3's production, and not the field carrying it.
+//! `WWW-Authenticate` is the one this crate reads today; `Proxy-Authenticate`
+//! is the same production under a different name, and a rule for it declares
+//! these same eleven rather than eleven of its own.
+//!
+//! **The wording is still the field's, and that is the part left to move.**
+//! The messages come from [`crate::helpers::auth::ChallengeDefect`], which was
+//! written for one field and says `WWW-Authenticate` in every sentence. The
+//! ids do not, so the catalogue is already right; the day a second field
+//! reports one of these, the sentence is what has to be parameterised, and no
+//! id has to change. That is the order this campaign wants those two things
+//! done in.
+//!
+//! Two defects here are the *list's* rather than one challenge's — an empty
+//! member, and a parameter arriving before any scheme — because
+//! `WWW-Authenticate = #challenge` is read before its members are, and the
+//! member boundaries are where those two are visible.
+
+use crate::helpers::auth::ChallengeDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::quoted_string::quoted_string_defect;
+use crate::violations::{defects, ViolationDef};
+
+/// The parameters the framework is built out of: the scheme's `token`, the
+/// `auth-param` pair, and the `token68` alternative.
+pub const RFC_9110_11_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2",
+    note: "Authentication Parameters — `auth-scheme = token`, `auth-param = token BWS \"=\" BWS ( token / quoted-string )`, and `token68`'s alphabet",
+};
+
+/// The challenge itself: a scheme, and then one of two alternatives.
+pub const RFC_9110_11_3: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.3",
+    note: "Challenge and Response — `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`",
+};
+
+/// The field as a list, which is what the two member defects are answered by.
+pub const RFC_9110_11_6_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.1",
+    note: "`WWW-Authenticate = #challenge` — the list whose members are grouped into challenges before any of them is read",
+};
+
+defects! {
+    /// A challenge with nothing in it. `challenge` opens with an `auth-scheme`,
+    /// which is a `token`, and `token` is `1*tchar` — so the empty value
+    /// derives from nothing at all.
+    ///
+    // cite(RFC 9110 § 11.3): "challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]"
+    CHALLENGE_EMPTY = {
+        id: "challenge_empty",
+        title: "Authentication challenge is empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_3),
+    }
+
+    /// An empty member of the field's `#challenge` list — a doubled comma, or
+    /// one at either end. Kept apart from [`CHALLENGE_EMPTY`] because it is
+    /// found while the members are being grouped, and because it may sit
+    /// between two challenges that are each well formed.
+    ///
+    // cite(RFC 9110 § 11.6.1): "WWW-Authenticate = #challenge"
+    CHALLENGE_MEMBER_EMPTY = {
+        id: "challenge_member_empty",
+        title: "Authentication challenge list has an empty member",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_6_1),
+    }
+
+    /// An `auth-param` where the list has not had an `auth-scheme` yet. The
+    /// parameter belongs to a challenge, and there is no challenge for it to
+    /// belong to.
+    ///
+    // cite(RFC 9110 § 11.3): "challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]"
+    CHALLENGE_SCHEME_MISSING = {
+        id: "challenge_scheme_missing",
+        title: "Authentication parameter arrives before any scheme",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_3),
+    }
+
+    /// A non-`tchar` octet in the `auth-scheme`. The scheme is a `token`, and a
+    /// recipient matches it case-insensitively against a registry — so an octet
+    /// outside the class is a name nothing can be looked up under.
+    ///
+    // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
+    CHALLENGE_SCHEME_CHARACTER_FORBIDDEN = {
+        id: "challenge_scheme_character_forbidden",
+        title: "Authentication scheme holds a character outside token",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_2),
+    }
+
+    /// A control octet where a `token68` was read. `error` by default, the same
+    /// instinct every other subject's invisible defect earns: the alphabet is
+    /// letters, digits, six punctuation marks and the padding, so a control
+    /// octet in one is something that happened to the value rather than
+    /// something a sender chose.
+    ///
+    // cite(RFC 9110 § 11.2): "token68        = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"=""
+    CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN = {
+        id: "challenge_token68_character_forbidden",
+        title: "Authentication token68 holds a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_11_2),
+    }
+
+    /// A single bare word after the scheme: `token68` by the grammar, and an
+    /// `auth-param` whose value someone forgot by eye. The one entry here that
+    /// no sentence refuses — which is why it carries no `spec` and defaults to
+    /// `info`. An operator reading challenges as data leaves it there; one who
+    /// has been bitten by `Bearer realm` raises it. Neither was expressible
+    /// while a rule had one severity, and flattening the heuristic in with the
+    /// grammar verdicts is what made it look like one.
+    CHALLENGE_TOKEN68_INVALID = {
+        id: "challenge_token68_invalid",
+        title: "Authentication token68 is indistinguishable from a parameter",
+        message: "",
+        default_severity: Severity::Info,
+        spec: None,
+    }
+
+    /// An empty member of a challenge's `#auth-param` list.
+    ///
+    // cite(RFC 9110 § 11.3): "challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]"
+    CHALLENGE_PARAMETER_EMPTY = {
+        id: "challenge_parameter_empty",
+        title: "Authentication challenge has an empty parameter",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_3),
+    }
+
+    /// A parameter whose name is empty — `=x`, which has a value and nothing
+    /// for it to belong to.
+    ///
+    // cite(RFC 9110 § 11.2): "auth-param     = token BWS "=" BWS ( token / quoted-string )"
+    CHALLENGE_PARAMETER_NAME_EMPTY = {
+        id: "challenge_parameter_name_empty",
+        title: "Authentication parameter has an empty name",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_2),
+    }
+
+    /// An `auth-param` with no value. The production writes the `"="` and both
+    /// alternatives after it, so the value is not optional — `Basic realm` is
+    /// the shortest way to reach this.
+    ///
+    // cite(RFC 9110 § 11.2): "auth-param     = token BWS "=" BWS ( token / quoted-string )"
+    CHALLENGE_PARAMETER_VALUE_MISSING = {
+        id: "challenge_parameter_value_missing",
+        title: "Authentication parameter has no value",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_2),
+    }
+
+    /// A non-`tchar` octet in an `auth-param` name. The same complaint as
+    /// [`CHALLENGE_SCHEME_CHARACTER_FORBIDDEN`] under a different production,
+    /// and kept apart from it for exactly that reason: an operator reading a
+    /// report is told which half of the challenge the octet was in.
+    ///
+    // cite(RFC 9110 § 11.2): "auth-param     = token BWS "=" BWS ( token / quoted-string )"
+    CHALLENGE_PARAMETER_NAME_CHARACTER_FORBIDDEN = {
+        id: "challenge_parameter_name_character_forbidden",
+        title: "Authentication parameter name holds a character outside token",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_2),
+    }
+
+    /// A non-`tchar` octet in an unquoted `auth-param` value. The value has a
+    /// second alternative — the quoted one — which is where such an octet is
+    /// admitted, so this is also the defect whose fix is most often a pair of
+    /// DQUOTEs rather than a different character.
+    ///
+    // cite(RFC 9110 § 11.2): "auth-param     = token BWS "=" BWS ( token / quoted-string )"
+    CHALLENGE_PARAMETER_VALUE_CHARACTER_FORBIDDEN = {
+        id: "challenge_parameter_value_character_forbidden",
+        title: "Authentication parameter value holds a character outside token",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_2),
+    }
+}
+
+/// The defect a parsed [`ChallengeDefect`] reports as.
+///
+/// The last arm hands the question to [`crate::violations::quoted_string`],
+/// which is the point of that module: a value between two DQUOTEs is the same
+/// production in an `auth-param` as in a `Cache-Control` directive, and reports
+/// under the same names.
+pub fn challenge_defect(defect: ChallengeDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        ChallengeDefect::Empty => &CHALLENGE_EMPTY,
+        ChallengeDefect::EmptyMember => &CHALLENGE_MEMBER_EMPTY,
+        ChallengeDefect::SchemeMissing => &CHALLENGE_SCHEME_MISSING,
+        ChallengeDefect::SchemeCharacter(_) => &CHALLENGE_SCHEME_CHARACTER_FORBIDDEN,
+        ChallengeDefect::Token68ControlCharacter => &CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN,
+        ChallengeDefect::SuspiciousSingleToken(_) => &CHALLENGE_TOKEN68_INVALID,
+        ChallengeDefect::EmptyParameter => &CHALLENGE_PARAMETER_EMPTY,
+        ChallengeDefect::EmptyParameterName => &CHALLENGE_PARAMETER_NAME_EMPTY,
+        ChallengeDefect::ParameterMissingValue(_) => &CHALLENGE_PARAMETER_VALUE_MISSING,
+        ChallengeDefect::ParameterNameCharacter(_) => &CHALLENGE_PARAMETER_NAME_CHARACTER_FORBIDDEN,
+        ChallengeDefect::ParameterValueCharacter(_) => {
+            &CHALLENGE_PARAMETER_VALUE_CHARACTER_FORBIDDEN
+        }
+        ChallengeDefect::ParameterQuotedValue { defect, .. } => quoted_string_defect(defect),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Twelve variants, twelve ids, spelled out — the last of them belonging to
+    /// another subject, which is the mapping most worth pinning: a quoted value
+    /// inside an `auth-param` is a `quoted-string` defect, not a challenge one.
+    #[test]
+    fn each_challenge_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (ChallengeDefect::Empty, "challenge_empty"),
+            (ChallengeDefect::EmptyMember, "challenge_member_empty"),
+            (ChallengeDefect::SchemeMissing, "challenge_scheme_missing"),
+            (
+                ChallengeDefect::SchemeCharacter('@'),
+                "challenge_scheme_character_forbidden",
+            ),
+            (
+                ChallengeDefect::Token68ControlCharacter,
+                "challenge_token68_character_forbidden",
+            ),
+            (
+                ChallengeDefect::SuspiciousSingleToken("realm"),
+                "challenge_token68_invalid",
+            ),
+            (ChallengeDefect::EmptyParameter, "challenge_parameter_empty"),
+            (
+                ChallengeDefect::EmptyParameterName,
+                "challenge_parameter_name_empty",
+            ),
+            (
+                ChallengeDefect::ParameterMissingValue("realm"),
+                "challenge_parameter_value_missing",
+            ),
+            (
+                ChallengeDefect::ParameterNameCharacter('@'),
+                "challenge_parameter_name_character_forbidden",
+            ),
+            (
+                ChallengeDefect::ParameterValueCharacter('@'),
+                "challenge_parameter_value_character_forbidden",
+            ),
+            (
+                ChallengeDefect::ParameterQuotedValue {
+                    name: "realm",
+                    value: "\"x",
+                    defect: crate::helpers::quoted_string::QuotedStringDefect::NotQuoted,
+                },
+                "quoted_string_delimiter_missing",
+            ),
+        ] {
+            assert_eq!(challenge_defect(defect).id, id);
+        }
+    }
+
+    /// The heuristic is the one entry with no sentence behind it, and the
+    /// severities are not one value repeated — which is what a rule reporting
+    /// all of these could only ever have been.
+    #[test]
+    fn the_heuristic_is_the_one_without_a_spec() {
+        assert!(CHALLENGE_TOKEN68_INVALID.spec.is_none());
+        assert_eq!(CHALLENGE_TOKEN68_INVALID.default_severity, Severity::Info);
+        assert_eq!(
+            CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN.default_severity,
+            Severity::Error
+        );
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -29,10 +29,12 @@ use crate::rules::SpecRef;
 use linkme::distributed_slice;
 use std::sync::LazyLock;
 
+pub mod challenge;
 pub mod cookie;
 pub mod domain;
 pub mod language;
 pub mod mailbox;
+pub mod quoted_string;
 pub mod uri;
 
 /// One reportable defect.
@@ -339,7 +341,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 43;
+        const FLOOR: usize = 57;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/quoted_string.rs
+++ b/lint-http-rules/src/violations/quoted_string.rs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Quoted-string defects — the ways the production between two DQUOTEs is not
+//! one.
+//!
+//! One grammar, everywhere. `quoted-string` is RFC 9110 § 5.6.4's, and this
+//! crate reads one out of a `WWW-Authenticate` `auth-param`, a
+//! `Cache-Control` directive argument, a `Content-Disposition` `filename`, a
+//! `Warning` text, a `TE` parameter and a `Strict-Transport-Security` value —
+//! seven rules and three helpers so far, all through
+//! [`crate::helpers::quoted_string`]. So the defect belongs here rather than to
+//! whichever field noticed it, and an operator who does not care about an
+//! unescaped DQUOTE says so once.
+//!
+//! The interior is where the reading happens, and the messages are written
+//! against the whole value: a caller embeds them after naming the parameter or
+//! the directive the value belonged to.
+
+use crate::helpers::quoted_string::QuotedStringDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The production, its interior class and its escape — one section behind all
+/// four entries, because § 5.6.4 is where the whole of `quoted-string` is
+/// written.
+pub const RFC_9110_5_6_4: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4",
+    note: "`quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape",
+};
+
+defects! {
+    /// No opening DQUOTE, or nothing closing it. The production *is* its two
+    /// delimiters and what they enclose, so a value missing one of them has no
+    /// interior to examine rather than a bad one — which is why this is the one
+    /// defect answered before the walk starts.
+    ///
+    // cite(RFC 9110 § 5.6.4): "quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE"
+    QUOTED_STRING_DELIMITER_MISSING = {
+        id: "quoted_string_delimiter_missing",
+        title: "Quoted-string is missing one of its DQUOTEs",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_6_4),
+    }
+
+    /// An escape that is not a `quoted-pair`: a backslash before an octet the
+    /// pair does not admit, or a backslash with nothing after it at all. One
+    /// def for both, because the operator's fix is the escape either way — the
+    /// same judgment `mailbox_quoted_pair_malformed` makes about RFC 5322's
+    /// spelling of the same production.
+    ///
+    // cite(RFC 9110 § 5.6.4): "quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )"
+    QUOTED_STRING_QUOTED_PAIR_MALFORMED = {
+        id: "quoted_string_quoted_pair_malformed",
+        title: "Quoted-string holds an escape that is not a quoted-pair",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_6_4),
+    }
+
+    /// A DQUOTE inside the interior that no backslash introduced. The interior
+    /// runs between the production's two delimiters, so a third one closes the
+    /// value early and everything after it derives from nothing — which is why
+    /// this is the defect most likely to change what a recipient reads rather
+    /// than merely to be refused.
+    ///
+    // cite(RFC 9110 § 5.6.4): "qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text"
+    QUOTED_STRING_QUOTE_ESCAPE_MISSING = {
+        id: "quoted_string_quote_escape_missing",
+        title: "Quoted-string holds an unescaped DQUOTE",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_6_4),
+    }
+
+    /// A control octet `qdtext` excludes — HTAB is not one of them, since it is
+    /// in the class by name. `error` by default, for the reason every other
+    /// subject's invisible defect is: `qdtext` runs from %x20 up, so a control
+    /// octet in a quoted value is something that happened to it rather than
+    /// something a sender chose, and it is in the class a field value is split
+    /// with.
+    ///
+    // cite(RFC 9110 § 5.6.4): "qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text"
+    QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN = {
+        id: "quoted_string_control_character_forbidden",
+        title: "Quoted-string holds a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_5_6_4),
+    }
+}
+
+/// The defect a parsed [`QuotedStringDefect`] reports as.
+pub fn quoted_string_defect(defect: QuotedStringDefect) -> &'static ViolationDef {
+    match defect {
+        QuotedStringDefect::NotQuoted => &QUOTED_STRING_DELIMITER_MISSING,
+        QuotedStringDefect::BadQuotedPair | QuotedStringDefect::TrailingEscape => {
+            &QUOTED_STRING_QUOTED_PAIR_MALFORMED
+        }
+        QuotedStringDefect::UnescapedQuote => &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+        QuotedStringDefect::ControlCharacter => &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The mapping, spelled out — including the place two variants answer with
+    /// one def, which is a decision and not an oversight.
+    #[test]
+    fn each_quoted_string_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (
+                QuotedStringDefect::NotQuoted,
+                "quoted_string_delimiter_missing",
+            ),
+            (
+                QuotedStringDefect::BadQuotedPair,
+                "quoted_string_quoted_pair_malformed",
+            ),
+            (
+                QuotedStringDefect::TrailingEscape,
+                "quoted_string_quoted_pair_malformed",
+            ),
+            (
+                QuotedStringDefect::UnescapedQuote,
+                "quoted_string_quote_escape_missing",
+            ),
+            (
+                QuotedStringDefect::ControlCharacter,
+                "quoted_string_control_character_forbidden",
+            ),
+        ] {
+            assert_eq!(quoted_string_defect(defect).id, id);
+        }
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1638,7 +1638,7 @@ sources:
     snippet: Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 488
+      line: 511
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 210
   - label: lint-http-rules/src/helpers/websocket.rs
@@ -3042,7 +3042,7 @@ sources:
     snippet: b64token    = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 580
+      line: 603
 - label: RFC 6797
   url: https://www.rfc-editor.org/rfc/rfc6797.html
   fragments:
@@ -3761,7 +3761,7 @@ sources:
     snippet: For historical reasons, the nc value MUST be exactly 8 hexadecimal digits.
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 641
+      line: 664
 - label: RFC 7617
   url: https://www.rfc-editor.org/rfc/rfc7617.html
   fragments:
@@ -3776,19 +3776,19 @@ sources:
     snippet: The user-id and password MUST NOT contain any control characters
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 501
+      line: 524
   - label: basic-credentials base64
     section: § 2
     snippet: and obtains the basic-credentials by encoding this octet sequence using Base64
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 485
+      line: 508
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 2
     snippet: constructs the user-pass by concatenating the user-id, a single colon (":") character, and the password
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 493
+      line: 516
 - label: RFC 7838
   url: https://www.rfc-editor.org/rfc/rfc7838.html
   fragments:
@@ -5211,13 +5211,13 @@ sources:
     snippet: New and existing authentication schemes are specified independently and ought to be registered
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 123
+      line: 142
   - label: auth_scheme_registered (2)
     section: § 16.4.1
     snippet: The "Hypertext Transfer Protocol (HTTP) Authentication Scheme Registry" defines the namespace for the authentication schemes in challenges and credentials.
     cited_by:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 124
+      line: 143
   - label: authentication_challenge_valid
     section: § 11.5
     snippet: Note that a response can have multiple challenges with the same auth-scheme but with different realms.
@@ -5298,6 +5298,24 @@ sources:
     cited_by:
     - file: lint-http-rules/src/rules/cached_validators_reused.rs
       line: 138
+  - label: challenge
+    section: § 11.2
+    snippet: auth-param     = token BWS "=" BWS ( token / quoted-string )
+    cited_by:
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 155
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 168
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 182
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 196
+  - label: challenge (2)
+    section: § 11.2
+    snippet: token68        = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
+    cited_by:
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 117
   - label: charset_present
     section: § 8.3.2
     snippet: HTTP uses "charset" names to indicate or negotiate the character encoding scheme
@@ -6449,39 +6467,49 @@ sources:
     snippet: It uses a case-insensitive token to identify the authentication scheme
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 388
+      line: 411
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
-      line: 110
+      line: 129
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
       line: 85
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
       line: 90
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
       line: 95
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 102
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 11.3
     snippet: 'challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 225
+      line: 248
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 62
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 89
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 143
   - label: lint-http-rules/src/helpers/auth.rs (3)
     section: § 11.4
     snippet: 'credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 400
+      line: 423
   - label: lint-http-rules/src/helpers/auth.rs (4)
     section: § 11.6.1
     snippet: 'WWW-Authenticate = #challenge'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 95
+      line: 103
+    - file: lint-http-rules/src/violations/challenge.rs
+      line: 76
   - label: 1#element expansion
     section: § 5.6.1.1
     snippet: 1#element => element *( OWS "," OWS element )
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
-      line: 96
+      line: 104
     - file: lint-http-rules/src/helpers/list.rs
       line: 35
     - file: lint-http-rules/src/helpers/list.rs
@@ -7038,6 +7066,8 @@ sources:
       line: 430
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 594
+    - file: lint-http-rules/src/violations/quoted_string.rs
+      line: 57
   - label: lint-http-rules/src/helpers/list.rs (5)
     section: § 5.6.4
     snippet: quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
@@ -7066,6 +7096,8 @@ sources:
       line: 415
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 116
+    - file: lint-http-rules/src/violations/quoted_string.rs
+      line: 42
   - label: lint-http-rules/src/helpers/mailbox.rs
     section: § 10.1.2
     snippet: mailbox = <mailbox, see [RFC5322], Section 3.4>
@@ -7300,6 +7332,10 @@ sources:
       line: 416
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 547
+    - file: lint-http-rules/src/violations/quoted_string.rs
+      line: 72
+    - file: lint-http-rules/src/violations/quoted_string.rs
+      line: 88
   - label: qvalue grammar
     section: § 12.4.2
     snippet: qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
@@ -8725,7 +8761,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 175
     - file: lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
-      line: 103
+      line: 132
   - label: status_code_semantics (5)
     section: § 11.7.1
     snippet: A proxy MUST send at least one Proxy-Authenticate header field in each 407 (Proxy Authentication Required) response that it generates.


### PR DESCRIPTION
`www_authenticate_challenge_syntax` converts, and the shared production under it comes with it. Fifteen defects where the rule had one voice: eleven for `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, and four for the `quoted-string` an `auth-param` value may take — which is RFC 9110 §5.6.4's production, read by seven other rules through the same helper, so the value between two DQUOTEs reports under one name however the field spelled it.

Three severities where there was one, and the spread is the argument for the whole split. A control octet in a `token68` is `error`: the alphabet is letters, digits, six punctuation marks and the padding, so nothing a sender chose puts one there. A bare word after the scheme is `info` and carries no citation at all: `token68` admits it, no sentence refuses it, and what this crate reports is that it is indistinguishable from an `auth-param` whose value someone forgot. Flattened together, that heuristic read as a syntax verdict.

`split_and_group_challenges` answers with the same defect type as the validator rather than a sentence of its own, since the two read one field value between them and a caller should not match on two types to report it. That is also what lets `auth_scheme_registered` declare the two list defects and report them under the ids `www_authenticate_challenge_syntax` uses — a shared subject with two rules on it, not a promise of one.

The citation floor drops by one, which is the conversion: the grouping site cited §11.6.1 and the def it now reports through carries that sentence.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
