### PR TITLE
Two rules stop saying the same thing twice

### DIFF
--- a/docs/rules/cache_control_token_valid.md
+++ b/docs/rules/cache_control_token_valid.md
@@ -13,6 +13,9 @@ Validate `Cache-Control` directive names and unquoted values follow the `token` 
 ## Specifications
 
 - [RFC 9111 §5.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2): Cache-Control directives and general directive syntax
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 
 ## Configuration
 

--- a/lint-http-rules/src/helpers/cache_control.rs
+++ b/lint-http-rules/src/helpers/cache_control.rs
@@ -150,24 +150,50 @@ pub fn directives(headers: &HeaderMap) -> impl Iterator<Item = Directive<'_>> {
 /// rules do *after* the name is read is genuinely different, and stays theirs.
 // cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
 // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
-pub fn read_member(member: &str) -> Result<Directive<'_>, String> {
+pub fn read_member(member: &str) -> Result<Directive<'_>, MemberDefect<'_>> {
     if member.is_empty() {
-        return Err("Empty directive in Cache-Control header".into());
+        return Err(MemberDefect::Empty);
     }
     let directive = Directive::parse(member);
     if directive.name.is_empty() {
-        return Err(format!(
-            "Empty directive name in Cache-Control member: '{}'",
-            member
-        ));
+        return Err(MemberDefect::NameEmpty(member));
     }
     if let Some(c) = crate::helpers::token::find_invalid_token_char(directive.name) {
-        return Err(format!(
-            "Directive name contains invalid character: '{}'",
-            c
-        ));
+        return Err(MemberDefect::NameCharacter(c));
     }
     Ok(directive)
+}
+
+/// What one `Cache-Control` list member fails to be.
+///
+/// Three variants and not one of them is this field's: the first is the list
+/// construct's, and the other two are the `token` a directive name has to be.
+/// The type exists so the two rules reading this field can name *which* — they
+/// used to receive one rendered sentence and could only pass it on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberDefect<'a> {
+    /// A member contributing nothing to the list: a stray or trailing comma.
+    Empty,
+    /// A member whose name is empty — `=abc`, the `=` with nothing before it.
+    /// Carries the member, because the finding shows what was written.
+    NameEmpty(&'a str),
+    /// A character in the directive name that no `tchar` admits.
+    NameCharacter(char),
+}
+
+impl MemberDefect<'_> {
+    /// The finding, worded as both rules have always worded it.
+    pub fn message(self) -> String {
+        match self {
+            Self::Empty => "Empty directive in Cache-Control header".into(),
+            Self::NameEmpty(member) => {
+                format!("Empty directive name in Cache-Control member: '{}'", member)
+            }
+            Self::NameCharacter(c) => {
+                format!("Directive name contains invalid character: '{}'", c)
+            }
+        }
+    }
 }
 
 /// Whether the section carries the named directive at all.
