### PR TITLE
A forwarded node is a node anywhere

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1331,6 +1331,34 @@ severity = "warn"
 # Mailbox is followed by something else
 severity = "warn"
 
+[violations.node_ipv4_address_malformed]
+# Node identifier is digits and dots that are not an IPv4 address
+severity = "warn"
+
+[violations.node_ipv6_address_malformed]
+# Node identifier brackets something that is not an IPv6 address
+severity = "warn"
+
+[violations.node_ipv6_brackets_missing]
+# Node identifier holds an IPv6 address without its square brackets
+severity = "warn"
+
+[violations.node_ipv6_closing_bracket_missing]
+# Node identifier opens an IPv6 literal and never closes it
+severity = "warn"
+
+[violations.node_ipv6_representation_invalid]
+# Node identifier writes an IPv6 address outside the recommended representation
+severity = "info"
+
+[violations.node_malformed]
+# Node identifier derives from no alternative of the production
+severity = "warn"
+
+[violations.node_port_malformed]
+# Node identifier holds something that is not a node-port
+severity = "warn"
+
 [violations.percent_encoding_digits_missing]
 # Percent-encoding stops before its two hexadecimal digits
 severity = "warn"
@@ -1370,6 +1398,26 @@ severity = "warn"
 [violations.token68_whitespace_or_control_forbidden]
 # token68 holds whitespace or a control character
 severity = "error"
+
+[violations.uri_host_bracket_forbidden]
+# Host holds a square bracket outside an IP literal
+severity = "warn"
+
+[violations.uri_host_character_forbidden]
+# Host holds a character outside the registered-name alphabet
+severity = "warn"
+
+[violations.uri_host_closing_bracket_missing]
+# Host opens an IP literal and never closes it
+severity = "warn"
+
+[violations.uri_host_ip_literal_malformed]
+# Host brackets something that is not an IP literal
+severity = "warn"
+
+[violations.uri_port_character_forbidden]
+# Port holds a character that is not a digit
+severity = "warn"
 
 [violations.uri_scheme_character_forbidden]
 # URI scheme holds a character outside letters, digits, '+', '-' and '.'

