### PR TITLE
A word fails at one of its halves

### DIFF
--- a/lint-http-rules/src/helpers/media_type.rs
+++ b/lint-http-rules/src/helpers/media_type.rs
@@ -224,11 +224,11 @@ pub fn media_type_parts_defect(parsed: &ParsedMediaType<'_>) -> Option<String> {
             // around the whole clause rather than around the name alone -- a
             // control octet inside the quoted-string is exactly what that reason
             // is about, and it arrived raw.
-            Err(WordDefect::NotQuotedString(e)) => {
+            Err(WordDefect::NotQuotedString(defect)) => {
                 return Some(format!(
                     "parameter '{}' has invalid quoted-string: {}",
                     parameter.name.escape_debug(),
-                    e.escape_debug()
+                    defect.message(parameter.value).escape_debug()
                 ))
             }
         }

--- a/lint-http-rules/src/helpers/word.rs
+++ b/lint-http-rules/src/helpers/word.rs
@@ -41,7 +41,7 @@ use crate::helpers::shown::describe_char;
 /// measurements behind it; **the wording, and the verdict on
 /// [`WordDefect::Empty`], stay at the caller** — which is where each field's own
 /// sentence about it is.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WordDefect {
     /// The value is empty, and neither alternative derives the empty string:
     /// `token = 1*tchar` has a one-character floor, and the shortest
@@ -53,8 +53,16 @@ pub enum WordDefect {
     /// elimination rather than by inspection: see [`token_or_quoted_string`].
     NotToken(char),
     /// A leading DQUOTE opened something that is not a well-formed
-    /// `quoted-string`, carrying the interior walk's own account of it.
-    NotQuotedString(String),
+    /// `quoted-string`, carrying that production's own defect.
+    ///
+    /// Nested rather than rendered, for the reason
+    /// [`UriHostDefect::PercentEncoding`](crate::helpers::uri::UriHostDefect::PercentEncoding)
+    /// nests its own: a `quoted-string` is the same production wherever it is
+    /// read, and this alternation adds nothing to it. It carried a `String`
+    /// while [`unescape_quoted_string`] rendered one, which put prose inside a
+    /// typed defect and left every caller matching this variant unable to name
+    /// *which* of the four ways the value failed.
+    NotQuotedString(crate::helpers::quoted_string::QuotedStringDefect),
 }
 
 /// Read one `( token / quoted-string )` and return what it holds.
@@ -87,7 +95,7 @@ pub fn token_or_quoted_string(value: &str) -> Result<std::borrow::Cow<'_, str>, 
     if value.starts_with('"') {
         return unescape_quoted_string(value)
             .map(std::borrow::Cow::Owned)
-            .map_err(|defect| WordDefect::NotQuotedString(defect.message(value)));
+            .map_err(WordDefect::NotQuotedString);
     }
     match crate::helpers::token::find_invalid_token_char(value) {
         Some(c) => Err(WordDefect::NotToken(c)),
@@ -173,7 +181,7 @@ pub fn parse_token_bws_word(member: &str) -> Result<TokenBwsWord<'_>, String> {
             Err(WordDefect::NotToken(c)) => {
                 return Err(format!("value contains {}", describe_char(c)))
             }
-            Err(WordDefect::NotQuotedString(e)) => return Err(e),
+            Err(WordDefect::NotQuotedString(defect)) => return Err(defect.message(v)),
         },
     };
 

--- a/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -402,12 +402,14 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                                             p, hdr
                                         )));
                                 }
-                                Err(crate::helpers::word::WordDefect::NotQuotedString(e)) => {
+                                Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => {
                                     return Some(self.violation(
                                         ctx.severity,
                                         format!(
                                             "Invalid quoted-string parameter '{}' in {} header: {}",
-                                            p, hdr, e
+                                            p,
+                                            hdr,
+                                            defect.message(v)
                                         ),
                                     ));
                                 }

--- a/lint-http-rules/src/rules/alt_svc_header_syntax.rs
+++ b/lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -274,9 +274,10 @@ fn check_parameter(shown: &str, parameter: &str) -> Option<String> {
                     describe_char(c)
                 ))
         }
