### PR TITLE
Basic credentials keep only what is theirs

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1059,6 +1059,18 @@ severity = "warn"
 # Authentication scheme holds a character outside token
 severity = "warn"
 
+[violations.base64_malformed]
+# Value is not a base64 encoding
+severity = "warn"
+
+[violations.basic_credentials_control_character_forbidden]
+# Basic credentials hold a control character
+severity = "error"
+
+[violations.basic_credentials_separator_missing]
+# Basic credentials hold no ':' separator
+severity = "warn"
+
 [violations.challenge_empty]
 # Authentication challenge is empty
 severity = "warn"

--- a/docs/rules/basic_auth_base64_valid.md
+++ b/docs/rules/basic_auth_base64_valid.md
@@ -12,8 +12,10 @@ Validate that `Authorization: Basic ...` credentials are syntactically valid Bas
 
 ## Specifications
 
-- [RFC 7617 §2](https://www.rfc-editor.org/rfc/rfc7617.html#section-2): The Basic authentication scheme and the `user-pass` encoding (Base64)
+- [RFC 7617 §2](https://www.rfc-editor.org/rfc/rfc7617.html#section-2): The 'Basic' Authentication Scheme — `user-pass = userid ":" password`, base64-encoded, with control characters forbidden in either half
 - [RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4): Base64 encoding used for `token68`
+- [RFC 4648 §3.3](https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3): Interpretation of non-alphabet characters — a MUST to reject data outside the base alphabet, unless the referring specification says otherwise
+- [RFC 9110 §11.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.6.2): Authorization — the field's value *consists of* credentials, which is stricter than § 11.4's optional second half
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/basic_auth_base64_valid.rs
+++ b/lint-http-rules/src/rules/basic_auth_base64_valid.rs
@@ -4,18 +4,33 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::base64::{BASE64_MALFORMED, RFC_4648_3_3};
+use crate::violations::basic_credentials::{
+    basic_credentials_defect, BASIC_CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN,
+    BASIC_CREDENTIALS_SEPARATOR_MISSING, RFC_7617_2,
+};
+use crate::violations::credentials::{CREDENTIALS_MISSING, RFC_9110_11_6_2};
+use crate::violations::ViolationDef;
 
 pub struct BasicAuthBase64Valid;
+
+/// The defects this rule reports. Two are RFC 7617's own — the separator and
+/// the control characters it forbids — and two are not this scheme's at all: a
+/// `Basic` with nothing after it is the framework's `credentials_missing`,
+/// which `authorization_credentials_present` reports about the same request,
+/// and a value that does not decode is `base64_malformed`, which the WebSocket
+/// handshake's key will report under the same name. Naming either of them after
+/// this scheme would give an operator one id per field for one mistake.
+static DECLARED: &[&ViolationDef] = &[
+    &BASIC_CREDENTIALS_SEPARATOR_MISSING,
+    &BASIC_CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN,
+    &CREDENTIALS_MISSING,
+    &BASE64_MALFORMED,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
 /// exactly these, so the docs and the citations cannot name different text.
-const RFC_7617_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7617",
-    section: Some("2"),
-    url: "https://www.rfc-editor.org/rfc/rfc7617.html#section-2",
-    note: "The Basic authentication scheme and the `user-pass` encoding (Base64)",
-};
 const RFC_4648_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 4648",
     section: Some("4"),
@@ -39,7 +54,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_7617_2, RFC_4648_4]
+        &[RFC_7617_2, RFC_4648_4, RFC_4648_3_3, RFC_9110_11_6_2]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -88,8 +107,12 @@ impl Rule for BasicAuthBase64Valid {
                         if scheme.eq_ignore_ascii_case("Basic") {
                             let creds = parts.next().unwrap_or("").trim();
                             if creds.is_empty() {
-                                return Some(self.violation(
-                                    ctx.severity,
+                                // The framework's defect rather than this
+                                // scheme's: a scheme with nothing after it is
+                                // what `credentials` says must not happen,
+                                // whichever scheme was named.
+                                return Some(ctx.report_with(
+                                    &CREDENTIALS_MISSING,
                                     "Basic Authorization missing credentials".into(),
                                 ));
                             }
@@ -101,9 +124,8 @@ impl Rule for BasicAuthBase64Valid {
                             if let Err(defect) =
                                 crate::helpers::auth::validate_basic_credentials(creds)
                             {
-                                return Some(self.cited(
-                                    &RFC_7617_2,
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    basic_credentials_defect(&defect),
                                     format!(
                                         "Invalid Basic credentials: {} (RFC 7617)",
                                         defect.message()
@@ -136,6 +158,46 @@ mod tests {
     use base64::Engine;
     use hyper::header::HeaderValue;
     use rstest::rstest;
+
+    /// Four names where the rule had one, and two of them are not this
+    /// scheme's: a `Basic` with nothing after it is the framework's defect,
+    /// reported under the id `authorization_credentials_present` reports about
+    /// the same request, and a value that does not decode is the encoding's.
+    /// The control octet defaults a level above the rest — RFC 7617 forbids it
+    /// in either half in so many words.
+    #[rstest]
+    #[case("Basic", "credentials_missing", crate::lint::Severity::Warn)]
+    #[case("Basic not-base64", "base64_malformed", crate::lint::Severity::Warn)]
+    #[case(
+        "Basic YWJj",
+        "basic_credentials_separator_missing",
+        crate::lint::Severity::Warn
+    )]
+    #[case(
+        "Basic YQE6Yg==",
+        "basic_credentials_control_character_forbidden",
+        crate::lint::Severity::Error
+    )]
+    fn each_finding_names_the_defect_and_carries_its_severity(
+        #[case] header: &str,
+        #[case] violation: &str,
+        #[case] severity: crate::lint::Severity,
+    ) -> anyhow::Result<()> {
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request
+            .headers
+            .append("authorization", HeaderValue::from_str(header)?);
+        let v = crate::test_helpers::run_rule(
+            &BasicAuthBase64Valid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["basic_auth_base64_valid"]),
+        )
+        .unwrap_or_else(|| panic!("expected a finding for {header:?}"));
+        assert_eq!(v.violation, violation, "{}", v.message);
+        assert_eq!(v.severity, severity, "{}", v.message);
+        Ok(())
+    }
 
     #[rstest]
     #[case(Some("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="), false)]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1270,14 +1270,15 @@ severity = "warn"
     /// `www_authenticate_challenge_syntax` the one that read the `#challenge`
     /// list before its members were grouped, and
     /// `authorization_credentials_present` the one that read the credentials
-    /// after the scheme.
+    /// after the scheme, and `basic_auth_base64_valid` the one that read what
+    /// was inside them.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 164;
+        const FLOOR: usize = 163;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/violations/base64.rs
+++ b/lint-http-rules/src/violations/base64.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Base64 defects — a value that does not decode, wherever it was carried.
+//!
+//! RFC 4648's encoding is read in at least three places here: the
+//! `basic-credentials` of an `Authorization`, the `Sec-WebSocket-Key` of a
+//! handshake, and its `Sec-WebSocket-Accept` answer. The sentence that makes a
+//! bad one a finding is one sentence — § 3.3's MUST — so the defect is one
+//! defect and an operator who does not care about a mangled encoding says so
+//! once.
+//!
+//! One entry today, and it is deliberately coarse: `base64::DecodeError` is
+//! what the `Basic` reader has, and it distinguishes nothing this catalogue
+//! could name. The WebSocket reader *does* split the same failure three ways —
+//! alphabet, shape, and pad bits a conforming encoder zeroes — so when it
+//! converts, its defects join this subject beside this one rather than
+//! replacing it. A coarse def and a fine one in the same subject are two
+//! readers, not two vocabularies.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The instruction that makes a malformed encoding a finding rather than a
+/// judgment call — and it is addressed to the *decoder*, which is what a proxy
+/// reading someone else's credentials is.
+pub const RFC_4648_3_3: SpecRef = SpecRef {
+    spec: "RFC 4648",
+    section: Some("3.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc4648.html#section-3.3",
+    note: "Interpretation of non-alphabet characters — a MUST to reject data outside the base alphabet, unless the referring specification says otherwise",
+};
+
+defects! {
+    /// A value that is not an encoding the alphabet and the quantum produce: an
+    /// octet outside the sixty-four characters, a length no group of symbols
+    /// accounts for, or padding somewhere other than the end.
+    ///
+    // cite(RFC 4648 § 3.3): "Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."
+    BASE64_MALFORMED = {
+        id: "base64_malformed",
+        title: "Value is not a base64 encoding",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_4648_3_3),
+    }
+}

--- a/lint-http-rules/src/violations/basic_credentials.rs
+++ b/lint-http-rules/src/violations/basic_credentials.rs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Basic credentials defects — what the octets behind the base64 have to be.
+//!
+//! RFC 7617 § 2 builds one value out of two: `user-pass = userid ":" password`,
+//! encoded with base64 into the `token68` of an `Authorization: Basic`. The two
+//! defects here are what is left after the encoding is undone — the separator
+//! that says where the user-id stops, and the control characters the section
+//! forbids in either half.
+//!
+//! Everything else the value can fail at belongs to somebody else, and that is
+//! most of it: an absent `token68` is [`credentials_missing`], because a scheme
+//! with nothing after it is the framework's defect and not this scheme's, and a
+//! value that does not decode is [`base64_malformed`], because RFC 4648's
+//! sentence answers for every field that carries an encoding. What remains is
+//! the two lines RFC 7617 writes itself.
+//!
+//! [`credentials_missing`]: crate::violations::credentials::CREDENTIALS_MISSING
+//! [`base64_malformed`]: crate::violations::base64::BASE64_MALFORMED
+
+use crate::helpers::auth::BasicCredentialsDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::base64::BASE64_MALFORMED;
+use crate::violations::credentials::CREDENTIALS_MISSING;
+use crate::violations::{defects, ViolationDef};
+
+/// The scheme's own section: how the value is built, and the one restriction it
+/// places on what goes into it.
+pub const RFC_7617_2: SpecRef = SpecRef {
+    spec: "RFC 7617",
+    section: Some("2"),
+    url: "https://www.rfc-editor.org/rfc/rfc7617.html#section-2",
+    note: "The 'Basic' Authentication Scheme — `user-pass = userid \":\" password`, base64-encoded, with control characters forbidden in either half",
+};
+
+defects! {
+    /// Decoded octets with no `:` in them. Without the separator there is no
+    /// telling where the user-id stops — and an empty user-id is a different
+    /// thing from an absent one, which is why this is not read as "the user-id
+    /// is missing".
+    ///
+    // cite(RFC 7617 § 2): "constructs the user-pass by concatenating the user-id, a single colon (":") character, and the password"
+    BASIC_CREDENTIALS_SEPARATOR_MISSING = {
+        id: "basic_credentials_separator_missing",
+        title: "Basic credentials hold no ':' separator",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7617_2),
+    }
+
+    /// A control octet in the user-id or in the password. One def for both
+    /// halves, because one sentence forbids them in both and the fix is the
+    /// same fix; the message still says which half it was in. `error` by
+    /// default, the same reading every other subject's invisible defect gets —
+    /// and here with a MUST NOT behind it rather than an inference.
+    ///
+    // cite(RFC 7617 § 2): "The user-id and password MUST NOT contain any control characters"
+    BASIC_CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN = {
+        id: "basic_credentials_control_character_forbidden",
+        title: "Basic credentials hold a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_7617_2),
+    }
+}
+
+/// The defect a parsed [`BasicCredentialsDefect`] reports as.
+///
+/// Two of the five arms leave this subject, which is the point: what is missing
+/// after a scheme is the framework's defect, and what fails to decode is the
+/// encoding's. Only the two that RFC 7617 writes sentences about are named
+/// here.
+///
+/// By reference, because the decode arm carries `base64::DecodeError` and the
+/// site needs the defect again for its message — the same shape `path_defect`
+/// takes for the same reason.
+pub fn basic_credentials_defect(defect: &BasicCredentialsDefect) -> &'static ViolationDef {
+    match defect {
+        BasicCredentialsDefect::Empty => &CREDENTIALS_MISSING,
+        BasicCredentialsDefect::Base64(_) => &BASE64_MALFORMED,
+        BasicCredentialsDefect::MissingColon => &BASIC_CREDENTIALS_SEPARATOR_MISSING,
+        BasicCredentialsDefect::UserIdControlCharacter(_)
+        | BasicCredentialsDefect::PasswordControlCharacter(_) => {
+            &BASIC_CREDENTIALS_CONTROL_CHARACTER_FORBIDDEN
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Five variants, four ids — three of the mappings leave this subject or
+    /// collapse two variants, and each of those is a decision rather than an
+    /// oversight, so all five are spelled out.
+    #[test]
+    fn each_basic_credentials_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (BasicCredentialsDefect::Empty, "credentials_missing"),
+            (
+                BasicCredentialsDefect::Base64(base64::DecodeError::InvalidPadding),
+                "base64_malformed",
+            ),
+            (
+                BasicCredentialsDefect::MissingColon,
+                "basic_credentials_separator_missing",
+            ),
+            (
+                BasicCredentialsDefect::UserIdControlCharacter(0x01),
+                "basic_credentials_control_character_forbidden",
+            ),
+            (
+                BasicCredentialsDefect::PasswordControlCharacter(0x01),
+                "basic_credentials_control_character_forbidden",
+            ),
+        ] {
+            assert_eq!(basic_credentials_defect(&defect).id, id);
+        }
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -30,6 +30,8 @@ use linkme::distributed_slice;
 use std::sync::LazyLock;
 
 pub mod auth_scheme;
+pub mod base64;
+pub mod basic_credentials;
 pub mod challenge;
 pub mod cookie;
 pub mod credentials;
@@ -343,7 +345,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 60;
+        const FLOOR: usize = 63;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1641,6 +1641,8 @@ sources:
       line: 511
     - file: lint-http-rules/src/helpers/websocket.rs
       line: 210
+    - file: lint-http-rules/src/violations/base64.rs
+      line: 41
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 3.5
     snippet: MAY chose to reject an encoding if the pad bits have not been set to zero.
@@ -3770,13 +3772,15 @@ sources:
     snippet: The value is computed based on user-id and password as defined below.
     cited_by:
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 100
+      line: 123
   - label: lint-http-rules/src/helpers/auth.rs
     section: § 2
     snippet: The user-id and password MUST NOT contain any control characters
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 524
+    - file: lint-http-rules/src/violations/basic_credentials.rs
+      line: 60
   - label: basic-credentials base64
     section: § 2
     snippet: and obtains the basic-credentials by encoding this octet sequence using Base64
@@ -3789,6 +3793,8 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/auth.rs
       line: 516
+    - file: lint-http-rules/src/violations/basic_credentials.rs
+      line: 45
 - label: RFC 7838
   url: https://www.rfc-editor.org/rfc/rfc7838.html
   fragments:
@@ -6473,7 +6479,7 @@ sources:
     - file: lint-http-rules/src/rules/auth_scheme_registered.rs
       line: 129
     - file: lint-http-rules/src/rules/basic_auth_base64_valid.rs
-      line: 85
+      line: 104
     - file: lint-http-rules/src/rules/bearer_token_syntax.rs
       line: 90
     - file: lint-http-rules/src/rules/digest_auth_valid.rs


### PR DESCRIPTION
`basic_auth_base64_valid` converts, and most of what it reports turns out not to belong to the scheme. RFC 7617 §2 writes two sentences of its own — the colon that says where the user-id stops, and the control characters forbidden in either half — so those are the two defects named after it, the second at `error` because the document says MUST NOT rather than leaving it to be inferred.

The other two leave. A `Basic` with nothing after it is `credentials_missing`, the framework's defect, which the rule reading the same request through §11.4 already reports under that name — one `Authorization: Basic` drew two differently-worded findings before, and now draws one name twice. A value that does not decode is `base64_malformed`, in a subject of its own, because RFC 4648 §3.3's MUST answers for every field carrying an encoding: the WebSocket handshake's key and its accept token are the next two, and that reader splits the same failure three ways, so a coarse def and finer ones will sit in the subject together — two readers, not two vocabularies.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
