### PR TITLE
An Accept member is a media type too

### DIFF
--- a/docs/rules/accept_header_media_type_syntax.md
+++ b/docs/rules/accept_header_media_type_syntax.md
@@ -27,7 +27,9 @@ Check that an `Accept` header reads as `#( media-range [ weight ] )`: each membe
 - [RFC 9110 §12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1): Accept: the `#( media-range [ weight ] )` list, the three shapes a `media-range` takes and what the asterisk ranges over, the removal of the extension parameters that once followed the weight, and the meaning of an Accept sent in a response
 - [RFC 9110 §12.4.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.4.2): Quality Values: the `qvalue` production and its three-digit bound, and that the parameter name is matched case-insensitively
 - [RFC 9110 §8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1): Media Type: `type` and `subtype` are both `token`, which is what the character checks enforce
-- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters: the `name=value` grammar and the two alternatives a value may take. Its prohibition on whitespace around `=` is NOT enforced here
+- [RFC 9110 §5.6.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6): Parameters — `parameters = *( OWS ";" OWS [ parameter ] )`, the `name=value` pair inside it with neither half optional, and the bracketing that leaves a trailing `;` conforming
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
+- [RFC 9110 §5.6.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.4): `quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE` — the two delimiters, the class between them, and the backslash escape
 - [RFC 9110 §5.6.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.2): Sender Requirements for lists: the bracketing that makes an empty list element something a recipient may ignore
 
 ## Configuration

--- a/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
+++ b/lint-http-rules/src/rules/accept_header_media_type_syntax.rs
@@ -2,10 +2,53 @@
 //
 // SPDX-License-Identifier: ISC
 
+use crate::helpers::parameter::ParameterDefect;
+use crate::helpers::word::WordDefect;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::parameter::{
+    PARAMETER_EQUALS_MISSING, PARAMETER_VALUE_EMPTY, RFC_9110_5_6_6,
+};
+use crate::violations::quoted_string::{
+    quoted_string_defect, QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+    QUOTED_STRING_DELIMITER_MISSING, QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    QUOTED_STRING_QUOTE_ESCAPE_MISSING, RFC_9110_5_6_4,
+};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN, TOKEN_EMPTY,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct AcceptHeaderMediaTypeSyntax;
+
+/// Everything in an `Accept` member that is a `token`, a `parameter` or a
+/// `quoted-string` — which is everything about a member except what makes it a
+/// *media-range* and what makes a `q` a weight.
+///
+/// `media-range = ( "*/*" / ( type "/" "*" ) / ( type "/" subtype ) )
+/// parameters` borrows both of its halves: each side of the slash is a `token`
+/// and the tail is § 5.6.6's, the same two productions `Content-Type` is
+/// written out of. So the nine ids below are `content_type_valid`'s nine, and
+/// the character in `Accept: text/pl@in` draws the same one as the character in
+/// `Content-Type: text/pl@in`.
+///
+/// What stays on the older API is what only this field can say: an empty
+/// media-range, whitespace inside one, a `/` that is missing, a bare `*`, a
+/// wildcard type beside a concrete subtype, a parameter written after the
+/// weight, and a `q` whose value is no `qvalue`. Those are § 12.5.1's and
+/// § 12.4.2's, and neither has a subject yet.
+static DECLARED: &[&ViolationDef] = &[
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+    &TOKEN_EMPTY,
+    &PARAMETER_EQUALS_MISSING,
+    &PARAMETER_VALUE_EMPTY,
+    &QUOTED_STRING_DELIMITER_MISSING,
+    &QUOTED_STRING_QUOTED_PAIR_MALFORMED,
+    &QUOTED_STRING_QUOTE_ESCAPE_MISSING,
+    &QUOTED_STRING_CONTROL_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -27,12 +70,6 @@ const RFC_9110_8_3_1: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("8.3.1"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1",
     note: "Media Type: `type` and `subtype` are both `token`, which is what the character checks enforce",
-};
-const RFC_9110_5_6_6: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.6"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.6",
-    note: "Parameters: the `name=value` grammar and the two alternatives a value may take. Its prohibition on whitespace around `=` is NOT enforced here",
 };
 const RFC_9110_5_6_1_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -66,8 +103,14 @@ severity = "warn"
             RFC_9110_12_4_2,
             RFC_9110_8_3_1,
             RFC_9110_5_6_6,