--- a/docs/rules/x_forwarded_consistent.md
+++ b/docs/rules/x_forwarded_consistent.md
@@ -26,10 +26,15 @@ Despite its name, this rule checks each field on its own and cross-checks nothin
 
 - [RFC 7239 §7.4](https://www.rfc-editor.org/rfc/rfc7239.html#section-7.4): Transition: what each `X-Forwarded-*` field converts into, and the one difference in how an IPv6 address is written there. The only sentences in any specification that reach these fields.
 - [RFC 7239 §1](https://www.rfc-editor.org/rfc/rfc7239.html#section-1): Names `X-Forwarded-For`, `X-Forwarded-By` and `X-Forwarded-Proto` as non-standard header fields
-- [RFC 7239 §6](https://www.rfc-editor.org/rfc/rfc7239.html#section-6): `node` — the identifier an `X-Forwarded-For` / `X-Forwarded-By` member becomes once §7.4's conversion prepends `for=` / `by=`
+- [RFC 7239 §6](https://www.rfc-editor.org/rfc/rfc7239.html#section-6): `node` — an IPv4 address, a bracketed IPv6 address, `unknown` or an obfuscated identifier, each optionally followed by a `node-port`
+- [RFC 7239 §6.1](https://www.rfc-editor.org/rfc/rfc7239.html#section-6.1): How an `IPv6address` is spelled in a node identifier: always in square brackets, and following RFC 5952's textual representation recommendations
 - [RFC 7239 §5.4](https://www.rfc-editor.org/rfc/rfc7239.html#section-5.4): `proto` is a URI scheme name; `http` and `https` are called typical, not exhaustive
 - [RFC 7239 §5.3](https://www.rfc-editor.org/rfc/rfc7239.html#section-5.3): `host` conforms to the `Host` field ABNF. That `X-Forwarded-Host` is the field this parameter carries is a reading of §7.4's `X-Forwarded-*` wildcard, not a sentence.
 - [RFC 9110 §7.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.2): `Host = uri-host [ ":" port ]`, the production an `X-Forwarded-Host` member is measured against
+- [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1): Scheme — `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, the name before the first colon
+- [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2): Host — `host = IP-literal / IPv4address / reg-name`, where the square brackets of the IP literal are the only ones the URI syntax admits anywhere
+- [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
+- [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/uri.rs
+++ b/lint-http-rules/src/helpers/uri.rs
@@ -1242,17 +1242,52 @@ pub fn port_number(digits: &str) -> Option<u16> {
 // cite(RFC 9110 § 7.2, label: Host grammar): "Host = uri-host [ ":" port ]"
 // cite(RFC 3986 § 3.2.3): "The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character."
 // cite(RFC 3986 § 3.2.3): "URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default."
-pub fn validate_host_and_optional_port(value: &str) -> Result<(), String> {
+pub fn validate_host_and_optional_port(value: &str) -> Result<(), HostAndPortDefect<'_>> {
     let (host, port) = split_host_and_port(value);
 
-    validate_uri_host(host).map_err(UriHostDefect::message)?;
+    validate_uri_host(host).map_err(HostAndPortDefect::Host)?;
 
     if let Some(port) = port {
         if let Some(c) = port.chars().find(|c| !c.is_ascii_digit()) {
-            return Err(format!("invalid character '{}' in port '{}'", c, port));
+            return Err(HostAndPortDefect::PortCharacter { character: c, port });
         }
     }
     Ok(())
+}
+
+/// What a `uri-host [ ":" port ]` fails to be.
+///
+/// Two halves and therefore two variants: everything the host can be wrong
+/// about is [`UriHostDefect`]'s and is nested rather than flattened, because a
+/// host is the same production wherever it is read and this composition adds
+/// nothing to it. What the composition does add is the second half — a `port`
+/// of `*DIGIT` — and that is the only defect spelled out here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostAndPortDefect<'a> {
+    /// The `uri-host` half.
+    Host(UriHostDefect<'a>),
+    /// A character in the port that is not a `DIGIT`. There is no out-of-range
+    /// variant beside it: `port = *DIGIT` bounds nothing at either end, and a
+    /// rule wanting the transport's namespace wants [`port_number`] and a
+    /// sentence of its own.
+    PortCharacter {
+        /// The character.
+        character: char,
+        /// The port it was found in.
+        port: &'a str,
+    },
+}
+
+impl HostAndPortDefect<'_> {
+    /// The finding fragment.
+    pub fn message(self) -> String {
+        match self {
+            Self::Host(defect) => defect.message(),
+            Self::PortCharacter { character, port } => {
+                format!("invalid character '{}' in port '{}'", character, port)
+            }
+        }
+    }
 }
 
 // ── The serialized origin ────────────────────────────────────────────

--- a/lint-http-rules/src/rules/forwarded_header_valid.rs
+++ b/lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -54,7 +54,12 @@ fn validate_node(param: &str, value: &str) -> Option<String> {
 fn validate_host(value: &str) -> Option<String> {
     crate::helpers::uri::validate_host_and_optional_port(value)
         .err()
-        .map(|e| format!("Forwarded 'host' is not a Host field value: {}", e))
+        .map(|defect| {
+            format!(
+                "Forwarded 'host' is not a Host field value: {}",
+                defect.message()
+            )
+        })
 }
 
 /// A `proto=` value, after unescaping: a URI scheme name.

--- a/lint-http-rules/src/rules/host_header.rs
+++ b/lint-http-rules/src/rules/host_header.rs
@@ -249,11 +249,15 @@ impl Rule for HostHeader {
             // is the `Host` production; the port it admits is `*DIGIT`, which is
             // the whole of what RFC 3986 §3.2.3 says a port looks like.
             // cite(RFC 9110 § 7.2, label: Host grammar): "Host = uri-host [ ":" port ]"
-            if let Err(msg) = crate::helpers::uri::validate_host_and_optional_port(s) {
+            if let Err(defect) = crate::helpers::uri::validate_host_and_optional_port(s) {
                 return Some(self.cited(
                     &RFC_9110_7_2,
                     ctx.severity,
-                    format!("Host field value '{}' is not a host and port: {}", s, msg),
+                    format!(
+                        "Host field value '{}' is not a host and port: {}",
+                        s,
+                        defect.message()
+                    ),
                 ));
             }
 

--- a/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
+++ b/lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
@@ -53,9 +53,10 @@ fn connect_authority_finding(authority: &str) -> Option<String> {
     }
 
     let (host, port) = crate::helpers::uri::split_host_and_port(authority);
-    if let Err(msg) = crate::helpers::uri::validate_host_and_optional_port(authority) {
+    if let Err(defect) = crate::helpers::uri::validate_host_and_optional_port(authority) {
+        let message = defect.message();
         return Some(format!(
-            "CONNECT ':authority' '{shown}' is not a host and port: {msg}"
+            "CONNECT ':authority' '{shown}' is not a host and port: {message}"
         ));
     }
 
@@ -461,12 +462,15 @@ impl Rule for Http2PseudoHeadersValid {
                 // an IP literal, the address inside it, and a port of digits. The
                 // copy this replaced guessed at an unbracketed IPv6 literal by
                 // counting colons.
-                if let Err(msg) = crate::helpers::uri::validate_host_and_optional_port(&authority) {
+                if let Err(defect) =
+                    crate::helpers::uri::validate_host_and_optional_port(&authority)
+                {
                     return Some(self.violation(
                         ctx.severity,
                         format!(
-                            "Authority '{}' is not a host and port: {msg}",
-                            crate::helpers::shown::shown_in_finding(&authority)
+                            "Authority '{}' is not a host and port: {}",
+                            crate::helpers::shown::shown_in_finding(&authority),
+                            defect.message()
                         ),
                     ));
                 }

--- a/lint-http-rules/src/rules/referer_uri_valid.rs
+++ b/lint-http-rules/src/rules/referer_uri_valid.rs
@@ -475,11 +475,11 @@ impl Rule for RefererUriValid {
                 // `uri-host [ ":" port ]` is one question with one answer, and the
                 // shared reader is where it lives: the bracket that distinguishes an
                 // IP literal, the address inside it, and a port of digits.
-                if let Err(msg) = validate_host_and_optional_port(host_and_port) {
+                if let Err(defect) = validate_host_and_optional_port(host_and_port) {
                     return violation(format!(
                         "Referer value '{}' does not carry a well-formed authority: {}",
                         shown_referer(value),
-                        msg
+                        defect.message()
                     ));
                 }
             }

--- a/lint-http-rules/src/rules/warning_header_syntax.rs
+++ b/lint-http-rules/src/rules/warning_header_syntax.rs
@@ -506,11 +506,11 @@ fn validate_warn_agent(agent: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    validate_host_and_optional_port(agent).map_err(|e| {
+    validate_host_and_optional_port(agent).map_err(|defect| {
         format!(
             "has a warn-agent '{}' that is neither a pseudonym nor a host and port: {}",
             shown_in_finding(agent),
-            e
+            defect.message()
         )
     })
 }

--- a/lint-http-rules/src/rules/x_forwarded_consistent.rs
+++ b/lint-http-rules/src/rules/x_forwarded_consistent.rs
@@ -20,6 +20,20 @@ use crate::helpers::forwarded_node::NodeForm;
 use crate::helpers::headers::combined_field_value_as_written;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::node::{
+    node_defect, NODE_IPV4_ADDRESS_MALFORMED, NODE_IPV6_ADDRESS_MALFORMED,
+    NODE_IPV6_BRACKETS_MISSING, NODE_IPV6_CLOSING_BRACKET_MISSING,
+    NODE_IPV6_REPRESENTATION_INVALID, NODE_MALFORMED, NODE_PORT_MALFORMED, RFC_7239_6,
+    RFC_7239_6_1,
+};
+use crate::violations::uri::{
+    host_and_port, scheme_name, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED,
+    RFC_3986_2_1, RFC_3986_3_1, RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN,
+    URI_HOST_CHARACTER_FORBIDDEN, URI_HOST_CLOSING_BRACKET_MISSING, URI_HOST_IP_LITERAL_MALFORMED,
+    URI_PORT_CHARACTER_FORBIDDEN, URI_SCHEME_CHARACTER_FORBIDDEN, URI_SCHEME_EMPTY,
+    URI_SCHEME_LEADING_LETTER_MISSING,
+};
+use crate::violations::ViolationDef;
 
 /// The production a field's members are measured against, after §7.4's
 /// conversion has said which `Forwarded` parameter each field becomes.
@@ -71,8 +85,49 @@ fn members(value: &str) -> impl Iterator<Item = &str> {
         .filter(|m| !m.is_empty())
 }
 
-/// One member of one field: the finding's text, or `None`.
-fn check_member(field: &str, kind: Members, member: &str) -> Option<String> {
+/// Everything this rule can say, and none of it is this rule's own: three
+/// productions read through three shared helpers, so every id here is the
+/// vocabulary of a document rather than of a field the specifications call
+/// non-standard. That is the whole of §7.4's conversion made into a catalogue —
+/// an `X-Forwarded-For` member that is not a node identifier draws the same
+/// defect a `Forwarded` `for=` value will, because it is the same defect.
+///
+/// Two of the node entries are unreachable from here and declared anyway. The
+/// brackets and the textual representation are asked of the `Forwarded`
+/// spelling only — §7.4 records that these fields do not bracket — so the
+/// mapping is exhaustive over a helper whose other caller reaches them.
+static DECLARED: &[&ViolationDef] = &[
+    &NODE_IPV6_BRACKETS_MISSING,
+    &NODE_IPV6_CLOSING_BRACKET_MISSING,
+    &NODE_IPV6_ADDRESS_MALFORMED,
+    &NODE_IPV4_ADDRESS_MALFORMED,
+    &NODE_MALFORMED,
+    &NODE_IPV6_REPRESENTATION_INVALID,
+    &NODE_PORT_MALFORMED,
+    &URI_SCHEME_EMPTY,
+    &URI_SCHEME_LEADING_LETTER_MISSING,
+    &URI_SCHEME_CHARACTER_FORBIDDEN,
+    &URI_HOST_CLOSING_BRACKET_MISSING,
+    &URI_HOST_IP_LITERAL_MALFORMED,
+    &URI_HOST_BRACKET_FORBIDDEN,
+    &URI_HOST_CHARACTER_FORBIDDEN,
+    &URI_PORT_CHARACTER_FORBIDDEN,
+    &PERCENT_ENCODING_DIGITS_MISSING,
+    &PERCENT_ENCODING_MALFORMED,
+];
+
+/// One member of one field: the defect it reports as and the finding's text, or
+/// `None`.
+///
+/// The pair is what a judge function hands back once the catalogue exists. The
+/// message is still formatted here, where its arguments are, and the def comes
+/// from the subject that owns the production — so the one site below decides
+/// nothing about either.
+fn check_member(
+    field: &str,
+    kind: Members,
+    member: &str,
+) -> Option<(&'static ViolationDef, String)> {
     match kind {
         // §7.4 converts an element of this field into a `for=` value by
         // prepending `for=`, and §5.2 sends that value to §6's `node` — so an
@@ -86,7 +141,12 @@ fn check_member(field: &str, kind: Members, member: &str) -> Option<String> {
         Members::Node => {
             crate::helpers::forwarded_node::validate_node(member, NodeForm::XForwarded)
                 .err()
-                .map(|defect| format!("{} {}", field, defect.message()))
+                .map(|defect| {
+                    (
+                        node_defect(defect),
+                        format!("{} {}", field, defect.message()),
+                    )
+                })
         }
 
         // The MUST has two halves and this is the first. A scheme is also
@@ -99,7 +159,12 @@ fn check_member(field: &str, kind: Members, member: &str) -> Option<String> {
         // cite(RFC 7239 § 5.4): "Typical values are "http" or "https"."
         Members::Proto => crate::helpers::uri::validate_scheme_name(member)
             .err()
-            .map(|defect| format!("{} is not a URI scheme name: {}", field, defect.message())),
+            .map(|defect| {
+                (
+                    scheme_name(defect),
+                    format!("{} is not a URI scheme name: {}", field, defect.message()),
+                )
+            }),
 
         // The `Host` ABNF, whole: a `uri-host` and an optional `port`, where the
         // port is `*DIGIT` and has neither a lower bound nor an upper one. The
@@ -112,7 +177,12 @@ fn check_member(field: &str, kind: Members, member: &str) -> Option<String> {
         // cite(RFC 9110 § 7.2, label: Host grammar): "Host = uri-host [ ":" port ]"
         Members::Host => crate::helpers::uri::validate_host_and_optional_port(member)
             .err()
-            .map(|e| format!("{} is not a Host field value: {}", field, e)),
+            .map(|defect| {
+                (
+                    host_and_port(defect),
+                    format!("{} is not a Host field value: {}", field, defect.message()),
+                )
+            }),
     }
 }
 
@@ -132,12 +202,6 @@ const RFC_7239_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("1"),
     url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-1",
     note: "Names `X-Forwarded-For`, `X-Forwarded-By` and `X-Forwarded-Proto` as non-standard header fields",
-};
-const RFC_7239_6: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 7239",
-    section: Some("6"),
-    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6",
-    note: "`node` — the identifier an `X-Forwarded-For` / `X-Forwarded-By` member becomes once §7.4's conversion prepends `for=` / `by=`",
 };
 const RFC_7239_5_4: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 7239",
@@ -182,10 +246,19 @@ severity = "warn"
             RFC_7239_7_4,
             RFC_7239_1,
             RFC_7239_6,
+            RFC_7239_6_1,
             RFC_7239_5_4,
             RFC_7239_5_3,
             RFC_9110_7_2,
+            RFC_3986_3_1,
+            RFC_3986_3_2_2,
+            RFC_3986_3_2_3,
+            RFC_3986_2_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -262,8 +335,8 @@ impl Rule for XForwardedConsistent {
                     continue;
                 };
                 for member in members(&value) {
-                    if let Some(message) = check_member(field, *kind, member) {
-                        return Some(self.violation(ctx.severity, message));
+                    if let Some((def, message)) = check_member(field, *kind, member) {
+                        return Some(ctx.report_with(def, message));
                     }
                 }
             }
@@ -312,6 +385,75 @@ mod tests {
     fn judge(pairs: &[(&str, &str)]) -> Option<String> {
         let octets: Vec<(&str, &[u8])> = pairs.iter().map(|(n, v)| (*n, v.as_bytes())).collect();
         judge_bytes(&octets)
+    }
+
+    /// The same transaction, judged for the defect it reports rather than for
+    /// what the message says.
+    fn judge_defect(pairs: &[(&str, &str)]) -> Option<(String, crate::lint::Severity)> {
+        let rule = XForwardedConsistent;
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers = crate::test_helpers::make_headers_from_pairs(pairs);
+        crate::test_helpers::run_rule(
+            &rule,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+        )
+        .map(|v| (v.violation, v.severity))
+    }
+
+    /// Three fields, three productions, three subjects' vocabularies — and not
+    /// one of the ids names this rule or the fields it reads. A member of a
+    /// field no document defines draws the defect of the thing §7.4 says it
+    /// becomes, which is the whole of what this rule's licence amounts to.
+    ///
+    /// The percent-encoding row is the one worth reading twice: a `Cookie`
+    /// `Path` and an `X-Forwarded-Host` report the *same* id for the same
+    /// mistake, which is the state a rule-shaped catalogue could not reach.
+    #[rstest]
+    #[case("x-forwarded-for", "not-an-ip", "node_malformed")]
+    #[case("x-forwarded-for", "010.1.2.3", "node_ipv4_address_malformed")]
+    #[case("x-forwarded-for", "[::1", "node_ipv6_closing_bracket_missing")]
+    #[case("x-forwarded-for", "[nope]", "node_ipv6_address_malformed")]
+    #[case("x-forwarded-for", "192.0.2.43:999999", "node_port_malformed")]
+    #[case("x-forwarded-proto", "2https", "uri_scheme_leading_letter_missing")]
+    #[case("x-forwarded-proto", "ht/tps", "uri_scheme_character_forbidden")]
+    #[case("x-forwarded-host", "user@host", "uri_host_character_forbidden")]
+    #[case("x-forwarded-host", "[::1", "uri_host_closing_bracket_missing")]
+    #[case("x-forwarded-host", "[::zz]", "uri_host_ip_literal_malformed")]
+    #[case("x-forwarded-host", "example.com]:80", "uri_host_bracket_forbidden")]
+    #[case("x-forwarded-host", "[::1]:notnum", "uri_port_character_forbidden")]
+    #[case("x-forwarded-host", "%zz.example.com", "percent_encoding_malformed")]
+    #[case(
+        "x-forwarded-host",
+        "example.com/%4",
+        "percent_encoding_digits_missing"
+    )]
+    fn a_member_reports_the_defect_of_the_production_it_is_measured_against(
+        #[case] name: &str,
+        #[case] value: &str,
+        #[case] id: &str,
+    ) {
+        let (violation, _) = judge_defect(&[(name, value)]).expect("a finding");
+        assert_eq!(violation, id, "{name}: {value}");
+    }
+
+    /// The reason the subject is worth splitting out of the rule at all: one
+    /// `ctx.severity` said everything this rule says at one level, and the
+    /// defects do not agree about level. Both of these are well-formed values
+    /// carrying no grammar failure — the first is the port `*DIGIT` admits and
+    /// the second the address §6.1 spells differently — and only one of them is
+    /// reported at all.
+    #[test]
+    fn the_defect_carries_the_level_and_not_the_rule() {
+        let (violation, severity) =
+            judge_defect(&[("x-forwarded-for", "not-an-ip")]).expect("a finding");
+        assert_eq!(violation, "node_malformed");
+        assert_eq!(severity, crate::lint::Severity::Warn);
+
+        // `[::1]:70000` is a `Host` value and `192.0.2.43:999999` is not a node
+        // identifier: two ports, two productions, one of them silent.
+        assert_eq!(judge_defect(&[("x-forwarded-host", "[::1]:70000")]), None);
     }
 
     #[rstest]

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -39,6 +39,7 @@ pub mod credentials;
 pub mod domain;
 pub mod language;
 pub mod mailbox;
+pub mod node;
 pub mod quoted_string;
 pub mod token68;
 pub mod uri;
@@ -347,7 +348,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 80;
+        const FLOOR: usize = 92;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/node.rs
+++ b/lint-http-rules/src/violations/node.rs
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! Node identifier defects — RFC 7239 §6's `node`, in both of its spellings.
+//!
+//! A `Forwarded` `for=` or `by=` value *is* a node identifier by §5.1 and §5.2,
+//! and an `X-Forwarded-For` or `X-Forwarded-By` element *becomes* one by §7.4's
+//! conversion. Two fields, two rules, one production — so the defects are named
+//! after the production and neither field's name appears in an id.
+//!
+//! Six of the seven entries are the production failing: the four `nodename`
+//! alternatives, the value that is none of them, and the `node-port` after the
+//! colon. The seventh is not a grammar failure at all — the address parses, and
+//! only its spelling is discouraged — which is why it defaults a level below
+//! every other entry here.
+
+use crate::helpers::forwarded_node::NodeDefect;
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The identifier itself: the four alternatives a nodename takes, and the
+/// optional port after them. Both fields that carry one reach this section —
+/// `Forwarded` through §5.1 and §5.2, the legacy family through §7.4 — so the
+/// note names the production rather than either caller.
+pub const RFC_7239_6: SpecRef = SpecRef {
+    spec: "RFC 7239",
+    section: Some("6"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6",
+    note: "`node` — an IPv4 address, a bracketed IPv6 address, `unknown` or an obfuscated identifier, each optionally followed by a `node-port`",
+};
+
+/// The two things said about the IPv6 address inside a node identifier, both of
+/// them about how it is *written* rather than which address it is: the brackets
+/// it always wears, and the representation RFC 5952 recommends for it.
+pub const RFC_7239_6_1: SpecRef = SpecRef {
+    spec: "RFC 7239",
+    section: Some("6.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc7239.html#section-6.1",
+    note: "How an `IPv6address` is spelled in a node identifier: always in square brackets, and following RFC 5952's textual representation recommendations",
+};
+
+defects! {
+    /// An IPv6 address written with no brackets around it at all, where the
+    /// spelling being read requires them. Asked of the whole value before it is
+    /// split, because every colon in such an address looks like the one that
+    /// opens a `node-port`.
+    ///
+    /// Reported for a `Forwarded` node and never for the legacy family, where
+    /// §7.4 records the unbracketed form as the conforming one.
+    ///
+    // cite(RFC 7239 § 6.1): "Also, note that an IPv6 address is always enclosed in square brackets."
+    NODE_IPV6_BRACKETS_MISSING = {
+        id: "node_ipv6_brackets_missing",
+        title: "Node identifier holds an IPv6 address without its square brackets",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7239_6_1),
+    }
+
+    /// A `[`-led nodename that never closes. Told apart from a literal whose
+    /// contents are not an address because the fix differs: this value was cut
+    /// or joined, that one names something that is not an IPv6 address.
+    ///
+    // cite(RFC 7239 § 6, label: nodename grammar): "nodename = IPv4address / "[" IPv6address "]" / "unknown" / obfnode"
+    NODE_IPV6_CLOSING_BRACKET_MISSING = {
+        id: "node_ipv6_closing_bracket_missing",
+        title: "Node identifier opens an IPv6 literal and never closes it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7239_6),
+    }
+
+    /// Brackets around something that is not an `IPv6address`. The brackets are
+    /// what choose this alternative of the production, so what they hold is
+    /// measured against that address grammar and nothing else.
+    ///
+    // cite(RFC 7239 § 6, label: nodename grammar): "nodename = IPv4address / "[" IPv6address "]" / "unknown" / obfnode"
+    NODE_IPV6_ADDRESS_MALFORMED = {
+        id: "node_ipv6_address_malformed",
+        title: "Node identifier brackets something that is not an IPv6 address",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7239_6),
+    }
+
+    /// Digits and dots that are not an `IPv4address` — `010.1.2.3`, `1.2.3`,
+    /// `256.0.0.1`. Kept apart from the catch-all below because the value said
+    /// which alternative it was trying to be.
+    ///
+    // cite(RFC 7239 § 6, label: nodename grammar): "nodename = IPv4address / "[" IPv6address "]" / "unknown" / obfnode"
+    NODE_IPV4_ADDRESS_MALFORMED = {
+        id: "node_ipv4_address_malformed",
+        title: "Node identifier is digits and dots that are not an IPv4 address",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7239_6),
+    }
+
+    /// A nodename no alternative of the production generates. The everyday
+    /// shape behind it is an identifier that was obfuscated without the leading
+    /// underscore that says so, which is what §6.3 requires to distinguish one.
+    ///
+    // cite(RFC 7239 § 6, label: nodename grammar): "nodename = IPv4address / "[" IPv6address "]" / "unknown" / obfnode"
+    NODE_MALFORMED = {
+        id: "node_malformed",
+        title: "Node identifier derives from no alternative of the production",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7239_6),
+    }
+
+    /// A well-formed `IPv6address` written against §6.1's recommendation —
+    /// uppercase hexadecimal, or zeroes left uncompressed. `info`, and the only
+    /// entry in this subject below `warn`: the address is the address the sender
+    /// meant, the octets are not in dispute, and a SHOULD about how they are
+    /// spelled does not outrank a value that has no parse at all.
+    ///
+    // cite(RFC 7239 § 6.1): "The "IPv6address" SHOULD comply with textual representation recommendations [RFC5952] (for example, lowercase, compression of zeros)."
+    NODE_IPV6_REPRESENTATION_INVALID = {
+        id: "node_ipv6_representation_invalid",
+        title: "Node identifier writes an IPv6 address outside the recommended representation",
+        message: "",
+        default_severity: Severity::Info,
+        spec: Some(RFC_7239_6_1),
+    }
+
+    /// Something after the `:` that is neither `1*5DIGIT` nor an `obfport`.
+    /// The numeric form is five digits and no range: the port namespace a
+    /// transport registers in is a different sentence than this one.
+    ///
+    // cite(RFC 7239 § 6, label: node-port grammar): "node-port     = port / obfport port          = 1*5DIGIT obfport       = "_" 1*(ALPHA / DIGIT / "." / "_" / "-")"
+    NODE_PORT_MALFORMED = {
+        id: "node_port_malformed",
+        title: "Node identifier holds something that is not a node-port",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_7239_6),
+    }
+}
+
+/// The defect a parsed [`NodeDefect`] reports as.
+///
+/// Exhaustive, so a variant added to the helper does not compile until it is
+/// named here — and one-to-one, because the seven ways a node identifier fails
+/// are seven different fixes.
+pub fn node_defect(defect: NodeDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        NodeDefect::UnbracketedIpv6(_) => &NODE_IPV6_BRACKETS_MISSING,
+        NodeDefect::UnclosedBrackets(_) => &NODE_IPV6_CLOSING_BRACKET_MISSING,
+        NodeDefect::NotIpv6(_) => &NODE_IPV6_ADDRESS_MALFORMED,
+        NodeDefect::NotIpv4(_) => &NODE_IPV4_ADDRESS_MALFORMED,
+        NodeDefect::NotANode { .. } => &NODE_MALFORMED,
+        NodeDefect::TextualRepresentation { .. } => &NODE_IPV6_REPRESENTATION_INVALID,
+        NodeDefect::NodePort(_) => &NODE_PORT_MALFORMED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::forwarded_node::NodeForm;
+
+    /// Seven variants, seven ids: nothing here answers with a def another
+    /// subject owns, and nothing collapses two variants into one entry.
+    #[test]
+    fn each_node_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (
+                NodeDefect::UnbracketedIpv6("2001:db8::1"),
+                "node_ipv6_brackets_missing",
+            ),
+            (
+                NodeDefect::UnclosedBrackets("[::1"),
+                "node_ipv6_closing_bracket_missing",
+            ),
+            (NodeDefect::NotIpv6("nope"), "node_ipv6_address_malformed"),
+            (
+                NodeDefect::NotIpv4("010.1.2.3"),
+                "node_ipv4_address_malformed",
+            ),
+            (
+                NodeDefect::NotANode {
+                    nodename: "x-foo",
+                    form: NodeForm::XForwarded,
+                },
+                "node_malformed",
+            ),
+            (
+                NodeDefect::TextualRepresentation {
+                    written: "2001:DB8::1",
+                    recommended: "2001:db8::1".parse().expect("an IPv6 address"),
+                },
+                "node_ipv6_representation_invalid",
+            ),
+            (NodeDefect::NodePort("999999"), "node_port_malformed"),
+        ] {
+            assert_eq!(node_defect(defect).id, id);
+        }
+    }
+
+    /// The spelling recommendation is the one entry here that is not a grammar
+    /// failure, and the severities say so. This is the whole reason the subject
+    /// is worth splitting out of the rule: one `ctx.severity` reported an
+    /// address a recipient can act on at the same level as one nothing
+    /// generates.
+    #[test]
+    fn the_recommended_representation_sits_below_the_grammar() {
+        assert_eq!(
+            NODE_IPV6_REPRESENTATION_INVALID.default_severity,
+            Severity::Info
+        );
+        for def in [
+            &NODE_IPV6_BRACKETS_MISSING,
+            &NODE_IPV6_CLOSING_BRACKET_MISSING,
+            &NODE_IPV6_ADDRESS_MALFORMED,
+            &NODE_IPV4_ADDRESS_MALFORMED,
+            &NODE_MALFORMED,
+            &NODE_PORT_MALFORMED,
+        ] {
+            assert!(
+                def.default_severity > NODE_IPV6_REPRESENTATION_INVALID.default_severity,
+                "{} defaults at or below the spelling recommendation",
+                def.id,
+            );
+        }
+    }
+}

--- a/lint-http-rules/src/violations/uri.rs
+++ b/lint-http-rules/src/violations/uri.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: ISC
 
-//! URI defects — the escapes and the scheme name, wherever a field carries a
-//! reference.
+//! URI defects — the escapes, the scheme name and the host, wherever a field
+//! carries a reference.
 //!
 //! A `%` obliges two hexadecimal digits wherever it is written, and this crate
 //! reads escapes in a request target, a `Location`, a cookie `Path`, an
@@ -16,8 +16,20 @@
 //! catalogue was small enough for corrections to be free. `cookie_path` shipped
 //! a `cookie_path_percent_encoding_malformed` of its own, which was the same
 //! reasoning error the rule-shaped catalogue is being split to fix.
+//!
+//! The `uri_host_*` and `uri_port_*` entries are the same argument at the scale
+//! it matters most. Seven rules in this tree measure a host and an optional
+//! port through one helper — a `Host` field, an HTTP/2 `:authority`, a
+//! `Forwarded` `host`, a `Warning` `warn-agent`, a `Referer` authority, a
+//! request target and `X-Forwarded-Host` — and the fix an operator makes
+//! for `user@host` is the same fix whichever of them reported it. The port owns
+//! exactly one entry, because `port = *DIGIT` has exactly one way to fail; a
+//! number too large for a socket is a different sentence and belongs to the
+//! rule that can name the transport.
 
-use crate::helpers::uri::{PercentEncodingDefect, SchemeNameDefect};
+use crate::helpers::uri::{
+    HostAndPortDefect, PercentEncodingDefect, SchemeNameDefect, UriHostDefect,
+};
 use crate::lint::Severity;
 use crate::rules::SpecRef;
 use crate::violations::{defects, ViolationDef};
@@ -30,6 +42,26 @@ pub const RFC_3986_3_1: SpecRef = SpecRef {
     section: Some("3.1"),
     url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1",
     note: "Scheme — `scheme = ALPHA *( ALPHA / DIGIT / \"+\" / \"-\" / \".\" )`, the name before the first colon",
+};
+
+/// The host, whose three alternatives are told apart by their brackets: an IP
+/// literal wears them, and nothing else in the URI syntax does. Read out of a
+/// `Host` field, a `:authority`, a `Forwarded` `host`, a `Via` `received-by`
+/// and every authority this crate parses, all through one helper.
+pub const RFC_3986_3_2_2: SpecRef = SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2",
+    note: "Host — `host = IP-literal / IPv4address / reg-name`, where the square brackets of the IP literal are the only ones the URI syntax admits anywhere",
+};
+
+/// The port, and the whole of what its production says: digits, any number of
+/// them, none of them required.
+pub const RFC_3986_3_2_3: SpecRef = SpecRef {
+    spec: "RFC 3986",
+    section: Some("3.2.3"),
+    url: "https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3",
+    note: "Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string",
 };
 
 /// The triplet a `%` obliges, and the only sentence either percent defect here
@@ -102,6 +134,75 @@ defects! {
         default_severity: Severity::Warn,
         spec: Some(RFC_3986_3_1),
     }
+    /// A host that opens an IP literal and never closes it. The `[` is what
+    /// chooses that alternative, so there is no reading of the value in which
+    /// the bracket was meant as something else.
+    ///
+    // cite(RFC 3986 § 3.2.2): "IP-literal = "[" ( IPv6address / IPvFuture  ) "]""
+    URI_HOST_CLOSING_BRACKET_MISSING = {
+        id: "uri_host_closing_bracket_missing",
+        title: "Host opens an IP literal and never closes it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_2_2),
+    }
+
+    /// Brackets around something that is neither an `IPv6address` nor an
+    /// `IPvFuture`. Both alternatives are read, unlikely as the second is: the
+    /// production generates it, and a finding against what a grammar admits is
+    /// wrong however rare the value.
+    ///
+    // cite(RFC 3986 § 3.2.2): "IP-literal = "[" ( IPv6address / IPvFuture  ) "]""
+    URI_HOST_IP_LITERAL_MALFORMED = {
+        id: "uri_host_ip_literal_malformed",
+        title: "Host brackets something that is not an IP literal",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_2_2),
+    }
+
+    /// A bracket somewhere other than around an IP literal — a closing one with
+    /// nothing that opened it, most often, in a value assembled from an address
+    /// and a port by string concatenation. Told apart from the two above
+    /// because this value is not trying to be a literal at all.
+    ///
+    // cite(RFC 3986 § 3.2.2): "This is the only place where square bracket characters are allowed in the URI syntax."
+    URI_HOST_BRACKET_FORBIDDEN = {
+        id: "uri_host_bracket_forbidden",
+        title: "Host holds a square bracket outside an IP literal",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_2_2),
+    }
+
+    /// A character no `reg-name` admits: not `unreserved`, not the `%` that
+    /// opens a triplet, not `sub-delims`. The alphabet is wide — every one of
+    /// the delimiters a URI reserves for a *later* component is in it — so what
+    /// reaches this defect is usually a component that was never split off: an
+    /// `@` left with its userinfo, a `/` left with its path.
+    ///
+    // cite(RFC 3986 § 3.2.2): "reg-name    = *( unreserved / pct-encoded / sub-delims )"
+    URI_HOST_CHARACTER_FORBIDDEN = {
+        id: "uri_host_character_forbidden",
+        title: "Host holds a character outside the registered-name alphabet",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_2_2),
+    }
+
+    /// A character in the port that is not a digit. There is no companion
+    /// defect for a port outside a transport's range: `port = *DIGIT` bounds
+    /// nothing, so a number too large for any socket is this production's and
+    /// a finding about it needs a sentence naming the transport.
+    ///
+    // cite(RFC 3986 § 3.2.3): "The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character."
+    URI_PORT_CHARACTER_FORBIDDEN = {
+        id: "uri_port_character_forbidden",
+        title: "Port holds a character that is not a digit",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_3986_3_2_3),
+    }
 }
 
 /// The defect a parsed [`SchemeNameDefect`] reports as.
@@ -118,6 +219,32 @@ pub fn percent_encoding(defect: PercentEncodingDefect<'_>) -> &'static Violation
     match defect {
         PercentEncodingDefect::Incomplete => &PERCENT_ENCODING_DIGITS_MISSING,
         PercentEncodingDefect::NotHexDigits(_) => &PERCENT_ENCODING_MALFORMED,
+    }
+}
+
+/// The defect a parsed [`UriHostDefect`] reports as.
+///
+/// The percent arm delegates rather than naming a host-shaped id of its own: a
+/// malformed triplet is the same defect wherever it is read, which is what the
+/// helper's own nesting already says.
+pub fn uri_host(defect: UriHostDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        UriHostDefect::UnclosedBracket(_) => &URI_HOST_CLOSING_BRACKET_MISSING,
+        UriHostDefect::NotAnIpLiteral(_) => &URI_HOST_IP_LITERAL_MALFORMED,
+        UriHostDefect::Bracket(_) => &URI_HOST_BRACKET_FORBIDDEN,
+        UriHostDefect::PercentEncoding(defect) => percent_encoding(defect),
+        UriHostDefect::BadCharacter { .. } => &URI_HOST_CHARACTER_FORBIDDEN,
+    }
+}
+
+/// The defect a parsed [`HostAndPortDefect`] reports as.
+///
+/// The composition owns exactly one id — the port's — and hands the rest to
+/// the host's own mapping, which is the same split the helper makes.
+pub fn host_and_port(defect: HostAndPortDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        HostAndPortDefect::Host(defect) => uri_host(defect),
+        HostAndPortDefect::PortCharacter { .. } => &URI_PORT_CHARACTER_FORBIDDEN,
     }
 }
 