-        Err(WordDefect::NotQuotedString(e)) => {
+        Err(WordDefect::NotQuotedString(defect)) => {
+            let defect = defect.message(value);
             return Some(format!(
-                    "Alt-Svc parameter '{}' in '{shown}' has a value that is not a well-formed `quoted-string`: {e}",
+                    "Alt-Svc parameter '{}' in '{shown}' has a value that is not a well-formed `quoted-string`: {defect}",
                     shown_in_finding(name)
                 ))
         }

--- a/lint-http-rules/src/rules/cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -140,9 +140,10 @@ fn member_defect(member: &str) -> Option<String> {
         // behavior change. (`foo=""` is genuinely valid: quoted-string permits
         // empty content.)
         Err(crate::helpers::word::WordDefect::Empty) => None,
-        Err(crate::helpers::word::WordDefect::NotQuotedString(e)) => {
-            Some(format!("Invalid quoted-string in directive value: {}", e))
-        }
+        Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => Some(format!(
+            "Invalid quoted-string in directive value: {}",
+            defect.message(argument)
+        )),
         Err(crate::helpers::word::WordDefect::NotToken(c)) => Some(format!(
             "Directive value contains invalid character: '{}'",
             c

--- a/lint-http-rules/src/rules/expect_header_valid.rs
+++ b/lint-http-rules/src/rules/expect_header_valid.rs
@@ -498,11 +498,11 @@ fn validate_parameters(after_value: &str, member: &str) -> Result<(), String> {
                     crate::helpers::shown::shown_in_finding(seg)
                 ))
             }
-            Err(crate::helpers::word::WordDefect::NotQuotedString(e)) => {
+            Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => {
                 return Err(format!(
                     "Invalid quoted-string in Expect parameter '{}': {}",
                     crate::helpers::shown::shown_in_finding(seg),
-                    e
+                    defect.message(pvalue)
                 ))
             }
             Err(crate::helpers::word::WordDefect::NotToken(c)) => {

--- a/lint-http-rules/src/rules/keep_alive_header_valid.rs
+++ b/lint-http-rules/src/rules/keep_alive_header_valid.rs
@@ -608,9 +608,12 @@ fn validate_param_value(value: &str) -> Result<(), String> {
         // would have named are `obs-text`, and those are `qdtext` -- so one
         // reaches a finding here only inside a quoted-string that is already
         // malformed. Rendering them is the helper's to fix, at its callers.
-        Err(WordDefect::NotQuotedString(e)) => Err(format!(
-            "has a value that is not a well-formed quoted-string: {e}"
-        )),
+        Err(WordDefect::NotQuotedString(defect)) => {
+            let defect = defect.message(value);
+            Err(format!(
+                "has a value that is not a well-formed quoted-string: {defect}"
+            ))
+        }
     }
 }
 

--- a/lint-http-rules/src/rules/pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/pragma_token_valid.rs
@@ -183,8 +183,11 @@ fn check_pragma_value(s: &str) -> Option<String> {
                 // arm rather than as a pre-check, because it is a verdict this
                 // rule reaches and not a step of reading the value.
                 Err(crate::helpers::word::WordDefect::Empty) => continue,
-                Err(crate::helpers::word::WordDefect::NotQuotedString(e)) => {
-                    return Some(format!("Invalid quoted-string in directive value: {}", e));
+                Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => {
+                    return Some(format!(
+                        "Invalid quoted-string in directive value: {}",
+                        defect.message(vpart)
+                    ));
                 }
                 Err(crate::helpers::word::WordDefect::NotToken(c)) => {
                     return Some(format!(

--- a/lint-http-rules/src/rules/server_timing_header_syntax.rs
+++ b/lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -585,9 +585,10 @@ fn check_param<'a>(metric: &str, param: &'a str, seen: &mut Vec<&'a str>) -> Opt
                 describe_char(c)
             ))
         }
-        Err(WordDefect::NotQuotedString(e)) => {
+        Err(WordDefect::NotQuotedString(defect)) => {
+            let defect = defect.message(value);
             return Some(format!(
-                "Server-Timing parameter '{}' has a malformed quoted-string value: {e}",
+                "Server-Timing parameter '{}' has a malformed quoted-string value: {defect}",
                 shown_in_finding(name)
             ))
         }

--- a/lint-http-rules/src/violations/token.rs
+++ b/lint-http-rules/src/violations/token.rs
@@ -24,8 +24,10 @@
 //! `token68` admits `/` and `=` and no `!#$%&'*^\`|~` — and a value that is one
 //! is not measured against the other anywhere in this crate.
 
+use crate::helpers::word::WordDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
+use crate::violations::quoted_string::quoted_string_defect;
 use crate::violations::{defects, ViolationDef};
 
 /// The production and its character set, in the one section that writes both.
@@ -87,6 +89,31 @@ pub fn token_character(c: char) -> &'static ViolationDef {
     }
 }
 
+/// The defect a [`WordDefect`] reports as — `None` when the answer is the
+/// caller's rather than the catalogue's.
+///
+/// `( token / quoted-string )` is an alternation and owns no defect of its
+/// own: a value that failed did so at one of the two halves, and each half has
+/// a subject. This lives here rather than in a `word` file because a value that
+/// does not open with a DQUOTE is a `token` by elimination, which is the same
+/// reasoning [`crate::helpers::word::token_or_quoted_string`] uses to pick the
+/// alternative — and the quoted half delegates, the way every nested mapping in
+/// this catalogue does.
+///
+/// [`WordDefect::Empty`] is the `None`, and deliberately so. Neither
+/// alternative derives the empty string, which is arithmetic — but what a
+/// *field* does about a value that is empty is a per-field verdict, and
+/// `helpers::word` records that six callers had answered it in four different
+/// ways. Two of them tolerate it outright. A def here would be this catalogue
+/// deciding a question its callers have not agreed on.
+pub fn word_defect(defect: WordDefect) -> Option<&'static ViolationDef> {
+    match defect {
+        WordDefect::Empty => None,
+        WordDefect::NotToken(c) => Some(token_character(c)),
+        WordDefect::NotQuotedString(defect) => Some(quoted_string_defect(defect)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,6 +135,28 @@ mod tests {
         ] {
             assert_eq!(token_character(c).id, "token_character_forbidden", "{c:?}");
         }
+    }
+
+    /// The alternation answers with the half that failed, and with nothing at
+    /// all for the empty value — which is the one verdict this catalogue leaves
+    /// to the field.
+    #[test]
+    fn a_word_answers_with_the_half_that_failed() {
+        use crate::helpers::quoted_string::QuotedStringDefect;
+
+        assert_eq!(word_defect(WordDefect::Empty).map(|d| d.id), None);
+        assert_eq!(
+            word_defect(WordDefect::NotToken('@')).map(|d| d.id),
+            Some("token_character_forbidden"),
+        );
+        assert_eq!(
+            word_defect(WordDefect::NotToken(' ')).map(|d| d.id),
+            Some("token_whitespace_or_control_forbidden"),
+        );
+        assert_eq!(
+            word_defect(WordDefect::NotQuotedString(QuotedStringDefect::NotQuoted)).map(|d| d.id),
+            Some("quoted_string_delimiter_missing"),
+        );
     }
 
     /// The pair defaults a level apart, which is the convention

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -659,19 +659,19 @@ sources:
     snippet: If dur is an error, return 0; Otherwise return dur.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 638
+      line: 639
   - label: server_timing_header_syntax (10)
     section: § 3.2
     snippet: Let dur be the result of parsing this’s params["dur"] using the rules for parsing floating-point number values.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 637
+      line: 638
   - label: server_timing_header_syntax (11)
     section: § 3.3
     snippet: The description getter steps are to return this’s params["desc"] if it exists, otherwise the empty string.
     cited_by:
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
-      line: 621
+      line: 622
 - label: Permissions Policy
   url: https://w3c.github.io/webappsec-permissions-policy/
   type: text/html
@@ -762,7 +762,7 @@ sources:
     snippet: The value of the "timeout" parameter is a single integer in seconds.
     cited_by:
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 623
+      line: 626
 - label: MDN Content-Type
   url: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
   fragments:
@@ -3845,7 +3845,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 179
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 475
+      line: 476
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 328
   - label: alt_svc_h3_advertisement_valid (2)
@@ -3873,7 +3873,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 21
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 325
+      line: 326
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 368
   - label: alt_svc_h3_advertisement_valid (5)
@@ -3897,7 +3897,7 @@ sources:
     snippet: This document uses the Augmented BNF defined in [RFC5234] and updated by [RFC7405] along with the "#rule" extension defined in Section 7 of [RFC7230].
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 559
+      line: 560
   - label: alt_svc_header_syntax (2)
     section: § 2
     snippet: Note that for the purpose of this specification, an ALPN protocol name implicitly includes TLS in the suite of protocols it identifies, unless specified otherwise in its definition.
@@ -3909,13 +3909,13 @@ sources:
     snippet: A field value containing the special value "clear" indicates that the origin requests all alternatives for that origin to be invalidated (including those specified in the same response, in case of an invalid reply containing both "clear" and alternative services).
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 544
+      line: 545
   - label: alt_svc_header_syntax (4)
     section: § 3
     snippet: Alt-Svc MAY occur in any HTTP response message, regardless of the status code.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 492
+      line: 493
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 349
   - label: alt_svc_header_syntax (5)
@@ -3995,7 +3995,7 @@ sources:
     snippet: alternative   = protocol-id "=" alt-authority
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 318
+      line: 319
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 400
   - label: alt_svc_header_syntax (17)
@@ -4003,7 +4003,7 @@ sources:
     snippet: protocol-id   = token ; percent-encoded ALPN protocol name
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 319
+      line: 320
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 135
   - label: alt_svc_header_syntax (18)
@@ -4011,19 +4011,19 @@ sources:
     snippet: Alternative services that are intended to be longer lived (such as those that are not specific to the client access network) can carry the "persist" parameter with a value "1" as a hint that the service is potentially useful beyond a network configuration change.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 289
+      line: 290
   - label: alt_svc_header_syntax (19)
     section: § 3.1
     snippet: Clients MUST ignore "persist" parameters with values other than "1".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 291
+      line: 292
   - label: alt_svc_header_syntax (20)
     section: § 3.1
     snippet: This specification only defines a single value for "persist".
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 290
+      line: 291
   - label: alt_svc_header_syntax (21)
     section: § 8
     snippet: An internationalized domain name that appears in either the header field (Section 3) or the HTTP/2 frame (Section 4) MUST be expressed using A-labels ([RFC5890], Section 2.3.2.1).
@@ -5235,7 +5235,7 @@ sources:
     snippet: All HTTP requirements applicable to an origin server also apply to the outbound communication of a gateway.
     cited_by:
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 476
+      line: 477
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 329
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -6615,7 +6615,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 85
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 560
+      line: 561
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 105
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -7083,7 +7083,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 145
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 534
+      line: 535
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 515
   - label: lint-http-rules/src/helpers/list.rs (2)
@@ -7103,7 +7103,7 @@ sources:
     - file: lint-http-rules/src/helpers/list.rs
       line: 121
     - file: lint-http-rules/src/helpers/word.rs
-      line: 80
+      line: 88
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 75
     - file: lint-http-rules/src/rules/range_header_syntax.rs
@@ -7111,7 +7111,7 @@ sources:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 48
     - file: lint-http-rules/src/violations/token.rs
-      line: 66
+      line: 68
   - label: lint-http-rules/src/helpers/list.rs (4)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
@@ -7143,7 +7143,7 @@ sources:
     - file: lint-http-rules/src/helpers/quoted_string.rs
       line: 190
     - file: lint-http-rules/src/helpers/word.rs
-      line: 82
+      line: 90
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 117
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -7421,9 +7421,9 @@ sources:
     - file: lint-http-rules/src/helpers/token.rs
       line: 7
     - file: lint-http-rules/src/helpers/word.rs
-      line: 81
+      line: 89
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 320
+      line: 321
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 407
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
@@ -7439,7 +7439,7 @@ sources:
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 227
     - file: lint-http-rules/src/violations/token.rs
-      line: 52
+      line: 54
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
@@ -7527,7 +7527,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 180
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
-      line: 509
+      line: 510
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 359
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -7537,7 +7537,7 @@ sources:
     snippet: The BWS rule is used where the grammar allows optional whitespace only for historical reasons.
     cited_by:
     - file: lint-http-rules/src/helpers/word.rs
-      line: 141
+      line: 149
   - label: location_header_uri_valid
     section: § 10.2.2
     snippet: A Location field value cannot allow a list of members because the comma list separator is a valid data character within a URI-reference.
@@ -9404,7 +9404,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 303
     - file: lint-http-rules/src/rules/keep_alive_header_valid.rs
-      line: 624
+      line: 627
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 51
   - label: lint-http-rules/src/helpers/cache_control.rs


### PR DESCRIPTION
`WordDefect::NotQuotedString` carried a rendered sentence inside a typed defect — prose in the one place a caller most needs a name — so eight rules matching that variant could say a value was not a well-formed quoted-string and nothing about which of the four ways it failed. It nests the defect now, and each of the eight renders it against the value it was reading.

`word = token / quoted-string` owns no defect of its own, so the mapping answers with the half that failed and delegates to that half's subject. The empty value is the one `None`: neither alternative derives it, but what a field does about that is a per-field verdict, and two of the callers tolerate it outright.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
