### PR TITLE
One name for a scheme, whichever way it went

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1055,6 +1055,10 @@ severity = "warn"
 enabled = true
 severity = "warn"
 
+[violations.auth_scheme_character_forbidden]
+# Authentication scheme holds a character outside token
+severity = "warn"
+
 [violations.challenge_empty]
 # Authentication challenge is empty
 severity = "warn"
@@ -1081,10 +1085,6 @@ severity = "warn"
 
 [violations.challenge_parameter_value_missing]
 # Authentication parameter has no value
-severity = "warn"
-
-[violations.challenge_scheme_character_forbidden]
-# Authentication scheme holds a character outside token
 severity = "warn"
 
 [violations.challenge_scheme_missing]
@@ -1142,6 +1142,18 @@ severity = "warn"
 [violations.cookie_path_whitespace_invalid]
 # Set-Cookie Path attribute holds unencoded whitespace
 severity = "info"
+
+[violations.credentials_control_character_forbidden]
+# Credentials hold a control character
+severity = "error"
+
+[violations.credentials_empty]
+# Credentials are empty
+severity = "warn"
+
+[violations.credentials_missing]
+# Credentials are absent after the scheme
+severity = "warn"
 
 [violations.domain_label_character_forbidden]
 # Domain label holds a character outside letters, digits and hyphen

--- a/docs/rules/authorization_credentials_present.md
+++ b/docs/rules/authorization_credentials_present.md
@@ -12,7 +12,9 @@ The `Authorization` request header field MUST include an authentication scheme f
 
 ## Specifications
 
