### PR TITLE
A tchar is a tchar in every field

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1399,6 +1399,14 @@ severity = "warn"
 # token68 holds whitespace or a control character
 severity = "error"
 
+[violations.token_character_forbidden]
+# Token holds a character outside tchar
+severity = "warn"
+
+[violations.token_whitespace_or_control_forbidden]
+# Token holds whitespace or a control character
+severity = "error"
+
 [violations.uri_host_bracket_forbidden]
 # Host holds a square bracket outside an IP literal
 severity = "warn"

--- a/docs/rules/forwarded_header_valid.md
+++ b/docs/rules/forwarded_header_valid.md
@@ -29,6 +29,7 @@ What this rule does not check: an extension parameter's name against the IANA "H
 - [RFC 3986 §3.2.3](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.3): Port — `port = *DIGIT`, which has no lower bound, no upper bound, and admits the empty string
 - [RFC 3986 §2.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1): Percent-Encoding — `pct-encoded = "%" HEXDIG HEXDIG`, the two digits every `%` still owes
 - [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/forwarded_header_valid.rs
+++ b/lint-http-rules/src/rules/forwarded_header_valid.rs
@@ -27,6 +27,10 @@ use crate::violations::quoted_string::{
     QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
     QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
 };
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
 use crate::violations::uri::{
     host_and_port, scheme_name, PERCENT_ENCODING_DIGITS_MISSING, PERCENT_ENCODING_MALFORMED,
     RFC_3986_2_1, RFC_3986_3_1, RFC_3986_3_2_2, RFC_3986_3_2_3, URI_HOST_BRACKET_FORBIDDEN,
@@ -79,6 +83,8 @@ static DECLARED: &[&ViolationDef] = &[
     &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
     &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
     &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
 ];
 
 /// Every octet of a field line as the `char` of the same value.
@@ -212,10 +218,17 @@ impl ForwardedHeaderValid {
             if name.is_empty() {
                 return violation(format!("Forwarded parameter '{}' has no name", param));
             }
+            // The name production is `token`, whole and unmodified, so the
+            // character that fails it is the `token` subject's defect and not
+            // this field's — the same id a media type's parameter name, a
+            // cache directive and seventy-six other sites report.
             if let Some(c) = find_invalid_token_char(name) {
-                return violation(format!(
-                    "Forwarded parameter name '{}' is not a token ({:?} is not a tchar)",
-                    name, c
+                return Some(ctx.report_with(
+                    token_character(c),
+                    format!(
+                        "Forwarded parameter name '{}' is not a token ({:?} is not a tchar)",
+                        name, c
+                    ),
                 ));
             }
 
@@ -262,9 +275,12 @@ impl ForwardedHeaderValid {
                     return violation(format!("Forwarded parameter '{}' has no value", param));
                 }
                 if let Some(c) = find_invalid_token_char(raw_value) {
-                    return violation(format!(
-                        "Forwarded '{}' value '{}' is neither a token ({:?} is not a tchar) nor a quoted-string",
-                        name, raw_value, c
+                    return Some(ctx.report_with(
+                        token_character(c),
+                        format!(
+                            "Forwarded '{}' value '{}' is neither a token ({:?} is not a tchar) nor a quoted-string",
+                            name, raw_value, c
+                        ),
                     ));
                 }
                 raw_value.to_string()
@@ -421,6 +437,7 @@ severity = "warn"
             RFC_3986_3_2_3,
             RFC_3986_2_1,
             RFC_9110_5_6_4,
+            RFC_9110_5_6_2,
         ]
     }
 
@@ -648,6 +665,21 @@ mod tests {
             let (violation, severity) = judge_defect(value).unwrap_or_else(|| panic!("{value:?}"));
             assert_eq!(violation, id, "{value:?}");
             assert_eq!(severity, crate::lint::Severity::Warn, "{value:?}");
+        }
+    }
+
+    /// A parameter name and a bare parameter value are both `token`, so the
+    /// character that fails one fails the other under the same id — and the
+    /// split inside it is by what the character is. `@` is a delimiter a sender
+    /// typed; the space in `for=a b` never reaches here, because the element's
+    /// own no-whitespace check answers first, which is a fact about this field
+    /// and not about the production.
+    #[test]
+    fn a_name_and_a_bare_value_are_the_token_production() {
+        for value in ["@=1", "foo=bad@value"] {
+            let (violation, severity) = judge_defect(value).unwrap_or_else(|| panic!("{value}"));
+            assert_eq!(violation, "token_character_forbidden", "{value}");
+            assert_eq!(severity, crate::lint::Severity::Warn, "{value}");
         }
     }
 

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -41,6 +41,7 @@ pub mod language;
 pub mod mailbox;
 pub mod node;
 pub mod quoted_string;
+pub mod token;
 pub mod token68;
 pub mod uri;
 
@@ -348,7 +349,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 92;
+        const FLOOR: usize = 94;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/token.rs
+++ b/lint-http-rules/src/violations/token.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `token` defects — the character set HTTP is written in.
+//!
+//! `token = 1*tchar` is the most-read production in this tree: seventy-nine
+//! sites ask [`crate::helpers::token::find_invalid_token_char`] whether a value
+//! is one, across field names, parameter names, directive names, media type
+//! subtypes, transfer codings, method names and every `auth-param` label. One
+//! sentence answers all of them, so one pair of ids does — and an operator who
+//! does not care about a `_` where a `-` belongs says so once rather than in
+//! seventy-nine places.
+//!
+//! **Two entries, split the way `docs/development.md` mandates.** `tchar` is
+//! fifteen punctuation marks, the digits and the letters; everything else fails,
+//! and *which* thing failed is the whole of the difference between a sender who
+//! typed the wrong character and a value that something did to. A space or a
+//! control octet in a name is the second — most often a value that was split,
+//! joined or padded on the way — and it defaults a level above.
+//!
+//! Not here: `token68`, which is a different alphabet under a similar name and
+//! lives in [`crate::violations::token68`]. The two share no character class —
+//! `token68` admits `/` and `=` and no `!#$%&'*^\`|~` — and a value that is one
+//! is not measured against the other anywhere in this crate.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::{defects, ViolationDef};
+
+/// The production and its character set, in the one section that writes both.
+/// Every field name, parameter name and directive name in HTTP reaches it.
+pub const RFC_9110_5_6_2: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
+    note: "Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits",
+};
+
+defects! {
+    /// Whitespace or a control octet where a `token` was written. `error` by
+    /// default, the convention every subject with this pair follows: `tchar` is
+    /// letters, digits and fifteen visible marks, so neither a space nor an
+    /// invisible octet is a character a sender chose to put in a name — it is a
+    /// value that was split, joined or padded by something between them.
+    ///
+    /// It is also the octet that changes what a recipient parses. Field lines,
+    /// list members and parameters are all cut apart on whitespace or on a
+    /// delimiter beside it, so a space inside a name is read as the end of one
+    /// construct and the start of another.
+    ///
+    // cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN = {
+        id: "token_whitespace_or_control_forbidden",
+        title: "Token holds whitespace or a control character",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9110_5_6_2),
+    }
+
+    /// A visible octet outside `tchar` — one of the delimiters § 5.6.2 names,
+    /// most often, or an octet at or above %x80 in a name that was written in
+    /// something other than US-ASCII. The sender chose the character; what is
+    /// wrong is that the production does not admit it.
+    ///
+    // cite(RFC 9110 § 5.6.2): "Delimiters are chosen from the set of US-ASCII visual characters not allowed in a token (DQUOTE and "(),/:;<=>?@[\]{}")."
+    TOKEN_CHARACTER_FORBIDDEN = {
+        id: "token_character_forbidden",
+        title: "Token holds a character outside tchar",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_6_2),
+    }
+}
+
+/// The defect a character outside `tchar` reports as.
+///
+/// The reader that found it — [`crate::helpers::token::find_invalid_token_char`]
+/// — answers with one `char` and no verdict, because the production draws no
+/// distinction inside "not a `tchar`". The catalogue does, so the sort happens
+/// here: this is the shape 2.10's bearer token settled, and the reason a coarse
+/// helper can feed a catalogue finer than itself.
+pub fn token_character(c: char) -> &'static ViolationDef {
+    match c.is_whitespace() || c.is_control() {
+        true => &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+        false => &TOKEN_CHARACTER_FORBIDDEN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The split is by what the character *is*, not by where it was found.
+    #[test]
+    fn the_invisible_octet_and_the_chosen_one_are_two_ids() {
+        for c in [' ', '\t', '\u{1}', '\u{7f}', '\r'] {
+            assert_eq!(
+                token_character(c).id,
+                "token_whitespace_or_control_forbidden",
+                "{c:?}",
+            );
+        }
+        // Every one of these is a delimiter § 5.6.2 names, plus an `obs-text`
+        // octet that no `tchar` admits either.
+        for c in [
+            '(', ')', ',', '/', ':', ';', '<', '=', '>', '?', '@', '"', '\u{e9}',
+        ] {
+            assert_eq!(token_character(c).id, "token_character_forbidden", "{c:?}");
+        }
+    }
+
+    /// The pair defaults a level apart, which is the convention
+    /// `docs/development.md` states and the only reason to have two entries.
+    #[test]
+    fn the_invisible_octet_outranks_the_chosen_one() {
+        assert!(
+            TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN.default_severity
+                > TOKEN_CHARACTER_FORBIDDEN.default_severity
+        );
+    }
+}

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -3234,67 +3234,67 @@ sources:
     snippet: This specification uses the Augmented Backus-Naur Form (ABNF) notation of [RFC5234] with the list rule extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 323
