### PR TITLE
Two more lists borrow the same two ids

### DIFF
--- a/docs/rules/connection_header_tokens_valid.md
+++ b/docs/rules/connection_header_tokens_valid.md
@@ -26,8 +26,8 @@ Scope: this rule reads header sections — a request's and a response's — and 
 
 - [RFC 9110 §7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1): The field itself: its grammar, the case-insensitivity of its options, the note that an option need not correspond to a field present in the message, and the MUST NOT this rule implements for the one field the section names
 - [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not
-- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement, which is why the shared list reader is not used here
-- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): `token` and `tchar`: what a connection-option is made of, and the delimiters it excludes
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2): Several `Connection` lines in one field section are one field value, so the members are counted after the lines are joined
 
 ## Configuration

--- a/docs/rules/trailer_header_valid.md
+++ b/docs/rules/trailer_header_valid.md
@@ -24,7 +24,8 @@ The broader question — whether a *nameable* field such as `ETag` or `Expires` 
 
 - [RFC 9110 §6.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-6.6.2): The `Trailer` field itself: what its value means, and the SHOULD that asks a sender to write one
 - [RFC 9110 §A](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A): The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not
-- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement and is why the shared list reader is not used here
+- [RFC 9110 §5.6.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1): The list construct — `1#element => element *( OWS "," OWS element )`, and the sender's MUST NOT against an empty element
+- [RFC 9110 §5.6.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2): Tokens — `token = 1*tchar`, and the fifteen punctuation marks besides the digits and letters that `tchar` admits
 - [RFC 9110 §5.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.2): Several `Trailer` lines in one field section are one field value, so the members are counted after the lines are joined
 - [RFC 9110 §7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1): `Connection` and hop-by-hop semantics; the sentence that removes connection-options from a trailer section is the MUST behind the nomination finding. This said RFC 7230 §6.1 — the right section of an obsoleted document, with the two notes swapped between them
 - [RFC 9110 §6.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-6.5.1): Limitations on use of trailers. Applied here only to `Trailer` naming itself; the general question is `trailer_fields_valid`'s

--- a/lint-http-rules/src/rules/connection_header_tokens_valid.rs
+++ b/lint-http-rules/src/rules/connection_header_tokens_valid.rs
@@ -6,8 +6,30 @@ use crate::helpers::headers::{combined_field_value_as_written, trim_ows};
 use crate::helpers::list::sender_list_members;
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 pub struct ConnectionHeaderTokensValid;
+
+/// The two defects a `#connection-option` list can have that are not this
+/// field's: a member that is empty, and a member holding an octet no `tchar`
+/// admits. `Connection = #connection-option` and `connection-option = token`,
+/// so both belong to the constructs the field is written out of.
+///
+/// What stays is § 7.6.1's own sentence, and it is the whole reason this rule
+/// is not `allow_header_method_tokens_valid` with another name: a
+/// connection-option naming a field intended for all recipients of the content
+/// — `Cache-Control`, which the section names — is a well-formed token in a
+/// well-formed list that says something a sender MUST NOT say.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 impl ConnectionHeaderTokensValid {
     /// One field section's `Connection` value, measured against the production the
