### PR TITLE
A Content-Range says how it failed to parse

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1107,6 +1107,50 @@ severity = "warn"
 # Authentication token68 is indistinguishable from a parameter
 severity = "info"
 
+[violations.content_range_complete_length_conflicting]
+# Content-Range complete-length does not exceed its last-pos
+severity = "error"
+
+[violations.content_range_empty]
+# Content-Range is empty
+severity = "warn"
+
+[violations.content_range_incl_range_malformed]
+# Content-Range range is not first-pos '-' last-pos
+severity = "warn"
+
+[violations.content_range_numeral_invalid]
+# Content-Range numeral is too large to represent
+severity = "warn"
+
+[violations.content_range_numeral_malformed]
+# Content-Range numeral is not 1*DIGIT
+severity = "warn"
+
+[violations.content_range_positions_conflicting]
+# Content-Range first-pos is greater than its last-pos
+severity = "error"
+
+[violations.content_range_slash_missing]
+# Content-Range has no '/'
+severity = "warn"
+
+[violations.content_range_spec_missing]
+# Content-Range has no range after its unit
+severity = "warn"
+
+[violations.content_range_spec_whitespace_forbidden]
+# Content-Range holds whitespace after its single space
+severity = "warn"
+
+[violations.content_range_unit_malformed]
+# Content-Range unit is not a token
+severity = "warn"
+
+[violations.content_range_unsatisfied_range_malformed]
+# Content-Range writes something other than '*' before its '/'
+severity = "warn"
+
 [violations.cookie_domain_empty]
 # Set-Cookie Domain attribute is empty
 severity = "warn"

--- a/docs/rules/range_and_content_range_consistent.md
+++ b/docs/rules/range_and_content_range_consistent.md
@@ -27,6 +27,8 @@ A 416 answering a *partial PUT* is the exception: such a request names its range
 - [RFC 9110 §15.3.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7): 206 Partial Content: single-part 206 responses MUST include a `Content-Range` header describing the enclosed range
 - [RFC 9110 §15.3.7.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2): 206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response
 - [RFC 9110 §14.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4): Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges
+- [RFC 9110 §14.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1): Range Units — the `range-unit` token, case-insensitive and registered
+- [RFC 9110 §14.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2): Byte Ranges — positions are decimal numbers of octets, and recipients must anticipate large ones rather than overflow on them
 - [RFC 9110 §15.5.17](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.5.17): 416 Range Not Satisfiable: the status code is the rejection of the ranges in the request's `Range` field; a server answering a *byte*-range request SHOULD include `Content-Range: bytes */<complete-length>`
 
 ## Configuration

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1271,14 +1271,16 @@ severity = "warn"
     /// list before its members were grouped, and
     /// `authorization_credentials_present` the one that read the credentials
     /// after the scheme, `basic_auth_base64_valid` the one that read what was
-    /// inside them, and `bearer_token_syntax` the one that read the token.
+    /// inside them, `bearer_token_syntax` the one that read the token, and
+    /// `range_and_content_range_consistent` the one that parsed the
+    /// `Content-Range` it goes on to compare.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 162;
+        const FLOOR: usize = 161;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/range_and_content_range_consistent.rs
+++ b/lint-http-rules/src/rules/range_and_content_range_consistent.rs
@@ -4,8 +4,39 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_range::{
+    content_range_defect, CONTENT_RANGE_COMPLETE_LENGTH_CONFLICTING, CONTENT_RANGE_EMPTY,
+    CONTENT_RANGE_INCL_RANGE_MALFORMED, CONTENT_RANGE_NUMERAL_INVALID,
+    CONTENT_RANGE_NUMERAL_MALFORMED, CONTENT_RANGE_POSITIONS_CONFLICTING,
+    CONTENT_RANGE_SLASH_MISSING, CONTENT_RANGE_SPEC_MISSING,
+    CONTENT_RANGE_SPEC_WHITESPACE_FORBIDDEN, CONTENT_RANGE_UNIT_MALFORMED,
+    CONTENT_RANGE_UNSATISFIED_RANGE_MALFORMED, RFC_9110_14_1, RFC_9110_14_1_2, RFC_9110_14_4,
+};
+use crate::violations::ViolationDef;
 
 pub struct RangeAndContentRangeConsistent;