@@ -146,6 +273,62 @@ mod tests {
         ] {
             assert_eq!(scheme_name(defect).id, id);
         }
+    }
+
+    /// Five variants, four ids of this subject's own and one borrowed: the
+    /// malformed triplet inside a host is the percent-encoding's defect and
+    /// says so, which is the pair of ids `cookie_path` had to be corrected to.
+    #[test]
+    fn each_uri_host_defect_maps_to_its_own_id() {
+        for (defect, id) in [
+            (
+                UriHostDefect::UnclosedBracket("[::1"),
+                "uri_host_closing_bracket_missing",
+            ),
+            (
+                UriHostDefect::NotAnIpLiteral("nope"),
+                "uri_host_ip_literal_malformed",
+            ),
+            (
+                UriHostDefect::Bracket("2001:db8::1]"),
+                "uri_host_bracket_forbidden",
+            ),
+            (
+                UriHostDefect::PercentEncoding(PercentEncodingDefect::NotHexDigits("%zz")),
+                "percent_encoding_malformed",
+            ),
+            (
+                UriHostDefect::BadCharacter {
+                    character: '@',
+                    host: "user@host",
+                },
+                "uri_host_character_forbidden",
+            ),
+        ] {
+            assert_eq!(uri_host(defect).id, id);
+        }
+    }
+
+    /// The port is the one thing the composition adds, and the host half
+    /// answers with exactly what it answers with on its own.
+    #[test]
+    fn the_composition_owns_only_the_port() {
+        assert_eq!(
+            host_and_port(HostAndPortDefect::PortCharacter {
+                character: 'n',
+                port: "notnum",
+            })
+            .id,
+            "uri_port_character_forbidden",
+        );
+        assert_eq!(
+            host_and_port(HostAndPortDefect::Host(UriHostDefect::BadCharacter {
+                character: '@',
+                host: "user@host",
+            }))
+            .id,
+            "uri_host_character_forbidden",
+        );
     }
 
     #[test]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -42,19 +42,19 @@ sources:
     snippet: The origin serialization defined here is more constrained than [RFC3986]’s grammar in two substantial ways.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1311
