### PR TITLE
A list of tokens is a list of tokens

### DIFF
--- a/docs/rules/allow_header_method_tokens_valid.md
+++ b/docs/rules/allow_header_method_tokens_valid.md
@@ -28,8 +28,8 @@ Scope: this rule reads header sections — a request's and a response's — and 
 
 - [RFC 9110 §10.2.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.1): The field itself: its grammar, what the set of methods means, and the sentence that gives an empty field value a meaning rather than making it a defect
 - [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not, and where `method = token` is quotable
-- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The sender's half of the list construct — the empty-member finding. The recipient's half (§5.6.1.2, parse and ignore them) is a different party's requirement, which is why the lenient list reader is not used here
-- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): `token = 1*tchar`, transcribed once in `helpers::token::is_tchar`, and the delimiter set that makes splitting this field on every comma exact
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5): A field value excludes the whitespace around it, so a value that is only whitespace is the empty value — and `obs-text` is an octet field content admits, which is why the value is read as octets rather than through a UTF-8 decode
 - [RFC 9110 §2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-2.2): The sentence that makes a value outside its own grammar a violation, and the reason both halves of the exchange are measured: it addresses whoever generated the element
 

--- a/docs/rules/vary_header_valid.md
+++ b/docs/rules/vary_header_valid.md
@@ -18,6 +18,8 @@ Because `Vary` is a comma-separated (`#`) list, an entirely empty value is a leg
 ## Specifications
 
 - [RFC 9110 §12.5.5](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.5): Vary = #( "*" / field-name ) — a comma-separated list; "*" is an ordinary member (RFC 7231's "*"-or-a-list form is obsolete). Not checked: the same section's "A proxy MUST NOT generate \"*\"", since a forwarded "*" is indistinguishable from a generated one in an observed response
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
+++ b/lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
@@ -7,8 +7,29 @@ use crate::helpers::list::sender_list_members;
 use crate::helpers::shown::{describe_octet, shown_in_finding};
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct AllowHeaderMethodTokensValid;
+
+/// Both of this rule's findings, and neither is `Allow`'s. `Allow = #method`
+/// and `method = token`, so the field contributes the *meaning* — which methods
+/// a resource allows — and borrows the whole of its grammar: a stray comma is
+/// the list construct's defect and an octet no `tchar` admits is the token's.
+///
+/// A rule can be converted whole and own nothing, which is what a field defined
+/// as a list of one production looks like from the catalogue's side. The
+/// empty *value* is the third thing this rule reads and the one it does not
+/// report: § 10.2.1 gives it a meaning, so there is no defect to name.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 impl AllowHeaderMethodTokensValid {
     /// One field section's `Allow` value, measured against the production the
