### PR TITLE
A deprecated field borrows every defect

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1259,6 +1259,10 @@ severity = "warn"
 # Language tag holds whitespace or a control character
 severity = "error"
 
+[violations.list_member_empty]
+# List holds an empty element
+severity = "warn"
+
 [violations.mailbox_angle_addr_missing]
 # Mailbox has no angle-addr where the name-addr wants one
 severity = "warn"
@@ -1401,6 +1405,10 @@ severity = "error"
 
 [violations.token_character_forbidden]
 # Token holds a character outside tchar
+severity = "warn"
+
+[violations.token_empty]
+# Token is written with no characters in it
 severity = "warn"
 
 [violations.token_whitespace_or_control_forbidden]

--- a/docs/rules/pragma_token_valid.md
+++ b/docs/rules/pragma_token_valid.md
@@ -15,6 +15,9 @@ This rule flags malformed directives, invalid token characters, empty members, a
 ## Specifications
 
 - [RFC 9111 §5.4](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.4): Pragma
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/pragma_token_valid.rs
+++ b/lint-http-rules/src/rules/pragma_token_valid.rs
@@ -4,6 +4,45 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::quoted_string::{
+    QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN, QUOTED_STRING_DELIMITER_MISSING,
+    QUOTED_STRING_QUOTED_PAIR_MALFORMED, QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
+
+/// Everything this rule reports, and none of it is `Pragma`'s.
+///
+/// The field's own document deprecates it and states no grammar at all — RFC
+/// 9111 § 5.4 names it and stops — so what is left to measure is machinery this
+/// rule *borrows*: the `#` list construct, `token`, and `quoted-string`, each
+/// current RFC 9110 § 5.6 and each already a subject. A deprecated field with
+/// no grammar of its own turns out to be the cleanest possible demonstration
+/// that the defect belongs to the production and not to the field.
+///
+/// `cache_control_token_valid` writes two of these messages out in the same
+/// words, which is one of the fourteen duplicate templates the campaign's
+/// measurement found; when it converts, the two rules will report one id apiece
+/// rather than two identical sentences under two rule names.
+///
+/// The non-UTF-8 site stays on the old API. Its verdict is the wrong claim —
+/// `to_str` refuses every octet outside visible US-ASCII, so the finding names
+/// an encoding where the defect is an octet the grammar does not admit — and
+/// the right conversion is an octet-wise reader first, not a def for the claim.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// `Pragma` header directives must follow `directive = token ["=" ( token / quoted-string )]`
 /// and be syntactically valid. This rule flags invalid tokens, malformed quoted-strings,
@@ -42,7 +81,16 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9111_5_4]
+        &[
+            RFC_9111_5_4,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -91,9 +139,9 @@ impl Rule for PragmaTokenValid {
                         if v.is_empty() {
                             continue;
                         }
-                        if let Some(msg) = check_pragma_value(v) {
-                            return Some(self.violation(
-                                ctx.severity,
+                        if let Some((def, msg)) = check_pragma_value(v) {
+                            return Some(ctx.report_with(
+                                def,
                                 format!("Invalid Pragma header in request: {}", msg),
                             ));
                         }
@@ -117,9 +165,9 @@ impl Rule for PragmaTokenValid {
                             if v.is_empty() {
                                 continue;
                             }
-                            if let Some(msg) = check_pragma_value(v) {
-                                return Some(self.violation(
-                                    ctx.severity,
+                            if let Some((def, msg)) = check_pragma_value(v) {
+                                return Some(ctx.report_with(
+                                    def,
                                     format!("Invalid Pragma header in response: {}", msg),
                                 ));
                             }
@@ -138,7 +186,7 @@ impl Rule for PragmaTokenValid {
     }
 }
 
-fn check_pragma_value(s: &str) -> Option<String> {
+fn check_pragma_value(s: &str) -> Option<(&'static ViolationDef, String)> {
     // The `token ["=" (token / quoted-string)]` directive shape is RFC 7234 §5.4's historical
     // `extension-pragma` (dropped by RFC 9111). The pieces enforced below — the `#`-list split,
     // the empty-element rule, `token`, and `quoted-string` — are all current RFC 9110 §5.6.
@@ -147,7 +195,10 @@ fn check_pragma_value(s: &str) -> Option<String> {
         // forbidden, unlike the empty whole value skipped by the callers above.
         // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
         if member.is_empty() {
-            return Some("Empty directive in Pragma header".into());
+            return Some((
+                &LIST_MEMBER_EMPTY,
+                "Empty directive in Pragma header".into(),
+            ));
         }
 
         let mut kv = member.splitn(2, '=');
@@ -156,17 +207,17 @@ fn check_pragma_value(s: &str) -> Option<String> {
         // cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
         let name = kv.next().unwrap().trim();
         if name.is_empty() {
-            return Some(format!(
-                "Empty directive name in Pragma member: '{}'",
-                member
+            return Some((
+                &TOKEN_EMPTY,
+                format!("Empty directive name in Pragma member: '{}'", member),
             ));
         }
 
         // Grammar owned by the helper (RFC 9110 §5.6.2 `token`).
         if let Some(c) = crate::helpers::token::find_invalid_token_char(name) {
-            return Some(format!(
-                "Directive name contains invalid character: '{}'",
-                c
+            return Some((
+                token_character(c),
+                format!("Directive name contains invalid character: '{}'", c),
             ));
         }
 
@@ -182,17 +233,25 @@ fn check_pragma_value(s: &str) -> Option<String> {
                 // deliberate tolerance for this deprecated field. Written as an
                 // arm rather than as a pre-check, because it is a verdict this
                 // rule reaches and not a step of reading the value.
+                //
+                // It is also the one answer the catalogue leaves open: the
+                // alternation's mapping returns nothing for an empty value,
+                // because the verdict is each field's, and this field's is
+                // written here.
                 Err(crate::helpers::word::WordDefect::Empty) => continue,
                 Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => {
-                    return Some(format!(
-                        "Invalid quoted-string in directive value: {}",
-                        defect.message(vpart)
+                    return Some((
+                        crate::violations::quoted_string::quoted_string_defect(defect),
+                        format!(
+                            "Invalid quoted-string in directive value: {}",
+                            defect.message(vpart)
+                        ),
                     ));
                 }
                 Err(crate::helpers::word::WordDefect::NotToken(c)) => {
-                    return Some(format!(
-                        "Directive value contains invalid character: '{}'",
-                        c
+                    return Some((
+                        token_character(c),
+                        format!("Directive value contains invalid character: '{}'", c),
                     ));
                 }
             }
@@ -227,6 +286,49 @@ mod tests {
             trailers: None,
         });
         tx
+    }
+
+    /// Every defect this deprecated field reports is a borrowed one, and the
+    /// ids say which document it was borrowed from: the list construct, the
+    /// token and the quoted-string, all RFC 9110 § 5.6. `Pragma`'s own document
+    /// states no grammar, so there was never anything else for these findings to
+    /// be named after — and the space in `bad token` is `error` while the `@` a
+    /// sender typed is `warn`, which one rule severity could not express.
+    #[test]
+    fn every_defect_is_the_borrowed_productions_and_not_the_fields() {
+        for (value, id, severity) in [
+            (
+                "no-cache,,foo",
+                "list_member_empty",
+                crate::lint::Severity::Warn,
+            ),
+            ("=abc", "token_empty", crate::lint::Severity::Warn),
+            (
+                "bad token",
+                "token_whitespace_or_control_forbidden",
+                crate::lint::Severity::Error,
+            ),
+            (
+                "foo=bad@value",
+                "token_character_forbidden",
+                crate::lint::Severity::Warn,
+            ),
+            (
+                "foo=\"unterminated",
+                "quoted_string_delimiter_missing",
+                crate::lint::Severity::Warn,
+            ),
+        ] {
+            let found = crate::test_helpers::run_rule(
+                &PragmaTokenValid,
+                &make_req(value),
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&["pragma_token_valid"]),
+            )
+            .unwrap_or_else(|| panic!("{value:?}"));
+            assert_eq!(found.violation, id, "{value:?}");
+            assert_eq!(found.severity, severity, "{value:?}");
+        }
     }
 
     #[rstest]

--- a/lint-http-rules/src/violations/list.rs
+++ b/lint-http-rules/src/violations/list.rs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! List defects — the `#` construct HTTP writes its comma-separated fields in.
+//!
+//! Twenty-three rules in this tree quote the same sentence: a sender must not
+//! generate an empty list element. It is one requirement, written once, about a
+//! construct that every list-valued field borrows unchanged — so the stray
+//! comma in `Accept-Encoding: gzip,,br`, in `Vary: ,`, in a `Cache-Control` and
+//! in a `Pragma` is one defect with one name, however differently each rule
+//! words the finding.
+//!
+//! What is deliberately *not* here is the recipient's half. § 5.6.1.2 tells a
+//! recipient to ignore empty elements, and this catalogue reports the sender's
+//! requirement: a rule that drops the member rather than reporting it is doing
+//! the recipient's job, which is the correction several of those rules already
+//! carry in their own comments.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// The list construct: what `#` expands to, and the one thing a sender may not
+/// do with it.
+pub const RFC_9110_5_6_1_1: SpecRef = SpecRef {
+    spec: "RFC 9110",
+    section: Some("5.6.1.1"),
+    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
+    note: "The list construct — `1#element => element *( OWS \",\" OWS element )`, and the sender's MUST NOT against an empty element",
+};
+
+defects! {
+    /// A member that contributes nothing to the list: two commas in a row, a
+    /// leading one, a trailing one, or a member holding only whitespace. The
+    /// grammar generates the comma *between* elements, so an element that is
+    /// not there is a comma that should not be.
+    ///
+    /// One id for every list-valued field, because it is one sentence for every
+    /// list-valued field — and the fix is the same comma either way.
+    ///
+    // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
+    LIST_MEMBER_EMPTY = {
+        id: "list_member_empty",
+        title: "List holds an empty element",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_6_1_1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole of this subject so far, and the assertion that matters about
+    /// it: the id names the construct and no field.
+    #[test]
+    fn the_empty_member_is_named_after_the_list_and_not_after_a_field() {
+        assert_eq!(LIST_MEMBER_EMPTY.id, "list_member_empty");
+        assert_eq!(LIST_MEMBER_EMPTY.default_severity, Severity::Warn);
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -38,6 +38,7 @@ pub mod cookie;
 pub mod credentials;
 pub mod domain;
 pub mod language;
+pub mod list;
 pub mod mailbox;
 pub mod node;
 pub mod quoted_string;
@@ -349,7 +350,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 94;
+        const FLOOR: usize = 96;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/lint-http-rules/src/violations/token.rs
+++ b/lint-http-rules/src/violations/token.rs
@@ -60,6 +60,25 @@ defects! {
         spec: Some(RFC_9110_5_6_2),
     }
 
+    /// A token with no characters in it: the `=` of a parameter with nothing
+    /// before it, a directive that is only its argument, a media type with an
+    /// empty subtype. `token = 1*tchar` has a one-character floor, so this is
+    /// arithmetic on the production and not a per-field tolerance.
+    ///
+    /// Not to be confused with the *value* half of `word = token /
+    /// quoted-string` being empty, which is a verdict each field makes for
+    /// itself — [`word_defect`] answers `None` there, and this def is not its
+    /// substitute.
+    ///
+    // cite(RFC 9110 § 5.6.2): "token = 1*tchar tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA"
+    TOKEN_EMPTY = {
+        id: "token_empty",
+        title: "Token is written with no characters in it",
+        message: "",
+        default_severity: Severity::Warn,
+        spec: Some(RFC_9110_5_6_2),
+    }
+
     /// A visible octet outside `tchar` — one of the delimiters § 5.6.2 names,
     /// most often, or an octet at or above %x80 in a name that was written in
     /// something other than US-ASCII. The sender chose the character; what is

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6631,7 +6631,7 @@ sources:
     - file: lint-http-rules/src/rules/link_header_valid.rs
       line: 523
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 148
+      line: 196
     - file: lint-http-rules/src/rules/prefer_header_valid.rs
       line: 298
     - file: lint-http-rules/src/rules/preference_applied_header_valid.rs
@@ -6654,6 +6654,8 @@ sources:
       line: 274
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 349
+    - file: lint-http-rules/src/violations/list.rs
+      line: 42
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -7111,7 +7113,7 @@ sources:
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
       line: 48
     - file: lint-http-rules/src/violations/token.rs
-      line: 68
+      line: 87
   - label: lint-http-rules/src/helpers/list.rs (4)
     section: § 5.6.4
     snippet: quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
@@ -7427,7 +7429,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_protocol_registered.rs
       line: 407
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 156
+      line: 207
     - file: lint-http-rules/src/rules/sec_websocket_headers_consistent.rs
       line: 118
     - file: lint-http-rules/src/rules/server_timing_header_syntax.rs
@@ -7440,6 +7442,8 @@ sources:
       line: 227
     - file: lint-http-rules/src/violations/token.rs
       line: 54
+    - file: lint-http-rules/src/violations/token.rs
+      line: 73
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 7.1
     snippet: A URI reference is resolved to its absolute form in order to obtain the "target URI".
@@ -9290,7 +9294,7 @@ sources:
     - file: lint-http-rules/src/rules/cache_control_and_pragma_consistent.rs
       line: 84
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 86
+      line: 134
   - label: cache_control_directive_valid
     section: § 5.2
     snippet: The "Cache-Control" header field is used to list directives for caches along the request/response chain.
@@ -9556,7 +9560,7 @@ sources:
     snippet: As a result, this specification deprecates Pragma.
     cited_by:
     - file: lint-http-rules/src/rules/pragma_token_valid.rs
-      line: 111
+      line: 159
   - label: range_request_and_caching
     section: § 3.3
     snippet: A cache MAY complete a stored incomplete response by making a subsequent range request (Section 14.2 of [HTTP]) and combining the successful response with the stored response, as defined in Section 3.4.


### PR DESCRIPTION
`Pragma`'s own document deprecates it and states no grammar, so every finding this rule makes is about machinery it borrows: the `#` list construct, `token`, and `quoted-string`. It reports their ids now, which makes it the cleanest demonstration the campaign has that a defect belongs to the production and not to the field that noticed it.

Two defs the borrowing needed. `list_member_empty` is the sender's MUST NOT against an empty element — one sentence, quoted by twenty-three rules in this tree, so the stray comma has one name whatever field it is in. `token_empty` is `1*tchar`'s one-character floor, which is arithmetic on the production and not the per-field verdict an empty *value* gets.

The space in `Pragma: bad token` is an error and the `@` a sender typed is a warning. One rule severity said both at once.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
