### PR TITLE
A timestamp no recipient can read

### DIFF
--- a/docs/rules/cookie_attribute_consistent.md
+++ b/docs/rules/cookie_attribute_consistent.md
@@ -24,7 +24,7 @@ Validate `Set-Cookie` attributes for syntactic correctness and common security c
 - [RFC 6265 §5.2.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-5.2.2): The Max-Age attribute — ignored unless it is a `-`-or-DIGIT first character with an all-DIGIT remainder
 - [draft-ietf-httpbis-rfc6265bis](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis): `SameSite` value grammar and the `SameSite=None` requires `Secure` rule. No section: a draft renumbers between revisions
 - [MDN Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie): SameSite cookies (SameSite=None should be Secure) — browser compatibility guidance on `SameSite` usage
-- [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7): HTTP-date (IMF-fixdate) — used for the `Expires` attribute
+- [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7): Date/Time Formats — `HTTP-date = IMF-fixdate / obs-date`, the recipient's MUST to accept all three, and the sender's MUST to generate only the first
 
 ## Configuration
 

--- a/docs/rules/date_and_time_headers_consistent.md
+++ b/docs/rules/date_and_time_headers_consistent.md
@@ -16,6 +16,7 @@ Validate that date/time related headers are well-formed and mutually consistent.
 - [RFC 9110 §8.8.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.2): `Last-Modified` header
 - [RFC 9110 §13.1.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3): `If-Modified-Since` (conditional requests)
 - [RFC 8594 §3](https://www.rfc-editor.org/rfc/rfc8594.html#section-3): `Sunset` header semantics
+- [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7): Date/Time Formats — `HTTP-date = IMF-fixdate / obs-date`, the recipient's MUST to accept all three, and the sender's MUST to generate only the first
 
 ## Configuration
 

--- a/docs/rules/sunset_and_deprecation_consistent.md
+++ b/docs/rules/sunset_and_deprecation_consistent.md
@@ -16,6 +16,7 @@ When both `Sunset` and `Deprecation` response headers are present they must be l
 - [RFC 9745 §2.1](https://www.rfc-editor.org/rfc/rfc9745.html#section-2.1): `Deprecation` is a Structured Field Date (`@<seconds>`)
 - [RFC 9745 §4](https://www.rfc-editor.org/rfc/rfc9745.html#section-4): Sunset MUST NOT be earlier than Deprecation
 - [RFC 9651 §3.3.7](https://www.rfc-editor.org/rfc/rfc9651.html#section-3.3.7): Structured Field `Date` item syntax
+- [RFC 9110 §5.6.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7): Date/Time Formats — `HTTP-date = IMF-fixdate / obs-date`, the recipient's MUST to accept all three, and the sender's MUST to generate only the first
 
 ## Configuration
 

--- a/lint-http-rules/src/rules/cookie_attribute_consistent.rs
+++ b/lint-http-rules/src/rules/cookie_attribute_consistent.rs
@@ -4,8 +4,22 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::http_date::{HTTP_DATE_MALFORMED, RFC_9110_5_6_7};
+use crate::violations::ViolationDef;
 
 pub struct CookieAttributeConsistent;
+
+/// The one attribute this rule reads through a production another field
+/// already owns. `sane-cookie-date` is RFC 6265's name for the timestamp RFC
+/// 9110 § 5.6.7 writes, so a `Expires` a recipient cannot read is the same
+/// defect a `Date` or a `Sunset` a recipient cannot read is — and the rule
+/// keeps every other finding of its own, because the rest of a `cookie-av` is
+/// the cookie's grammar and nothing else's.
+///
+/// The remaining sixteen sites are not converted: the cookie-pair, the
+/// `Max-Age` integer and the `SameSite` values are subjects nothing has
+/// written, and the non-UTF-8 line is the family open question 1 refuses.
+static DECLARED: &[&ViolationDef] = &[&HTTP_DATE_MALFORMED];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -35,12 +49,6 @@ const MDN_SET_COOKIE: crate::rules::SpecRef = crate::rules::SpecRef {
     url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie",
     note: "SameSite cookies (SameSite=None should be Secure) — browser compatibility guidance on `SameSite` usage",
 };
-const RFC_9110_5_6_7: crate::rules::SpecRef = crate::rules::SpecRef {
-    spec: "RFC 9110",
-    section: Some("5.6.7"),
-    url: "https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7",
-    note: "HTTP-date (IMF-fixdate) — used for the `Expires` attribute",
-};
 
 impl CookieAttributeConsistent {
     /// The first defect in one `Set-Cookie` field line, if it has one.
@@ -49,7 +57,14 @@ impl CookieAttributeConsistent {
     /// different grammars: the pair is judged here, each attribute by
     /// [`Self::attribute_defect`], and the one question that needs both — a
     /// `SameSite=None` cookie that is not `Secure` — after the walk.
-    fn set_cookie_defect(&self, line: &str, severity: crate::lint::Severity) -> Option<Violation> {
+    fn set_cookie_defect(
+        &self,
+        line: &str,
+        ctx: &crate::rules::RuleContext<'_>,
+    ) -> Option<Violation> {
+        // The unconverted branches read the rule's own severity, exactly as
+        // they did before the context was threaded through.
+        let severity = ctx.severity;
         let (pair, attributes) = crate::helpers::cookie::split_set_cookie(line);
         if pair.is_empty() {
             return Some(self.violation(severity, "Set-Cookie header missing cookie-pair".into()));
@@ -71,7 +86,7 @@ impl CookieAttributeConsistent {
         let mut secure_present = false;
         let mut same_site: Option<String> = None;
         for attribute in attributes {
-            if let Some(defect) = self.attribute_defect(&attribute, severity) {
+            if let Some(defect) = self.attribute_defect(&attribute, ctx) {
                 return Some(defect);
             }
             // Past the defect check the values are known good, so what is
@@ -104,8 +119,9 @@ impl CookieAttributeConsistent {
     fn attribute_defect(
         &self,
         attribute: &crate::helpers::cookie::Attribute<'_>,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
+        let severity = ctx.severity;
         // The two flag attributes: the grammar admits no "=", so the attribute
         // is its own presence and a value written after it is a defect.
         // cite(RFC 6265 § 4.1.1): "secure-av         = "Secure""
@@ -177,11 +193,15 @@ impl CookieAttributeConsistent {
                     "Set-Cookie attribute 'Expires' requires a HTTP-date value".into(),
                 ));
             };
+            // `sane-cookie-date` is the timestamp § 5.6.7 writes, under RFC
+            // 6265's name for it, so what is wrong with an unreadable `Expires`
+            // is not a fact about cookies. This is the recipient's parse — the
+            // one § 5.6.7 obliges every reader to perform — so a failure means
+            // the attribute names no instant at all.
             // cite(RFC 6265 § 4.1.1): "expires-av        = "Expires=" sane-cookie-date"
             return (!crate::http_date::is_valid_http_date(value)).then(|| {
-                self.cited(
-                    &RFC_6265_4_1_1,
-                    severity,
+                ctx.report_with(
+                    &HTTP_DATE_MALFORMED,
                     format!(
                         "Set-Cookie attribute 'Expires' is not a valid HTTP-date: '{}'",
                         value
@@ -261,6 +281,10 @@ severity = "warn"
         ]
     }
 
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
+    }
+
     fn examples(&self) -> &'static [crate::rules::Example] {
         use crate::rules::{Compliance, Example};
         &[
@@ -317,7 +341,7 @@ impl Rule for CookieAttributeConsistent {
                         ctx.severity,
                         "Set-Cookie header value is not valid UTF-8".into(),
                     )),
-                    Ok(line) => self.set_cookie_defect(line, ctx.severity),
+                    Ok(line) => self.set_cookie_defect(line, ctx),
                 })
         };
         Vec::from_iter(finding())

--- a/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
+++ b/lint-http-rules/src/rules/date_and_time_headers_consistent.rs
@@ -4,9 +4,26 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::http_date::{HTTP_DATE_MALFORMED, RFC_9110_5_6_7};
+use crate::violations::ViolationDef;
 
 /// Validate Date, Last-Modified, If-Modified-Since and Sunset header consistency and formats.
 pub struct DateAndTimeHeadersConsistent;
+
+/// The one defect this rule reports about a timestamp itself; everything else
+/// it says is about two of them disagreeing.
+///
+/// This is the *recipient's* half of § 5.6.7 — `parse_http_date_to_datetime`
+/// accepts all three formats, so a failure here means no recipient could read
+/// the value at all, which is exactly what `http_date_malformed` names. The
+/// sender's half (an obsolete spelling, a padded one) belongs to the per-field
+/// format rules and is deliberately not asked here, so the two obsolete ids are
+/// not declared: this rule cannot reach them.
+///
+/// The non-UTF-8 lines stay on the older API: the verdict names an encoding
+/// where the defect is an octet the field's grammar does not admit, and the
+/// right conversion for such a site is an octet-wise reader before a def.
+static DECLARED: &[&ViolationDef] = &[&HTTP_DATE_MALFORMED];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -90,18 +107,17 @@ impl DateAndTimeHeadersConsistent {
     fn date_is_readable(
         &self,
         headers: &hyper::HeaderMap,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         match timestamp(headers, "date") {
             Timestamp::Absent | Timestamp::At(..) => None,
             Timestamp::Unreadable => Some(self.cited(
                 &RFC_9110_6_6_1,
-                severity,
+                ctx.severity,
                 "Date header contains non-UTF8 bytes and is invalid".into(),
             )),
-            Timestamp::Unparseable => Some(self.cited(
-                &RFC_9110_6_6_1,
-                severity,
+            Timestamp::Unparseable => Some(ctx.report_with(
+                &HTTP_DATE_MALFORMED,
                 "Date header is not a valid HTTP-date (RFC 9110 §5.6.7)".into(),
             )),
         }
@@ -152,22 +168,22 @@ impl DateAndTimeHeadersConsistent {
         date: chrono::DateTime<chrono::Utc>,
         date_text: &str,
         skew: chrono::Duration,
-        severity: crate::lint::Severity,
+        ctx: &crate::rules::RuleContext<'_>,
     ) -> Option<Violation> {
         headers
             .get_all("sunset")
             .iter()
             .find_map(|line| match Timestamp::of(line) {
                 Timestamp::Unreadable => Some(self.violation(
-                    severity,
+                    ctx.severity,
                     "Sunset header contains non-UTF8 bytes and is invalid".into(),
                 )),
-                Timestamp::Unparseable => Some(self.violation(
-                    severity,
+                Timestamp::Unparseable => Some(ctx.report_with(
+                    &HTTP_DATE_MALFORMED,
                     "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into(),
                 )),
                 Timestamp::At(sunset, text) if sunset <= date - skew => {
-                    Some(self.cited(&RFC_8594_3, severity, format!(
+                    Some(self.cited(&RFC_8594_3, ctx.severity, format!(
                         "Sunset header '{}' is before or equal to Date '{}'; Sunset should indicate a future shutdown date",
                         text, date_text
                     )))
@@ -232,7 +248,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_9110_6_6_1, RFC_9110_8_8_2, RFC_9110_13_1_3, RFC_8594_3]
+        &[
+            RFC_9110_6_6_1,
+            RFC_9110_8_8_2,
+            RFC_9110_13_1_3,
+            RFC_8594_3,
+            RFC_9110_5_6_7,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -279,12 +305,12 @@ impl Rule for DateAndTimeHeadersConsistent {
             let skew = chrono::Duration::seconds(ALLOWED_SKEW_SECS);
             let severity = ctx.severity;
 
-            if let Some(v) = self.date_is_readable(&tx.request.headers, severity) {
+            if let Some(v) = self.date_is_readable(&tx.request.headers, ctx) {
                 return Some(v);
             }
 
             if let Some(resp) = &tx.response {
-                if let Some(v) = self.date_is_readable(&resp.headers, severity) {
+                if let Some(v) = self.date_is_readable(&resp.headers, ctx) {
                     return Some(v);
                 }
                 // The two comparisons below are against Date, so they are asked
@@ -301,7 +327,7 @@ impl Rule for DateAndTimeHeadersConsistent {
                         return Some(v);
                     }
                     if let Some(v) =
-                        self.sunset_is_after_date(&resp.headers, date, date_text, skew, severity)
+                        self.sunset_is_after_date(&resp.headers, date, date_text, skew, ctx)
                     {
                         return Some(v);
                     }
@@ -322,6 +348,74 @@ static REGISTRATION: &dyn crate::rules::Rule = &DateAndTimeHeadersConsistent;
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    /// Three fields, four sites, one id. `Date` and `Sunset` are read here,
+    /// `Sunset` again by `sunset_and_deprecation_consistent` out of a body that
+    /// shares no line with this one, and `Expires` by
+    /// `cookie_attribute_consistent` through a cookie attribute walk. All four
+    /// ask the *recipient's* question — can this value be read as a timestamp
+    /// at all — so all four answer `http_date_malformed`.
+    ///
+    /// The two `Sunset` readings are also one of S6's fourteen duplicate
+    /// templates: byte-identical prose from two rules, which until now was two
+    /// findings under two names and is now two findings under one.
+    #[test]
+    fn a_timestamp_no_recipient_can_read_is_one_defect_in_three_fields() {
+        let response = |pairs: &[(&str, &str)]| {
+            let mut tx = crate::test_helpers::make_test_transaction_with_response(200, &[]);
+            tx.response.as_mut().expect("a response").headers =
+                crate::test_helpers::make_headers_from_pairs(pairs);
+            tx
+        };
+        let here = |pairs: &[(&str, &str)]| {
+            crate::test_helpers::run_rule(
+                &DateAndTimeHeadersConsistent,
+                &response(pairs),
+                &crate::transaction_history::TransactionHistory::empty(),
+                &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                    "date_and_time_headers_consistent",
+                ]),
+            )
+            .expect("a finding")
+        };
+        let readable_date = ("date", "Wed, 21 Oct 2015 07:28:00 GMT");
+
+        assert_eq!(
+            here(&[("date", "not-a-date")]).violation,
+            "http_date_malformed"
+        );
+        let sunset_here = here(&[readable_date, ("sunset", "not-a-date")]);
+        assert_eq!(sunset_here.violation, "http_date_malformed");
+
+        let sunset = crate::test_helpers::run_rule(
+            &crate::rules::sunset_and_deprecation_consistent::SunsetAndDeprecationConsistent,
+            &response(&[("sunset", "not-a-date")]),
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "sunset_and_deprecation_consistent",
+            ]),
+        )
+        .expect("a finding");
+        assert_eq!(sunset.violation, "http_date_malformed");
+
+        let expires = crate::test_helpers::run_rule(
+            &crate::rules::cookie_attribute_consistent::CookieAttributeConsistent,
+            &response(&[("set-cookie", "id=1; Expires=not-a-date")]),
+            &crate::transaction_history::TransactionHistory::empty(),
+            &crate::test_helpers::make_test_config_with_enabled_rules(&[
+                "cookie_attribute_consistent",
+            ]),
+        )
+        .expect("a finding");
+        assert_eq!(expires.violation, "http_date_malformed");
+
+        // The duplicate template, still duplicated — the id is what makes the
+        // pair visible, and collapsing it is Phase 5's decision, not this
+        // commit's.
+        assert_eq!(sunset_here.message, sunset.message);
+        // And a rule that reads another field still names it.
+        assert_ne!(sunset.message, expires.message);
+    }
 
     #[rstest]
     #[case(Some(vec![("date", "not-a-date")] ), true)]

--- a/lint-http-rules/src/rules/mod.rs
+++ b/lint-http-rules/src/rules/mod.rs
@@ -1273,14 +1273,18 @@ severity = "warn"
     /// after the scheme, `basic_auth_base64_valid` the one that read what was
     /// inside them, `bearer_token_syntax` the one that read the token, and
     /// `range_and_content_range_consistent` the one that parsed the
-    /// `Content-Range` it goes on to compare.
+    /// `Content-Range` it goes on to compare, `accept_header_media_type_syntax`
+    /// the one that read a `media-range`'s parts, and — three at once, which is
+    /// what a production shared across unrelated fields costs — the `Date`,
+    /// `Sunset` and `Set-Cookie` `Expires` readings that each named § 5.6.7's
+    /// timestamp in their own field's words.
     #[test]
     fn citation_coverage_does_not_regress() {
         /// Finding sites that name the specification sentence they enforce.
         /// The rest are the per-rule reading that has not happened yet — the
         /// denominator is computed below, because merges and conversions both
         /// move it.
-        const FLOOR: usize = 160;
+        const FLOOR: usize = 157;
 
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules");
         let mut cited = 0;

--- a/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
+++ b/lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
@@ -4,9 +4,26 @@
 
 use crate::lint::Violation;
 use crate::rules::{Rule, RuleMeta};
+use crate::violations::http_date::{HTTP_DATE_MALFORMED, RFC_9110_5_6_7};
+use crate::violations::ViolationDef;
 use chrono::TimeZone;
 
 pub struct SunsetAndDeprecationConsistent;
+
+/// The one defect this rule reports about a value, rather than about two
+/// values disagreeing — and it is the same id
+/// `date_and_time_headers_consistent` reports for the same field, out of two
+/// code paths that share nothing but the helper they parse with.
+///
+/// `parse_http_date_to_datetime` is the recipient's parse, so a failure means
+/// no recipient could read the value at all. The sender's obligation — the
+/// IMF-fixdate a `Sunset` should be written in — is asked by neither rule, so
+/// neither declares the two ids that answer it.
+///
+/// The `Deprecation` half is a Structured Field `Date` and not an `HTTP-date`,
+/// so nothing here answers for it; its non-UTF-8 line stays on the older API
+/// for the reason every such site does.
+static DECLARED: &[&ViolationDef] = &[&HTTP_DATE_MALFORMED];
 
 /// The specification references this rule declares, each named so a finding
 /// site can cite the one it enforces. `specifications()` below is built from
@@ -56,7 +73,17 @@ severity = "warn"
     }
 
     fn specifications(&self) -> &'static [crate::rules::SpecRef] {
-        &[RFC_8594_3, RFC_9745_2_1, RFC_9745_4, RFC_9651_3_3_7]
+        &[
+            RFC_8594_3,
+            RFC_9745_2_1,
+            RFC_9745_4,
+            RFC_9651_3_3_7,
+            RFC_9110_5_6_7,
+        ]
+    }
+
+    fn violations(&self) -> &'static [&'static ViolationDef] {
+        DECLARED
     }
 
     fn examples(&self) -> &'static [crate::rules::Example] {
@@ -103,9 +130,8 @@ impl Rule for SunsetAndDeprecationConsistent {
                 Some(s) => match crate::http_date::parse_http_date_to_datetime(s) {
                     Ok(dt) => Some((s.to_string(), dt)),
                     Err(_) => {
-                        return Some(self.cited(
-                            &RFC_8594_3,
-                            ctx.severity,
+                        return Some(ctx.report_with(
+                            &HTTP_DATE_MALFORMED,
                             "Sunset header is not a valid HTTP-date (RFC 8594 §3)".into(),
                         ));
                     }

--- a/specs/specs_generated.yaml
+++ b/specs/specs_generated.yaml
@@ -717,13 +717,13 @@ sources:
     snippet: samesite-value = "Strict" / "Lax" / "None"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 132
+      line: 148
   - label: cookie_attribute_consistent (2)
     section: § 5.7
     snippet: If the cookie's "same-site-flag" is "None", abort this algorithm and ignore the cookie entirely unless the cookie's secure-only-flag is true.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 89
+      line: 104
   - label: cookie_same_site_enforced
     section: § 4.1.2.7
     snippet: If the "SameSite" attribute's value is "Strict", the cookie will only be sent along with "same-site" requests.
@@ -2125,43 +2125,43 @@ sources:
     snippet: cookie-pair       = cookie-name "=" cookie-value cookie-name       = token
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 62
+      line: 77
   - label: cookie_attribute_consistent (2)
     section: § 4.1.1
     snippet: expires-av        = "Expires=" sane-cookie-date
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 180
+      line: 201
   - label: cookie_attribute_consistent (3)
     section: § 4.1.1
     snippet: extension-av      = <any CHAR except CTLs or ";">
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 103
+      line: 118
   - label: cookie_attribute_consistent (4)
     section: § 4.1.1
     snippet: httponly-av       = "HttpOnly"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 112
+      line: 128
   - label: cookie_attribute_consistent (5)
     section: § 4.1.1
     snippet: secure-av         = "Secure"
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 111
+      line: 127
   - label: cookie_attribute_consistent (6)
     section: § 5.2.2
     snippet: If the first character of the attribute-value is not a DIGIT or a "-" character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 159
+      line: 175
   - label: cookie_attribute_consistent (7)
     section: § 5.2.2
     snippet: If the remainder of attribute-value contains a non-DIGIT character, ignore the cookie-av.
     cited_by:
     - file: lint-http-rules/src/rules/cookie_attribute_consistent.rs
-      line: 160
+      line: 176
   - label: cookie_domain_matching
     section: § 5.4
     snippet: 'Let cookie-list be the set of cookies from the cookie store that meets all of the following requirements:'
@@ -4474,9 +4474,9 @@ sources:
     snippet: The Sunset value is an HTTP-date timestamp, as defined in Section 7.1.1.1 of [RFC7231], and SHOULD be a timestamp in the future.
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 148
+      line: 164
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 100
+      line: 127
 - label: RFC 8615
   url: https://www.rfc-editor.org/rfc/rfc8615.html
   fragments:
@@ -5305,7 +5305,7 @@ sources:
     - file: lint-http-rules/src/rules/cache_coherence.rs
       line: 144
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 89
+      line: 106
   - label: cache_coherence (3)
     section: § 8.8.2
     snippet: The "Last-Modified" header field in a response provides a timestamp indicating the date and time at which the origin server believes the selected representation was last modified
@@ -5807,7 +5807,7 @@ sources:
     snippet: An origin server with a clock (as defined in Section 5.6.7) MUST NOT generate a Last-Modified date that is later than the server's time of message origination (Date, Section 6.6.1).
     cited_by:
     - file: lint-http-rules/src/rules/date_and_time_headers_consistent.rs
-      line: 115
+      line: 131
   - label: early_data_header_safe_method
     section: § 16.1.1
     snippet: 'HTTP method registrations MUST include the following fields:'
@@ -10987,7 +10987,7 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 118
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 129
+      line: 155
   - label: lint-http-rules/src/helpers/structured_fields.rs
     section: § 3.1.2
     snippet: Note that parameters are ordered, and parameter keys cannot contain uppercase letters.
@@ -11457,10 +11457,10 @@ sources:
     - file: lint-http-rules/src/rules/deprecation_header_syntax.rs
       line: 117
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 128
+      line: 154
   - label: sunset_and_deprecation_consistent
     section: § 4
     snippet: The timestamp given in the Sunset HTTP header field MUST NOT be earlier than the one given in the Deprecation header field.
     cited_by:
     - file: lint-http-rules/src/rules/sunset_and_deprecation_consistent.rs
-      line: 167
+      line: 193


### PR DESCRIPTION
`Date`, `Sunset` and a `Set-Cookie` `Expires` are three fields with nothing in common but the production their values are written in, and each worded the same verdict about it: this value is not a timestamp anybody can read. That is `http_date_malformed`, and the three rules now declare it and report it rather than saying so in their own words.

All four sites ask the recipient's question — `parse_http_date_to_datetime` and `is_valid_http_date` accept all three formats, which is what § 5.6.7 obliges every reader to do — so a failure means the field names no instant at all. The sender's half of that section (an obsolete spelling, a padded one) is asked by none of them, so none declares the two ids that answer it.

The two `Sunset` readings are byte-identical prose from two rules that share no code, which is one of the duplicate templates the campaign measured; they now carry one id, asserted together with the `Date` and `Expires` readings in one test.

`cookie_attribute_consistent`'s own § 5.6.7 reference is deleted in favour of the subject's — its note claimed IMF-fixdate at a site that performs the recipient parse, and the gate comparing a def's spec against its rule's would have refused the second const anyway.

Eleven other rules read the same helper and are deliberately untouched: each uses the predicate to decide whether to speak rather than to report, and a gate that stays silent has no defect to name.

Citation floor 160 -> 157: three of the four sites were cited ones, and the sentence moved onto the def rather than stopping being read.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
