### PR TITLE
A scheme name is a scheme name

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1370,3 +1370,15 @@ severity = "warn"
 [violations.token68_whitespace_or_control_forbidden]
 # token68 holds whitespace or a control character
 severity = "error"
+
+[violations.uri_scheme_character_forbidden]
+# URI scheme holds a character outside letters, digits, '+', '-' and '.'
+severity = "warn"
+
+[violations.uri_scheme_empty]
+# URI scheme is empty
+severity = "warn"
+
+[violations.uri_scheme_leading_letter_missing]
+# URI scheme does not begin with a letter
+severity = "warn"

--- a/docs/rules/referer_uri_valid.md
+++ b/docs/rules/referer_uri_valid.md
@@ -45,6 +45,7 @@ Reads the `Referer` request header field against the production RFC 9110 §10.1.
 - [RFC 3986 §4.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.3): Absolute URI — the form without a fragment identifier
 - [RFC 3986 §4.4](https://www.rfc-editor.org/rfc/rfc3986.html#section-4.4): Same-Document Reference — what an empty value is
 - [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — the triplet the `%` obliges
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/referer_uri_valid.rs
@@ -11,8 +11,29 @@ use crate::helpers::uri::{
 };
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::uri::{
+    RFC_3986_3_1, URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY,
+    URI_SCHEME_LEADING_LETTER_MISSING,
+};
+use crate::violations::ViolationDef;
 
 pub struct RefererUriValid;
+
+/// The defects this rule reports through the catalogue so far — the three ways
+/// a scheme name is not one. They are the *scheme's* and not the `Referer`'s:
+/// six rules in this tree read a scheme through the same helper, from a
+/// `Forwarded` `proto`, a `Link` target, an `Alt-Svc` value and an
+/// absolute-form request target, and each of them will report these three.
+///
+/// The rest of what this rule says about a URI reference is still on the old
+/// API: those messages are this field's own reading of `Referer =
+/// absolute-URI / partial-URI` and convert with the subjects that own the
+/// components — the authority, the path, the fragment.
+static DECLARED: &[&ViolationDef] = &[
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
+];
 
 /// The value as a finding may print it: escaped, and with the password half of a
 /// userinfo subcomponent withheld.
@@ -142,7 +163,12 @@ severity = "warn"
             RFC_3986_4_3,
             RFC_3986_4_4,
             RFC_3986_2_1,
+            RFC_3986_3_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -373,10 +399,13 @@ impl Rule for RefererUriValid {
             let scheme = scheme_prefix(value);
             if let Some(scheme) = scheme {
                 if let Err(defect) = validate_scheme_name(scheme) {
-                    return violation(format!(
+                    return Some(ctx.report_with(
+                        crate::violations::uri::scheme_name(defect),
+                        format!(
                         "Referer value '{}' derives from neither alternative of `Referer = absolute-URI / partial-URI`: {} — and a first path segment holding a colon is no `path-noscheme` either, so it is not a relative reference (RFC 3986 §4.2)",
                         shown_referer(value),
                         defect.message()
+                        ),
                     ));
                 }
             }
@@ -508,6 +537,27 @@ mod tests {
     use super::*;
     use hyper::header::{HeaderName, HeaderValue};
     use rstest::rstest;
+
+    /// The scheme findings, by name. Three ways a value's scheme candidate is
+    /// not a scheme, reported under ids that belong to RFC 3986 § 3.1 rather
+    /// than to this field — the same three a `Forwarded` `proto` or a `Link`
+    /// target will report when those rules convert.
+    #[rstest]
+    #[case(":/x", "uri_scheme_empty")]
+    #[case("1http://example.com/", "uri_scheme_leading_letter_missing")]
+    #[case("ht_tp://example.com/", "uri_scheme_character_forbidden")]
+    fn a_scheme_that_is_not_one_names_which_way(#[case] referer: &str, #[case] violation: &str) {
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("referer", referer)]);
+        let v = crate::test_helpers::run_rule(
+            &RefererUriValid,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_severity("referer_uri_valid", "warn"),
+        )
+        .unwrap_or_else(|| panic!("expected a finding for {referer:?}"));
+        assert_eq!(v.violation, violation, "{}", v.message);
+    }
 
     /// Run the rule over a request carrying `referer` field lines, with the
     /// request-target the caller names.

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 77;
+        const FLOOR: usize = 80;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/uri.rs
+++ b/lint-http-rules/src/violations/uri.rs
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! URI defects — today, the two ways a percent-encoded triplet is not one.
+//! URI defects — the escapes and the scheme name, wherever a field carries a
+//! reference.
 //!
 //! A `%` obliges two hexadecimal digits wherever it is written, and this crate
 //! reads escapes in a request target, a `Location`, a cookie `Path`, an
@@ -16,12 +17,23 @@
 //! a `cookie_path_percent_encoding_malformed` of its own, which was the same
 //! reasoning error the rule-shaped catalogue is being split to fix.
 
-use crate::helpers::uri::PercentEncodingDefect;
+use crate::helpers::uri::{PercentEncodingDefect, SchemeNameDefect};
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::{defects, ViolationDef};
 
-/// The triplet a `%` obliges, and the only sentence either defect here needs.
+/// The scheme name: one production, and the three ways a value is not it.
+/// Read out of a `Referer`, a `Forwarded` `proto`, a `Link` target, an
+/// `Alt-Svc` and an absolute-form request target, all through one helper.
+pub const RFC_3986_3_1: SpecRef = SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1",
+    note: "Scheme — `scheme = ALPHA *( ALPHA / DIGIT / \"+\" / \"-\" / \".\" )`, the name before the first colon",
+};
+
+/// The triplet a `%` obliges, and the only sentence either percent defect here
+/// needs.
 pub const RFC_3986_2_1: SpecRef = SpecRef {
     spec: "RFC 3986",
     section: Some("2.1"),
@@ -54,6 +66,51 @@ defects! {
         default_severity: Severity::Warn,
         spec: Some(RFC_3986_2_1),
     }
+    /// A value whose scheme candidate is empty — the colon with nothing before
+    /// it. `ALPHA *( … )` generates nothing empty, so this derives from no
+    /// alternative of the production.
+    ///
+    // cite(RFC 3986 § 3.1): "scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )"
+    URI_SCHEME_EMPTY = {
+        id: "uri_scheme_empty",
+        title: "URI scheme is empty",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_1),
+    }
+
+    /// A scheme opening on something that is not a letter — a digit, most
+    /// often, in a value whose first path segment happens to hold a colon.
+    ///
+    // cite(RFC 3986 § 3.1): "scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )"
+    URI_SCHEME_LEADING_LETTER_MISSING = {
+        id: "uri_scheme_leading_letter_missing",
+        title: "URI scheme does not begin with a letter",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_1),
+    }
+
+    /// A character after the first that the production does not admit: only
+    /// letters, digits, `+`, `-` and `.` follow the opening letter.
+    ///
+    // cite(RFC 3986 § 3.1): "scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )"
+    URI_SCHEME_CHARACTER_FORBIDDEN = {
+        id: "uri_scheme_character_forbidden",
+        title: "URI scheme holds a character outside letters, digits, '+', '-' and '.'",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_1),
+    }
+}
+
+/// The defect a parsed [`SchemeNameDefect`] reports as.
+pub fn scheme_name(defect: SchemeNameDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        SchemeNameDefect::Empty => &URI_SCHEME_EMPTY,
+        SchemeNameDefect::DoesNotBeginWithLetter(_) => &URI_SCHEME_LEADING_LETTER_MISSING,
+        SchemeNameDefect::BadCharacter { .. } => &URI_SCHEME_CHARACTER_FORBIDDEN,
+    }
 }
 
 /// The defect a parsed [`PercentEncodingDefect`] reports as.