@@ -25,9 +47,11 @@ impl ConnectionHeaderTokensValid {
     fn check_field_section(
         &self,
         headers: &hyper::HeaderMap,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let violation = |message: String| Some(self.violation(severity, message));
+        // The list's and the token's defects report through the catalogue; the
+        // sentences this field owns still emit at the rule's severity.
+        let violation = |message: String| Some(self.violation(ctx.severity, message));
 
         let value = combined_field_value_as_written(headers, "connection")?;
 
@@ -79,10 +103,13 @@ impl ConnectionHeaderTokensValid {
                 // character that stopped the parse is by definition one the grammar
                 // did not admit — often a control octet, which written through would
                 // corrupt the finding rather than describe it.
-                return violation(format!(
-                    "Connection header holds invalid character '{}' in member '{}'; a member is a connection-option, which is a token",
-                    ch.escape_debug(),
-                    member.escape_debug()
+                return Some(ctx.report_with(
+                    token_character(ch),
+                    format!(
+                        "Connection header holds invalid character '{}' in member '{}'; a member is a connection-option, which is a token",
+                        ch.escape_debug(),
+                        member.escape_debug()
+                    ),
                 ));
             }
 
@@ -105,9 +132,12 @@ impl ConnectionHeaderTokensValid {
         }
 
         if saw_an_empty_element {
-            return violation(format!(
-                "Connection header holds an empty member: '{}'",
-                value.escape_debug()
+            return Some(ctx.report_with(
+                &LIST_MEMBER_EMPTY,
+                format!(
+                    "Connection header holds an empty member: '{}'",
+                    value.escape_debug()
+                ),
             ));
         }
 
@@ -129,19 +159,6 @@ const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("A"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
     note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
-};
-const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-    note: "The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement, which is why the shared list reader is not used here",
-};
-const RFC_9110_5_6_2: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.2"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.2",
-    note:
-        "`token` and `tchar`: what a connection-option is made of, and the delimiters it excludes",
 };
 const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -173,6 +190,10 @@ severity = "warn"
             RFC_9110_5_6_2,
             RFC_9110_5_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -232,12 +253,12 @@ impl Rule for ConnectionHeaderTokensValid {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            if let Some(v) = self.check_field_section(&tx.request.headers, ctx.severity) {
+            if let Some(v) = self.check_field_section(&tx.request.headers, ctx) {
                 return Some(v);
             }
 
             if let Some(resp) = &tx.response {
-                if let Some(v) = self.check_field_section(&resp.headers, ctx.severity) {
+                if let Some(v) = self.check_field_section(&resp.headers, ctx) {
                     return Some(v);
                 }
             }
@@ -258,6 +279,38 @@ mod tests {
 
     use hyper::header::HeaderValue;
     use rstest::rstest;
+
+    /// One sentence, four fields. `Allow`, `Vary`, `Connection` and `Trailer`
+    /// are `#`-lists of `token`s that differ only in what a member means, and a
+    /// stray comma in any of them is now RFC 9110 § 5.6.1.1's one defect rather
+    /// than four rules' four wordings. The token half is asserted beside it,
+    /// because the two ids travel together wherever this shape appears.
+    #[test]
+    fn four_token_lists_report_one_stray_comma() {
+        let found = connection(Section::Request, &[b"keep-alive,,close"]).expect("a finding");
+        assert_eq!(found.violation, "list_member_empty");
+
+        let bad_octet = connection(Section::Request, &[b"keep@alive"]).expect("a finding");
+        assert_eq!(bad_octet.violation, "token_character_forbidden");
+
+        // The three siblings declare the same two ids, which is what makes the
+        // sentence above one an operator can silence in one place.
+        for rule in [
+            "allow_header_method_tokens_valid",
+            "vary_header_valid",
+            "trailer_header_valid",
+        ] {
+            let declared: Vec<&str> = crate::rules::all_rules()
+                .filter(|r| r.id() == rule)
+                .flat_map(|r| r.violations().iter().map(|d| d.id))
+                .collect();
+            assert!(
+                declared.contains(&"list_member_empty")
+                    && declared.contains(&"token_character_forbidden"),
+                "{rule} declares {declared:?}",
+            );
+        }
+    }
 
     #[derive(Clone, Copy, Debug)]
     enum Section {

--- a/lint-http-rules/src/rules/trailer_header_valid.rs
+++ b/lint-http-rules/src/rules/trailer_header_valid.rs
@@ -4,6 +4,12 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::list::{LIST_MEMBER_EMPTY, RFC_9110_5_6_1_1};
+use crate::violations::token::{
+    token_character, RFC_9110_5_6_2, TOKEN_CHARACTER_FORBIDDEN,
+    TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+};
+use crate::violations::ViolationDef;
 
 /// The `Trailer` header field's own syntax, and the fields it may name.
 ///
@@ -15,6 +21,22 @@ use crate::rules::{Rule, RuleMeta};
 /// cite(RFC 9110 § 6.5.2): "The "Trailer" header field (Section 6.6.2) can be sent to indicate fields likely to be sent in the trailer section, which allows recipients to prepare for their receipt before processing the content."
 #[derive(Debug, Clone)]
 pub struct TrailerHeaderValid;
+
+/// The list's and the token's defects, which is everything this rule says about
+/// the *shape* of the declaration. `Trailer = #field-name` and `field-name =
+/// token`, the same two productions `Allow`, `Vary` and `Connection` are built
+/// from.
+///
+/// What stays is what the declaration *names*: a `Trailer` nominating `Trailer`
+/// itself, which announces a section the recipient has finished reading, and a
+/// nomination of a connection-specific field, which does not survive the hop.
+/// Both are well-formed tokens in a well-formed list, and both are about what
+/// the name means rather than what it is.
+static DECLARED: &[&ViolationDef] = &[
+    &LIST_MEMBER_EMPTY,
+    &TOKEN_WHITESPACE_OR_CONTROL_FORBIDDEN,
+    &TOKEN_CHARACTER_FORBIDDEN,
+];
 
 use crate::helpers::headers::{combined_field_value_as_written, trim_ows};
 use crate::helpers::list::sender_list_members;
@@ -34,9 +56,11 @@ impl TrailerHeaderValid {
     fn check_field_section(
         &self,
         hdrs: &hyper::HeaderMap,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
-        let violation = |message: String| Some(self.violation(severity, message));
+        // The list's and the token's defects report through the catalogue; the
+        // sentences this field owns still emit at the rule's severity.
+        let violation = |message: String| Some(self.violation(ctx.severity, message));
 
         let value = combined_field_value_as_written(hdrs, "trailer")?;
         let connection_val = combined_field_value_as_written(hdrs, "connection");
@@ -75,9 +99,12 @@ impl TrailerHeaderValid {
             //
             // cite(RFC 9110 § A, label: field-name grammar): "field-name = token field-value = *field-content"
             if let Some(ch) = crate::helpers::token::find_invalid_token_char(member) {
-                return violation(format!(
-                    "Trailer header contains invalid character '{}' in member '{}'; a member is a field-name, which is a token",
-                    ch, member
+                return Some(ctx.report_with(
+                    token_character(ch),
+                    format!(
+                        "Trailer header contains invalid character '{}' in member '{}'; a member is a field-name, which is a token",
+                        ch, member
+                    ),
                 ));
             }
 
@@ -119,7 +146,10 @@ impl TrailerHeaderValid {
         }
 
         if saw_an_empty_element {
-            return violation(format!("Trailer header holds an empty member: '{}'", value));
+            return Some(ctx.report_with(
+                &LIST_MEMBER_EMPTY,
+                format!("Trailer header holds an empty member: '{}'", value),
+            ));
         }
 
         None
@@ -140,12 +170,6 @@ const RFC_9110_A: crate::rules::SpecRef = crate::rules::SpecRef {
     section: Some("A"),
     url: "https://www.rfc-editor.org/rfc/rfc9110.html#appendix-A",
     note: "The collected grammar, where the list construct is expanded for a sender — the form that shows both that the whole value may be empty and that a member may not",
-};
-const RFC_9110_5_6_1_1: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.1.1"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.1.1",
-    note: "The sender's half of the list construct. The recipient's half (§5.6.1.2, ignore empty elements) is a different party's requirement and is why the shared list reader is not used here",
 };
 const RFC_9110_5_2: crate::rules::SpecRef = crate::rules::SpecRef {
     spec: "RFC 9110",
@@ -192,11 +216,16 @@ severity = "warn"
             RFC_9110_6_6_2,
             RFC_9110_A,
             RFC_9110_5_6_1_1,
+            RFC_9110_5_6_2,
             RFC_9110_5_2,
             RFC_9110_7_6_1,
             RFC_9110_6_5_1,
             RFC_9112_7_1_2,
         ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -251,12 +280,12 @@ impl Rule for TrailerHeaderValid {
         // Single-finding body behind an Option: `?` ends it early, and the
         // one finding (or none) becomes the vector.
         let finding = || -> Option<Violation> {
-            if let Some(v) = self.check_field_section(&tx.request.headers, ctx.severity) {
+            if let Some(v) = self.check_field_section(&tx.request.headers, ctx) {
                 return Some(v);
             }
 
             if let Some(resp) = &tx.response {
-                if let Some(v) = self.check_field_section(&resp.headers, ctx.severity) {
+                if let Some(v) = self.check_field_section(&resp.headers, ctx) {
                     return Some(v);
                 }
             }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -4869,7 +4869,7 @@ sources:
     - file: lint-http-rules/src/rules/accept_ranges_values_valid.rs
       line: 178
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 76
+      line: 100
   - label: accept_header_media_type_syntax (7)
     section: § 8.3.1
     snippet: media-type = type "/" subtype parameters type       = token subtype    = token
@@ -5509,13 +5509,13 @@ sources:
     snippet: A sender MUST NOT send a connection option corresponding to a field that is intended for all recipients of the content.  For example, Cache-Control is never appropriate as a connection option (Section 5.2 of [CACHING]).
     cited_by:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 99
+      line: 126
   - label: Connection grammar
     section: § 7.6.1
     snippet: 'Connection        = #connection-option connection-option = token'
     cited_by:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 24
+      line: 46
     - file: lint-http-rules/src/rules/transfer_encoding_chunked_final.rs
       line: 166
   - label: connection_header_tokens_valid (2)
@@ -5523,19 +5523,19 @@ sources:
     snippet: The "Connection" header field allows the sender to list desired control options for the current connection.
     cited_by:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 23
+      line: 45
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 221
+      line: 242
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 219
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 33
+      line: 55
   - label: Connection grammar, sender-expanded
     section: § A
     snippet: Connection = [ connection-option *( OWS "," OWS connection-option ) ]
     cited_by:
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 50
+      line: 74
   - label: content_disposition_token_valid
     section: § 5.5
     snippet: Field values are usually constrained to the range of US-ASCII characters [USASCII].
@@ -6067,7 +6067,7 @@ sources:
     - file: lint-http-rules/src/rules/header_field_names_token_valid.rs
       line: 162
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 76
+      line: 100
   - label: host_and_authority_consistent
     section: § 4.2.1
     snippet: If the port subcomponent is empty or not given, TCP port 80 (the reserved port for WWW services) is the default.
@@ -6377,7 +6377,7 @@ sources:
     - file: lint-http-proxy/src/proxy/hop_by_hop.rs
       line: 108
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 98
+      line: 125
   - label: lint-http-proxy/src/proxy/hop_by_hop.rs (7)
     section: § 7.6.1
     snippet: Furthermore, intermediaries SHOULD remove or replace fields that are known to require removal before forwarding, whether or not they appear as a connection-option, after applying those fields' semantics.
@@ -6399,7 +6399,7 @@ sources:
     - file: lint-http-rules/src/helpers/field_placement.rs
       line: 177
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 109
+      line: 136
   - label: lint-http-proxy/src/proxy/websocket/handshake.rs
     section: § 15.2
     snippet: A 1xx response is terminated by the end of the header section; it cannot contain content or trailers.
@@ -6619,7 +6619,7 @@ sources:
     - file: lint-http-rules/src/rules/caching_directive_interaction.rs
       line: 105
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 65
+      line: 89
     - file: lint-http-rules/src/rules/forwarded_header_valid.rs
       line: 341
     - file: lint-http-rules/src/rules/if_match_etag_syntax.rs
@@ -6643,7 +6643,7 @@ sources:
     - file: lint-http-rules/src/rules/timing_allow_origin_valid.rs
       line: 160
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 68
+      line: 92
     - file: lint-http-rules/src/rules/upgrade_header_syntax.rs
       line: 151
     - file: lint-http-rules/src/rules/via_header_syntax.rs
@@ -6869,7 +6869,7 @@ sources:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 234
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 90
+      line: 117
     - file: lint-http-rules/src/rules/user_agent_present.rs
       line: 111
     - file: lint-http-rules/src/rules/user_agent_token_valid.rs
@@ -7177,7 +7177,7 @@ sources:
     - file: lint-http-rules/src/rules/allow_header_method_tokens_valid.rs
       line: 80
     - file: lint-http-rules/src/rules/connection_header_tokens_valid.rs
-      line: 51
+      line: 75
     - file: lint-http-rules/src/rules/from_header_email_syntax.rs
       line: 293
     - file: lint-http-rules/src/rules/host_and_authority_consistent.rs
@@ -7897,7 +7897,7 @@ sources:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 227
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 93
+      line: 120
   - label: post_creates_resource (3)
     section: § 9.3.3
     snippet: An origin server indicates response semantics by choosing an appropriate status code depending on the result of processing the POST request; almost all of the status codes defined by this specification could be received in a response to POST (the exceptions being 206 (Partial Content), 304 (Not Modified), and 416 (Range Not Satisfiable)).
@@ -9003,7 +9003,7 @@ sources:
     - file: lint-http-rules/src/rules/trailer_fields_valid.rs
       line: 283
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 91
+      line: 118
   - label: trailer_fields_valid (3)
     section: § 7.6.1
     snippet: When a field aside from Connection is used to supply control information for or about the current connection, the sender MUST list the corresponding field name within the Connection header field.
@@ -9017,19 +9017,19 @@ sources:
     snippet: The "Trailer" header field (Section 6.6.2) can be sent to indicate fields likely to be sent in the trailer section, which allows recipients to prepare for their receipt before processing the content.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 15
+      line: 21
   - label: trailer_header_valid (2)
     section: § 6.6
     snippet: Fields that describe the message itself, such as when and how the message has been generated, can appear in both requests and responses.
     cited_by:
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 240
+      line: 269
   - label: Trailer grammar
     section: § A
     snippet: Trailer = [ field-name *( OWS "," OWS field-name ) ]
     cited_by:
     - file: lint-http-rules/src/rules/trailer_header_valid.rs
-      line: 52
+      line: 76
   - label: transfer_coding_registered
     section: § 10.1.4
     snippet: 'TE                 = #t-codings t-codings          = "trailers" / ( transfer-coding [ weight ] ) transfer-coding    = token *( OWS ";" OWS transfer-parameter ) transfer-parameter = token BWS "=" BWS ( token / quoted-string )'


### PR DESCRIPTION
`Connection = #connection-option` and `Trailer = #field-name` are the same shape as Allow and Vary, and their stray commas and bad octets are now the same two ids — four fields, one sentence apiece, asserted where the fourth one lands.

Each keeps what it is actually named for. Connection reports a connection-option naming a field intended for all recipients of the content; Trailer reports a declaration nominating Trailer itself, and one naming a field that does not survive the hop. All three are well-formed tokens in well-formed lists, saying something the specification refuses.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