+      line: 1346
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 3.2
     snippet: This supplants the definition in The Web Origin Concept
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1306
+      line: 1341
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 3.2
     snippet: serialized-origin = serialized-scheme "://" serialized-host [ ":" serialized-port ]
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1305
+      line: 1340
   - label: origin_matching_for_cors
     section: § 4.10
     snippet: If the result of byte-serializing a request origin with request is not origin, then return failure.
@@ -342,7 +342,7 @@ sources:
     snippet: A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port.
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1371
+      line: 1406
   - label: refresh_header_syntax
     section: § 1.1
     snippet: A code point is found that is not a URL unit.
@@ -1161,6 +1161,8 @@ sources:
       line: 50
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1175
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 169
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 2
     snippet: A URI is composed from a limited set of characters consisting of digits, letters, and a few graphic symbols.
@@ -1214,9 +1216,9 @@ sources:
     - file: lint-http-rules/src/rules/well_known_uri_syntax.rs
       line: 49
     - file: lint-http-rules/src/violations/uri.rs
-      line: 49
+      line: 81
     - file: lint-http-rules/src/violations/uri.rs
-      line: 61
+      line: 93
   - label: lint-http-rules/src/helpers/uri.rs (7)
     section: § 2.2
     snippet: A component's ABNF syntax rule will not use the reserved or gen-delims rule names directly; instead, each syntax rule lists the characters allowed within that component (i.e., not delimiting it), and any of those characters that are also in the reserved set are "reserved" for use as subcomponent delimiters within the component.