+      line: 339
   - label: forwarded_header_valid (2)
     section: § 4
     snippet: '"Forwarded" is only for use in HTTP requests and is not to be used in HTTP responses.'
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 496
+      line: 513
   - label: forwarded_header_valid (3)
     section: § 4
     snippet: Each parameter MUST NOT occur more than once per field-value.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 192
+      line: 198
   - label: Forwarded grammar
     section: § 4
     snippet: Forwarded   = 1#forwarded-element
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 324
+      line: 340
   - label: forwarded_header_valid (4)
     section: § 4
     snippet: Note that as ":" and "[]" are not valid characters in "token", IPv6 addresses are written as "quoted-string".
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 239
+      line: 252
   - label: forwarded_header_valid (5)
     section: § 4
     snippet: The parameter names are case-insensitive.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 222
+      line: 235
   - label: forwarded-element grammar
     section: § 4
     snippet: forwarded-element = [ forwarded-pair ] *( ";" [ forwarded-pair ] )
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 179
+      line: 185
   - label: forwarded-pair grammar
     section: § 4
     snippet: forwarded-pair = token "=" value value          = token / quoted-string
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 202
+      line: 208
   - label: forwarded_header_valid (6)
     section: § 5.1
     snippet: The syntax of a "by" value, after potential quoted-string unescaping, conforms to the "node" ABNF described in Section 6.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 109