+            RFC_9110_5_6_2,
+            RFC_9110_5_6_4,
             RFC_9110_5_6_1_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -243,9 +286,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                             if let Some(c) =
                                 crate::helpers::token::find_invalid_token_char(parsed.type_)
                             {
-                                return Some(self.cited(
-                                    &RFC_9110_8_3_1,
-                                    ctx.severity,
+                                return Some(ctx.report_with(
+                                    token_character(c),
                                     format!(
                                         "Invalid token '{}' in media type '{}' of {}",
                                         c, parsed.type_, hdr
@@ -272,8 +314,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                                 if let Some(c) =
                                     crate::helpers::token::find_invalid_token_char(parsed.subtype)
                                 {
-                                    return Some(self.violation(
-                                        ctx.severity,
+                                    return Some(ctx.report_with(
+                                        token_character(c),
                                         format!(
                                             "Invalid token '{}' in media subtype '{}' of {}",
                                             c, parsed.subtype, hdr
@@ -322,9 +364,9 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         };
                         let parsed = match parsed {
                             Ok(parsed) => parsed,
-                            Err(crate::helpers::parameter::ParameterDefect::NoEquals(_)) => {
-                                return Some(self.violation(
-                                    ctx.severity,
+                            Err(ParameterDefect::NoEquals(_)) => {
+                                return Some(ctx.report_with(
+                                    &PARAMETER_EQUALS_MISSING,
                                     format!(
                                         "Invalid parameter '{}' in {} header: missing '='",
                                         p, hdr
@@ -343,16 +385,15 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         // on its own; §5.6.2's sentence carries the same point and
                         // covers the whitespace check above as well.)
                         // cite(RFC 9110 § 5.6.6): "parameter-name  = token"
-                        // cite(RFC 9110 § 5.6.2): "Tokens are short textual identifiers that do not include whitespace or delimiters."
                         if k.is_empty() {
-                            return Some(self.violation(ctx.severity, format!(
+                            return Some(ctx.report_with(&TOKEN_EMPTY, format!(
                                     "Empty parameter name in '{}' of {} header: a token is one or more characters",
                                     p, hdr
                                 )));
                         }
                         if let Some(c) = crate::helpers::token::find_invalid_token_char(k) {
-                            return Some(self.violation(
-                                ctx.severity,
+                            return Some(ctx.report_with(
+                                token_character(c),
                                 format!(
                                     "Invalid character '{}' in parameter name '{}' in {} header",
                                     c, k, hdr
@@ -384,7 +425,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                         } else {
                             // `parameter-value` is `( token / quoted-string )`, and
                             // the alternation is read by the helper that owns it.
-                            // cite(RFC 9110 § 5.6.6): "parameter-value = ( token / quoted-string )"
+                            // Each half's defect is named after the half, which is
+                            // why the three arms below report three subjects.
                             match crate::helpers::word::token_or_quoted_string(v) {
                                 Ok(_) => {}
                                 // The same shape the parameter *name* above was
@@ -396,15 +438,15 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                                 // `quoted-string` is its two DQUOTEs -- so the value
                                 // as written derives from no `parameter-value`.
                                 // (`x=""` is a different value and still conforms.)
-                                Err(crate::helpers::word::WordDefect::Empty) => {
-                                    return Some(self.violation(ctx.severity, format!(
+                                Err(WordDefect::Empty) => {
+                                    return Some(ctx.report_with(&PARAMETER_VALUE_EMPTY, format!(
                                             "Empty parameter value in '{}' of {} header: a parameter-value is a token or a quoted-string, and neither derives the empty string",
                                             p, hdr
                                         )));
                                 }
-                                Err(crate::helpers::word::WordDefect::NotQuotedString(defect)) => {
-                                    return Some(self.violation(
-                                        ctx.severity,
+                                Err(WordDefect::NotQuotedString(defect)) => {
+                                    return Some(ctx.report_with(
+                                        quoted_string_defect(defect),
                                         format!(
                                             "Invalid quoted-string parameter '{}' in {} header: {}",
                                             p,
@@ -413,8 +455,8 @@ impl Rule for AcceptHeaderMediaTypeSyntax {
                                         ),
                                     ));
                                 }
-                                Err(crate::helpers::word::WordDefect::NotToken(c)) => {
-                                    return Some(self.violation(ctx.severity, format!(
+                                Err(WordDefect::NotToken(c)) => {
+                                    return Some(ctx.report_with(token_character(c), format!(
                                             "Invalid token '{}' in parameter value '{}' of {} header",
                                             c, v, hdr
                                         )));
@@ -500,6 +542,49 @@ mod tests {
             &cfg,
         );
         assert!(v.is_some(), "text/html carrying %xA0 drew nothing");
+    }
+
+    /// A media-range is a media type in another field, and a member's parts now
+    /// say so by name: the same value read as an `Accept` member and as a
+    /// `Content-Type` draws one id, out of two rules that share no code on this
+    /// path — this one walks the member itself, `content_type_valid` reads it
+    /// through the media type helper.
+    ///
+    /// Six rows: both halves of the slash, and every position a parameter has.
+    #[rstest]
+    #[case("te@xt/html", "token_character_forbidden")]
+    #[case("text/ht@ml", "token_character_forbidden")]
+    #[case("text/html; charset", "parameter_equals_missing")]
+    #[case("text/html; =value", "token_empty")]
+    #[case("text/html; charset=", "parameter_value_empty")]
+    #[case("text/html; param=\"unterminated", "quoted_string_delimiter_missing")]
+    fn an_accept_member_and_a_content_type_report_one_id(#[case] value: &str, #[case] id: &str) {
+        let history = crate::transaction_history::TransactionHistory::empty();
+
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers = crate::test_helpers::make_headers_from_pairs(&[("accept", value)]);
+        let member = crate::test_helpers::run_rule(
+            &AcceptHeaderMediaTypeSyntax,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "accept_header_media_type_syntax",
+            ]),
+        )
+        .expect("a finding about the Accept member");
+        assert_eq!(member.violation, id, "Accept: {value}");
+
+        let mut tx = crate::test_helpers::make_test_transaction();
+        tx.request.headers =
+            crate::test_helpers::make_headers_from_pairs(&[("content-type", value)]);
+        let field = crate::test_helpers::run_rule(
+            &crate::rules::content_type_valid::ContentTypeValid,
+            &tx,
+            &history,
+            &crate::test_helpers::make_test_config_with_enabled_rules(&["content_type_valid"]),
+        )
+        .expect("a finding about the Content-Type");
+        assert_eq!(field.violation, id, "Content-Type: {value}");
     }
 
     #[rstest]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1280,7 +1280,7 @@ severity = "warn"
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 161;
+        const FLOOR: usize = 160;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4643,7 +4643,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 154
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 154
+      line: 197
   - label: accept_and_content_type_negotiation (7)
     section: § 12.5.1
     snippet: If more than one media range applies to a given type, the most specific reference has precedence.
@@ -4657,7 +4657,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 255
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 368
+      line: 409
   - label: accept_and_content_type_negotiation (9)
     section: § 12.5.1
     snippet: The "Accept" header field can be used by user agents to specify their preferences regarding response media types.
@@ -4665,7 +4665,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 121
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 136
+      line: 179
   - label: accept_and_content_type_negotiation (10)
     section: § 12.5.1
     snippet: The asterisk "*" character is used to group media types into ranges, with "*/*" indicating all media types and "type/*" indicating all subtypes of that type.
@@ -4673,7 +4673,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 244
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 213
+      line: 256
     - file: lint-http-rules/src/rules/content_type_valid.rs
       line: 309
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -4691,7 +4691,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_and_content_type_negotiation.rs
       line: 243
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 212
+      line: 255
   - label: accept_and_content_type_negotiation (13)
     section: § 15.5.7
     snippet: The 406 (Not Acceptable) status code indicates that the target resource does not have a current representation that would be acceptable to the user agent
@@ -4719,7 +4719,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 250
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 367
+      line: 408
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 184
   - label: accept_encoding_parameter_valid (2)
@@ -4833,7 +4833,7 @@ sources:
     snippet: A sender of qvalue MUST NOT generate more than three digits after the decimal point.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 376
+      line: 417
     - file: lint-http-rules/src/rules/te_header_valid.rs
       line: 280
   - label: accept_header_media_type_syntax (2)
@@ -4841,33 +4841,31 @@ sources:
     snippet: Each media-range might be followed by optional applicable media type parameters (e.g., charset), followed by an optional "q" parameter for indicating a relative weight (Section 12.4.2).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 155
+      line: 198
   - label: accept_header_media_type_syntax (3)
     section: § 12.5.1
     snippet: Senders using weights SHOULD send "q" last (after all media-range parameters).
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 306
+      line: 348
   - label: accept_header_media_type_syntax (4)
     section: § 12.5.1
     snippet: The accept extension grammar (accept-params, accept-ext) has been removed because it had a complicated definition, was not being used in practice, and is more easily deployed through new header fields.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 305
+      line: 347
   - label: accept_header_media_type_syntax (5)
     section: § 12.5.1
     snippet: When sent by a server in a response, Accept provides information about which content types are preferred in the content of a subsequent request to the same resource.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 137
+      line: 180
   - label: accept_header_media_type_syntax (6)
     section: § 5.6.2
     snippet: Tokens are short textual identifiers that do not include whitespace or delimiters.
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 201
-    - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 346
+      line: 244
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 178
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -4877,7 +4875,7 @@ sources:
     snippet: media-type = type "/" subtype parameters type       = token subtype    = token
     cited_by:
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 241
+      line: 284
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
       line: 42
   - label: accept_language_weight_valid
@@ -6471,7 +6469,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_present.rs
       line: 135
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 169
+      line: 212
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 310
     - file: lint-http-rules/src/rules/content_transfer_encoding_valid.rs
@@ -7027,7 +7025,7 @@ sources:
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 82
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 183
+      line: 226
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 330
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -7081,7 +7079,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_encoding_parameter_valid.rs
       line: 175
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 168
+      line: 211
     - file: lint-http-rules/src/rules/accept_language_weight_valid.rs
       line: 145
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
@@ -7223,7 +7221,7 @@ sources:
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 108
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 345
+      line: 387
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 401
   - label: parameter-value grammar
@@ -7234,8 +7232,6 @@ sources:
       line: 308
     - file: lint-http-rules/src/helpers/word.rs
       line: 26
-    - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 387
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 402
     - file: lint-http-rules/src/rules/patch_method_content_type_match.rs
@@ -7253,7 +7249,7 @@ sources:
     - file: lint-http-rules/src/helpers/parameter.rs
       line: 79
     - file: lint-http-rules/src/rules/accept_header_media_type_syntax.rs
-      line: 182
+      line: 225
     - file: lint-http-rules/src/rules/expect_header_valid.rs
       line: 399
     - file: lint-http-rules/src/rules/multipart_boundary_syntax.rs


### PR DESCRIPTION
`media-range` borrows both of its halves — each side of the slash is a `token`, the tail is the same `parameters` a `Content-Type` carries — so every character check and every parameter check this rule makes was a second wording of a defect another rule already reports. Nine ids now, all of them declared elsewhere, and a test runs six values past this rule and `content_type_valid` to show the two agree on the name while keeping their own sentences.

What stays is what only this field can say: an empty media-range, whitespace inside one, a bare asterisk, a wildcard type beside a concrete subtype, a parameter after the weight, and a `q` that is no qvalue.

The citation floor moves down one. The media type's character check was the rule's only `cited(` site among these, and its sentence is now on the def — the same trade every conversion makes, and the counter measures sites rather than statements.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