+
+/// The defects this rule reports so far, and they are all one field's: the
+/// eleven ways `Content-Range = range-unit SP ( range-resp / unsatisfied-range )`
+/// is not that. They are the *field's* rather than this rule's — five other
+/// rules parse the same value, and the four that only ask whether it parsed
+/// will report these same ids when they say why.
+///
+/// The rest of what this rule says is about two fields *agreeing*, which is a
+/// different subject and converts with the reading that owns the pair.
+static DECLARED: &[&ViolationDef] = &[
+    &CONTENT_RANGE_EMPTY,
+    &CONTENT_RANGE_UNIT_MALFORMED,
+    &CONTENT_RANGE_SPEC_MISSING,
+    &CONTENT_RANGE_SPEC_WHITESPACE_FORBIDDEN,
+    &CONTENT_RANGE_SLASH_MISSING,
+    &CONTENT_RANGE_UNSATISFIED_RANGE_MALFORMED,
+    &CONTENT_RANGE_INCL_RANGE_MALFORMED,
+    &CONTENT_RANGE_NUMERAL_MALFORMED,
+    &CONTENT_RANGE_NUMERAL_INVALID,
+    &CONTENT_RANGE_POSITIONS_CONFLICTING,
+    &CONTENT_RANGE_COMPLETE_LENGTH_CONFLICTING,
+];
 
 pub struct RangeConsistencyConfig {
     pub severity: crate::lint::Severity,
@@ -99,12 +130,6 @@ const RFC_9110_15_3_7_2: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7.2",
     note: "206 Partial Content, multiple parts: the parts carry the `Content-Range` fields and the header section MUST NOT carry one; a request for a single range MUST NOT be answered with a multipart response",
 };
-const RFC_9110_14_4: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("14.4"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4",
-    note: "Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges",
-};
 const RFC_9110_15_5_17: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
     section: Some("15.5.17"),
@@ -152,8 +177,14 @@ units = ["bytes"]
             RFC_9110_15_3_7,
             RFC_9110_15_3_7_2,
             RFC_9110_14_4,
