### PR TITLE
A declared length is wrong in one way

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -1107,6 +1107,10 @@ severity = "warn"
 # Authentication token68 is indistinguishable from a parameter
 severity = "info"
 
+[violations.content_length_conflicting]
+# Content-Length disagrees with the octets received
+severity = "error"
+
 [violations.content_range_complete_length_conflicting]
 # Content-Range complete-length does not exceed its last-pos
 severity = "error"

--- a/docs/rules/request_body_length_accuracy.md
+++ b/docs/rules/request_body_length_accuracy.md
@@ -19,7 +19,7 @@ Checks that a request's `Content-Length` matches the number of body octets actua
 ## Specifications
 
 - [RFC 9112 §6.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3): Message body length — item 6 is what licenses this rule at all, and its condition is 'without Transfer-Encoding'; item 3 is why a message carrying both is measured by neither
-- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — why a mismatch matters rather than merely differing. Also the MUST NOT against sending it beside Transfer-Encoding, which is another rule's finding
+- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end
 - [RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6): Where the field and its `1*DIGIT` grammar are actually defined — the syntax itself is `content_length_valid`'s subject, not this rule's
 
 ## Configuration

--- a/docs/rules/response_body_length_accuracy.md
+++ b/docs/rules/response_body_length_accuracy.md
@@ -25,7 +25,7 @@ Checks that a response's `Content-Length` matches the number of body octets actu
 
 - [RFC 9112 §6.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3): Message body length, in precedence order — this rule is item 6, and items 1, 2 and 3 are why most responses are exempt rather than checked
 - [RFC 9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6): Content-Length: the field, its grammar, the MUSTs that make a HEAD or 304 response's value describe a body it did not send, and the MUST NOT against forwarding a value known to be incorrect — this rule's reason to exist
-- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing, and the MUST NOT against sending it beside Transfer-Encoding — another rule's finding
+- [RFC 9112 §6.2](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2): Content-Length as framing — the declared length is how a recipient determines where the data and the message end
 - [RFC 9110 §9.3.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2): HEAD — servers SHOULD answer it with the fields they would have sent for GET, which is what made the exemption the common case rather than a corner
 
 ## Configuration

--- a/lint-http-rules/src/rules/request_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/request_body_length_accuracy.rs
@@ -4,8 +4,22 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_length::{CONTENT_LENGTH_CONFLICTING, RFC_9112_6_2};
+use crate::violations::ViolationDef;
 
 pub struct RequestBodyLengthAccuracy;
+
+/// The one defect this rule and its mirror both report. A declared length that
+/// disagrees with the octets received is the same defect whichever end of the
+/// exchange wrote it, so the id names `Content-Length` and neither the
+/// direction nor the rule — and the `error` default the two rules had each
+/// chosen for themselves is now stated once, where an operator can change it
+/// for both at once.
+///
+/// The rule's other findings, where it has them, are about *whether* a length
+/// may be declared at all rather than about it being wrong, and they belong to
+/// the message-framing subject nothing has written yet.
+static DECLARED: &[&ViolationDef] = &[&CONTENT_LENGTH_CONFLICTING];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -15,12 +29,6 @@ const RFC_9112_6_3: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("6.3"),
     url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3",
     note: "Message body length — item 6 is what licenses this rule at all, and its condition is 'without Transfer-Encoding'; item 3 is why a message carrying both is measured by neither",