+      line: 115
   - label: forwarded_header_valid (7)
     section: § 5.2
     snippet: The syntax of a "for" value, after potential quoted-string unescaping, conforms to the "node" ABNF described in Section 6.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 108
+      line: 114
   - label: forwarded_header_valid (8)
     section: § 5.3
     snippet: The syntax for a "host" value, after potential quoted-string unescaping, MUST conform to the Host ABNF described in Section 5.4 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 122
+      line: 128
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 176
   - label: forwarded_header_valid (9)
@@ -3302,7 +3302,7 @@ sources:
     snippet: The syntax of a "proto" value, after potential quoted-string unescaping, MUST conform to the URI scheme name as defined in Section 3.1 in [RFC3986] and registered with IANA according to [RFC4395].
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 146
+      line: 152
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs
       line: 158
   - label: forwarded_header_valid (10)
@@ -3310,33 +3310,33 @@ sources:
     snippet: All extension parameters SHOULD be registered in the "HTTP Forwarded Parameter" registry.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 286
+      line: 302
   - label: forwarded_header_valid (11)
     section: § 6
     snippet: It is important to note that an IPv6 address and any nodename with node-port specified MUST be quoted, since ":" is not an allowed character in "token".
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 240
+      line: 253
   - label: forwarded_header_valid (12)
     section: § 7.1
     snippet: Note that an HTTP list allows white spaces to occur between the identifiers, and the list may be split over multiple header fields.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 178