@@ -1306,11 +1308,11 @@ sources:
     - file: lint-http-rules/src/rules/referer_uri_valid.rs
       line: 397
     - file: lint-http-rules/src/violations/uri.rs
-      line: 73
+      line: 105
     - file: lint-http-rules/src/violations/uri.rs
-      line: 85
+      line: 117
     - file: lint-http-rules/src/violations/uri.rs
-      line: 97
+      line: 129
   - label: lint-http-rules/src/helpers/uri.rs (17)
     section: § 3.2
     snippet: The authority component is preceded by a double slash ("//") and is terminated by the next slash ("/"), question mark ("?"), or number sign ("#") character, or by the end of the URI.
@@ -1324,7 +1326,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 205
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1353
+      line: 1388
   - label: lint-http-rules/src/helpers/uri.rs (18)
     section: § 3.2.1
     snippet: Applications should not render as clear text any data after the first colon (":") character found within a userinfo subcomponent unless the data after the colon is the empty string (indicating no password).
@@ -1351,6 +1353,10 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1053
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 141
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 155
   - label: lint-http-rules/src/helpers/uri.rs (22)
     section: § 3.2.2
     snippet: IPvFuture  = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
@@ -1381,6 +1387,8 @@ sources:
       line: 207
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 499
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 184
   - label: lint-http-rules/src/helpers/uri.rs (23)
     section: § 3.2.3
     snippet: The port subcomponent of authority is designated by an optional port number in decimal following the host and delimited from it by a single colon (":") character.