-};
-const RFC_9112_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-    note: "Content-Length as framing — why a mismatch matters rather than merely differing. Also the MUST NOT against sending it beside Transfer-Encoding, which is another rule's finding",
 };
 const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -46,6 +54,10 @@ severity = "error"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9112_6_3, RFC_9112_6_2, RFC_9110_8_6]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -174,8 +186,8 @@ impl Rule for RequestBodyLengthAccuracy {
             // cite(RFC 9110 § 8.6): "The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets."
             if let Some(body_len) = req.body_length {
                 if declared != body_len as u128 {
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &CONTENT_LENGTH_CONFLICTING,
                         format!(
                             "Content-Length ({}) does not match captured body bytes ({})",
                             declared, body_len
@@ -502,6 +514,38 @@ mod tests {
         crate::test_helpers::enable_rule(&mut cfg, "request_body_length_accuracy");
         crate::rules::validate_rules(&cfg)?;
         Ok(())
+    }
+
+    /// The mirror rule reports the same id for the same defect, and at the
+    /// same level — which is now a property of one def rather than of two
+    /// configuration examples that happened to agree. The severity is `error`
+    /// where nearly everything else in the catalogue defaults to `warn`,
+    /// because the value is what a recipient frames the message with.
+    #[test]
+    fn both_directions_report_one_id_at_one_level() {
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.method = "POST".into();
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-length", "5")]);
+        tx.request.body_length = Some(9);
+        let found = crate::test_helpers::run_rule(
+            &RequestBodyLengthAccuracy,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "request_body_length_accuracy",
+            ]),
+        )
+        .expect("a finding");
+        assert_eq!(found.violation, "content_length_conflicting");
+        assert_eq!(found.severity, crate::lint::Severity::Error);
+        assert_eq!(
+            crate::rules::response_body_length_accuracy::ResponseBodyLengthAccuracy
+                .violations()
+                .first()
+                .map(|d| d.id),
+            Some("content_length_conflicting"),
+        );
     }
 
     #[test]

--- a/lint-http-rules/src/rules/response_body_length_accuracy.rs
+++ b/lint-http-rules/src/rules/response_body_length_accuracy.rs
@@ -4,8 +4,22 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::content_length::{CONTENT_LENGTH_CONFLICTING, RFC_9112_6_2};
+use crate::violations::ViolationDef;
 
 pub struct ResponseBodyLengthAccuracy;
+
+/// The one defect this rule and its mirror both report. A declared length that
+/// disagrees with the octets received is the same defect whichever end of the
+/// exchange wrote it, so the id names `Content-Length` and neither the
+/// direction nor the rule — and the `error` default the two rules had each
+/// chosen for themselves is now stated once, where an operator can change it
+/// for both at once.
+///
+/// The rule's other findings, where it has them, are about *whether* a length
+/// may be declared at all rather than about it being wrong, and they belong to
+/// the message-framing subject nothing has written yet.
+static DECLARED: &[&ViolationDef] = &[&CONTENT_LENGTH_CONFLICTING];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -21,12 +35,6 @@ const RFC_9110_8_6: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("8.6"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6",
     note: "Content-Length: the field, its grammar, the MUSTs that make a HEAD or 304 response's value describe a body it did not send, and the MUST NOT against forwarding a value known to be incorrect — this rule's reason to exist",
-};
-const RFC_9112_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9112",
-    section: Some("6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
-    note: "Content-Length as framing, and the MUST NOT against sending it beside Transfer-Encoding — another rule's finding",
 };
 const RFC_9110_9_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -52,6 +60,10 @@ severity = "error"
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
         &[RFC_9112_6_3, RFC_9110_8_6, RFC_9112_6_2, RFC_9110_9_3_2]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -224,8 +236,8 @@ impl Rule for ResponseBodyLengthAccuracy {
             // cite(RFC 9110 § 8.6): "The "Content-Length" header field indicates the associated representation's data length as a decimal non-negative integer number of octets."
             if let Some(body_len) = resp.body_length {
                 if declared != body_len as u128 {
-                    return Some(self.violation(
-                        ctx.severity,
+                    return Some(ctx.report_with(
+                        &CONTENT_LENGTH_CONFLICTING,
                         format!(
                             "Content-Length ({}) does not match captured body bytes ({})",
                             declared, body_len

--- a/lint-http-rules/src/violations/content_length.rs
+++ b/lint-http-rules/src/violations/content_length.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Alexandre Gomes Gaigalas <alganet@gmail.com>
+//
+// SPDX-License-Identifier: ISC
+
+//! `Content-Length` defects — the declared length against the octets that came.
+//!
+//! The field is framing before it is metadata: RFC 9112 § 6.2 makes its value
+//! the information a recipient uses to decide where the message ends, so a
+//! value that disagrees with the body is not a description that happens to be
+//! stale — it is a recipient reading the next message from the wrong offset.
+//! That is why the entry here defaults to `error` while most grammar defects in
+//! this catalogue default to `warn`, and it is not this catalogue's judgment
+//! alone: the two rules that report it had each chosen `error` in their own
+//! configuration example, separately, before there was one place to say it.
+//!
+//! One id for both directions. A request whose declared length is wrong and a
+//! response whose declared length is wrong are the same defect at opposite ends
+//! of the same exchange, and the mirror rules that report them differ in which
+//! message they read and in nothing else.
+
+use crate::lint::Severity;
+use crate::rules::SpecRef;
+use crate::violations::defects;
+
+/// Why a mismatch matters rather than merely differing: the value is what a
+/// recipient frames the message with.
+pub const RFC_9112_6_2: SpecRef = SpecRef {
+    spec: "RFC 9112",
+    section: Some("6.2"),
+    url: "https://www.rfc-editor.org/rfc/rfc9112.html#section-6.2",
+    note: "Content-Length as framing — the declared length is how a recipient determines where the data and the message end",
+};
+
+defects! {
+    /// The declared length and the octets that arrived do not agree, whichever
+    /// way the difference runs. Too few octets and the recipient waits for a
+    /// message that has ended; too many and it reads the surplus as the start
+    /// of the next one.
+    ///
+    /// The comparison is only ever made where the two are comparable: the
+    /// captured length counts octets with the transfer coding resolved and any
+    /// `Content-Encoding` left alone, which is what the field counts too.
+    ///
+    // cite(RFC 9112 § 6.2): "For messages that do include content, the Content-Length field value provides the framing information necessary for determining where the data (and message) ends."
+    CONTENT_LENGTH_CONFLICTING = {
+        id: "content_length_conflicting",
+        title: "Content-Length disagrees with the octets received",
+        message: "",
+        default_severity: Severity::Error,
+        spec: Some(RFC_9112_6_2),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The default is the one thing worth pinning about a single-entry subject,
+    /// because it is the reason the entry is not `warn` like its neighbours.
+    #[test]
+    fn a_framing_disagreement_defaults_above_a_grammar_defect() {
+        assert_eq!(CONTENT_LENGTH_CONFLICTING.default_severity, Severity::Error);
+    }
+}

--- a/lint-http-rules/src/violations/mod.rs
+++ b/lint-http-rules/src/violations/mod.rs
@@ -33,6 +33,7 @@ pub mod auth_scheme;
 pub mod base64;
 pub mod basic_credentials;
 pub mod challenge;
+pub mod content_length;
 pub mod content_range;
 pub mod cookie;
 pub mod credentials;
@@ -350,7 +351,7 @@ mod tests {
     #[test]
     fn every_violation_declares_a_spec() {
         /// Raised by the commit that adds defs with specs; never lowered.
-        const FLOOR: usize = 96;
+        const FLOOR: usize = 97;
         let cited = VIOLATIONS.iter().filter(|d| d.spec.is_some()).count();
         assert!(
             cited >= FLOOR,

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -5579,9 +5579,9 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 256
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 174
+      line: 186
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 224
+      line: 236
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 206
   - label: content_location_and_uri_consistent
@@ -6013,7 +6013,7 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 72
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 133
+      line: 145
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 178
   - label: head_response_headers_match_get (6)
@@ -6059,7 +6059,7 @@ sources:
     - file: lint-http-rules/src/rules/head_response_headers_match_get.rs
       line: 250
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 145
+      line: 157
   - label: field-name grammar
     section: § A
     snippet: field-name = token field-value = *field-content
@@ -7783,7 +7783,7 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 268
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 134
+      line: 146
   - label: no_body_for_1xx_204_304 (6)
     section: § 8.6
     snippet: A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).
@@ -8511,7 +8511,7 @@ sources:
     snippet: As a result, a sender MUST NOT forward a message with a Content-Length header field value that is known to be incorrect.
     cited_by:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 213
+      line: 225
   - label: retry_after_date_or_delay
     section: § 10.2.3
     snippet: A delay-seconds value is a non-negative decimal integer, representing time in seconds.
@@ -9679,9 +9679,9 @@ sources:
     - file: lint-http-rules/src/rules/content_length_vs_transfer_encoding.rs
       line: 82
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 146
+      line: 158
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 204
+      line: 216
   - label: content_length_vs_transfer_encoding (2)
     section: § 6.3
     snippet: An intermediary that chooses to forward the message MUST first remove the received Content-Length field and process the Transfer-Encoding
@@ -9697,9 +9697,9 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 254
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 129
+      line: 141
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 199
+      line: 211
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 203
   - label: content_transfer_encoding_valid
@@ -9721,7 +9721,7 @@ sources:
     - file: lint-http-rules/src/rules/content_type_present.rs
       line: 133
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 186
+      line: 198
   - label: content_type_present (2)
     section: § 6.3
     snippet: Any response to a HEAD request and any response with a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status code is always terminated by the first empty line after the header fields, regardless of the header fields present in the message, and thus cannot contain a message body or trailer section.
@@ -9731,7 +9731,7 @@ sources:
     - file: lint-http-rules/src/rules/no_body_for_1xx_204_304.rs
       line: 187
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 128
+      line: 140
   - label: content_type_present (3)
     section: § 6.3
     snippet: Otherwise, this is a response message without a declared message body length, so the message body length is determined by the number of octets received prior to the server closing the connection.
@@ -9739,7 +9739,7 @@ sources:
     - file: lint-http-rules/src/rules/content_type_present.rs
       line: 155
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 219
+      line: 231
   - label: head_response_headers_match_get
     section: § 6.1
     snippet: This indication is not required, however, because any recipient on the response chain (including the origin server) can remove transfer codings when they are not needed.
@@ -9863,7 +9863,7 @@ sources:
     - file: lint-http-rules/src/helpers/content_length.rs
       line: 63
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 111
+      line: 123
   - label: lint-http-rules/src/helpers/uri.rs
     section: § 3.2
     snippet: A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.
@@ -9925,9 +9925,9 @@ sources:
     - file: lint-http-rules/src/rules/problem_details_structure_valid.rs
       line: 255
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 124
+      line: 136
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 200
+      line: 212
     - file: lint-http-rules/src/rules/status_200_vs_204_body_consistent.rs
       line: 205
   - label: proxy_connection_discouraged
@@ -9953,35 +9953,37 @@ sources:
     snippet: For messages that do include content, the Content-Length field value provides the framing information necessary for determining where the data (and message) ends.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 157
+      line: 169
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 214
+      line: 226
+    - file: lint-http-rules/src/violations/content_length.rs
+      line: 44
   - label: request_body_length_accuracy (2)
     section: § 6.2
     snippet: When a message does not have a Transfer-Encoding header field, a Content-Length header field (Section 8.6 of [HTTP]) can provide the anticipated size, as a decimal number of octets, for potential content.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 145
+      line: 157
   - label: request_body_length_accuracy (3)
     section: § 6.3
     snippet: If a Transfer-Encoding header field is present and the chunked transfer coding (Section 7.1) is the final encoding, the message body length is determined by reading and decoding the chunked data until the transfer coding indicates the data is complete.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 130
+      line: 142
   - label: request_body_length_accuracy (4)
     section: § 6.3
     snippet: If the sender closes the connection or the recipient times out before the indicated number of octets are received, the recipient MUST consider the message to be incomplete and close the connection.
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 158
+      line: 170
   - label: request_body_length_accuracy (5)
     section: § 6.3
     snippet: The length of a message body is determined by one of the following (in order of precedence)
     cited_by:
     - file: lint-http-rules/src/rules/request_body_length_accuracy.rs
-      line: 116
+      line: 128
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 116
+      line: 128
   - label: request_target_form_valid
     section: § 3.2
     snippet: A recipient SHOULD NOT attempt to autocorrect and then process the request without a redirect, since the invalid request-line might be deliberately crafted to bypass security filters along the request chain.
@@ -10091,7 +10093,7 @@ sources:
     snippet: A client MUST ignore any Content-Length or Transfer-Encoding header fields received in such a message.
     cited_by:
     - file: lint-http-rules/src/rules/response_body_length_accuracy.rs
-      line: 187
+      line: 199
   - label: status_code_valid_range
     section: § 4
     snippet: A client SHOULD ignore the reason-phrase content because it is not a reliable channel for information


### PR DESCRIPTION
A request whose Content-Length disagrees with the octets received and a response whose Content-Length disagrees are the same defect at opposite ends of one exchange, and the two mirror rules wrote the same sentence out to say so. One id now, in both directions.

It defaults to `error` where nearly everything in the catalogue defaults to `warn`: the value is what a recipient frames the message with, so a wrong one leaves it reading the next message from the wrong offset. That is not this catalogue's judgment alone — both rules had already chosen `error` in their own configuration examples, separately, and there was no one place to say it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