+      line: 184
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 478
+      line: 495
   - label: forwarded_header_valid (13)
     section: § 8.2
     snippet: This header field should never be copied into response messages by origin servers or intermediaries, as it can reveal the whole proxy chain to the client.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 497
+      line: 514
   - label: forwarded_header_valid (14)
     section: § 9
     snippet: New parameters and their values MUST conform with the forwarded-pair as defined in ABNF in Section 4.
     cited_by:
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 287
+      line: 303
   - label: lint-http-rules/src/helpers/forwarded_node.rs
     section: § 6
     snippet: To distinguish an "obfport" from a port, the "obfport" MUST have a leading underscore. Further, it MUST also consist of only "ALPHA", "DIGIT", and the characters ".", "_", and "-".
@@ -6477,7 +6477,7 @@ sources:
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
       line: 116
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 342
+      line: 358
     - file: lint-http-rules/src/rules/range_and_content_range_consistent.rs
       line: 300
     - file: lint-http-rules/src/rules/status_code_semantics.rs
@@ -6623,7 +6623,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 189
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 325
+      line: 341
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
       line: 155
     - file: lint-http-rules/src/rules/if_none_match_etag_syntax.rs
@@ -7110,6 +7110,8 @@ sources:
       line: 133
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 48
+    - file: lint-http-rules/src/violations/token.rs
+      line: 66
   - label: lint-http-rules/src/helpers/list.rs (4)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
@@ -7121,7 +7123,7 @@ sources:
     - file: lint-http-rules/src/helpers/quoted_string.rs
       line: 192
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 525
+      line: 542
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 594
     - file: lint-http-rules/src/violations/quoted_string.rs
@@ -7385,7 +7387,7 @@ sources:
     - file: lint-http-rules/src/helpers/quoted_string.rs
       line: 191
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 96
+      line: 102
     - file: lint-http-rules/src/rules/transfer_coding_registered.rs
       line: 416
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
@@ -7436,6 +7438,8 @@ sources:
       line: 258
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 227
+    - file: lint-http-rules/src/violations/token.rs
+      line: 52
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
@@ -7453,7 +7457,7 @@ sources:
     - file: lint-http-rules/src/helpers/uri.rs
       line: 1242
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
-      line: 123
+      line: 129
     - file: lint-http-rules/src/rules/host_header.rs
       line: 251
     - file: lint-http-rules/src/rules/x_forwarded_consistent.rs


### PR DESCRIPTION
`token = 1*tchar` is the most-read production in the tree — seventy-nine sites ask the same helper whether a value is one — and it had no name in the catalogue. It has two: the octet a sender chose, and the whitespace or control octet that was done to the value, which defaults a level above because it is also the octet that changes where a recipient thinks a construct ends.

The helper answers with one `char` and no verdict, so the sort lives beside the defs. `forwarded_header_valid` takes the first two sites: a parameter name and a bare parameter value are the same production, and they now report the same id a media type parameter or a cache directive will when those convert.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