@@ -1397,6 +1405,8 @@ sources:
       line: 52
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 408
+    - file: lint-http-rules/src/violations/uri.rs
+      line: 198
   - label: lint-http-rules/src/helpers/uri.rs (24)
     section: § 3.2.3
     snippet: URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.
@@ -2365,7 +2375,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 187
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 101
+      line: 102
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 6
     snippet: TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their port number registries.
@@ -2375,7 +2385,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 186
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 100
+      line: 101
 - label: RFC 6454
   url: https://www.rfc-editor.org/rfc/rfc6454.html
   fragments:
@@ -2392,7 +2402,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 355
     - file: lint-http-rules/src/helpers/uri.rs
-      line: 1307
+      line: 1342
 - label: RFC 6455
   url: https://www.rfc-editor.org/rfc/rfc6455.html
   fragments:
@@ -3224,49 +3234,49 @@ sources:
     snippet: This specification uses the Augmented Backus-Naur Form (ABNF) notation of [RFC5234] with the list rule extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 225
+      line: 230
   - label: forwarded_header_valid (2)
     section: § 4
     snippet: '"Forwarded" is only for use in HTTP requests and is not to be used in HTTP responses.'
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 401
+      line: 406
   - label: forwarded_header_valid (3)
     section: § 4
     snippet: Each parameter MUST NOT occur more than once per field-value.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 111