-- [RFC 9110 §11.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2): Authorization
+- [RFC 9110 §11.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2): Authorization — the field's value *consists of* credentials, which is stricter than § 11.4's optional second half
+- [RFC 9110 §11.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.4): Credentials — `credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, the request-side mirror of `challenge`
+- [RFC 9110 §11.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2): Authentication Parameters — `auth-scheme = token`, `auth-param = token BWS "=" BWS ( token / quoted-string )`, and `token68`'s alphabet
 - [RFC 7617](https://www.rfc-editor.org/rfc/rfc7617.html): Basic Authentication
 - [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750.html): The OAuth 2.0 Authorization Framework: Bearer Token Usage
 

--- a/lint-http-rules/src/rules/authorization_credentials_present.rs
+++ b/lint-http-rules/src/rules/authorization_credentials_present.rs
@@ -4,18 +4,36 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::auth_scheme::{AUTH_SCHEME_CHARACTER_FORBIDDEN, RFC_9110_11_2};
+use crate::violations::credentials::{
+    credentials_defect, CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN, CREDENTIALS_EMPTY,
+    CREDENTIALS_MISSING, RFC_9110_11_4, RFC_9110_11_6_2,
+};
+use crate::violations::ViolationDef;
 
 pub struct AuthorizationCredentialsPresent;
+
+/// The defects this rule reports. Three belong to `credentials = auth-scheme
+/// [ 1*SP ( token68 / #auth-param ) ]`, which `Proxy-Authorization` carries
+/// too; the fourth is the scheme's, shared with the response side of the
+/// framework — `www_authenticate_challenge_syntax` reports the same id about a
+/// server's `WWW-Authenticate`, because `auth-scheme = token` is written once
+/// and used from both directions.
+///
+/// The non-UTF-8 finding below is not here on purpose: the verdict it reports
+/// names an encoding where the defect is an octet the field's grammar does not
+/// admit, and the conversion it needs is an octet-wise reader rather than a
+/// name for the claim as it stands.
+static DECLARED: &[&ViolationDef] = &[
+    &CREDENTIALS_EMPTY,
+    &CREDENTIALS_MISSING,
+    &CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN,
+    &AUTH_SCHEME_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_9110_11_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("11.6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2",
-    note: "Authorization",
-};
 const RFC_7617: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7617",
     section: None,
@@ -45,7 +63,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_11_6_2, RFC_7617, RFC_6750]
+        &[
+            RFC_9110_11_6_2,
+            RFC_9110_11_4,
+            RFC_9110_11_2,
+            RFC_7617,
+            RFC_6750,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -100,9 +128,8 @@ impl Rule for AuthorizationCredentialsPresent {
                         // cite(RFC 9110 § 11.6.2): "Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested"
                         if let Err(defect) = crate::helpers::auth::validate_authorization_syntax(s)
                         {
-                            return Some(self.cited(
-                                &RFC_9110_11_6_2,
-                                ctx.severity,
+                            return Some(ctx.report_with(
+                                credentials_defect(defect),
                                 format!("Invalid Authorization header: {}", defect.message()),
                             ));
                         }
@@ -168,6 +195,60 @@ mod tests {
             assert!(v.is_none());
         }
         Ok(())
+    }
+
+    /// Four names where the rule had one, and the last row is the point of the
+    /// shared subject: a scheme with a character no `token` admits reports
+    /// under the same id whether a user agent wrote it into `Authorization` or
+    /// a server wrote it into `WWW-Authenticate`. The control octet defaults a
+    /// level above the rest, because neither alternative of the production
+    /// admits one and nobody types it.
+    #[rstest]
+    #[case("", "credentials_empty", crate::lint::Severity::Warn)]
+    #[case("Basic", "credentials_missing", crate::lint::Severity::Warn)]
+    #[case("Basic ", "credentials_missing", crate::lint::Severity::Warn)]
+    #[case(
+        "B@sic xyz",
+        "auth_scheme_character_forbidden",
+        crate::lint::Severity::Warn
+    )]
+    fn each_finding_names_the_defect_and_carries_its_severity(
+        #[case] header: &str,
+        #[case] violation: &str,
+        #[case] severity: crate::lint::Severity,
+    ) -> anyhow::Result<()> {
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers.append(
+            "authorization",
+            hyper::header::HeaderValue::from_str(header)?,
+        );
+        let v = crate::test_helpers::run_rule(
+            &AuthorizationCredentialsPresent,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "authorization_credentials_present",
+            ]),
+        )
+        .unwrap_or_else(|| panic!("expected a finding for {header:?}"));
+        assert_eq!(v.violation, violation, "{}", v.message);
+        assert_eq!(v.severity, severity, "{}", v.message);
+        Ok(())
+    }
+
+    /// A control octet cannot reach the rule through a `HeaderValue`, which
+    /// refuses to hold one — so the defect is declared, reported by the helper,
+    /// and asserted where it is constructible.
+    #[test]
+    fn a_control_octet_in_the_credentials_is_the_helpers_to_find() {
+        assert!(hyper::header::HeaderValue::from_bytes(b"Basic ab\x01c").is_err());
+        assert_eq!(
+            crate::violations::credentials::credentials_defect(
+                crate::helpers::auth::AuthorizationDefect::CredentialsControlCharacter
+            )
+            .id,
+            "credentials_control_character_forbidden",
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1268,14 +1268,16 @@ severity = "warn"
     /// was the first and took one cited site with it; `cookie_domain_valid`
     /// took three more, `language_tag_syntax` one, and
     /// `www_authenticate_challenge_syntax` the one that read the `#challenge`
-    /// list before its members were grouped.
+    /// list before its members were grouped, and
+    /// `authorization_credentials_present` the one that read the credentials
+    /// after the scheme.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 165;
+        const FLOOR: usize = 164;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
+++ b/lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
@@ -4,13 +4,13 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::auth_scheme::{AUTH_SCHEME_CHARACTER_FORBIDDEN, RFC_9110_11_2};
 use crate::violations::challenge::{
     challenge_defect, CHALLENGE_EMPTY, CHALLENGE_MEMBER_EMPTY, CHALLENGE_PARAMETER_EMPTY,
     CHALLENGE_PARAMETER_NAME_CHARACTER_FORBIDDEN, CHALLENGE_PARAMETER_NAME_EMPTY,
     CHALLENGE_PARAMETER_VALUE_CHARACTER_FORBIDDEN, CHALLENGE_PARAMETER_VALUE_MISSING,
-    CHALLENGE_SCHEME_CHARACTER_FORBIDDEN, CHALLENGE_SCHEME_MISSING,
-    CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN, CHALLENGE_TOKEN68_INVALID, RFC_9110_11_2, RFC_9110_11_3,
-    RFC_9110_11_6_1,
+    CHALLENGE_SCHEME_MISSING, CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN, CHALLENGE_TOKEN68_INVALID,
+    RFC_9110_11_3, RFC_9110_11_6_1,
 };
 use crate::violations::quoted_string::{
     QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN, QUOTED_STRING_DELIMITER_MISSING,
@@ -20,16 +20,18 @@ use crate::violations::ViolationDef;
 
 pub struct WwwAuthenticateChallengeSyntax;
 
-/// The defects this rule reports, and none of them is its own. The eleven
+/// The defects this rule reports, and none of them is its own. The ten
 /// `challenge_*` belong to `challenge = auth-scheme [ 1*SP ( token68 /
 /// #auth-param ) ]`, which `Proxy-Authenticate` carries under another name; the
 /// four `quoted_string_*` belong to the production a parameter's value may
-/// take, which seven other rules read through the same helper.
+/// take, which seven other rules read through the same helper; and the scheme's
+/// own defect is shared with the request side of the framework, where
+/// `authorization_credentials_present` reports it about an `Authorization`.
 static DECLARED: &[&ViolationDef] = &[
     &CHALLENGE_EMPTY,
     &CHALLENGE_MEMBER_EMPTY,
     &CHALLENGE_SCHEME_MISSING,
-    &CHALLENGE_SCHEME_CHARACTER_FORBIDDEN,
+    &AUTH_SCHEME_CHARACTER_FORBIDDEN,
     &CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN,
     &CHALLENGE_TOKEN68_INVALID,
     &CHALLENGE_PARAMETER_EMPTY,

--- a/lint-http-rules/src/violations/auth_scheme.rs
+++ b/lint-http-rules/src/violations/auth_scheme.rs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Authentication scheme defects — the name at the front of a challenge and of
+//! credentials alike.
+//!
+//! `auth-scheme = token` is written once in RFC 9110 § 11.2 and used by both
+//! sides of the framework: § 11.3's `challenge`, which a server writes into
+//! `WWW-Authenticate`, and § 11.4's `credentials`, which a user agent writes
+//! into `Authorization`. So an octet no `token` admits is one defect with two
+//! senders, and this is where it lives — not in
+//! [`crate::violations::challenge`], which is where it was first written and
+//! where it was named after the half of the framework that happened to be
+//! converted first.
+//!
+//! The messages still name the field, because the helper enums that produce
+//! them do; the id does not, which is the half that has to be right while
+//! configuration is being written against it.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The framework's vocabulary: the scheme's `token`, the `auth-param` pair
+/// built on it, and the `token68` alternative. One section behind all three,
+/// which is why `challenge` and `credentials` both point their parameter
+/// defects here.
+pub const RFC_9110_11_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2",
+    note: "Authentication Parameters — `auth-scheme = token`, `auth-param = token BWS \"=\" BWS ( token / quoted-string )`, and `token68`'s alphabet",
+};
+
+defects! {
+    /// A non-`tchar` octet in the scheme name. A recipient matches the scheme
+    /// case-insensitively against a registry, so an octet outside the class is
+    /// a name nothing can be looked up under — whichever direction the field
+    /// was travelling.
+    ///
+    // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
+    AUTH_SCHEME_CHARACTER_FORBIDDEN = {
+        id: "auth_scheme_character_forbidden",
+        title: "Authentication scheme holds a character outside token",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_2),
+    }
+}

--- a/lint-http-rules/src/violations/challenge.rs
+++ b/lint-http-rules/src/violations/challenge.rs
@@ -8,7 +8,12 @@
 //! RFC 9110 § 11.3's production, and not the field carrying it.
 //! `WWW-Authenticate` is the one this crate reads today; `Proxy-Authenticate`
 //! is the same production under a different name, and a rule for it declares
-//! these same eleven rather than eleven of its own.
+//! these same ten rather than ten of its own.
+//!
+//! The scheme at the front of a challenge is *not* here. `auth-scheme = token`
+//! is § 11.2's, shared with § 11.4's `credentials`, and its defect lives in
+//! [`crate::violations::auth_scheme`] where an `Authorization` value reports
+//! the same one.
 //!
 //! **The wording is still the field's, and that is the part left to move.**
 //! The messages come from [`crate::helpers::auth::ChallengeDefect`], which was
@@ -26,17 +31,9 @@
 use crate::helpers::auth::ChallengeDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+use crate::violations::auth_scheme::{AUTH_SCHEME_CHARACTER_FORBIDDEN, RFC_9110_11_2};
 use crate::violations::quoted_string::quoted_string_defect;
 use crate::violations::{defects, ViolationDef};
-
-/// The parameters the framework is built out of: the scheme's `token`, the
-/// `auth-param` pair, and the `token68` alternative.
-pub const RFC_9110_11_2: SpecRef = SpecRef {
-    spec: "RFC 9110",
-    section: Some("11.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.2",
-    note: "Authentication Parameters — `auth-scheme = token`, `auth-param = token BWS \"=\" BWS ( token / quoted-string )`, and `token68`'s alphabet",
-};
 
 /// The challenge itself: a scheme, and then one of two alternatives.
 pub const RFC_9110_11_3: SpecRef = SpecRef {
@@ -93,19 +90,6 @@ defects! {
         message: "",
         default_severity: Severity::Warn,
         spec: Some(RFC_9110_11_3),
-    }
-
-    /// A non-`tchar` octet in the `auth-scheme`. The scheme is a `token`, and a
-    /// recipient matches it case-insensitively against a registry — so an octet
-    /// outside the class is a name nothing can be looked up under.
-    ///
-    // cite(RFC 9110 § 11.1): "It uses a case-insensitive token to identify the authentication scheme"
-    CHALLENGE_SCHEME_CHARACTER_FORBIDDEN = {
-        id: "challenge_scheme_character_forbidden",
-        title: "Authentication scheme holds a character outside token",
-        message: "",
-        default_severity: Severity::Warn,
-        spec: Some(RFC_9110_11_2),
     }
 
     /// A control octet where a `token68` was read. `error` by default, the same
@@ -175,7 +159,7 @@ defects! {
     }
 
     /// A non-`tchar` octet in an `auth-param` name. The same complaint as
-    /// [`CHALLENGE_SCHEME_CHARACTER_FORBIDDEN`] under a different production,
+    /// [`AUTH_SCHEME_CHARACTER_FORBIDDEN`] under a different production,
     /// and kept apart from it for exactly that reason: an operator reading a
     /// report is told which half of the challenge the octet was in.
     ///
@@ -214,7 +198,7 @@ pub fn challenge_defect(defect: ChallengeDefect<'_>) -> &'static ViolationDef {
         ChallengeDefect::Empty => &CHALLENGE_EMPTY,
         ChallengeDefect::EmptyMember => &CHALLENGE_MEMBER_EMPTY,
         ChallengeDefect::SchemeMissing => &CHALLENGE_SCHEME_MISSING,
-        ChallengeDefect::SchemeCharacter(_) => &CHALLENGE_SCHEME_CHARACTER_FORBIDDEN,
+        ChallengeDefect::SchemeCharacter(_) => &AUTH_SCHEME_CHARACTER_FORBIDDEN,
         ChallengeDefect::Token68ControlCharacter => &CHALLENGE_TOKEN68_CHARACTER_FORBIDDEN,
         ChallengeDefect::SuspiciousSingleToken(_) => &CHALLENGE_TOKEN68_INVALID,
         ChallengeDefect::EmptyParameter => &CHALLENGE_PARAMETER_EMPTY,
@@ -232,9 +216,11 @@ pub fn challenge_defect(defect: ChallengeDefect<'_>) -> &'static ViolationDef {
 mod tests {
     use super::*;
 
-    /// Twelve variants, twelve ids, spelled out — the last of them belonging to
-    /// another subject, which is the mapping most worth pinning: a quoted value
-    /// inside an `auth-param` is a `quoted-string` defect, not a challenge one.
+    /// Twelve variants, twelve ids, spelled out — two of them belonging to other
+    /// subjects, which are the mappings most worth pinning: the scheme is
+    /// § 11.2's `auth-scheme` wherever it was written, and a quoted value
+    /// inside an `auth-param` is a `quoted-string` defect and not a challenge
+    /// one.
     #[test]
     fn each_challenge_defect_maps_to_its_own_id() {
         for (defect, id) in [
@@ -243,7 +229,7 @@ mod tests {
             (ChallengeDefect::SchemeMissing, "challenge_scheme_missing"),
             (
                 ChallengeDefect::SchemeCharacter('@'),
-                "challenge_scheme_character_forbidden",
+                "auth_scheme_character_forbidden",
             ),
             (
                 ChallengeDefect::Token68ControlCharacter,

--- a/lint-http-rules/src/violations/credentials.rs
+++ b/lint-http-rules/src/violations/credentials.rs
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Credentials defects — the request half of the authentication framework.
+//!
+//! `credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]` is RFC 9110
+//! § 11.4's, and it is `challenge`'s mirror image: the same vocabulary, written
+//! by the user agent instead of by the server. The subject is the production,
+//! so `Proxy-Authorization` reports these same three.
+//!
+//! Only three, because this is deliberately the shallow reading. What the
+//! credentials have to *be* is the scheme's own document's question — RFC 7617
+//! for `Basic`, RFC 6750 for `Bearer` — and those have their own subjects. What
+//! is here is the framework's shape: something is there, and the octets are
+//! ones a field value may carry.
+//!
+//! The scheme name is not here either: `auth-scheme = token` is § 11.2's and
+//! shared with the challenge side, so it reports as
+//! [`crate::violations::auth_scheme`]'s one defect from both directions.
+
+use crate::helpers::auth::AuthorizationDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::auth_scheme::AUTH_SCHEME_CHARACTER_FORBIDDEN;
+use crate::violations::{defects, ViolationDef};
+
+/// The production: a scheme, and then — optionally, as far as the framework is
+/// concerned — what the scheme's own document asks for.
+pub const RFC_9110_11_4: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.4",
+    note: "Credentials — `credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, the request-side mirror of `challenge`",
+};
+
+/// The field, and the sentence that says its value carries the user agent's
+/// authentication information — which is what makes a bare scheme a finding
+/// where the framework grammar alone would not.
+pub const RFC_9110_11_6_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("11.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2",
+    note: "Authorization — the field's value *consists of* credentials, which is stricter than § 11.4's optional second half",
+};
+
+defects! {
+    /// A field that is present and carries nothing at all. `credentials` opens
+    /// with an `auth-scheme`, which is a `token`, so the empty value derives
+    /// from nothing.
+    ///
+    // cite(RFC 9110 § 11.4): "credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]"
+    CREDENTIALS_EMPTY = {
+        id: "credentials_empty",
+        title: "Credentials are empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_6_2),
+    }
+
+    /// A scheme with nothing after it. § 11.4's grammar makes the second half
+    /// optional, so this defect is *not* the framework's — it is every
+    /// concrete scheme's. `Basic` (RFC 7617), `Bearer` (RFC 6750) and `Digest`
+    /// (RFC 7616) each mandate credentials, and the field's own definition says
+    /// its value consists of them, which is the sentence carried here.
+    ///
+    // cite(RFC 9110 § 11.6.2): "Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested"
+    CREDENTIALS_MISSING = {
+        id: "credentials_missing",
+        title: "Credentials are absent after the scheme",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_11_6_2),
+    }
+
+    /// A control octet in the credentials. `error` by default, for the reason
+    /// every other subject's invisible defect earns it: neither alternative of
+    /// the production admits one — `token68`'s alphabet has none and an
+    /// `auth-param` is tokens and quoted-strings — so an octet below %x20 in a
+    /// value this shape is something that happened to it in transit.
+    ///
+    // cite(RFC 9110 § 11.4): "credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]"
+    CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN = {
+        id: "credentials_control_character_forbidden",
+        title: "Credentials hold a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_11_4),
+    }
+}
+
+/// The defect a parsed [`AuthorizationDefect`] reports as.
+///
+/// The scheme arm leaves this subject on purpose: an octet no `token` admits is
+/// the same defect in a `WWW-Authenticate` challenge, and reports under the
+/// same id.
+pub fn credentials_defect(defect: AuthorizationDefect) -> &'static ViolationDef {
+    match defect {
+        AuthorizationDefect::Empty => &CREDENTIALS_EMPTY,
+        AuthorizationDefect::SchemeCharacter(_) => &AUTH_SCHEME_CHARACTER_FORBIDDEN,
+        AuthorizationDefect::MissingCredentials => &CREDENTIALS_MISSING,
+        AuthorizationDefect::CredentialsControlCharacter => {
+            &CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Four variants, four ids — one of which is the challenge side's too,
+    /// which is the row this test exists for.
+    #[test]
+    fn each_authorization_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (AuthorizationDefect::Empty, "credentials_empty"),
+            (
+                AuthorizationDefect::SchemeCharacter('@'),
+                "auth_scheme_character_forbidden",
+            ),
+            (
+                AuthorizationDefect::MissingCredentials,
+                "credentials_missing",
+            ),
+            (
+                AuthorizationDefect::CredentialsControlCharacter,
+                "credentials_control_character_forbidden",
+            ),
+        ] {
+            assert_eq!(credentials_defect(defect).id, id);
+        }
+    }
+
+    /// The same defect, reported from both directions, is one entry: a server
+    /// writing `b@d` into a challenge and a user agent writing it into
+    /// `Authorization` are configured together, which is the whole reason the
+    /// scheme is not one of this subject's own.
+    #[test]
+    fn the_scheme_defect_is_the_challenge_sides_too() {
+        assert!(std::ptr::eq(
+            credentials_defect(AuthorizationDefect::SchemeCharacter('@')),
+            crate::violations::challenge::challenge_defect(
+                crate::helpers::auth::ChallengeDefect::SchemeCharacter('@')
+            ),
+        ));
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -29,8 +29,10 @@ use crate::rules::SpecRef;
 use linkme::distributed_slice;
 use std::sync::LazyLock;
 
+pub mod auth_scheme;
 pub mod challenge;
 pub mod cookie;
+pub mod credentials;
 pub mod domain;
 pub mod language;
 pub mod mailbox;
@@ -341,7 +343,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 57;
+        const FLOOR: usize = 60;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5255,7 +5255,9 @@ sources:
     snippet: Its value consists of credentials containing the authentication information of the user agent for the realm of the resource being requested
     cited_by:
     - file: lint-http-rules/src/rules/authorization_credentials_present.rs
-      line: 100
+      line: 128
+    - file: lint-http-rules/src/violations/credentials.rs
+      line: 67
   - label: cache_coherence
     section: § 15.4.5
     snippet: there is no need for the server to transfer a representation of the target resource because the request indicates that the client, which made the request conditional, already has a valid representation
@@ -5303,19 +5305,19 @@ sources:
     snippet: auth-param     = token BWS "=" BWS ( token / quoted-string )
     cited_by:
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 155
+      line: 139
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 168
+      line: 152
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 182
+      line: 166
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 196
+      line: 180
   - label: challenge (2)
     section: § 11.2
     snippet: token68        = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="
     cited_by:
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 117
+      line: 101
   - label: charset_present
     section: § 8.3.2
     snippet: HTTP uses "charset" names to indicate or negotiate the character encoding scheme
@@ -6476,8 +6478,8 @@ sources:
       line: 90
     - file: lint-http-rules/src/rules/digest_auth_valid.rs
       line: 95
-    - file: lint-http-rules/src/violations/challenge.rs
-      line: 102
+    - file: lint-http-rules/src/violations/auth_scheme.rs
+      line: 42
   - label: lint-http-rules/src/helpers/auth.rs (2)
     section: § 11.3
     snippet: 'challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
@@ -6485,17 +6487,21 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 248
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 62
+      line: 59
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 89
+      line: 86
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 143
+      line: 127
   - label: lint-http-rules/src/helpers/auth.rs (3)
     section: § 11.4
     snippet: 'credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]'
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 423
+    - file: lint-http-rules/src/violations/credentials.rs
+      line: 52
+    - file: lint-http-rules/src/violations/credentials.rs
+      line: 82
   - label: lint-http-rules/src/helpers/auth.rs (4)
     section: § 11.6.1
     snippet: 'WWW-Authenticate = #challenge'
@@ -6503,7 +6509,7 @@ sources:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 103
     - file: lint-http-rules/src/violations/challenge.rs
-      line: 76
+      line: 73
   - label: 1#element expansion
     section: § 5.6.1.1
     snippet: 1#element => element *( OWS "," OWS element )
@@ -8761,7 +8767,7 @@ sources:
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 175
     - file: lint-http-rules/src/rules/www_authenticate_challenge_syntax.rs
-      line: 132
+      line: 134
   - label: status_code_semantics (5)
     section: § 11.7.1
     snippet: A proxy MUST send at least one Proxy-Authenticate header field in each 407 (Proxy Authentication Required) response that it generates.


### PR DESCRIPTION
`authorization_credentials_present` converts: `credentials = auth-scheme [ 1*SP ( token68 / #auth-param ) ]` is §11.4's, the request-side mirror of the challenge, so its three defects are the production's and `Proxy-Authorization` will report the same ones. The control octet defaults to `error` — neither alternative admits one, so it is something that happened to the value rather than something a user agent chose — and a bare scheme keeps `warn` while carrying the field's own sentence, since §11.4's grammar permits it and only the concrete schemes do not.

It also corrects the commit before it. `auth-scheme = token` is written once in §11.2 and used from both directions, so naming its defect after the challenge was the same mistake the catalogue is being split to fix: a server writing `b@d` into `WWW-Authenticate` and a user agent writing it into `Authorization` are one defect with two senders. It is `auth_scheme_character_forbidden` now, in a subject of its own, declared by both rules and asserted to be the same entry by identity. Free today, at sixty-two entries and no configuration in the world naming them.

The non-UTF-8 site stays on the old API and says why in the source: the verdict names an encoding where the defect is an octet the field's grammar does not admit, and what it needs is an octet-wise reader, not a name for the claim as it stands.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