@@ -469,16 +495,28 @@ mod tests {
 
     #[test]
     fn read_member_names_each_defect_in_the_directive_name() {
+        // The variant and the sentence it renders to, together: the callers
+        // that report through the catalogue match on the first and the caller
+        // that has not converted prints the second, so both halves are pinned.
+        assert_eq!(read_member("").unwrap_err(), MemberDefect::Empty);
         assert_eq!(
-            read_member("").unwrap_err(),
+            read_member("").unwrap_err().message(),
             "Empty directive in Cache-Control header"
         );
         assert_eq!(
             read_member("=1").unwrap_err(),
+            MemberDefect::NameEmpty("=1")
+        );
+        assert_eq!(
+            read_member("=1").unwrap_err().message(),
             "Empty directive name in Cache-Control member: '=1'"
         );
         assert_eq!(
             read_member("no cache").unwrap_err(),
+            MemberDefect::NameCharacter(' ')
+        );
+        assert_eq!(
+            read_member("no cache").unwrap_err().message(),
             "Directive name contains invalid character: ' '"
         );
         let directive = read_member("max-age=60").unwrap();

--- a/lint-http-rules/src/rules/cache_control_directive_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_directive_valid.rs
@@ -124,7 +124,11 @@ impl Rule for CacheControlDirectiveValid {
 fn member_defect(member: &str) -> Option<String> {
     let directive = match crate::helpers::cache_control::read_member(member) {
         Ok(directive) => directive,
-        Err(message) => return Some(message),
+        // The three defects the reader names are the list's and the token's,
+        // and `cache_control_token_valid` reports them through the catalogue.
+        // This rule is unconverted and renders them, which is the same finding
+        // in the same words it has always been.
+        Err(defect) => return Some(defect.message()),
     };
     let name = directive.name;
     // An empty argument is accepted for directives that take one; the `=` with

--- a/lint-http-rules/src/rules/cache_control_token_valid.rs
+++ b/lint-http-rules/src/rules/cache_control_token_valid.rs
@@ -4,8 +4,46 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{cache_directive_member, LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::quoted_string::{
+    quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct CacheControlTokenValid;
+
+/// The same eight defects `pragma_token_valid` declares, and for the same
+/// reason: this rule measures `cache-directive = token [ "=" ( token /
+/// quoted-string ) ]` and every part of that is RFC 9110 § 5.6 machinery the
+/// field borrows.
+///
+/// **The two rules used to write two of these findings out in identical words.**
+/// "Invalid quoted-string in directive value" and "Directive value contains
+/// invalid character" appear character for character in both files — one of the
+/// fourteen duplicate templates this campaign's measurement counted — because
+/// each rule had to word a finding about a production neither of them owns.
+/// They are one id apiece now, which is the state Phase 5's dedup can act on and
+/// a rule-shaped catalogue could not reach.
+///
+/// The non-UTF-8 site stays on the old API, with open question 1's reasoning:
+/// the verdict names an encoding where the defect is an octet the grammar does
+/// not admit, and the right conversion is an octet-wise reader first.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_EMPTY,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -29,19 +67,19 @@ impl CacheControlTokenValid {
         &self,
         headers: &hyper::HeaderMap,
         side: &str,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         for line in headers.get_all("cache-control").iter() {
             let Ok(line) = line.to_str() else {
                 return Some(self.violation(
-                    severity,
+                    ctx.severity,
                     "Cache-Control header contains non-UTF8 value".into(),
                 ));
             };
             for member in crate::helpers::cache_control::members_of(line) {
-                if let Some(message) = member_defect(member) {
-                    return Some(self.violation(
-                        severity,
+                if let Some((def, message)) = member_defect(member) {
+                    return Some(ctx.report_with(
+                        def,
                         format!("Invalid Cache-Control header in {}: {}", side, message),
                     ));
                 }
@@ -67,7 +105,16 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9111_5_2]
+        &[
+            RFC_9111_5_2,
+            RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -105,10 +152,10 @@ impl Rule for CacheControlTokenValid {
         // only the word in the finding differs.
         // cite(RFC 9111 § 5.2): "The "Cache-Control" header field is used to list directives for caches along the request/response chain."
         let finding = || -> Option<Violation> {
-            self.defect(&tx.request.headers, "request", ctx.severity)
+            self.defect(&tx.request.headers, "request", ctx)
                 .or_else(|| {
                     let resp = tx.response.as_ref()?;
-                    self.defect(&resp.headers, "response", ctx.severity)
+                    self.defect(&resp.headers, "response", ctx)
                 })
         };
         Vec::from_iter(finding())
@@ -121,10 +168,10 @@ impl Rule for CacheControlTokenValid {
 /// own question, which is about the value's *shape* rather than about what any
 /// particular directive means by it.
 // cite(RFC 9111 § 5.2): "cache-directive = token [ "=" ( token / quoted-string ) ]"
-fn member_defect(member: &str) -> Option<String> {
+fn member_defect(member: &str) -> Option<(&'static ViolationDef, String)> {
     let directive = match crate::helpers::cache_control::read_member(member) {
         Ok(directive) => directive,
-        Err(message) => return Some(message),
+        Err(defect) => return Some((cache_directive_member(defect), defect.message())),
     };
     let argument = directive.argument?;
 
@@ -140,13 +187,16 @@ fn member_defect(member: &str) -> Option<String> {
         // behavior change. (`foo=""` is genuinely valid: quoted-string permits
         // empty content.)
         Err(crate::helpers::word::WordDefect::Empty) => None,
-        Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => Some(format!(
-            "Invalid quoted-string in directive value: {}",
-            defect.message(argument)
+        Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => Some((
+            quoted_string_defect(defect),
+            format!(
+                "Invalid quoted-string in directive value: {}",
+                defect.message(argument)
+            ),
         )),
-        Err(crate::helpers::word::WordDefect::NotToken(c)) => Some(format!(
-            "Directive value contains invalid character: '{}'",
-            c
+        Err(crate::helpers::word::WordDefect::NotToken(c)) => Some((
+            token_character(c),
+            format!("Directive value contains invalid character: '{}'", c),
         )),
     }
 }
@@ -283,6 +333,49 @@ mod tests {
         );
         assert!(v.is_none());
         Ok(())
+    }
+
+    /// The pair of rules that used to write the same sentence twice now report
+    /// the same id, and the ids are the productions': the list, the token, the
+    /// quoted-string. Asserted here against the *other* rule's verdict on the
+    /// equivalent value, which is the whole claim in one assertion — two fields,
+    /// two rules, one name for one mistake.
+    #[test]
+    fn the_directive_and_the_pragma_rule_report_one_id_for_one_mistake() {
+        let judge = |rule: &dyn crate::rules::Rule, field: &str, value: &str| -> String {
+            let mut tx = crate::test_helpers::make_test_transaction();
+            tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[(field, value)]);
+            crate::test_helpers::run_rule(
+                rule,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[rule.id()]),
+            )
+            .unwrap_or_else(|| panic!("{field}: {value}"))
+            .violation
+        };
+
+        for (value, id) in [
+            ("no-cache,,foo", "list_member_empty"),
+            ("=abc", "token_empty"),
+            ("foo=bad@value", "token_character_forbidden"),
+            ("foo=\"unterminated", "quoted_string_delimiter_missing"),
+        ] {
+            assert_eq!(
+                judge(&CacheControlTokenValid, "cache-control", value),
+                id,
+                "{value}"
+            );
+            assert_eq!(
+                judge(
+                    &crate::rules::pragma_token_valid::PragmaTokenValid,
+                    "pragma",
+                    value
+                ),
+                id,
+                "{value}"
+            );
+        }
     }
 
     #[test]

--- a/lint-http-rules/src/violations/list.rs
+++ b/lint-http-rules/src/violations/list.rs
@@ -17,9 +17,11 @@
 //! the recipient's job, which is the correction several of those rules already
 //! carry in their own comments.
 
+use crate::helpers::cache_control::MemberDefect as CacheControlMemberDefect;
 use crate::lint::Severity;
 use crate::rules::SpecRef;
-use crate::violations::defects;
+use crate::violations::token::{token_character, TOKEN_EMPTY};
+use crate::violations::{defects, ViolationDef};
 
 /// The list construct: what `#` expands to, and the one thing a sender may not
 /// do with it.
@@ -49,9 +51,48 @@ defects! {
     }
 }
 
+/// The defect one `Cache-Control` list member reports as.
+///
+/// The reader is [`crate::helpers::cache_control::read_member`], shared by the
+/// two rules that measure that field's syntax, and none of its three defects is
+/// the field's: the first is this subject's, and the other two are the `token`
+/// a directive name has to be. The mapping lives here rather than beside the
+/// name's subject because the first thing the reader measures is the list
+/// member — and there is no `cache_control` subject file for it to live in,
+/// since a file holding no defect has no statement to cite and the citation
+/// ratchet reads every file under `violations/`.
+pub fn cache_directive_member(defect: CacheControlMemberDefect<'_>) -> &'static ViolationDef {
+    match defect {
+        CacheControlMemberDefect::Empty => &LIST_MEMBER_EMPTY,
+        CacheControlMemberDefect::NameEmpty(_) => &TOKEN_EMPTY,
+        CacheControlMemberDefect::NameCharacter(c) => token_character(c),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Three variants, three subjects' answers — and only the first of them is
+    /// this file's, which is the finding worth pinning: a `Cache-Control`
+    /// member that fails does so at the list, at the token, or not at all.
+    #[test]
+    fn a_cache_control_member_answers_with_the_production_it_failed() {
+        for (defect, id) in [
+            (CacheControlMemberDefect::Empty, "list_member_empty"),
+            (CacheControlMemberDefect::NameEmpty("=abc"), "token_empty"),
+            (
+                CacheControlMemberDefect::NameCharacter('@'),
+                "token_character_forbidden",
+            ),
+            (
+                CacheControlMemberDefect::NameCharacter(' '),
+                "token_whitespace_or_control_forbidden",
+            ),
+        ] {
+            assert_eq!(cache_directive_member(defect).id, id);
+        }
+    }
 
     /// The whole of this subject so far, and the assertion that matters about
     /// it: the id names the construct and no field.

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -6655,7 +6655,7 @@ sources:
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
       line: 349
     - file: lint-http-rules/src/violations/list.rs
-      line: 42
+      line: 44
   - label: lint-http-rules/src/helpers/comment.rs
     section: § 5.6.4
     snippet: The backslash octet ("\") can be used as a single-octet quoting mechanism within quoted-string and comment constructs.
@@ -9242,7 +9242,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 315
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 153
+      line: 157
   - label: age_header_numeric (2)
     section: § 1.2.2
     snippet: or the greatest positive integer it can conveniently represent.
@@ -9252,7 +9252,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 316
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 154
+      line: 158
   - label: age_header_numeric (3)
     section: § 5.1
     snippet: Although it is defined as a singleton header field, a cache encountering a message with a list-based Age field value SHOULD use the first member of the field value, discarding subsequent ones.
@@ -9274,7 +9274,7 @@ sources:
     - file: lint-http-rules/src/rules/alt_svc_h3_advertisement_valid.rs
       line: 304
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 138
+      line: 142
   - label: cache_coherence
     section: § 4.2.4
     snippet: A cache MUST NOT generate a stale response unless it is disconnected or doing so is explicitly permitted by the client or origin server
@@ -9302,13 +9302,13 @@ sources:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 106
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 106
+      line: 153
   - label: cache_control_directive_valid (2)
     section: § 5.2.2.7
     snippet: If a qualified private response directive is present, with an argument that lists one or more field names
     cited_by:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
-      line: 161
+      line: 165
   - label: cache_control_present
     section: § 4.2.2
     snippet: Since origin servers do not always provide explicit expiration times, a cache MAY assign a heuristic expiration time when an explicit time is not specified, employing algorithms that use other field values (such as the Last-Modified time) to estimate a plausible expiration time.
@@ -9416,25 +9416,25 @@ sources:
     snippet: If the max-age response directive (Section 5.2.2.1) is present, use its value, or If the Expires response header field (Section 5.3) is present, use its value minus the value of the Date response header field (using the time the message was received if it is not present, as per Section 6.6.1 of [HTTP]), or
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 325
+      line: 351
   - label: lint-http-rules/src/helpers/cache_control.rs (2)
     section: § 4.2.1
     snippet: Note that this calculation is intended to reduce clock skew by using the clock information provided by the origin server whenever possible.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 335
+      line: 361
   - label: lint-http-rules/src/helpers/cache_control.rs (3)
     section: § 4.2.3
     snippet: corrected_initial_age = max(apparent_age, corrected_age_value)
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 290
+      line: 316
   - label: lint-http-rules/src/helpers/cache_control.rs (4)
     section: § 5.1
     snippet: The "Age" response header field conveys the sender's estimate of the time since the response was generated or successfully validated at the origin server
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 289
+      line: 315
     - file: lint-http-rules/src/rules/age_header_numeric.rs
       line: 68
     - file: lint-http-rules/src/rules/max_age_directive_valid.rs
@@ -9462,13 +9462,13 @@ sources:
     - file: lint-http-rules/src/rules/cache_control_directive_valid.rs
       line: 123
     - file: lint-http-rules/src/rules/cache_control_token_valid.rs
-      line: 123
+      line: 170
   - label: lint-http-rules/src/helpers/cache_control.rs (8)
     section: § 5.2.2.4
     snippet: The no-cache response directive, in its unqualified form (without an argument), indicates that the response MUST NOT be used to satisfy any other request without forwarding it for validation and receiving a successful response
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 212
+      line: 238
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 134
   - label: lint-http-rules/src/helpers/cache_control.rs (9)
@@ -9478,7 +9478,7 @@ sources:
     - file: lint-http-rules/src/helpers/cache_control.rs
       line: 72
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 213
+      line: 239
     - file: lint-http-rules/src/rules/no_cache_revalidation.rs
       line: 150
   - label: lint-http-rules/src/helpers/cache_control.rs (10)
@@ -9486,7 +9486,7 @@ sources:
     snippet: The no-store response directive indicates that a cache MUST NOT store any part of either the immediate request or the response and MUST NOT use the response to satisfy any other request.
     cited_by:
     - file: lint-http-rules/src/helpers/cache_control.rs
-      line: 211
+      line: 237
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 150
     - file: lint-http-rules/src/rules/no_store_enforced.rs


### PR DESCRIPTION
"Invalid quoted-string in directive value" and "Directive value contains invalid character" were written out character for character in both Cache-Control-shaped rules — two of the fourteen duplicate templates the measurement found — because each had to word a finding about a production neither of them owns. They report one id apiece now.

`read_member` was the last rendered sentence in the way: it holds the three defects a directive member can have, and all three belong to somebody else, so it answers with them and the mapping sits beside the list. Its other caller renders the same words it always did.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