+      line: 116
   - label: Forwarded grammar
     section: § 4
     snippet: Forwarded   = 1#forwarded-element
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 226
+      line: 231
   - label: forwarded_header_valid (4)
     section: § 4
     snippet: Note that as ":" and "[]" are not valid characters in "token", IPv6 addresses are written as "quoted-string".
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 158
+      line: 163
   - label: forwarded_header_valid (5)
     section: § 4
     snippet: The parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 141
+      line: 146
   - label: forwarded-element grammar
     section: § 4
     snippet: forwarded-element = [ forwarded-pair ] *( ";" [ forwarded-pair ] )
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 98
+      line: 103
   - label: forwarded-pair grammar
     section: § 4
     snippet: forwarded-pair = token "=" value value          = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 121
+      line: 126
   - label: forwarded_header_valid (6)
     section: § 5.1
     snippet: The syntax of a "by" value, after potential quoted-string unescaping, conforms to the "node" ABNF described in Section 6.
@@ -3286,47 +3296,47 @@ sources:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 52
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 111
+      line: 176
   - label: forwarded_header_valid (9)
     section: § 5.4
     snippet: The syntax of a "proto" value, after potential quoted-string unescaping, MUST conform to the URI scheme name as defined in Section 3.1 in [RFC3986] and registered with IANA according to [RFC4395].
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 68
+      line: 73
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 98
+      line: 158
   - label: forwarded_header_valid (10)
     section: § 5.5
     snippet: All extension parameters SHOULD be registered in the "HTTP Forwarded Parameter" registry.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 196
+      line: 201
   - label: forwarded_header_valid (11)
     section: § 6
     snippet: It is important to note that an IPv6 address and any nodename with node-port specified MUST be quoted, since ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 159
+      line: 164
   - label: forwarded_header_valid (12)
     section: § 7.1
     snippet: Note that an HTTP list allows white spaces to occur between the identifiers, and the list may be split over multiple header fields.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 97
+      line: 102
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 383
+      line: 388
   - label: forwarded_header_valid (13)
     section: § 8.2
     snippet: This header field should never be copied into response messages by origin servers or intermediaries, as it can reveal the whole proxy chain to the client.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 402
+      line: 407
   - label: forwarded_header_valid (14)
     section: § 9
     snippet: New parameters and their values MUST conform with the forwarded-pair as defined in ABNF in Section 4.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 197
+      line: 202
   - label: lint-http-rules/src/helpers/forwarded_node.rs
     section: § 6
     snippet: To distinguish an "obfport" from a port, the "obfport" MUST have a leading underscore. Further, it MUST also consist of only "ALPHA", "DIGIT", and the characters ".", "_", and "-".
@@ -3347,12 +3357,22 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/forwarded_node.rs
       line: 273
+    - file: lint-http-rules/src/violations/node.rs
+      line: 133
   - label: nodename grammar
     section: § 6
     snippet: nodename = IPv4address / "[" IPv6address "]" / "unknown" / obfnode
     cited_by:
     - file: lint-http-rules/src/helpers/forwarded_node.rs
       line: 199
+    - file: lint-http-rules/src/violations/node.rs
+      line: 66
+    - file: lint-http-rules/src/violations/node.rs
+      line: 79
+    - file: lint-http-rules/src/violations/node.rs
+      line: 92
+    - file: lint-http-rules/src/violations/node.rs
+      line: 105
   - label: obfnode grammar
     section: § 6
     snippet: obfnode = "_" 1*( ALPHA / DIGIT / "." / "_" / "-")
@@ -3365,12 +3385,16 @@ sources:
     cited_by:
     - file: lint-http-rules/src/helpers/forwarded_node.rs
       line: 184
+    - file: lint-http-rules/src/violations/node.rs
+      line: 53
   - label: lint-http-rules/src/helpers/forwarded_node.rs (3)
     section: § 6.1
     snippet: The "IPv6address" SHOULD comply with textual representation recommendations [RFC5952] (for example, lowercase, compression of zeros).
     cited_by:
     - file: lint-http-rules/src/helpers/forwarded_node.rs
       line: 217
+    - file: lint-http-rules/src/violations/node.rs
+      line: 120
   - label: lint-http-rules/src/helpers/forwarded_node.rs (4)
     section: § 6.2
     snippet: The "unknown" identifier is used when the identity of the preceding entity is not known, but the proxy server still wants to signal that a forwarding of the request was made.
@@ -3394,31 +3418,31 @@ sources:
     snippet: A common way to disclose this information is by using the non-standard header fields such as X-Forwarded-For, X-Forwarded-By, and X-Forwarded-Proto.
     cited_by:
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 46
+      line: 60
   - label: x_forwarded_consistent (2)
     section: § 5.4
     snippet: Typical values are "http" or "https".
     cited_by:
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 99
+      line: 159
   - label: x_forwarded_consistent (3)
     section: § 7.4
     snippet: If a proxy gets incoming requests with X-Forwarded-* header fields present, it is encouraged to convert these into the header field described in this document, if it can be done in a sensible way.
     cited_by:
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 47
+      line: 61
   - label: x_forwarded_consistent (4)
     section: § 7.4
     snippet: If the request only contains one type -- for example, X-Forwarded-For -- this can be translated to "Forwarded", by prepending each element with "for=".
     cited_by:
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 84
+      line: 139
   - label: x_forwarded_consistent (5)
     section: § 8.3
     snippet: The default configuration for both the "by" and "for" parameters SHOULD contain obfuscated identifiers.
     cited_by:
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 85
+      line: 140
 - label: RFC 7240
   url: https://www.rfc-editor.org/rfc/rfc7240.html
   fragments:
@@ -4341,13 +4365,13 @@ sources:
     snippet: A new pseudo-header field :protocol MAY be included on request HEADERS indicating the desired protocol to be spoken on the tunnel created by CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 344
+      line: 345
   - label: http2_pseudo_headers_valid (2)
     section: § 4
     snippet: On requests that contain the :protocol pseudo-header field, the :scheme and :path pseudo-header fields of the target URI (see Section 5) MUST also be included.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 345
+      line: 346
   - label: lint-http-rules/src/helpers/websocket.rs
     section: § 5
     snippet: Implementations using this extended CONNECT to bootstrap WebSockets do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-Accept header fields of [RFC6455] as that functionality has been superseded by the :protocol pseudo-header field.
@@ -4937,7 +4961,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 355
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 334
+      line: 335
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 192
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -5203,7 +5227,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 107
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 311
+      line: 312
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 296
   - label: alt_svc_header_syntax
@@ -6087,7 +6111,7 @@ sources:
     snippet: For OPTIONS (Section 9.3.7), the request target can be a single asterisk ("*").
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 375
+      line: 376
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 231
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -6097,7 +6121,7 @@ sources:
     snippet: These forms MUST NOT be used with other methods.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 376
+      line: 377
     - file: lint-http-rules/src/rules/http3_pseudo_headers_valid.rs
       line: 232
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
@@ -6453,7 +6477,7 @@ sources:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
       line: 116
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 244
+      line: 249
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 300
     - file: lint-http-rules/src/rules/status_code_semantics.rs
@@ -6599,7 +6623,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 189
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 227
+      line: 232
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 155
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -7027,7 +7051,7 @@ sources:
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 153
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 66
+      line: 80
   - label: lint-http-rules/src/helpers/headers.rs (9)
     section: § 5.6.3
     snippet: The OWS rule is used where zero or more linear whitespace octets might appear.
@@ -7097,7 +7121,7 @@ sources:
     - file: lint-http-rules/src/helpers/quoted_string.rs
       line: 192
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 430
+      line: 435
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 594
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -7433,7 +7457,7 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 251
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
-      line: 112
+      line: 177
   - label: lint-http-rules/src/helpers/uri.rs (2)
     section: § 7.2
     snippet: In HTTP/2 [HTTP/2] and HTTP/3 [HTTP/3], the Host header field is, in some cases, supplanted by the ":authority" pseudo-header field of a request's control data.
@@ -7445,7 +7469,7 @@ sources:
     - file: lint-http-rules/src/rules/host_header.rs
       line: 23
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 358
+      line: 359
   - label: lint-http-rules/src/helpers/uri.rs (3)
     section: § 7.2
     snippet: The "Host" header field in a request provides the host and port information from the target URI, enabling the origin server to distinguish among resources while servicing requests for multiple host names.
@@ -10200,7 +10224,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 354
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 374
+      line: 375
     - file: lint-http-rules/src/rules/request_target_form_valid.rs
       line: 235
   - label: host_and_authority_consistent (2)
@@ -10230,7 +10254,7 @@ sources:
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
       line: 337
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 406
+      line: 407
   - label: host_and_authority_consistent (6)
     section: § 8.3.1
     snippet: The values of fields need to be normalized to compare them (see Section 6.2 of [RFC3986]).
@@ -10242,37 +10266,37 @@ sources:
     snippet: A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or HTAB, 0x20 or 0x09).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 324
+      line: 325
   - label: http2_pseudo_headers_valid (2)
     section: § 8.3
     snippet: Endpoints MUST treat a request or response that contains undefined or invalid pseudo-header fields as malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 312
+      line: 313
   - label: http2_pseudo_headers_valid (3)
     section: § 8.3.1
     snippet: '":authority" MUST NOT include the deprecated userinfo subcomponent for "http" or "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 446
+      line: 447
   - label: http2_pseudo_headers_valid (4)
     section: § 8.3.1
     snippet: '":scheme" is not restricted to "http" and "https" schemed URIs.'
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 411
+      line: 412
   - label: http2_pseudo_headers_valid (5)
     section: § 8.3.1
     snippet: All HTTP/2 requests MUST include exactly one valid value for the ":method", ":scheme", and ":path" pseudo-header fields, unless they are CONNECT requests (Section 8.5).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 386
+      line: 387
   - label: http2_pseudo_headers_valid (6)
     section: § 8.3.1
     snippet: The ":method" pseudo-header field includes the HTTP method (Section 9 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 307
+      line: 308
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
       line: 297
   - label: http2_pseudo_headers_valid (7)
@@ -10280,37 +10304,37 @@ sources:
     snippet: The ":scheme" pseudo-header field includes the scheme portion of the request target.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 405
+      line: 406
   - label: http2_pseudo_headers_valid (8)
     section: § 8.3.1
     snippet: This pseudo-header field MUST NOT be empty for "http" or "https" URIs; "http" or "https" URIs that do not contain a path component MUST include a value of '/'.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 385
+      line: 386
   - label: http2_pseudo_headers_valid (9)
     section: § 8.3.2
     snippet: For HTTP/2 responses, a single ":status" pseudo-header field is defined that carries the HTTP status code field (see Section 15 of [HTTP]).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 491
+      line: 495
   - label: http2_pseudo_headers_valid (10)
     section: § 8.3.2
     snippet: This pseudo-header field MUST be included in all responses, including interim responses; otherwise, the response is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 492
+      line: 496
   - label: http2_pseudo_headers_valid (11)
     section: § 8.5
     snippet: A CONNECT request that does not conform to these restrictions is malformed (Section 8.1.1).
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 350
+      line: 351
   - label: http2_pseudo_headers_valid (12)
     section: § 8.5
     snippet: A proxy that supports CONNECT establishes a TCP connection [TCP] to the host and port identified in the ":authority" pseudo-header field.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 99
+      line: 100
   - label: http2_pseudo_headers_valid (13)
     section: § 8.5
     snippet: The ":authority" pseudo-header field contains the host and port to connect to (equivalent to the authority-form of the request-target of CONNECT requests; see Section 3.2.3 of [HTTP/1.1]).
@@ -10318,13 +10342,13 @@ sources:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 20
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 349
+      line: 350
   - label: http2_pseudo_headers_valid (14)
     section: § 8.5
     snippet: The ":method" pseudo-header field is set to CONNECT.
     cited_by:
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
-      line: 335
+      line: 336
   - label: lint-http-core/src/http_version.rs
     section: § 8.3.1
     snippet: All HTTP/2 requests implicitly have a protocol version of "2.0"


### PR DESCRIPTION
RFC 7239 §6's node identifier becomes a subject of its own, and the `uri-host [ ":" port ]` reader beside it stops answering in prose. Seven `node_*` defects, five `uri_host_*` / `uri_port_*` ones, and `x_forwarded_consistent` — the first rule whose judge function hands back a def — reports through all three of the productions §7.4 says its fields convert into, plus the percent-encoding a host can carry.

The spelling recommendation is the reason the subject is worth splitting: a well-formed IPv6 address written uppercase is `info`, where a value no alternative generates is `warn`. One `ctx.severity` said both at once.

`validate_host_and_optional_port` now returns a defect rather than a rendered `String`, nesting the `UriHostDefect` that was already typed under it and adding the one arm the composition owns — a port character that is not a digit. Its six other callers render the same messages through `.message()`.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