@@ -36,10 +57,8 @@ impl AllowHeaderMethodTokensValid {
         &self,
         value: &str,
         section: &str,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let violation = |message: String| Some(self.violation(severity, message));
-
         // The field's own production, in the form the collected grammar gives a
         // sender, and the two things it says about emptiness. The outer `[ ]` is why
         // an `Allow:` carrying nothing is not reported: the field is `#method` and
@@ -125,11 +144,14 @@ impl AllowHeaderMethodTokensValid {
                     (ch as u32) <= 0xFF,
                     "the value is one `char` per octet; a wider `char` would truncate into a different octet"
                 );
-                return violation(format!(
-                    "Allow in the {} header section: member '{}' contains {}, which is not a `tchar`, so it derives from no `token` and therefore from no `method`",
-                    section,
-                    shown_in_finding(member),
-                    describe_octet(ch as u8)
+                return Some(ctx.report_with(
+                    token_character(ch),
+                    format!(
+                        "Allow in the {} header section: member '{}' contains {}, which is not a `tchar`, so it derives from no `token` and therefore from no `method`",
+                        section,
+                        shown_in_finding(member),
+                        describe_octet(ch as u8)
+                    ),
                 ));
             }
         }
@@ -140,10 +162,13 @@ impl AllowHeaderMethodTokensValid {
             // string the sender wrote: an `Allow:` line beside an `Allow: GET` line
             // combines to `GET,`, whose comma is the join's. An operator grepping a
             // capture for the quoted text would otherwise find nothing.
-            return violation(format!(
-                "Allow in the {} header section holds an empty list element; the section's field lines combine to '{}'. A resource that allows no methods says so with an empty field value; a comma with nothing beside it says nothing",
-                section,
-                shown_in_finding(value)
+            return Some(ctx.report_with(
+                &LIST_MEMBER_EMPTY,
+                format!(
+                    "Allow in the {} header section holds an empty list element; the section's field lines combine to '{}'. A resource that allows no methods says so with an empty field value; a comma with nothing beside it says nothing",
+                    section,
+                    shown_in_finding(value)
+                ),
             ));
         }
 
@@ -165,18 +190,6 @@ const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("A"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
     note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not, and where `method = token` is quotable",
-};
-const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-    note: "The sender's half of the list construct — the empty-member finding. The recipient's half (§5.6.1.2, parse and ignore them) is a different party's requirement, which is why the lenient list reader is not used here",
-};
-const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-    note: "`token = 1*tchar`, transcribed once in `helpers::token::is_tchar`, and the delimiter set that makes splitting this field on every comma exact",
 };
 const RFC_9110_5_5: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -219,6 +232,10 @@ severity = "error"
             RFC_9110_5_5,
             RFC_9110_2_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -328,13 +345,13 @@ impl Rule for AllowHeaderMethodTokensValid {
             }
 
             if let Some(value) = &request {
-                if let Some(v) = self.check_field_section(value, "request", ctx.severity) {
+                if let Some(v) = self.check_field_section(value, "request", ctx) {
                     return Some(v);
                 }
             }
 
             if let Some(value) = &response {
-                if let Some(v) = self.check_field_section(value, "response", ctx.severity) {
+                if let Some(v) = self.check_field_section(value, "response", ctx) {
                     return Some(v);
                 }
             }

--- a/lint-http-rules/src/rules/vary_header_valid.rs
+++ b/lint-http-rules/src/rules/vary_header_valid.rs
@@ -4,6 +4,12 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 /// Validate the `Vary` response header against RFC 9110 §12.5.5:
 /// `Vary = #( "*" / field-name )`. Each field-name must conform to the `token`
@@ -11,6 +17,22 @@ use crate::rules::{Rule, RuleMeta};
 /// zero-element list; `*` is an ordinary list member and may appear alongside
 /// field-names (RFC 7231's `"*" / 1#field-name` exclusivity was dropped).
 pub struct VaryHeaderValid;
+
+/// The same three `Allow` declares, for the same reason: `Vary = #( "*" /
+/// field-name )` is a list of `token`s and the field's own contribution is what
+/// the tokens *mean*, not what they may be. One rule reads methods and the
+/// other field names; a stray comma and an octet outside `tchar` are the same
+/// two defects in both.
+///
+/// The non-UTF-8 site is not converted, and the reason is at the site: the
+/// verdict names an encoding where the defect is an octet the field's grammar
+/// does not admit, and the right conversion is an octet-wise reader before a
+/// def. Four rules in this tree have already retired that claim.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -38,7 +60,11 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_12_5_5]
+        &[RFC_9110_12_5_5, RFC_9110_5_6_1_1, RFC_9110_5_6_2]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -111,11 +137,12 @@ impl Rule for VaryHeaderValid {
                 }
 
                 // An empty element within the list (trailing/leading/consecutive commas)
-                // is forbidden, unlike the empty whole value skipped above.
-                // cite(RFC 9110 § 5.6.1.1): "In any production that uses the list construct, a sender MUST NOT generate empty list elements."
+                // is forbidden, unlike the empty whole value skipped above. The
+                // sentence that forbids it is on the def, where the twenty-odd
+                // other fields reporting a stray comma read the same one.
                 for raw in s.split(',') {
                     if raw.trim().is_empty() {
-                        return Some(self.violation(ctx.severity, "Vary header contains empty token (e.g., trailing or consecutive commas)".into()));
+                        return Some(ctx.report_with(&LIST_MEMBER_EMPTY, "Vary header contains empty token (e.g., trailing or consecutive commas)".into()));
                     }
                 }
 
@@ -139,8 +166,8 @@ impl Rule for VaryHeaderValid {
 
                     // Every other member is a field-name, i.e. a token.
                     if let Some(c) = crate::helpers::token::find_invalid_token_char(token) {
-                        return Some(self.violation(
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            token_character(c),
                             format!(
                                 "Vary header contains invalid field-name token character: '{}'",
                                 c
@@ -164,6 +191,50 @@ static REGISTRATION: &dyn crate::rules::Rule = &VaryHeaderValid;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// `Allow` and `Vary` are one grammar apart: `#method` against
+    /// `#( "*" / field-name )`, both lists of `token`s, and the field's own
+    /// contribution is what the tokens mean rather than what they may be. So a
+    /// stray comma and an octet outside `tchar` draw one id from each rule —
+    /// which is what a rule that owns none of its defects looks like from
+    /// outside.
+    #[test]
+    fn a_list_of_tokens_reports_the_same_two_defects_as_allow() {
+        let vary = |value: &str| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(&[("vary", value)]);
+            crate::test_helpers::run_rule(
+                &VaryHeaderValid,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&["vary_header_valid"]),
+            )
+            .expect("a finding")
+        };
+        let allow = |value: &str| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(&[("allow", value)]);
+            crate::test_helpers::run_rule(
+                &crate::rules::allow_header_method_tokens_valid::AllowHeaderMethodTokensValid,
+                &tx,
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "allow_header_method_tokens_valid",
+                ]),
+            )
+            .expect("a finding")
+        };
+
+        assert_eq!(
+            vary("accept-encoding,,user-agent").violation,
+            "list_member_empty"
+        );
+        assert_eq!(allow("GET,,POST").violation, "list_member_empty");
+        assert_eq!(vary("x@bad").violation, "token_character_forbidden");
+        assert_eq!(allow("PO@T").violation, "token_character_forbidden");
+    }
 
     #[rstest]
     #[case(None, false)]

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4903,7 +4903,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 229
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 32
+      line: 53
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 46
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
@@ -4929,7 +4929,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 132
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 86
+      line: 105
   - label: accept_patch_header_valid (5)
     section: § 5.6.1.2
     snippet: 'In contrast, the following values would be invalid, since at least one non-empty element is required by the example-list production:'
@@ -5143,7 +5143,7 @@ sources:
     snippet: The response header fields below provide additional information about the response, beyond what is implied by the status code, including information about the server, about the target resource, or about related resources.
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 34
+      line: 55
     - file: lint-http-rules/src/rules/context_fields_direction.rs
       line: 45
     - file: lint-http-rules/src/rules/location_header_uri_valid.rs
@@ -5157,7 +5157,7 @@ sources:
     snippet: An empty Allow field value indicates that the resource allows no methods, which might occur in a 405 response if the resource has been temporarily disabled by configuration.
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 60
+      line: 79
     - file: lint-http-rules/src/rules/options_method_capabilities.rs
       line: 43
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -5167,13 +5167,13 @@ sources:
     snippet: The purpose of this field is strictly to inform the recipient of valid request methods associated with the resource.
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 33
+      line: 54
   - label: allow_header_method_tokens_valid (4)
     section: § 2.2
     snippet: A sender MUST NOT generate protocol elements that do not match the grammar defined by the corresponding ABNF rules.
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 285
+      line: 302
     - file: lint-http-rules/src/rules/content_location_and_uri_consistent.rs
       line: 292
     - file: lint-http-rules/src/rules/expect_header_valid.rs
@@ -5217,13 +5217,13 @@ sources:
     snippet: Allow = [ method *( OWS "," OWS method ) ]
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 59
+      line: 78
   - label: allow_header_method_tokens_valid (5)
     section: § A
     snippet: method = token minute = 2DIGIT
     cited_by:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 107
+      line: 126
     - file: lint-http-rules/src/rules/http2_pseudo_headers_valid.rs
       line: 312
     - file: lint-http-rules/src/rules/request_method_token_valid.rs
@@ -6613,7 +6613,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 333
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 85
+      line: 104
     - file: lint-http-rules/src/rules/alt_svc_header_syntax.rs
       line: 561
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
@@ -6646,8 +6646,6 @@ sources:
       line: 68
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 151
-    - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 115
     - file: lint-http-rules/src/rules/via_header_syntax.rs
       line: 274
     - file: lint-http-rules/src/rules/warning_header_syntax.rs
@@ -7105,7 +7103,7 @@ sources:
     - file: lint-http-rules/src/helpers/word.rs
       line: 88
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 75
+      line: 94
     - file: lint-http-rules/src/rules/range_header_syntax.rs
       line: 133
     - file: lint-http-rules/src/rules/status_405_allow_valid.rs
@@ -7177,7 +7175,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_patch_header_valid.rs
       line: 121
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
-      line: 61
+      line: 80
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
       line: 51
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
@@ -7517,7 +7515,7 @@ sources:
     - file: lint-http-rules/src/helpers/vary.rs
       line: 77
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 96
+      line: 122
   - label: lint-http-rules/src/helpers/vary.rs
     section: § 5.3
     snippet: A recipient MAY combine multiple field lines within a field section that have the same field name into one field line, without changing the semantics of the message, by appending each subsequent field line value to the initial field line value in order, separated by a comma (",") and optional whitespace (OWS, defined in Section 5.6.3).
@@ -9119,7 +9117,7 @@ sources:
     snippet: The "Vary" header field in a response describes what parts of a request message, aside from the method and target URI, might have influenced the origin server's process for selecting the content of this response.
     cited_by:
     - file: lint-http-rules/src/rules/vary_header_valid.rs
-      line: 91
+      line: 117
   - label: via_header_syntax
     section: § 4.1
     snippet: port = <port, see [URI], Section 3.2.3>


### PR DESCRIPTION
`Allow = #method` and `Vary = #( "*" / field-name )` differ in what their members mean and in nothing else: both are lists, both hold tokens, and between them they had four sentences for two defects. One id each now — a stray comma is the list construct's, an octet outside `tchar` is the token's — asserted across the two rules.

`Allow` converts whole and owns nothing, which is what a field defined as a list of one production looks like from the catalogue's side. Its third reading, the empty field value, stays unreported: the section gives it a meaning. `Vary` keeps its non-UTF-8 line, with the reason at the site.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
