### PR TITLE
An empty parameter value is one defect

### DIFF
--- a/docs/rules/charset_registered.md
+++ b/docs/rules/charset_registered.md
@@ -21,7 +21,9 @@ If a `Content-Type` header carries a `charset` parameter, this rule checks the n
 ## Specifications
 
 - [RFC 9110 §8.3.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2): Charset: what the parameter means, that names are matched case-insensitively, and the "ought to be registered" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies
-- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters: case-insensitive names, and `parameter-value = ( token / quoted-string )` — the fork this rule takes on the value
+- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters — `parameters = *( OWS ";" OWS [ parameter ] )`, the `name=value` pair inside it with neither half optional, and the bracketing that leaves a trailing `;` conforming
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 - [RFC 2978 §2.3](https://www.rfc-editor.org/rfc/rfc2978.html#section-2.3): `mime-charset`, the production a charset name actually follows. It and `token` are incomparable — `{`/`}` on one side, `*`/`.`/`|` on the other — so checking `token` is stricter in one direction and looser in the other, and neither direction changes a verdict
 - [IANA Character Sets](https://www.iana.org/assignments/character-sets/character-sets.xhtml): The registry this rule is named after but does not read; the configured `allowed` array stands in for it
 

--- a/docs/rules/multipart_boundary_syntax.md
+++ b/docs/rules/multipart_boundary_syntax.md
@@ -26,7 +26,9 @@ Check that a `Content-Type` naming a `multipart/*` media type carries a `boundar
 
 - [RFC 2046 §5.1.1](https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.1): Multipart common syntax: the required `boundary` parameter, the `boundary`/`bchars`/`bcharsnospace` grammar, the 1-to-70-character limit and the ban on a trailing space, and the warning that a boundary often has to be quoted
 - [RFC 9110 §8.3.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.3): Multipart Types: where HTTP adopts RFC 2046 §5.1.1 and makes the boundary part of the media type value. It also says HTTP framing does not use the boundary as a length indicator, so nothing here is a framing check
-- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters: the `parameters`/`parameter`/`parameter-value` grammar this walks, case-insensitive parameter names, and the equivalence of the quoted and unquoted forms
+- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters — `parameters = *( OWS ";" OWS [ parameter ] )`, the `name=value` pair inside it with neither half optional, and the bracketing that leaves a trailing `;` conforming
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 - [RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1): Media Type: the case-insensitivity of `type`, which is what scopes this rule to `multipart`
 
 ## Configuration

--- a/lint-http-rules/src/rules/charset_registered.rs
+++ b/lint-http-rules/src/rules/charset_registered.rs
@@ -4,8 +4,42 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::parameter::{PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6};
+use crate::violations::quoted_string::{
+    quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct CharsetRegistered;
+
+/// What this rule reports about the *parameter* it reads, which is everything
+/// it can say before the name is a charset at all. `charset=` with nothing
+/// after it, a `quoted-string` that does not close, an unquoted value holding
+/// an octet no `tchar` admits: none of those is about character sets, and each
+/// is the same defect `content_type_valid` reports about the same field line.
+///
+/// What stays on the older API is what this rule is named for — a name that is
+/// not in the configured list, and a `charset=""` whose quoting is well formed
+/// and whose *name* is empty. The second is the pair worth keeping apart:
+/// `charset=` is a parameter with no value and `charset=""` is a parameter
+/// whose value is a `quoted-string` deriving exactly as it should, holding a
+/// charset name of nothing. One is § 5.6.6's defect and the other is § 8.3.2's,
+/// and the `charset` subject that owns the second is unwritten.
+static DECLARED: &[&ViolationDef] = &[
+    &PARAMETER_VALUE_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -15,12 +49,6 @@ const RFC_9110_8_3_2: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("8.3.2"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.2",
     note: "Charset: what the parameter means, that names are matched case-insensitively, and the \"ought to be registered\" guidance that motivates this rule — guidance, not a requirement, and not something this rule verifies",
-};
-const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.6"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-    note: "Parameters: case-insensitive names, and `parameter-value = ( token / quoted-string )` — the fork this rule takes on the value",
 };
 const RFC_2978_2_3: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 2978",
@@ -77,9 +105,15 @@ allowed = ["utf-8", "iso-8859-1", "us-ascii"]
         &[
             RFC_9110_8_3_2,
             RFC_9110_5_6_6,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
             RFC_2978_2_3,
             IANA_CHARACTER_SETS,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -160,14 +194,15 @@ impl Rule for CharsetRegistered {
                         let value = parameter.value;
                         // cite(RFC 9110 § 5.6.6): "Parameter names are case-insensitive."
                         if parameter.name.eq_ignore_ascii_case("charset") {
-                            // An unquoted value must satisfy `token`, and `token`
-                            // is `1*tchar`, so nothing after the "=" is not a
-                            // charset name that happens to be unregistered — it
-                            // is not a parameter value at all.
-                            // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
+                            // Nothing after the "=" is not a charset name that
+                            // happens to be unregistered — it is not a
+                            // `parameter-value` at all, which is the parameter's
+                            // defect and not this field's. The sentence saying so
+                            // is on the def, where the three other rules reporting
+                            // it read the same one.
                             if value.is_empty() {
-                                return Some(CharsetRegistered.violation(
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    &PARAMETER_VALUE_EMPTY,
                                     format!(
                                         "Invalid Content-Type in {}: empty 'charset' parameter",
                                         which
@@ -186,10 +221,13 @@ impl Rule for CharsetRegistered {
                                 match crate::helpers::quoted_string::unescape_quoted_string(value) {
                                     Ok(u) => value_owned = Some(u),
                                     Err(defect) => {
-                                        return Some(CharsetRegistered.violation(ctx.severity, format!(
+                                        return Some(ctx.report_with(
+                                            quoted_string_defect(defect),
+                                            format!(
                                                 "Invalid Content-Type in {}: 'charset' quoted-string invalid: {}",
                                                 which, defect.message(value)
-                                            )))
+                                            ),
+                                        ))
                                     }
                                 }
                             } else {
@@ -213,14 +251,24 @@ impl Rule for CharsetRegistered {
                                 if let Some(c) =
                                     crate::helpers::token::find_invalid_token_char(value)
                                 {
-                                    return Some(CharsetRegistered.violation(ctx.severity, format!(
+                                    return Some(ctx.report_with(
+                                        token_character(c),
+                                        format!(
                                             "Invalid Content-Type in {}: charset contains invalid character '{}'",
                                             which, c
-                                        )));
+                                        ),
+                                    ));
                                 }
                             }
                             let value = value_owned.as_deref().unwrap_or(value);
 
+                            // `charset=""` reaches here and the branch above it
+                            // does not: the value *is* a `parameter-value`, a
+                            // `quoted-string` deriving exactly as it should, and
+                            // what is empty is the charset name inside it. So this
+                            // is § 8.3.2's defect rather than § 5.6.6's, and it
+                            // waits for a `charset` subject — the two look like
+                            // one finding and are two.
                             if value.is_empty() {
                                 return Some(CharsetRegistered.violation(
                                     ctx.severity,
@@ -325,6 +373,85 @@ mod tests {
             }),
         );
         cfg
+    }
+
+    /// One `Content-Type` line, two rules, one id — and a third field with a
+    /// different parameter name reaching the same one.
+    ///
+    /// `charset=` is read by this rule for its name and by
+    /// `content_type_valid` for its grammar, and before the def existed the two
+    /// wrote different sentences about the same absent value with no name in
+    /// common. `boundary=` is the same defect under another parameter, which is
+    /// the claim a subject named after the *production* makes and a subject
+    /// named after a field cannot.
+    #[test]
+    fn an_empty_parameter_value_is_one_id_across_three_readings() {
+        let response_with = |ct: &str| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(&[("content-type", ct)]);
+            tx
+        };
+        let history = crate::transaction_history::TransactionHistory::empty();
+
+        let charset = crate::test_helpers::run_rule(
+            &CharsetRegistered,
+            &response_with("text/plain; charset="),
+            &history,
+            &make_cfg(),
+        )
+        .expect("a finding about the charset parameter");
+        assert_eq!(charset.violation, "parameter_value_empty");
+
+        let grammar = crate::test_helpers::run_rule(
+            &crate::rules::content_type_valid::ContentTypeValid,
+            &response_with("text/plain; charset="),
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["content_type_valid"]),
+        )
+        .expect("a finding about the field");
+        assert_eq!(grammar.violation, charset.violation);
+        assert_ne!(
+            grammar.message, charset.message,
+            "each rule keeps its wording"
+        );
+
+        let boundary = crate::test_helpers::run_rule(
+            &crate::rules::multipart_boundary_syntax::MultipartBoundarySyntax,
+            &response_with("multipart/mixed; boundary="),
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "multipart_boundary_syntax",
+            ]),
+        )
+        .expect("a finding about the boundary parameter");
+        assert_eq!(boundary.violation, charset.violation);
+    }
+
+    /// `charset=""` is the pair that must not collapse into the one above: the
+    /// value is a `quoted-string` and derives exactly as § 5.6.6 says, so what
+    /// is empty is the charset name and the defect is this rule's own — still
+    /// on the older API, and reported at the rule's severity rather than the
+    /// parameter def's.
+    #[test]
+    fn a_quoted_empty_charset_is_not_the_parameters_defect() {
+        let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+        tx.response.as_mut().expect("a response").headers =
+            crate::test_helpers::make_headers_from_pairs(&[(
+                "content-type",
+                "text/plain; charset=\"\"",
+            )]);
+        let found = crate::test_helpers::run_rule(
+            &CharsetRegistered,
+            &tx,
+            &crate::transaction_history::TransactionHistory::empty(),
+            &make_cfg(),
+        )
+        .expect("a finding");
+        assert!(
+            found.violation.is_empty(),
+            "unconverted sites carry no defect id"
+        );
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/multipart_boundary_syntax.rs
+++ b/lint-http-rules/src/rules/multipart_boundary_syntax.rs
@@ -4,8 +4,42 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::parameter::{PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6};
+use crate::violations::quoted_string::{
+    quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct MultipartBoundarySyntax;
+
+/// What this rule reports about the *parameter* carrying the boundary, before
+/// anything about the boundary itself: `boundary=` with nothing after it, a
+/// `quoted-string` that does not close, an unquoted value holding an octet no
+/// `tchar` admits. Those are § 5.6.6's defects, read here because this rule
+/// walks the parameters, and they are the same seven `charset_registered`
+/// declares about the parameter *it* reads.
+///
+/// What stays on the older API is RFC 2046 § 5.1.1's, which is the whole of
+/// what this rule is named for: an absent boundary, an octet outside `bchars`,
+/// the 1-to-70 length and the trailing space. The two grammars are separate
+/// questions asked of one value — whether it may be written in a parameter at
+/// all, and whether it is a boundary — and only the first has a subject
+/// written.
+static DECLARED: &[&ViolationDef] = &[
+    &PARAMETER_VALUE_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -21,12 +55,6 @@ const RFC_9110_8_3_3: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("8.3.3"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.3",
     note: "Multipart Types: where HTTP adopts RFC 2046 §5.1.1 and makes the boundary part of the media type value. It also says HTTP framing does not use the boundary as a length indicator, so nothing here is a framing check",
-};
-const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.6"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-    note: "Parameters: the `parameters`/`parameter`/`parameter-value` grammar this walks, case-insensitive parameter names, and the equivalence of the quoted and unquoted forms",
 };
 const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -59,8 +87,14 @@ severity = "warn"
             RFC_2046_5_1_1,
             RFC_9110_8_3_3,
             RFC_9110_5_6_6,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
             RFC_9110_8_3_1,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -154,7 +188,7 @@ impl Rule for MultipartBoundarySyntax {
                     // below rejects it, as `bcharsnospace` is US-ASCII throughout.
                     // cite(RFC 9110 § 5.5): "A recipient SHOULD treat other allowed octets in field content (i.e., obs-text) as opaque data."
                     let s = crate::helpers::headers::field_line_as_written(hv);
-                    if let Some(v) = check_multipart_boundary(which, &s, ctx.severity) {
+                    if let Some(v) = check_multipart_boundary(which, &s, ctx) {
                         return Some(v);
                     }
                 }
@@ -177,10 +211,17 @@ impl Rule for MultipartBoundarySyntax {
     }
 }
 
+/// The reading of one field line: the parameter's half converted, the
+/// boundary's half not.
+///
+/// It takes the whole context rather than a severity because the two APIs
+/// coexist inside it — a `parameter-value` defect resolves the severity
+/// configured for that defect, while everything RFC 2046 § 5.1.1 says still
+/// emits at the rule's.
 fn check_multipart_boundary(
     which: &str,
     val: &str,
-    severity: crate::lint::Severity,
+    ctx: &crate::rules::RuleContext<'_>,
 ) -> Option<Violation> {
     // A value that is not a media-type at all has no type to compare and no
     // parameters to read. Saying so is `content_type_valid`'s
@@ -235,11 +276,12 @@ fn check_multipart_boundary(
                     found = true;
                     // Nothing after the "=" is not a boundary that happens
                     // to be too short — it is not a `parameter-value` at
-                    // all, since both alternatives are non-empty.
-                    // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
+                    // all, since both alternatives are non-empty. That is the
+                    // parameter's defect rather than the boundary's, and the
+                    // sentence saying so is on the def three other rules read.
                     if value.is_empty() {
-                        return Some(MultipartBoundarySyntax.violation(
-                            severity,
+                        return Some(ctx.report_with(
+                            &PARAMETER_VALUE_EMPTY,
                             format!(
                                 "Invalid multipart Content-Type in {}: empty 'boundary' parameter",
                                 which
@@ -266,8 +308,8 @@ fn check_multipart_boundary(
                         match crate::helpers::quoted_string::unescape_quoted_string(value) {
                             Ok(u) => u,
                             Err(defect) => {
-                                return Some(MultipartBoundarySyntax.violation(
-                                    severity,
+                                return Some(ctx.report_with(
+                                    quoted_string_defect(defect),
                                     format!(
                                         "Invalid multipart Content-Type in {}: boundary quoted-string invalid: {}",
                                         which,
@@ -287,8 +329,8 @@ fn check_multipart_boundary(
                         // are rejected either way and only the wording of the
                         // finding differs.
                         if let Some(c) = crate::helpers::token::find_invalid_token_char(value) {
-                            return Some(MultipartBoundarySyntax.violation(
-                                severity,
+                            return Some(ctx.report_with(
+                                token_character(c),
                                 format!(
                                     "Invalid multipart Content-Type in {}: boundary contains invalid token character '{}'",
                                     which, c
@@ -335,7 +377,7 @@ fn check_multipart_boundary(
                             continue;
                         }
                         return Some(MultipartBoundarySyntax.violation(
-                            severity,
+                            ctx.severity,
                             format!(
                                 "Invalid multipart Content-Type in {}: boundary contains invalid character '{}'",
                                 which, ch
@@ -353,7 +395,7 @@ fn check_multipart_boundary(
                     let len = boundary_unquoted.chars().count();
                     if len == 0 || len > 70 {
                         return Some(MultipartBoundarySyntax.violation(
-                            severity,
+                            ctx.severity,
                             format!(
                                 "Invalid multipart Content-Type in {}: 'boundary' must be between 1 and 70 characters",
                                 which
@@ -372,7 +414,7 @@ fn check_multipart_boundary(
                     // cite(RFC 2046 § 5.1.1): "boundary := 0*69<bchars> bcharsnospace"
                     if boundary_unquoted.ends_with(' ') {
                         return Some(MultipartBoundarySyntax.violation(
-                            severity,
+                            ctx.severity,
                             format!(
                                 "Invalid multipart Content-Type in {}: 'boundary' must not end with whitespace",
                                 which
@@ -397,7 +439,7 @@ fn check_multipart_boundary(
         // list is `content_type_valid`'s finding.
         if !found && !unreadable {
             return Some(MultipartBoundarySyntax.violation(
-                severity,
+                ctx.severity,
                 format!(
                     "Invalid multipart Content-Type in {}: missing required 'boundary' parameter",
                     which

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -873,13 +873,13 @@ sources:
     snippet: All subtypes of "multipart" must use this syntax.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 199
+      line: 240
   - label: multipart_boundary_syntax (2)
     section: § 5.1.1
     snippet: The Content-Type field for multipart entities requires one parameter, "boundary".
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 390
+      line: 432
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 121
   - label: multipart_boundary_syntax (3)
@@ -887,7 +887,7 @@ sources:
     snippet: The boundary delimiter line is then defined as a line consisting entirely of two hyphen characters ("-", decimal value 45) followed by the boundary parameter value from the Content-Type header field, optional linear whitespace, and a terminating CRLF.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 391
+      line: 433
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 222
   - label: multipart_boundary_syntax (4)
@@ -895,33 +895,33 @@ sources:
     snippet: The grammar for parameters on the Content-type field is such that it is often necessary to enclose the boundary parameter values in quotes on the Content-type line.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 263
+      line: 305
   - label: multipart_boundary_syntax (5)
     section: § 5.1.1
     snippet: The only mandatory global parameter for the "multipart" media type is the boundary parameter, which consists of 1 to 70 characters from a set of characters known to be very robust through mail gateways, and NOT ending with white space.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 352
+      line: 394
   - label: multipart_boundary_syntax (6)
     section: § 5.1.1
     snippet: bchars := bcharsnospace / " "
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 314
+      line: 356
   - label: multipart_boundary_syntax (7)
     section: § 5.1.1
     snippet: bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" / "+" / "_" / "," / "-" / "." / "/" / ":" / "=" / "?"
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 315
+      line: 357
   - label: multipart_boundary_syntax (8)
     section: § 5.1.1
     snippet: boundary := 0*69<bchars> bcharsnospace
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 351
+      line: 393
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 372
+      line: 414
   - label: multipart_content_type_and_body_consistent
     section: § 5.1.1
     snippet: An exact match of the entire candidate line is not required; it is sufficient that the boundary appear in its entirety following the CRLF.
@@ -5359,13 +5359,13 @@ sources:
     snippet: 'The "Content-Type" header field indicates the media type of the associated representation: either the representation enclosed in the message content or the selected representation, as determined by the message semantics.'
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 116
+      line: 150
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 180
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 142
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 124
+      line: 158
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 98
   - label: charset_registered (2)
@@ -5373,15 +5373,15 @@ sources:
     snippet: Charset names ought to be registered in the IANA "Character Sets" registry (<https://www.iana.org/assignments/character-sets>) according to the procedures defined in Section 2 of [RFC2978].
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 240
+      line: 288
   - label: charset_registered (3)
     section: § 8.3.2
     snippet: In both cases, charset names are matched case-insensitively.
     cited_by:
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 55
+      line: 83
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 241
+      line: 289
   - label: compression_and_transfer_encoding_consistent
     section: § 10.1.4
     snippet: transfer-coding    = token *( OWS ";" OWS transfer-parameter )
@@ -6963,7 +6963,7 @@ sources:
     - file: lint-http-rules/src/helpers/shown.rs
       line: 43
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 274
+      line: 322
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 221
     - file: lint-http-rules/src/rules/content_type_valid.rs
@@ -6971,7 +6971,7 @@ sources:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 260
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 155
+      line: 189
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 151
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -7209,9 +7209,9 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 256
     - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 161
+      line: 195
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 233
+      line: 274
   - label: lint-http-rules/src/helpers/media_type.rs (3)
     section: § 5.6.6
     snippet: parameter-name  = token
@@ -7236,12 +7236,8 @@ sources:
       line: 26
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
       line: 387
-    - file: lint-http-rules/src/rules/charset_registered.rs
-      line: 167
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 402
-    - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 239
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 89
     - file: lint-http-rules/src/violations/parameter.rs
@@ -7261,7 +7257,7 @@ sources:
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 399
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 223
+      line: 264
   - label: lint-http-rules/src/helpers/media_type.rs (5)
     section: § 8.3.1
     snippet: The type and subtype tokens are case-insensitive.
@@ -7279,7 +7275,7 @@ sources:
     - file: lint-http-rules/src/rules/media_type_suffix_valid.rs
       line: 211
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 200
+      line: 241
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 44
     - file: lint-http-rules/src/rules/problem_details_content_type.rs
@@ -7717,25 +7713,25 @@ sources:
     snippet: A parameter value that matches the token production can be transmitted either as a token or within a quoted-string.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 261
+      line: 303
   - label: multipart_boundary_syntax (2)
     section: § 5.6.6
     snippet: Parameter values might or might not be case-sensitive, depending on the semantics of the parameter name.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 316
+      line: 358
   - label: multipart_boundary_syntax (3)
     section: § 5.6.6
     snippet: The quoted and unquoted values are equivalent.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 262
+      line: 304
   - label: multipart_boundary_syntax (4)
     section: § 8.3.3
     snippet: All multipart types share a common syntax, as defined in Section 5.1.1 of [RFC2046], and include a boundary parameter as part of the media type value.
     cited_by:
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs
-      line: 198
+      line: 239
     - file: lint-http-rules/src/rules/multipart_content_type_and_body_consistent.rs
       line: 119
   - label: multipart_content_type_and_body_consistent


### PR DESCRIPTION
`charset_registered` and `multipart_boundary_syntax` each walk a media type's parameters to find the one they are named after, and each had its own sentence for a parameter with nothing after the `=`, a quoted-string that does not close, and an unquoted value holding an octet no `tchar` admits. None of those is about charsets or about boundaries. They now report the same ids `content_type_valid` reports about the same field line, and a test runs one `Content-Type: text/plain; charset=` past two rules to show they agree.

`charset=""` deliberately does not join them. The value is a quoted-string deriving exactly as the grammar says, and what is empty is the charset name inside it — a different defect, still reported at the rule's own severity, waiting for a subject about character sets.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