+            RFC_9110_14_1,
+            RFC_9110_14_1_2,
             RFC_9110_15_5_17,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -360,8 +391,8 @@ impl Rule for RangeAndContentRangeConsistent {
                         return Some(self.violation(config.severity, "206 response uses the unsatisfied-range form ('*/complete-length'), which describes no enclosed range (that form belongs in a 416)".into()));
                     }
                     Err(e) => {
-                        return Some(self.violation(
-                            config.severity,
+                        return Some(ctx.report_with(
+                            content_range_defect(e),
                             format!("Invalid Content-Range header '{}': {}", cr, e.message()),
                         ));
                     }
@@ -424,9 +455,8 @@ impl Rule for RangeAndContentRangeConsistent {
                                     .into()));
                     }
                     Err(e) => {
-                        return Some(self.cited(
-                            &RFC_9110_14_4,
-                            config.severity,
+                        return Some(ctx.report_with(
+                            content_range_defect(e),
                             format!("Invalid Content-Range header '{}': {}", cr, e.message()),
                         ));
                     }

--- a/lint-http-rules/src/violations/content_range.rs
+++ b/lint-http-rules/src/violations/content_range.rs
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Content-Range` defects — the eleven ways a server's account of what it sent
+//! is not one.
+//!
+//! `Content-Range = range-unit SP ( range-resp / unsatisfied-range )`, and the
+//! entries below follow the value left to right the way the parser does: the
+//! field, the unit, the single space, the `/`, the `-`, the numerals, and then
+//! the two conditions that are not grammar at all.
+//!
+//! **Those last two are why this subject has two severities.** § 14.4 writes one
+//! sentence declaring a value *invalid* when its `last-pos` precedes its
+//! `first-pos`, or when its `complete-length` does not exceed its `last-pos`.
+//! Such a value is well formed by the ABNF; what is wrong with it is that no
+//! representation has the shape it describes, and a cache that recombines on it
+//! writes octets nobody sent. Everything else here is a value a recipient
+//! cannot parse — bad, and bad in a way that stops at the parse.
+
+use crate::helpers::content_range::ContentRangeDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The field: its grammar, and the sentence that says which well-formed values
+/// are invalid anyway.
+pub const RFC_9110_14_4: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.4"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.4",
+    note: "Content-Range: syntax of `Content-Range` and the semantics for satisfied and unsatisfiable ranges",
+};
+
+/// Range units: what the name at the front of the value has to be.
+pub const RFC_9110_14_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1",
+    note: "Range Units — the `range-unit` token, case-insensitive and registered",
+};
+
+/// The sentence asking a recipient to anticipate numerals larger than it can
+/// hold, which is what the overflow defect reports rather than suffers.
+pub const RFC_9110_14_1_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("14.1.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2",
+    note: "Byte Ranges — positions are decimal numbers of octets, and recipients must anticipate large ones rather than overflow on them",
+};
+
+defects! {
+    /// A `Content-Range` present with nothing in it once the field's own
+    /// whitespace is off.
+    ///
+    // cite(RFC 9110 § 14.4): "Content-Range = range-unit SP ( range-resp / unsatisfied-range )"
+    CONTENT_RANGE_EMPTY = {
+        id: "content_range_empty",
+        title: "Content-Range is empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// A `range-unit` that is not a `token`. Not a unit this parser fails to
+    /// model — an unmodelled one parses fine and is answered elsewhere — but a
+    /// name no registry could hold.
+    ///
+    // cite(RFC 9110 § 14.1): "All range unit names are case-insensitive and ought to be registered within the "HTTP Range Unit Registry", as defined in Section 16.5.1."
+    CONTENT_RANGE_UNIT_MALFORMED = {
+        id: "content_range_unit_malformed",
+        title: "Content-Range unit is not a token",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_1),
+    }
+
+    /// A value that is a `range-unit` and then stops. The production is the
+    /// unit, one space, and a form after it.
+    ///
+    // cite(RFC 9110 § 14.4): "Content-Range = range-unit SP ( range-resp / unsatisfied-range )"
+    CONTENT_RANGE_SPEC_MISSING = {
+        id: "content_range_spec_missing",
+        title: "Content-Range has no range after its unit",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// Whitespace inside the part after the space. The production holds exactly
+    /// one, and it has already been used by the time this part is read.
+    ///
+    // cite(RFC 9110 § 14.4): "Content-Range = range-unit SP ( range-resp / unsatisfied-range )"
+    CONTENT_RANGE_SPEC_WHITESPACE_FORBIDDEN = {
+        id: "content_range_spec_whitespace_forbidden",
+        title: "Content-Range holds whitespace after its single space",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// No `/`. Both forms the field can take have one.
+    ///
+    // cite(RFC 9110 § 14.4): "range-resp = incl-range "/" ( complete-length / "*" )"
+    CONTENT_RANGE_SLASH_MISSING = {
+        id: "content_range_slash_missing",
+        title: "Content-Range has no '/'",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// Something before the `/` that opens with `*` and is not exactly `*`.
+    /// `unsatisfied-range` starts with a two-character literal rather than with
+    /// a wildcard that can be decorated.
+    ///
+    // cite(RFC 9110 § 14.4): "unsatisfied-range = "*/" complete-length"
+    CONTENT_RANGE_UNSATISFIED_RANGE_MALFORMED = {
+        id: "content_range_unsatisfied_range_malformed",
+        title: "Content-Range writes something other than '*' before its '/'",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// An `incl-range` that is not two positions around a `-`: the dash
+    /// missing, or a dash with nothing on one side of it. One def for both,
+    /// because one production answers for them and the fix is the same fix.
+    ///
+    // cite(RFC 9110 § 14.4): "incl-range = first-pos "-" last-pos"
+    CONTENT_RANGE_INCL_RANGE_MALFORMED = {
+        id: "content_range_incl_range_malformed",
+        title: "Content-Range range is not first-pos '-' last-pos",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// A numeral that is not `1*DIGIT` — whichever of the three it was, which
+    /// the message says.
+    ///
+    // cite(RFC 9110 § 14.4): "complete-length = 1*DIGIT"
+    CONTENT_RANGE_NUMERAL_MALFORMED = {
+        id: "content_range_numeral_malformed",
+        title: "Content-Range numeral is not 1*DIGIT",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// A numeral that *is* `1*DIGIT` and is larger than a reader can hold. It
+    /// derives from the grammar, so it is `_invalid` rather than `_malformed`:
+    /// § 14.1.2 asks recipients to anticipate large numerals instead of
+    /// overflowing on them, and this is that anticipation reported rather than
+    /// suffered — a position no recipient can represent addresses the octets of
+    /// no representation.
+    ///
+    // cite(RFC 9110 § 14.1.2): "In the byte-range syntax, first-pos, last-pos, and suffix-length are expressed as decimal number of octets.  Since there is no predefined limit to the length of content, recipients MUST anticipate potentially large decimal numerals and prevent parsing errors due to integer conversion overflows."
+    CONTENT_RANGE_NUMERAL_INVALID = {
+        id: "content_range_numeral_invalid",
+        title: "Content-Range numeral is too large to represent",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_14_1_2),
+    }
+
+    /// `last-pos` below `first-pos`. The first of § 14.4's two invalidity
+    /// conditions: the value is well formed and describes a range that runs
+    /// backwards, so nothing a server could have sent has that shape.
+    /// `error` by default — a recipient acting on it recombines octets from
+    /// positions the response never held.
+    ///
+    // cite(RFC 9110 § 14.4): "A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value."
+    CONTENT_RANGE_POSITIONS_CONFLICTING = {
+        id: "content_range_positions_conflicting",
+        title: "Content-Range first-pos is greater than its last-pos",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_14_4),
+    }
+
+    /// `complete-length` at or below `last-pos`. The second condition, and the
+    /// same reading: positions are zero-based and inclusive, so a `last-pos` of
+    /// 499 needs a length of 500 to be the last octet rather than one past the
+    /// end. `error` for the same reason as its neighbour — a cache sizing a
+    /// stored representation from this writes it short.
+    ///
+    // cite(RFC 9110 § 14.4): "A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value."
+    CONTENT_RANGE_COMPLETE_LENGTH_CONFLICTING = {
+        id: "content_range_complete_length_conflicting",
+        title: "Content-Range complete-length does not exceed its last-pos",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_14_4),
+    }
+}
+
+/// The defect a parsed [`ContentRangeDefect`] reports as.
+pub fn content_range_defect(defect: ContentRangeDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        ContentRangeDefect::Empty => &CONTENT_RANGE_EMPTY,
+        ContentRangeDefect::Unit(_) => &CONTENT_RANGE_UNIT_MALFORMED,
+        ContentRangeDefect::MissingRangeResp => &CONTENT_RANGE_SPEC_MISSING,
+        ContentRangeDefect::WhitespaceInRangeResp(_) => &CONTENT_RANGE_SPEC_WHITESPACE_FORBIDDEN,
+        ContentRangeDefect::MissingSlash => &CONTENT_RANGE_SLASH_MISSING,
+        ContentRangeDefect::ValueBeforeSlash => &CONTENT_RANGE_UNSATISFIED_RANGE_MALFORMED,
+        ContentRangeDefect::MissingDash | ContentRangeDefect::MissingPosition => {
+            &CONTENT_RANGE_INCL_RANGE_MALFORMED
+        }
+        ContentRangeDefect::NotDigits { .. } => &CONTENT_RANGE_NUMERAL_MALFORMED,
+        ContentRangeDefect::TooLarge { .. } => &CONTENT_RANGE_NUMERAL_INVALID,
+        ContentRangeDefect::FirstPosAfterLastPos => &CONTENT_RANGE_POSITIONS_CONFLICTING,
+        ContentRangeDefect::CompleteLengthNotAfterLastPos { .. } => {
+            &CONTENT_RANGE_COMPLETE_LENGTH_CONFLICTING
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::content_range::Numeral;
+
+    /// Twelve variants, eleven ids: the two halves of a malformed `incl-range`
+    /// answer with one def, which is a decision, and every other row is its
+    /// own.
+    #[test]
+    fn each_content_range_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (ContentRangeDefect::Empty, "content_range_empty"),
+            (
+                ContentRangeDefect::Unit("by tes"),
+                "content_range_unit_malformed",
+            ),
+            (
+                ContentRangeDefect::MissingRangeResp,
+                "content_range_spec_missing",
+            ),
+            (
+                ContentRangeDefect::WhitespaceInRangeResp("0-1 /2"),
+                "content_range_spec_whitespace_forbidden",
+            ),
+            (
+                ContentRangeDefect::MissingSlash,
+                "content_range_slash_missing",
+            ),
+            (
+                ContentRangeDefect::ValueBeforeSlash,
+                "content_range_unsatisfied_range_malformed",
+            ),
+            (
+                ContentRangeDefect::MissingDash,
+                "content_range_incl_range_malformed",
+            ),
+            (
+                ContentRangeDefect::MissingPosition,
+                "content_range_incl_range_malformed",
+            ),
+            (
+                ContentRangeDefect::NotDigits {
+                    numeral: Numeral::FirstPos,
+                    value: "x",
+                },
+                "content_range_numeral_malformed",
+            ),
+            (
+                ContentRangeDefect::TooLarge {
+                    numeral: Numeral::CompleteLength,
+                    value: "9".repeat(40).leak(),
+                },
+                "content_range_numeral_invalid",
+            ),
+            (
+                ContentRangeDefect::FirstPosAfterLastPos,
+                "content_range_positions_conflicting",
+            ),
+            (
+                ContentRangeDefect::CompleteLengthNotAfterLastPos {
+                    length: 10,
+                    last: 20,
+                },
+                "content_range_complete_length_conflicting",
+            ),
+        ] {
+            assert_eq!(content_range_defect(defect).id, id);
+        }
+    }
+
+    /// The two conditions § 14.4 calls *invalid* rank above the ones a parser
+    /// simply cannot get past: both of those values are well formed, and both
+    /// describe a representation that cannot exist.
+    #[test]
+    fn the_two_invalidity_conditions_rank_above_the_parse_failures() {
+        assert_eq!(
+            CONTENT_RANGE_POSITIONS_CONFLICTING.default_severity,
+            Severity::Error
+        );
+        assert_eq!(
+            CONTENT_RANGE_COMPLETE_LENGTH_CONFLICTING.default_severity,
+            Severity::Error
+        );
+        assert_eq!(CONTENT_RANGE_SLASH_MISSING.default_severity, Severity::Warn);
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -33,6 +33,7 @@ pub mod auth_scheme;
 pub mod base64;
 pub mod basic_credentials;
 pub mod challenge;
+pub mod content_range;
 pub mod cookie;
 pub mod credentials;
 pub mod domain;
@@ -346,7 +347,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 66;
+        const FLOOR: usize = 77;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5041,7 +5041,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_and_206_consistent.rs
       line: 118
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 236
+      line: 267
   - label: accept_ranges_on_partial_content
     section: § 14.2
     snippet: A server MUST ignore a Range header field received with a request method that is unrecognized or for which range handling is not defined.
@@ -6397,9 +6397,11 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 355
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 54
+      line: 85
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 241
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 69
   - label: lint-http-rules/src/helpers/accept_ranges.rs (2)
     section: § 14.1
     snippet: Range units are intended to be extensible, as described in Section 16.5.
@@ -6447,7 +6449,7 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 244
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 269
+      line: 300
     - file: lint-http-rules/src/rules/status_code_semantics.rs
       line: 16
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
@@ -6704,6 +6706,8 @@ sources:
       line: 338
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 394
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 158
   - label: lint-http-rules/src/helpers/content_range.rs (4)
     section: § 14.4
     snippet: A Content-Range field value is invalid if it contains a range-resp that has a last-pos value less than its first-pos value, or a complete-length value less than or equal to its last-pos value.
@@ -6712,6 +6716,10 @@ sources:
       line: 283
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 299
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 173
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 188
   - label: Content-Range grammar
     section: § 14.4
     snippet: Content-Range = range-unit SP ( range-resp / unsatisfied-range )
@@ -6720,6 +6728,12 @@ sources:
       line: 236
     - file: lint-http-rules/src/rules/singleton_fields_not_repeated.rs
       line: 36
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 56
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 81
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 93
   - label: lint-http-rules/src/helpers/content_range.rs (5)
     section: § 14.4
     snippet: complete-length = 1*DIGIT
@@ -6728,24 +6742,32 @@ sources:
       line: 258
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 337
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 142
   - label: lint-http-rules/src/helpers/content_range.rs (6)
     section: § 14.4
     snippet: incl-range = first-pos "-" last-pos
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 268
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 130
   - label: lint-http-rules/src/helpers/content_range.rs (7)
     section: § 14.4
     snippet: range-resp = incl-range "/" ( complete-length / "*" )
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 267
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 104
   - label: lint-http-rules/src/helpers/content_range.rs (8)
     section: § 14.4
     snippet: unsatisfied-range = "*/" complete-length
     cited_by:
     - file: lint-http-rules/src/helpers/content_range.rs
       line: 251
+    - file: lint-http-rules/src/violations/content_range.rs
+      line: 117
   - label: lint-http-rules/src/helpers/content_range.rs (9)
     section: § 5.5
     snippet: A field value does not include leading or trailing whitespace.
@@ -7229,7 +7251,7 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 164
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 73
+      line: 104
   - label: lint-http-rules/src/helpers/media_type.rs (6)
     section: § 8.3.1
     snippet: The type/subtype MAY be followed by semicolon-delimited parameters (Section 5.6.6) in the form of name/value pairs.
@@ -7913,97 +7935,97 @@ sources:
     snippet: If the representation data has a content coding applied, each byte range is calculated with respect to the encoded sequence of bytes, not the sequence of underlying bytes that would be obtained after decoding.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 331
+      line: 362
   - label: range_and_content_range_consistent (2)
     section: § 14.1.2
     snippet: The first-pos value in a bytes int-range gives the offset of the first byte in a range.  The last-pos value gives the offset of the last byte in the range; that is, the byte positions specified are inclusive.  Byte offsets start at zero.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 318
+      line: 349
   - label: range_and_content_range_consistent (3)
     section: § 14.4
     snippet: 'A server generating a 416 (Range Not Satisfiable) response to a byte-range request SHOULD send a Content-Range header field with an unsatisfied-range value, as in the following example:'
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 404
+      line: 435
   - label: range_and_content_range_consistent (4)
     section: § 14.4
     snippet: If a 206 (Partial Content) response contains a Content-Range header field with a range unit (Section 14.1) that the recipient does not understand, the recipient MUST NOT attempt to recombine it with a stored representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 319
+      line: 350
   - label: range_and_content_range_consistent (5)
     section: § 14.4
     snippet: The "Content-Range" header field is sent in a single part 206 (Partial Content) response to indicate the partial range of the selected representation enclosed as the message content, sent in each part of a multipart 206 response to indicate the range enclosed within each body part (Section 14.6), and sent in 416 (Range Not Satisfiable) responses to provide information about the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 243
+      line: 274
   - label: range_and_content_range_consistent (6)
     section: § 14.4
     snippet: The Content-Range header field has no meaning for status codes that do not explicitly describe its semantic.  For this specification, only the 206 (Partial Content) and 416 (Range Not Satisfiable) status codes describe a meaning for Content-Range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 204
+      line: 235
   - label: range_and_content_range_consistent (7)
     section: § 14.4
     snippet: The complete-length in a 416 response indicates the current length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 422
+      line: 453
   - label: range_and_content_range_consistent (8)
     section: § 14.5
     snippet: Some origin servers support PUT of a partial representation when the user agent sends a Content-Range header field (Section 14.4) in the request, though such support is inconsistent and depends on private agreements with user agents.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 387
+      line: 418
   - label: range_and_content_range_consistent (9)
     section: § 15.3.7
     snippet: A Content-Length header field present in a 206 response indicates the number of octets in the content of this message, which is usually not the complete length of the selected representation.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 330
+      line: 361
   - label: range_and_content_range_consistent (10)
     section: § 15.3.7.1
     snippet: If a single part is being transferred, the server generating the 206 response MUST generate a Content-Range header field, describing what range of the selected representation is enclosed, and a content consisting of the range.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 287
+      line: 318
   - label: range_and_content_range_consistent (11)
     section: § 15.3.7.2
     snippet: A server MUST NOT generate a multipart response to a request for a single range, since a client that does not request multiple parts might not support multipart responses.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 268
+      line: 299
   - label: range_and_content_range_consistent (12)
     section: § 15.3.7.2
     snippet: If multiple parts are being transferred, the server generating the 206 response MUST generate "multipart/byteranges" content, as defined in Section 14.6, and a Content-Type header field containing the "multipart/byteranges" media type and its required boundary parameter.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 254
+      line: 285
   - label: range_and_content_range_consistent (13)
     section: § 15.3.7.2
     snippet: To avoid confusion with single-part responses, a server MUST NOT generate a Content-Range header field in the HTTP header section of a multiple part response (this field will be sent in each part instead).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 256
+      line: 287
   - label: range_and_content_range_consistent (14)
     section: § 15.3.7.2
     snippet: Within the header area of each body part in the multipart content, the server MUST generate a Content-Range header field corresponding to the range being enclosed in that body part.
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 281
+      line: 312
   - label: range_and_content_range_consistent (15)
     section: § 15.5.17
     snippet: A server that generates a 416 response to a byte-range request SHOULD generate a Content-Range header field specifying the current length of the selected representation (Section 14.4).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 403
+      line: 434
   - label: range_and_content_range_consistent (16)
     section: § 15.5.17
     snippet: The 416 (Range Not Satisfiable) status code indicates that the set of ranges in the request's Range header field (Section 14.2) has been rejected either because none of the requested ranges are satisfiable or because the client has requested an excessive number of small or overlapping ranges (a potential denial of service attack).
     cited_by:
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
-      line: 386
+      line: 417
   - label: range_header_syntax
     section: § 14.1.1
     snippet: A ranges-specifier is invalid if it contains any range-spec that is invalid or undefined for the indicated range-unit.


### PR DESCRIPTION
`range_and_content_range_consistent` converts its two parsing sites: eleven names for the value `Content-Range = range-unit SP ( range-resp / unsatisfied-range )` can fail to be, following the parse left to right — the field, the unit, the single space, the slash, the dash, the numerals.

Two of them default to `error` and the rest to `warn`, which is the split the field's own section draws. §14.4 writes one sentence declaring a value *invalid* when its last-pos precedes its first-pos, or its complete-length does not exceed its last-pos: both are well formed by the ABNF, and both describe a representation that cannot exist, so a cache recombining on either writes octets nobody sent. The other nine are values a recipient cannot parse at all, which is a smaller problem.

The names are the field's rather than this rule's. Five rules parse the same value; four of them only ask whether it parsed, and when they say why they will say it under these ids.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