@@ -67,6 +124,29 @@ pub fn percent_encoding(defect: PercentEncodingDefect<'_>) -> &'static Violation
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Three variants, three ids: a scheme that is not one fails in exactly
+    /// the places the production has — nothing there, the wrong first
+    /// character, or the wrong later one.
+    #[test]
+    fn each_scheme_name_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (SchemeNameDefect::Empty, "uri_scheme_empty"),
+            (
+                SchemeNameDefect::DoesNotBeginWithLetter("1http"),
+                "uri_scheme_leading_letter_missing",
+            ),
+            (
+                SchemeNameDefect::BadCharacter {
+                    character: '_',
+                    scheme: "ht_tp",
+                },
+                "uri_scheme_character_forbidden",
+            ),
+        ] {
+            assert_eq!(scheme_name(defect).id, id);
+        }
+    }
 
     #[test]
     fn each_percent_encoding_defect_maps_to_its_own_id() {

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -1124,7 +1124,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 291
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 353
+      line: 379
   - label: host_and_authority_consistent
     section: § 6.2.3
     snippet: Normalization should not remove delimiters when their associated component is empty unless licensed to do so by the scheme specification.
@@ -1214,9 +1214,9 @@ sources:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 49
     - file: lint-http-rules/src/violations/uri.rs
-      line: 37
-    - file: lint-http-rules/src/violations/uri.rs
       line: 49
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 61
   - label: lint-http-rules/src/helpers/uri.rs (7)
     section: § 2.2
     snippet: A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component.
@@ -1244,7 +1244,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 574
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 259
+      line: 285
   - label: lint-http-rules/src/helpers/uri.rs (9)
     section: § 2.3
     snippet: URIs that differ in the replacement of an unreserved character with its corresponding percent-encoded US-ASCII octet are equivalent
@@ -1304,7 +1304,13 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 958
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 371
+      line: 397
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 73
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 85
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 97
   - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
@@ -1326,7 +1332,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 229
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 25
+      line: 46
   - label: lint-http-rules/src/helpers/uri.rs (19)
     section: § 3.2.1
     snippet: The user information, if present, is followed by a commercial at-sign ("@") that delimits it from the host.
@@ -1414,7 +1420,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 174
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 372
+      line: 398
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 91
   - label: lint-http-rules/src/helpers/uri.rs (26)
@@ -1528,19 +1534,19 @@ sources:
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
       line: 233
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 298
+      line: 324
   - label: referer_uri_valid
     section: § 3.2.1
     snippet: Use of the format "user:password" in the userinfo field is deprecated.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 403
+      line: 432
   - label: referer_uri_valid (2)
     section: § 3.5
     snippet: The fragment identifier component of a URI allows indirect identification of a secondary resource by reference to a primary resource and additional identifying information.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 354
+      line: 380
   - label: request_target_no_fragment
     section: § 2.2
     snippet: If data for a URI component would conflict with a reserved character's purpose as a delimiter, then the conflicting data must be percent-encoded before the URI is formed.
@@ -5165,7 +5171,7 @@ sources:
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 368
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 318
+      line: 344
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 272
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
@@ -5561,7 +5567,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 289
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 351
+      line: 377
   - label: content_location_and_uri_consistent (2)
     section: § 4.1
     snippet: Each protocol element in HTTP that allows a URI reference will indicate in its ABNF production whether the element allows any form of reference (URI-reference), only a URI in absolute form (absolute-URI), only the path and optional query components (partial-URI), or some combination of the above.
@@ -5569,7 +5575,7 @@ sources:
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 290
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 352
+      line: 378
   - label: content_location_and_uri_consistent (3)
     section: § 8.7
     snippet: Content-Location = absolute-URI / partial-URI
@@ -5697,7 +5703,7 @@ sources:
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 222
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 212
+      line: 238
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 538
   - label: context_fields_direction (2)
@@ -5723,7 +5729,7 @@ sources:
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 17
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 243
+      line: 269
   - label: context_fields_direction (5)
     section: § 10.1.4
     snippet: The "TE" header field describes capabilities of the client with regard to transfer codings and trailer sections.
@@ -6069,7 +6075,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 50
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 427
+      line: 456
   - label: host_header
     section: § 7.2
     snippet: A user agent MUST generate a Host header field in a request unless it sends that information as an ":authority" pseudo-header field.
@@ -7159,7 +7165,7 @@ sources:
     - file: lint-http-rules/src/rules/redirect_chain_valid.rs
       line: 243
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 275
+      line: 301
     - file: lint-http-rules/src/rules/status_426_upgrade_valid.rs
       line: 233
     - file: lint-http-rules/src/rules/te_header_valid.rs
@@ -8273,73 +8279,73 @@ sources:
     snippet: A user agent MUST NOT include the fragment and userinfo components of the URI reference [URI], if any, when generating the Referer field value.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 350
+      line: 376
   - label: referer_uri_valid (2)
     section: § 10.1.3
     snippet: A user agent MUST NOT send a Referer header field in an unsecured HTTP request if the referring resource was accessed with a secure protocol.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 479
+      line: 508
   - label: referer_uri_valid (3)
     section: § 10.1.3
     snippet: If the target URI was obtained from a source that does not have its own URI (e.g., input from the user keyboard, or an entry within the user's bookmarks/favorites), the user agent MUST either exclude the Referer header field or send it with a value of "about:blank".
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 299
+      line: 325
   - label: Referer grammar
     section: § 10.1.3
     snippet: Referer = absolute-URI / partial-URI
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 244
+      line: 270
   - label: referer_uri_valid (4)
     section: § 17.9
     snippet: Since the Referer header field tells a target site about the context that resulted in a request, it has the potential to reveal information about the user's immediate browsing history and any personal information that might be found in the referring resource's URI.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 484
+      line: 513
   - label: partial-URI
     section: § 4.1
     snippet: partial-URI   = relative-part [ "?" query ]
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 297
+      line: 323
   - label: referer_uri_valid (5)
     section: § 4.2.1
     snippet: A sender MUST NOT generate an "http" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 425
+      line: 454
   - label: referer_uri_valid (6)
     section: § 4.2.1
     snippet: The "http" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential HTTP origin server listening for TCP ([TCP]) connections on a given port.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 482
+      line: 511
   - label: referer_uri_valid (7)
     section: § 4.2.2
     snippet: A client MUST ensure that its HTTP requests for an "https" resource are secured, prior to being communicated, and that it only accepts secured responses to those requests.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 481
+      line: 510
   - label: referer_uri_valid (8)
     section: § 4.2.2
     snippet: A sender MUST NOT generate an "https" URI with an empty host identifier.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 426
+      line: 455
   - label: referer_uri_valid (9)
     section: § 4.2.2
     snippet: Resources made available via the "https" scheme have no shared identity with the "http" scheme.  They are distinct origins with separate namespaces.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 483
+      line: 512
   - label: referer_uri_valid (10)
     section: § 4.2.2
     snippet: The "https" URI scheme is hereby defined for minting identifiers within the hierarchical namespace governed by a potential origin server listening for TCP connections on a given port and capable of establishing a TLS ([TLS13]) connection that has been secured for HTTP communication.
     cited_by:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
-      line: 480
+      line: 509
   - label: request_method_token_valid
     section: § 9.1
     snippet: All such methods ought to be registered within the "Hypertext Transfer Protocol (HTTP) Method Registry", as described in Section 16.1.


### PR DESCRIPTION
`referer_uri_valid`'s scheme branch converts, and the three defects go where percent-encoding already lives: RFC 3986 §3.1's production is read out of a `Referer`, a `Forwarded` `proto`, a `Link` target, an `Alt-Svc` value and an absolute-form request target through one helper, so the name before the first colon fails in the same three ways whichever field carried it — nothing there, a first character that is not a letter, or a later one the production does not admit.

The rest of what this rule says about a URI reference stays on the old API. Those messages are its own reading of `Referer = absolute-URI / partial-URI`, and they convert with the subjects that own the components rather than with this one.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
